### PR TITLE
Clear passwords on __gr_dup/__pw_dup errors and fix memory leak

### DIFF
--- a/lib/commonio.c
+++ b/lib/commonio.c
@@ -1081,6 +1081,7 @@ int commonio_update (struct commonio_db *db, const void *eptr)
 	if (NULL != p) {
 		if (next_entry_by_name (db, p->next, db->ops->getname (eptr)) != NULL) {
 			fprintf (stderr, _("Multiple entries named '%s' in %s. Please fix this with pwck or grpck.\n"), db->ops->getname (eptr), db->filename);
+			db->ops->free (nentry);
 			return 0;
 		}
 		db->ops->free (p->eptr);

--- a/lib/groupmem.c
+++ b/lib/groupmem.c
@@ -55,15 +55,14 @@
 	gr->gr_name = strdup (grent->gr_name);
 	/*@=mustfreeonly@*/
 	if (NULL == gr->gr_name) {
-		free(gr);
+		gr_free(gr);
 		return NULL;
 	}
 	/*@-mustfreeonly@*/
 	gr->gr_passwd = strdup (grent->gr_passwd);
 	/*@=mustfreeonly@*/
 	if (NULL == gr->gr_passwd) {
-		free(gr->gr_name);
-		free(gr);
+		gr_free(gr);
 		return NULL;
 	}
 
@@ -73,21 +72,13 @@
 	gr->gr_mem = (char **) malloc ((i + 1) * sizeof (char *));
 	/*@=mustfreeonly@*/
 	if (NULL == gr->gr_mem) {
-		free(gr->gr_passwd);
-		free(gr->gr_name);
-		free(gr);
+		gr_free(gr);
 		return NULL;
 	}
 	for (i = 0; grent->gr_mem[i]; i++) {
 		gr->gr_mem[i] = strdup (grent->gr_mem[i]);
 		if (NULL == gr->gr_mem[i]) {
-			int j;
-			for (j=0; j<i; j++)
-				free(gr->gr_mem[j]);
-			free(gr->gr_mem);
-			free(gr->gr_passwd);
-			free(gr->gr_name);
-			free(gr);
+			gr_free(gr);
 			return NULL;
 		}
 	}

--- a/lib/pwmem.c
+++ b/lib/pwmem.c
@@ -56,45 +56,35 @@
 	pw->pw_name = strdup (pwent->pw_name);
 	/*@=mustfreeonly@*/
 	if (NULL == pw->pw_name) {
-		free(pw);
+		pw_free(pw);
 		return NULL;
 	}
 	/*@-mustfreeonly@*/
 	pw->pw_passwd = strdup (pwent->pw_passwd);
 	/*@=mustfreeonly@*/
 	if (NULL == pw->pw_passwd) {
-		free(pw->pw_name);
-		free(pw);
+		pw_free(pw);
 		return NULL;
 	}
 	/*@-mustfreeonly@*/
 	pw->pw_gecos = strdup (pwent->pw_gecos);
 	/*@=mustfreeonly@*/
 	if (NULL == pw->pw_gecos) {
-		free(pw->pw_passwd);
-		free(pw->pw_name);
-		free(pw);
+		pw_free(pw);
 		return NULL;
 	}
 	/*@-mustfreeonly@*/
 	pw->pw_dir = strdup (pwent->pw_dir);
 	/*@=mustfreeonly@*/
 	if (NULL == pw->pw_dir) {
-		free(pw->pw_gecos);
-		free(pw->pw_passwd);
-		free(pw->pw_name);
-		free(pw);
+		pw_free(pw);
 		return NULL;
 	}
 	/*@-mustfreeonly@*/
 	pw->pw_shell = strdup (pwent->pw_shell);
 	/*@=mustfreeonly@*/
 	if (NULL == pw->pw_shell) {
-		free(pw->pw_dir);
-		free(pw->pw_gecos);
-		free(pw->pw_passwd);
-		free(pw->pw_name);
-		free(pw);
+		pw_free(pw);
 		return NULL;
 	}
 


### PR DESCRIPTION
The functions __gr_dup and __pw_dup do not explicitly zero the
memory which hold the passwords after free. The gr_free and pw_free
functions do this explicitly.

To guarantee same behaviour, it's possible to call these *_free
functions directly from __*_dup, because the memory is initialized
with zeros at the beginning. Calling free(NULL) has no negative
effect and can be considered safe these days.

Also prevent a memory leak in commonio on one of its error paths.