### PR TITLE
Make shadow more robust in hostile environments

### DIFF
--- a/etc/login.defs
+++ b/etc/login.defs
@@ -393,3 +393,8 @@ USERGROUPS_ENAB yes
 #
 #CREATE_HOME     yes
 
+#
+# Force use shadow, even if shadow passwd & shadow group files are
+# missing.
+#
+#FORCE_SHADOW    yes

--- a/lib/commonio.c
+++ b/lib/commonio.c
@@ -968,11 +968,10 @@ int commonio_close (struct commonio_db *db)
 	} else {
 		/*
 		 * Default permissions for new [g]shadow files.
-		 * (passwd and group always exist...)
 		 */
-		sb.st_mode = 0400;
-		sb.st_uid = 0;
-		sb.st_gid = 0;
+		sb.st_mode = db->st_mode;
+		sb.st_uid = db->st_uid;
+		sb.st_gid = db->st_gid;
 	}
 
 	snprintf (buf, sizeof buf, "%s+", db->filename);

--- a/lib/commonio.h
+++ b/lib/commonio.h
@@ -124,6 +124,12 @@ struct commonio_db {
 	/*@null@*/security_context_t scontext;
 #endif
 	/*
+	 * Default permissions and owner for newly created data file.
+         */
+	mode_t st_mode;
+	uid_t st_uid;
+	gid_t st_gid;
+	/*
 	 * Head, tail, current position in linked list.
 	 */
 	/*@owned@*/ /*@null@*/struct commonio_entry *head;

--- a/lib/getdef.c
+++ b/lib/getdef.c
@@ -139,6 +139,7 @@ static struct itemdef def_table[] = {
 	{"TCB_SYMLINKS", NULL},
 	{"USE_TCB", NULL},
 #endif
+	{"FORCE_SHADOW", NULL},
 	{NULL, NULL}
 };
 

--- a/lib/getdef.c
+++ b/lib/getdef.c
@@ -49,6 +49,32 @@ struct itemdef {
 	/*@null@*/char *value;		/* value given, or NULL if no value     */
 };
 
+#define PAMDEFS					\
+	{"CHFN_AUTH", NULL},			\
+	{"CHSH_AUTH", NULL},			\
+	{"CRACKLIB_DICTPATH", NULL},		\
+	{"ENV_HZ", NULL},			\
+	{"ENVIRON_FILE", NULL},			\
+	{"ENV_TZ", NULL},			\
+	{"FAILLOG_ENAB", NULL},			\
+	{"FTMP_FILE", NULL},			\
+	{"ISSUE_FILE", NULL},			\
+	{"LASTLOG_ENAB", NULL},			\
+	{"LOGIN_STRING", NULL},			\
+	{"MAIL_CHECK_ENAB", NULL},		\
+	{"MOTD_FILE", NULL},			\
+	{"NOLOGINS_FILE", NULL},		\
+	{"OBSCURE_CHECKS_ENAB", NULL},		\
+	{"PASS_ALWAYS_WARN", NULL},		\
+	{"PASS_CHANGE_TRIES", NULL},		\
+	{"PASS_MAX_LEN", NULL},			\
+	{"PASS_MIN_LEN", NULL},			\
+	{"PORTTIME_CHECKS_ENAB", NULL},		\
+	{"QUOTAS_ENAB", NULL},			\
+	{"SU_WHEEL_ONLY", NULL},		\
+	{"ULIMIT", NULL},
+
+
 #define NUMDEFS	(sizeof(def_table)/sizeof(def_table[0]))
 static struct itemdef def_table[] = {
 	{"CHFN_RESTRICT", NULL},
@@ -102,29 +128,7 @@ static struct itemdef def_table[] = {
 	{"USERDEL_CMD", NULL},
 	{"USERGROUPS_ENAB", NULL},
 #ifndef USE_PAM
-	{"CHFN_AUTH", NULL},
-	{"CHSH_AUTH", NULL},
-	{"CRACKLIB_DICTPATH", NULL},
-	{"ENV_HZ", NULL},
-	{"ENVIRON_FILE", NULL},
-	{"ENV_TZ", NULL},
-	{"FAILLOG_ENAB", NULL},
-	{"FTMP_FILE", NULL},
-	{"ISSUE_FILE", NULL},
-	{"LASTLOG_ENAB", NULL},
-	{"LOGIN_STRING", NULL},
-	{"MAIL_CHECK_ENAB", NULL},
-	{"MOTD_FILE", NULL},
-	{"NOLOGINS_FILE", NULL},
-	{"OBSCURE_CHECKS_ENAB", NULL},
-	{"PASS_ALWAYS_WARN", NULL},
-	{"PASS_CHANGE_TRIES", NULL},
-	{"PASS_MAX_LEN", NULL},
-	{"PASS_MIN_LEN", NULL},
-	{"PORTTIME_CHECKS_ENAB", NULL},
-	{"QUOTAS_ENAB", NULL},
-	{"SU_WHEEL_ONLY", NULL},
-	{"ULIMIT", NULL},
+	PAMDEFS
 #endif
 #ifdef USE_SYSLOG
 	{"SYSLOG_SG_ENAB", NULL},
@@ -136,6 +140,13 @@ static struct itemdef def_table[] = {
 	{"USE_TCB", NULL},
 #endif
 	{NULL, NULL}
+};
+
+#define NUMKNOWNDEFS	(sizeof(knowndef_table)/sizeof(knowndef_table[0]))
+static struct itemdef knowndef_table[] = {
+#ifdef USE_PAM
+	PAMDEFS
+#endif
 };
 
 #ifndef LOGINDEFS
@@ -397,10 +408,17 @@ static /*@observer@*/ /*@null@*/struct itemdef *def_find (const char *name)
 	 * Item was never found.
 	 */
 
+	for (ptr = knowndef_table; NULL != ptr->name; ptr++) {
+		if (strcmp (ptr->name, name) == 0) {
+			goto out;
+		}
+	}
 	fprintf (stderr,
 	         _("configuration error - unknown item '%s' (notify administrator)\n"),
 	         name);
 	SYSLOG ((LOG_CRIT, "unknown configuration item `%s'", name));
+
+out:
 	return (struct itemdef *) NULL;
 }
 

--- a/lib/getdef.c
+++ b/lib/getdef.c
@@ -417,21 +417,24 @@ static void def_load (void)
 	char buf[1024], *name, *value, *s;
 
 	/*
+	 * Set the initialized flag.
+	 * (do it early to prevent recursion in putdef_str())
+	 */
+	def_loaded = true;
+
+	/*
 	 * Open the configuration definitions file.
 	 */
 	fp = fopen (def_fname, "r");
 	if (NULL == fp) {
+		if (errno == ENOENT)
+			return;
+
 		int err = errno;
 		SYSLOG ((LOG_CRIT, "cannot open login definitions %s [%s]",
 		         def_fname, strerror (err)));
 		exit (EXIT_FAILURE);
 	}
-
-	/*
-	 * Set the initialized flag.
-	 * (do it early to prevent recursion in putdef_str())
-	 */
-	def_loaded = true;
 
 	/*
 	 * Go through all of the lines in the file.

--- a/lib/groupio.c
+++ b/lib/groupio.c
@@ -130,6 +130,9 @@ static /*@owned@*/struct commonio_db group_db = {
 #ifdef WITH_SELINUX
 	NULL,			/* scontext */
 #endif
+	0644,                   /* st_mode */
+	0,                      /* st_uid */
+	0,                      /* st_gid */
 	NULL,			/* head */
 	NULL,			/* tail */
 	NULL,			/* cursor */

--- a/lib/pwio.c
+++ b/lib/pwio.c
@@ -105,6 +105,9 @@ static struct commonio_db passwd_db = {
 #ifdef WITH_SELINUX
 	NULL,			/* scontext */
 #endif
+	0644,                   /* st_mode */
+	0,                      /* st_uid */
+	0,                      /* st_gid */
 	NULL,			/* head */
 	NULL,			/* tail */
 	NULL,			/* cursor */

--- a/lib/sgroupio.c
+++ b/lib/sgroupio.c
@@ -228,6 +228,9 @@ static struct commonio_db gshadow_db = {
 #ifdef WITH_SELINUX
 	NULL,			/* scontext */
 #endif
+	0400,                   /* st_mode */
+	0,                      /* st_uid */
+	0,                      /* st_gid */
 	NULL,			/* head */
 	NULL,			/* tail */
 	NULL,			/* cursor */

--- a/lib/sgroupio.c
+++ b/lib/sgroupio.c
@@ -249,6 +249,8 @@ int sgr_setdbname (const char *filename)
 
 bool sgr_file_present (void)
 {
+	if (getdef_bool ("FORCE_SHADOW"))
+		return true;
 	return commonio_present (&gshadow_db);
 }
 

--- a/lib/shadowio.c
+++ b/lib/shadowio.c
@@ -125,6 +125,8 @@ int spw_setdbname (const char *filename)
 
 bool spw_file_present (void)
 {
+	if (getdef_bool ("FORCE_SHADOW"))
+		return true;
 	return commonio_present (&shadow_db);
 }
 

--- a/lib/shadowio.c
+++ b/lib/shadowio.c
@@ -104,6 +104,9 @@ static struct commonio_db shadow_db = {
 #ifdef WITH_SELINUX
 	NULL,			/* scontext */
 #endif				/* WITH_SELINUX */
+	0400,                   /* st_mode */
+	0,                      /* st_uid */
+	0,                      /* st_gid */
 	NULL,			/* head */
 	NULL,			/* tail */
 	NULL,			/* cursor */

--- a/lib/subordinateio.c
+++ b/lib/subordinateio.c
@@ -541,6 +541,9 @@ static struct commonio_db subordinate_uid_db = {
 #ifdef WITH_SELINUX
 	NULL,			/* scontext */
 #endif
+	0644,                   /* st_mode */
+	0,                      /* st_uid */
+	0,                      /* st_gid */
 	NULL,			/* head */
 	NULL,			/* tail */
 	NULL,			/* cursor */
@@ -619,6 +622,9 @@ static struct commonio_db subordinate_gid_db = {
 #ifdef WITH_SELINUX
 	NULL,			/* scontext */
 #endif
+	0644,                   /* st_mode */
+	0,                      /* st_uid */
+	0,                      /* st_gid */
 	NULL,			/* head */
 	NULL,			/* tail */
 	NULL,			/* cursor */

--- a/src/chage.c
+++ b/src/chage.c
@@ -592,7 +592,7 @@ static void open_files (bool readonly)
 		}
 		pw_locked = true;
 	}
-	if (pw_open (readonly ? O_RDONLY: O_RDWR) == 0) {
+	if (pw_open (readonly ? O_RDONLY: O_CREAT | O_RDWR) == 0) {
 		fprintf (stderr, _("%s: cannot open %s\n"), Prog, pw_dbname ());
 		SYSLOG ((LOG_WARN, "cannot open %s", pw_dbname ()));
 		fail_exit (E_NOPERM);
@@ -613,7 +613,7 @@ static void open_files (bool readonly)
 		}
 		spw_locked = true;
 	}
-	if (spw_open (readonly ? O_RDONLY: O_RDWR) == 0) {
+	if (spw_open (readonly ? O_RDONLY: O_CREAT | O_RDWR) == 0) {
 		fprintf (stderr,
 		         _("%s: cannot open %s\n"), Prog, spw_dbname ());
 		SYSLOG ((LOG_WARN, "cannot open %s", spw_dbname ()));

--- a/src/chfn.c
+++ b/src/chfn.c
@@ -463,7 +463,7 @@ static void update_gecos (const char *user, char *gecos)
 		fail_exit (E_NOPERM);
 	}
 	pw_locked = true;
-	if (pw_open (O_RDWR) == 0) {
+	if (pw_open (O_CREAT | O_RDWR) == 0) {
 		fprintf (stderr,
 		         _("%s: cannot open %s\n"), Prog, pw_dbname ());
 		fail_exit (E_NOPERM);

--- a/src/chgpasswd.c
+++ b/src/chgpasswd.c
@@ -316,7 +316,7 @@ static void open_files (void)
 		fail_exit (1);
 	}
 	gr_locked = true;
-	if (gr_open (O_RDWR) == 0) {
+	if (gr_open (O_CREAT | O_RDWR) == 0) {
 		fprintf (stderr,
 		         _("%s: cannot open %s\n"), Prog, gr_dbname ());
 		fail_exit (1);
@@ -332,7 +332,7 @@ static void open_files (void)
 			fail_exit (1);
 		}
 		sgr_locked = true;
-		if (sgr_open (O_RDWR) == 0) {
+		if (sgr_open (O_CREAT | O_RDWR) == 0) {
 			fprintf (stderr, _("%s: cannot open %s\n"),
 			         Prog, sgr_dbname ());
 			fail_exit (1);

--- a/src/chpasswd.c
+++ b/src/chpasswd.c
@@ -313,7 +313,7 @@ static void open_files (void)
 		fail_exit (1);
 	}
 	pw_locked = true;
-	if (pw_open (O_RDWR) == 0) {
+	if (pw_open (O_CREAT | O_RDWR) == 0) {
 		fprintf (stderr,
 		         _("%s: cannot open %s\n"), Prog, pw_dbname ());
 		fail_exit (1);
@@ -328,7 +328,7 @@ static void open_files (void)
 			fail_exit (1);
 		}
 		spw_locked = true;
-		if (spw_open (O_RDWR) == 0) {
+		if (spw_open (O_CREAT | O_RDWR) == 0) {
 			fprintf (stderr,
 			         _("%s: cannot open %s\n"),
 			         Prog, spw_dbname ());

--- a/src/chsh.c
+++ b/src/chsh.c
@@ -373,7 +373,7 @@ static void update_shell (const char *user, char *newshell)
 		fail_exit (1);
 	}
 	pw_locked = true;
-	if (pw_open (O_RDWR) == 0) {
+	if (pw_open (O_CREAT | O_RDWR) == 0) {
 		fprintf (stderr, _("%s: cannot open %s\n"), Prog, pw_dbname ());
 		SYSLOG ((LOG_WARN, "cannot open %s", pw_dbname ()));
 		fail_exit (1);

--- a/src/gpasswd.c
+++ b/src/gpasswd.c
@@ -370,7 +370,7 @@ static void open_files (void)
 
 	add_cleanup (log_gpasswd_failure_system, NULL);
 
-	if (gr_open (O_RDWR) == 0) {
+	if (gr_open (O_CREAT | O_RDWR) == 0) {
 		fprintf (stderr,
 		         _("%s: cannot open %s\n"),
 		         Prog, gr_dbname ());
@@ -380,7 +380,7 @@ static void open_files (void)
 
 #ifdef SHADOWGRP
 	if (is_shadowgrp) {
-		if (sgr_open (O_RDWR) == 0) {
+		if (sgr_open (O_CREAT | O_RDWR) == 0) {
 			fprintf (stderr,
 			         _("%s: cannot open %s\n"),
 			         Prog, sgr_dbname ());

--- a/src/groupadd.c
+++ b/src/groupadd.c
@@ -346,7 +346,7 @@ static void open_files (void)
 	add_cleanup (cleanup_report_add_group, group_name);
 
 	/* And now open the databases */
-	if (gr_open (O_RDWR) == 0) {
+	if (gr_open (O_CREAT | O_RDWR) == 0) {
 		fprintf (stderr, _("%s: cannot open %s\n"), Prog, gr_dbname ());
 		SYSLOG ((LOG_WARN, "cannot open %s", gr_dbname ()));
 		exit (E_GRP_UPDATE);
@@ -354,7 +354,7 @@ static void open_files (void)
 
 #ifdef	SHADOWGRP
 	if (is_shadow_grp) {
-		if (sgr_open (O_RDWR) == 0) {
+		if (sgr_open (O_CREAT | O_RDWR) == 0) {
 			fprintf (stderr,
 			         _("%s: cannot open %s\n"),
 			         Prog, sgr_dbname ());

--- a/src/groupdel.c
+++ b/src/groupdel.c
@@ -246,7 +246,7 @@ static void open_files (void)
 	add_cleanup (cleanup_report_del_group, group_name);
 
 	/* An now open the databases */
-	if (gr_open (O_RDWR) == 0) {
+	if (gr_open (O_CREAT | O_RDWR) == 0) {
 		fprintf (stderr,
 		         _("%s: cannot open %s\n"),
 		         Prog, gr_dbname ());
@@ -255,7 +255,7 @@ static void open_files (void)
 	}
 #ifdef	SHADOWGRP
 	if (is_shadow_grp) {
-		if (sgr_open (O_RDWR) == 0) {
+		if (sgr_open (O_CREAT | O_RDWR) == 0) {
 			fprintf (stderr,
 			         _("%s: cannot open %s\n"),
 			         Prog, sgr_dbname ());

--- a/src/groupmems.c
+++ b/src/groupmems.c
@@ -536,14 +536,14 @@ static void open_files (void)
 #endif
 	}
 
-	if (gr_open (list ? O_RDONLY : O_RDWR) == 0) {
+	if (gr_open (list ? O_RDONLY : O_CREAT | O_RDWR) == 0) {
 		fprintf (stderr, _("%s: cannot open %s\n"), Prog, gr_dbname ());
 		fail_exit (EXIT_GROUP_FILE);
 	}
 
 #ifdef SHADOWGRP
 	if (is_shadowgrp) {
-		if (sgr_open (list ? O_RDONLY : O_RDWR) == 0) {
+		if (sgr_open (list ? O_RDONLY : O_CREAT | O_RDWR) == 0) {
 			fprintf (stderr, _("%s: cannot open %s\n"), Prog, sgr_dbname ());
 			fail_exit (EXIT_GROUP_FILE);
 		}

--- a/src/groupmod.c
+++ b/src/groupmod.c
@@ -663,7 +663,7 @@ static void lock_files (void)
  */
 static void open_files (void)
 {
-	if (gr_open (O_RDWR) == 0) {
+	if (gr_open (O_CREAT | O_RDWR) == 0) {
 		fprintf (stderr, _("%s: cannot open %s\n"), Prog, gr_dbname ());
 		SYSLOG ((LOG_WARN, "cannot open %s", gr_dbname ()));
 		exit (E_GRP_UPDATE);
@@ -672,7 +672,7 @@ static void open_files (void)
 #ifdef	SHADOWGRP
 	if (   is_shadow_grp
 	    && (pflg || nflg)) {
-		if (sgr_open (O_RDWR) == 0) {
+		if (sgr_open (O_CREAT | O_RDWR) == 0) {
 			fprintf (stderr,
 			         _("%s: cannot open %s\n"),
 			         Prog, sgr_dbname ());
@@ -683,7 +683,7 @@ static void open_files (void)
 #endif				/* SHADOWGRP */
 
 	if (gflg) {
-		if (pw_open (O_RDWR) == 0) {
+		if (pw_open (O_CREAT | O_RDWR) == 0) {
 			fprintf (stderr,
 			         _("%s: cannot open %s\n"),
 			         Prog, pw_dbname ());

--- a/src/grpck.c
+++ b/src/grpck.c
@@ -299,7 +299,7 @@ static void open_files (void)
 	 * Open the files. Use O_RDONLY if we are in read_only mode,
 	 * O_RDWR otherwise.
 	 */
-	if (gr_open (read_only ? O_RDONLY : O_RDWR) == 0) {
+	if (gr_open (read_only ? O_RDONLY : O_CREAT | O_RDWR) == 0) {
 		fprintf (stderr, _("%s: cannot open %s\n"), Prog,
 		         grp_file);
 		if (use_system_grp_file) {
@@ -308,7 +308,7 @@ static void open_files (void)
 		fail_exit (E_CANT_OPEN);
 	}
 #ifdef	SHADOWGRP
-	if (is_shadow && (sgr_open (read_only ? O_RDONLY : O_RDWR) == 0)) {
+	if (is_shadow && (sgr_open (read_only ? O_RDONLY : O_CREAT | O_RDWR) == 0)) {
 		fprintf (stderr, _("%s: cannot open %s\n"), Prog,
 		         sgr_file);
 		if (use_system_sgr_file) {

--- a/src/grpconv.c
+++ b/src/grpconv.c
@@ -163,7 +163,7 @@ int main (int argc, char **argv)
 		fail_exit (5);
 	}
 	gr_locked = true;
-	if (gr_open (O_RDWR) == 0) {
+	if (gr_open (O_CREAT | O_RDWR) == 0) {
 		fprintf (stderr, _("%s: cannot open %s\n"), Prog, gr_dbname ());
 		fail_exit (1);
 	}

--- a/src/grpunconv.c
+++ b/src/grpunconv.c
@@ -166,7 +166,7 @@ int main (int argc, char **argv)
 		fail_exit (5);
 	}
 	gr_locked = true;
-	if (gr_open (O_RDWR) == 0) {
+	if (gr_open (O_CREAT | O_RDWR) == 0) {
 		fprintf (stderr,
 		         _("%s: cannot open %s\n"), Prog, gr_dbname ());
 		fail_exit (1);

--- a/src/newusers.c
+++ b/src/newusers.c
@@ -805,27 +805,27 @@ static void open_files (void)
 	}
 #endif				/* ENABLE_SUBIDS */
 
-	if (pw_open (O_RDWR) == 0) {
+	if (pw_open (O_CREAT | O_RDWR) == 0) {
 		fprintf (stderr, _("%s: cannot open %s\n"), Prog, pw_dbname ());
 		fail_exit (EXIT_FAILURE);
 	}
-	if (is_shadow && (spw_open (O_RDWR) == 0)) {
+	if (is_shadow && (spw_open (O_CREAT | O_RDWR) == 0)) {
 		fprintf (stderr, _("%s: cannot open %s\n"), Prog, spw_dbname ());
 		fail_exit (EXIT_FAILURE);
 	}
-	if (gr_open (O_RDWR) == 0) {
+	if (gr_open (O_CREAT | O_RDWR) == 0) {
 		fprintf (stderr, _("%s: cannot open %s\n"), Prog, gr_dbname ());
 		fail_exit (EXIT_FAILURE);
 	}
 #ifdef SHADOWGRP
-	if (is_shadow_grp && (sgr_open (O_RDWR) == 0)) {
+	if (is_shadow_grp && (sgr_open (O_CREAT | O_RDWR) == 0)) {
 		fprintf (stderr, _("%s: cannot open %s\n"), Prog, sgr_dbname ());
 		fail_exit (EXIT_FAILURE);
 	}
 #endif
 #ifdef ENABLE_SUBIDS
 	if (is_sub_uid) {
-		if (sub_uid_open (O_RDWR) == 0) {
+		if (sub_uid_open (O_CREAT | O_RDWR) == 0) {
 			fprintf (stderr,
 			         _("%s: cannot open %s\n"),
 			         Prog, sub_uid_dbname ());
@@ -833,7 +833,7 @@ static void open_files (void)
 		}
 	}
 	if (is_sub_gid) {
-		if (sub_gid_open (O_RDWR) == 0) {
+		if (sub_gid_open (O_CREAT | O_RDWR) == 0) {
 			fprintf (stderr,
 			         _("%s: cannot open %s\n"),
 			         Prog, sub_gid_dbname ());

--- a/src/passwd.c
+++ b/src/passwd.c
@@ -573,7 +573,7 @@ static void update_noshadow (void)
 		exit (E_PWDBUSY);
 	}
 	pw_locked = true;
-	if (pw_open (O_RDWR) == 0) {
+	if (pw_open (O_CREAT | O_RDWR) == 0) {
 		(void) fprintf (stderr,
 		                _("%s: cannot open %s\n"),
 		                Prog, pw_dbname ());
@@ -627,7 +627,7 @@ static void update_shadow (void)
 		exit (E_PWDBUSY);
 	}
 	spw_locked = true;
-	if (spw_open (O_RDWR) == 0) {
+	if (spw_open (O_CREAT | O_RDWR) == 0) {
 		(void) fprintf (stderr,
 		                _("%s: cannot open %s\n"),
 		                Prog, spw_dbname ());

--- a/src/pwck.c
+++ b/src/pwck.c
@@ -281,7 +281,7 @@ static void open_files (void)
 	 * Open the files. Use O_RDONLY if we are in read_only mode, O_RDWR
 	 * otherwise.
 	 */
-	if (pw_open (read_only ? O_RDONLY : O_RDWR) == 0) {
+	if (pw_open (read_only ? O_RDONLY : O_CREAT | O_RDWR) == 0) {
 		fprintf (stderr, _("%s: cannot open %s\n"),
 		         Prog, pw_dbname ());
 		if (use_system_pw_file) {
@@ -290,7 +290,7 @@ static void open_files (void)
 		fail_exit (E_CANTOPEN);
 	}
 	if (is_shadow && !use_tcb) {
-		if (spw_open (read_only ? O_RDONLY : O_RDWR) == 0) {
+		if (spw_open (read_only ? O_RDONLY : O_CREAT | O_RDWR) == 0) {
 			fprintf (stderr, _("%s: cannot open %s\n"),
 			         Prog, spw_dbname ());
 			if (use_system_spw_file) {
@@ -566,7 +566,7 @@ static void check_pw_file (int *errors, bool *changed)
 					continue;
 				}
 				spw_locked = true;
-				if (spw_open (read_only ? O_RDONLY : O_RDWR) == 0) {
+				if (spw_open (read_only ? O_RDONLY : O_CREAT | O_RDWR) == 0) {
 					fprintf (stderr,
 					         _("%s: cannot open %s\n"),
 					         Prog, spw_dbname ());

--- a/src/pwconv.c
+++ b/src/pwconv.c
@@ -200,7 +200,7 @@ int main (int argc, char **argv)
 		fail_exit (E_PWDBUSY);
 	}
 	pw_locked = true;
-	if (pw_open (O_RDWR) == 0) {
+	if (pw_open (O_CREAT | O_RDWR) == 0) {
 		fprintf (stderr,
 		         _("%s: cannot open %s\n"), Prog, pw_dbname ());
 		fail_exit (E_MISSING);

--- a/src/pwunconv.c
+++ b/src/pwunconv.c
@@ -166,7 +166,7 @@ int main (int argc, char **argv)
 		fail_exit (5);
 	}
 	pw_locked = true;
-	if (pw_open (O_RDWR) == 0) {
+	if (pw_open (O_CREAT | O_RDWR) == 0) {
 		fprintf (stderr,
 		         _("%s: cannot open %s\n"),
 		         Prog, pw_dbname ());

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -1537,7 +1537,7 @@ static void open_files (void)
 		exit (E_PW_UPDATE);
 	}
 	pw_locked = true;
-	if (pw_open (O_RDWR) == 0) {
+	if (pw_open (O_CREAT | O_RDWR) == 0) {
 		fprintf (stderr, _("%s: cannot open %s\n"), Prog, pw_dbname ());
 		fail_exit (E_PW_UPDATE);
 	}
@@ -1554,7 +1554,7 @@ static void open_files (void)
 		fail_exit (E_GRP_UPDATE);
 	}
 	gr_locked = true;
-	if (gr_open (O_RDWR) == 0) {
+	if (gr_open (O_CREAT | O_RDWR) == 0) {
 		fprintf (stderr, _("%s: cannot open %s\n"), Prog, gr_dbname ());
 		fail_exit (E_GRP_UPDATE);
 	}
@@ -1567,7 +1567,7 @@ static void open_files (void)
 			fail_exit (E_GRP_UPDATE);
 		}
 		sgr_locked = true;
-		if (sgr_open (O_RDWR) == 0) {
+		if (sgr_open (O_CREAT | O_RDWR) == 0) {
 			fprintf (stderr,
 			         _("%s: cannot open %s\n"),
 			         Prog, sgr_dbname ());
@@ -1584,7 +1584,7 @@ static void open_files (void)
 			fail_exit (E_SUB_UID_UPDATE);
 		}
 		sub_uid_locked = true;
-		if (sub_uid_open (O_RDWR) == 0) {
+		if (sub_uid_open (O_CREAT | O_RDWR) == 0) {
 			fprintf (stderr,
 			         _("%s: cannot open %s\n"),
 			         Prog, sub_uid_dbname ());
@@ -1599,7 +1599,7 @@ static void open_files (void)
 			fail_exit (E_SUB_GID_UPDATE);
 		}
 		sub_gid_locked = true;
-		if (sub_gid_open (O_RDWR) == 0) {
+		if (sub_gid_open (O_CREAT | O_RDWR) == 0) {
 			fprintf (stderr,
 			         _("%s: cannot open %s\n"),
 			         Prog, sub_gid_dbname ());
@@ -1621,7 +1621,7 @@ static void open_shadow (void)
 		fail_exit (E_PW_UPDATE);
 	}
 	spw_locked = true;
-	if (spw_open (O_RDWR) == 0) {
+	if (spw_open (O_CREAT | O_RDWR) == 0) {
 		fprintf (stderr,
 		         _("%s: cannot open %s\n"),
 		         Prog, spw_dbname ());

--- a/src/userdel.c
+++ b/src/userdel.c
@@ -565,7 +565,7 @@ static void open_files (void)
 		fail_exit (E_PW_UPDATE);
 	}
 	pw_locked = true;
-	if (pw_open (O_RDWR) == 0) {
+	if (pw_open (O_CREAT | O_RDWR) == 0) {
 		fprintf (stderr,
 		         _("%s: cannot open %s\n"), Prog, pw_dbname ());
 #ifdef WITH_AUDIT
@@ -590,7 +590,7 @@ static void open_files (void)
 			fail_exit (E_PW_UPDATE);
 		}
 		spw_locked = true;
-		if (spw_open (O_RDWR) == 0) {
+		if (spw_open (O_CREAT | O_RDWR) == 0) {
 			fprintf (stderr,
 			         _("%s: cannot open %s\n"),
 			         Prog, spw_dbname ());
@@ -616,7 +616,7 @@ static void open_files (void)
 		fail_exit (E_GRP_UPDATE);
 	}
 	gr_locked = true;
-	if (gr_open (O_RDWR) == 0) {
+	if (gr_open (O_CREAT | O_RDWR) == 0) {
 		fprintf (stderr, _("%s: cannot open %s\n"), Prog, gr_dbname ());
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_DEL_USER, Prog,
@@ -641,7 +641,7 @@ static void open_files (void)
 			fail_exit (E_GRP_UPDATE);
 		}
 		sgr_locked= true;
-		if (sgr_open (O_RDWR) == 0) {
+		if (sgr_open (O_CREAT | O_RDWR) == 0) {
 			fprintf (stderr, _("%s: cannot open %s\n"),
 			         Prog, sgr_dbname ());
 #ifdef WITH_AUDIT
@@ -669,7 +669,7 @@ static void open_files (void)
 			fail_exit (E_SUB_UID_UPDATE);
 		}
 		sub_uid_locked = true;
-		if (sub_uid_open (O_RDWR) == 0) {
+		if (sub_uid_open (O_CREAT | O_RDWR) == 0) {
 			fprintf (stderr,
 				_("%s: cannot open %s\n"), Prog, sub_uid_dbname ());
 #ifdef WITH_AUDIT
@@ -695,7 +695,7 @@ static void open_files (void)
 			fail_exit (E_SUB_GID_UPDATE);
 		}
 		sub_gid_locked = true;
-		if (sub_gid_open (O_RDWR) == 0) {
+		if (sub_gid_open (O_CREAT | O_RDWR) == 0) {
 			fprintf (stderr,
 				_("%s: cannot open %s\n"), Prog, sub_gid_dbname ());
 #ifdef WITH_AUDIT

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -1532,7 +1532,7 @@ static void open_files (void)
 		fail_exit (E_PW_UPDATE);
 	}
 	pw_locked = true;
-	if (pw_open (O_RDWR) == 0) {
+	if (pw_open (O_CREAT | O_RDWR) == 0) {
 		fprintf (stderr,
 		         _("%s: cannot open %s\n"),
 		         Prog, pw_dbname ());
@@ -1545,7 +1545,7 @@ static void open_files (void)
 		fail_exit (E_PW_UPDATE);
 	}
 	spw_locked = true;
-	if (is_shadow_pwd && (spw_open (O_RDWR) == 0)) {
+	if (is_shadow_pwd && (spw_open (O_CREAT | O_RDWR) == 0)) {
 		fprintf (stderr,
 		         _("%s: cannot open %s\n"),
 		         Prog, spw_dbname ());
@@ -1564,7 +1564,7 @@ static void open_files (void)
 			fail_exit (E_GRP_UPDATE);
 		}
 		gr_locked = true;
-		if (gr_open (O_RDWR) == 0) {
+		if (gr_open (O_CREAT | O_RDWR) == 0) {
 			fprintf (stderr,
 			         _("%s: cannot open %s\n"),
 			         Prog, gr_dbname ());
@@ -1578,7 +1578,7 @@ static void open_files (void)
 			fail_exit (E_GRP_UPDATE);
 		}
 		sgr_locked = true;
-		if (is_shadow_grp && (sgr_open (O_RDWR) == 0)) {
+		if (is_shadow_grp && (sgr_open (O_CREAT | O_RDWR) == 0)) {
 			fprintf (stderr,
 			         _("%s: cannot open %s\n"),
 			         Prog, sgr_dbname ());
@@ -1595,7 +1595,7 @@ static void open_files (void)
 			fail_exit (E_SUB_UID_UPDATE);
 		}
 		sub_uid_locked = true;
-		if (sub_uid_open (O_RDWR) == 0) {
+		if (sub_uid_open (O_CREAT | O_RDWR) == 0) {
 			fprintf (stderr,
 			         _("%s: cannot open %s\n"),
 			         Prog, sub_uid_dbname ());
@@ -1610,7 +1610,7 @@ static void open_files (void)
 			fail_exit (E_SUB_GID_UPDATE);
 		}
 		sub_gid_locked = true;
-		if (sub_gid_open (O_RDWR) == 0) {
+		if (sub_gid_open (O_CREAT | O_RDWR) == 0) {
 			fprintf (stderr,
 			         _("%s: cannot open %s\n"),
 			         Prog, sub_gid_dbname ());


### PR DESCRIPTION
I'm patching shadow to be more robust when operating in a-typical environments, but these improvements are general enough, that I believe warrant inclusion upstream by default.

Specifically there are deployments that use nss-altfiles / nss-extrausers and thus ship alternative group/passwd/shadow/gshadow files elsewhere on the filesystem (e.g. /var/lib/passwd). In such configurations admin modifiable files /etc/passwd, /etc/group and so on may not exist. Furthermore if one is bootstrapping a new distribution from scratch, it would be nice to point shadow utilities at an empty /etc and start creating default system accounts with useradd/usermod/groupadd/etc utilities without writing initial files by hand. Hence these changes:

* create all databases, with correct (?! used typical permissions here, please correct if different defaults are desired) permissions, even if they are missing / are empty.

* next /etc/shadow file existence is used as a flag file, whether or not shadow passwords should be used. I think this is very odd, hence I add FORCE_SHADOW option to make sure shadow/gshadow are used, even if those files are non-existent.

* during testing I have noticed that when shadow is compiled with PAM support, settings that are not-applicable any more, but present in the stock /etc/login.defs are being complained about. So I made a change for shadow to not complain about well-known settings, which are not in effect when compiled with PAM support. If this is undesirable, maybe instead we would want to pre-process login.defs at compile time to make sure they do not contain any unknown settings in a given configuration (with/without pam, with/without subuids, etc.)

* Lastly, I noticed that login command would bail out and exit, if /etc/login.defs file is not present on disk. I find that very odd - given that there are compiled in defaults for every single value for all shadow utils to operate normally. Thus I made it non fatal for login to operate without /etc/login.defs.

Overall my goal is to have fully usable system with empty /etc and with these initial patches this is achievable. At the moment I'm also working on adding full usermod support, when operating with nss-altfiles.

Please review and consider including these patches.