### PR TITLE
Tweak uid/gid map default configuration

### DIFF
--- a/etc/login.defs
+++ b/etc/login.defs
@@ -229,7 +229,7 @@ SYS_UID_MAX		  999
 # Extra per user uids
 SUB_UID_MIN		   100000
 SUB_UID_MAX		600100000
-SUB_UID_COUNT		    10000
+SUB_UID_COUNT		    65536
 
 #
 # Min/max values for automatic gid selection in groupadd(8)
@@ -242,7 +242,7 @@ SYS_GID_MAX		  999
 # Extra per user group ids
 SUB_GID_MIN		   100000
 SUB_GID_MAX		600100000
-SUB_GID_COUNT		    10000
+SUB_GID_COUNT		    65536
 
 #
 # Max number of login(1) retries if password is bad

--- a/libmisc/find_new_sub_gids.c
+++ b/libmisc/find_new_sub_gids.c
@@ -58,7 +58,7 @@ int find_new_sub_gids (const char *owner,
 
 	min = getdef_ulong ("SUB_GID_MIN", 100000UL);
 	max = getdef_ulong ("SUB_GID_MAX", 600100000UL);
-	count = getdef_ulong ("SUB_GID_COUNT", 10000);
+	count = getdef_ulong ("SUB_GID_COUNT", 65536);
 
 	if (min > max || count >= max || (min + count - 1) > max) {
 		(void) fprintf (stderr,

--- a/libmisc/find_new_sub_uids.c
+++ b/libmisc/find_new_sub_uids.c
@@ -58,7 +58,7 @@ int find_new_sub_uids (const char *owner,
 
 	min = getdef_ulong ("SUB_UID_MIN", 100000UL);
 	max = getdef_ulong ("SUB_UID_MAX", 600100000UL);
-	count = getdef_ulong ("SUB_UID_COUNT", 10000);
+	count = getdef_ulong ("SUB_UID_COUNT", 65536);
 
 	if (min > max || count >= max || (min + count - 1) > max) {
 		(void) fprintf (stderr,

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -1993,6 +1993,11 @@ int main (int argc, char **argv)
 #endif				/* USE_PAM */
 #endif				/* ACCT_TOOLS_SETUID */
 
+#ifdef ENABLE_SUBIDS
+	uid_t uid_min = (uid_t) getdef_ulong ("UID_MIN", 1000UL);
+	uid_t uid_max = (uid_t) getdef_ulong ("UID_MAX", 60000UL);
+#endif
+
 	/*
 	 * Get my name so that I can use it to report errors.
 	 */
@@ -2022,8 +2027,10 @@ int main (int argc, char **argv)
 	is_shadow_grp = sgr_file_present ();
 #endif
 #ifdef ENABLE_SUBIDS
-	is_sub_uid = sub_uid_file_present ();
-	is_sub_gid = sub_gid_file_present ();
+	is_sub_uid = sub_uid_file_present () && !rflg &&
+	    (!user_id || (user_id <= uid_max && user_id >= uid_min));
+	is_sub_gid = sub_gid_file_present () && !rflg &&
+	    (!user_id || (user_id <= uid_max && user_id >= uid_min));
 #endif				/* ENABLE_SUBIDS */
 
 	get_defaults ();


### PR DESCRIPTION
 - Use an allocation of 65536 uids and gids to allow for POSIX-compliant
   user owned namespaces.
 - Don't allocate a uid/gid map to system users.
   Unfortunately checking for --system isn't quite enough as some
   distribution wrappers always call useradd without --system and take care
   of choosing a uid and gid themselves, so also check whether the
   requested uid/gid is in the user range.

This is taken from a patch I wrote for Ubuntu a couple years ago and
which somehow didn't make it upstream.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>