### PR TITLE
man: Fix a number of typos for various commands.

### DIFF
--- a/man/chgpasswd.8.xml
+++ b/man/chgpasswd.8.xml
@@ -92,7 +92,7 @@
     <para>
       The default encryption algorithm can be defined for the system with
       the <option>ENCRYPT_METHOD</option> variable of <filename>/etc/login.defs</filename>,
-      and can be overwiten with the <option>-e</option>,
+      and can be overwritten with the <option>-e</option>,
       <option>-m</option>, or <option>-c</option> options.
     </para>
     <para>

--- a/man/chpasswd.8.xml
+++ b/man/chpasswd.8.xml
@@ -98,7 +98,7 @@
       The default encryption algorithm can be defined for the system with
       the <option>ENCRYPT_METHOD</option> or
       <option>MD5_CRYPT_ENAB</option> variables of
-      <filename>/etc/login.defs</filename>, and can be overwitten with the
+      <filename>/etc/login.defs</filename>, and can be overwritten with the
       <option>-e</option>, <option>-m</option>, or <option>-c</option>
       options.
     </para>
@@ -112,7 +112,7 @@
       <phrase condition="pam">Except when PAM is used to encrypt the
       passwords,</phrase> <command>chpasswd</command> first updates all the
       passwords in memory, and then commits all the changes to disk if no
-      errors occured for any user.
+      errors occurred for any user.
     </para>
     <para condition="pam">
       When PAM is used to encrypt the passwords (and update the passwords in

--- a/man/limits.5.xml
+++ b/man/limits.5.xml
@@ -108,7 +108,7 @@
       <listitem><para>A: max address space (KB)</para></listitem>
       <listitem><para>C: max core file size (KB)</para></listitem>
       <listitem><para>D: max data size (KB)</para></listitem>
-      <listitem><para>F: maximum filesize (KB)</para></listitem>
+      <listitem><para>F: maximum file size (KB)</para></listitem>
       <listitem><para>K: file creation mask, set by
 	<citerefentry>
 	  <refentrytitle>umask</refentrytitle><manvolnum>2</manvolnum>

--- a/man/newgidmap.1.xml
+++ b/man/newgidmap.1.xml
@@ -93,7 +93,7 @@
 	  <term>gid</term>
 	  <listitem>
 	    <para>
-	      Begining of the range of GIDs inside the user namespace.
+	      Beginning of the range of GIDs inside the user namespace.
 	    </para>
 	  </listitem>
 	</varlistentry>

--- a/man/nologin.8.xml
+++ b/man/nologin.8.xml
@@ -89,7 +89,7 @@
   <refsect1 id='history'>
     <title>HISTORY</title>
     <para>
-      The <command>nologin</command> command appearred in BSD 4.4.
+      The <command>nologin</command> command appeared in BSD 4.4.
     </para>
   </refsect1>
 </refentry>

--- a/man/passwd.1.xml
+++ b/man/passwd.1.xml
@@ -164,7 +164,7 @@
       </para>
 
       <para>
-	You can find advices on how to choose a strong password on
+	You can find advice on how to choose a strong password on
 	http://en.wikipedia.org/wiki/Password_strength
       </para>
     </refsect2>

--- a/man/pwck.8.xml
+++ b/man/pwck.8.xml
@@ -243,7 +243,7 @@
     <para condition="tcb">
       Note that when <option>USE_TCB</option> is enabled, you cannot
       specify an alternative <replaceable>shadow</replaceable> file. In
-      future releases, this paramater could be replaced by an alternate
+      future releases, this parameter could be replaced by an alternate
       TCB directory.
     </para>
   </refsect1>

--- a/man/shadow.5.xml
+++ b/man/shadow.5.xml
@@ -133,7 +133,7 @@
 	  </para>
 	  <para>
 	    The value 0 has a special meaning, which is that the user
-	    should change her pasword the next time she will log in the
+	    should change her password the next time she will log in the
 	    system.
 	  </para>
 	  <para>
@@ -228,7 +228,7 @@
 	  </para>
 	  <para>
 	    Note that an account expiration differs from a password
-	    expiration.  In case of an acount expiration, the user shall
+	    expiration.  In case of an account expiration, the user shall
 	    not be allowed to login.  In case of a password expiration,
 	    the user is not allowed to login using her password.
 	  </para>

--- a/man/su.1.xml
+++ b/man/su.1.xml
@@ -157,7 +157,7 @@
 	  </para>
 	  <para>
 	    The executed command will have no controlling terminal. This
-	    option cannot be used to execute interractive programs which
+	    option cannot be used to execute interactive programs which
 	    need a controlling TTY.
 	    <!-- This avoids TTY hijacking when su is used to lower
 	         privileges -->
@@ -191,7 +191,7 @@
 	  <para>The shell that will be invoked.</para>
 	  <para>
 	    The invoked shell is chosen from (highest priority first):
-	    <!--This should be an orderedlist, but lists inside another
+	    <!--This should be an ordered list, but lists inside another
 	        list does not work well with current docbook.
 	        - nekral - 2009.06.03 -->
 	    <variablelist>

--- a/man/suauth.5.xml
+++ b/man/suauth.5.xml
@@ -81,7 +81,7 @@
 
     <!-- .RS -->
     <literallayout remap='.nf'>
-      1) the user su is targetting
+      1) the user su is targeting
     </literallayout>
     <!-- .fi -->
     <para>
@@ -106,13 +106,13 @@
 
     <para>
       from-id is formatted the same as to-id except the extra word
-      <emphasis>GROUP</emphasis> is recognised. <emphasis>ALL EXCEPT
+      <emphasis>GROUP</emphasis> is recognized. <emphasis>ALL EXCEPT
       GROUP</emphasis> is perfectly valid too. Following
       <emphasis>GROUP</emphasis> appears one or more group names, delimited
       by ",". It is not sufficient to have primary group id of the relevant
       group, an entry in
       <citerefentry><refentrytitle>/etc/group</refentrytitle>
-      <manvolnum>5</manvolnum></citerefentry> is neccessary.
+      <manvolnum>5</manvolnum></citerefentry> is necessary.
     </para>
 
     <para> 

--- a/man/useradd.8.xml
+++ b/man/useradd.8.xml
@@ -307,7 +307,7 @@
 	  </para>
 	    Example: <option>-K</option>&nbsp;<replaceable>PASS_MAX_DAYS</replaceable>=<replaceable>-1</replaceable>
 	    can be used when creating system account to turn off password
-	    ageing, even though system account has no password at all.
+	    aging, even though system account has no password at all.
 	    Multiple <option>-K</option> options can be specified, e.g.:
 	    <option>-K</option>&nbsp;<replaceable>UID_MIN</replaceable>=<replaceable>100</replaceable>&nbsp;
 	    <option>-K</option>&nbsp;<replaceable>UID_MAX</replaceable>=<replaceable>499</replaceable>
@@ -326,7 +326,7 @@
 	  </para>
 	  <para>
 	    By default, the user's entries in the lastlog and faillog
-	    databases are resetted to avoid reusing the entry from a previously
+	    databases are reset to avoid reusing the entry from a previously
 	    deleted user.
 	  </para>
 	</listitem>


### PR DESCRIPTION
While reading the shadow.5 manpage a colleague noticed a typo, so I took it upon me to fix these. Thanks for a useful toolsuite!