### PR TITLE
*/Makefile.am: Replace INCLUDES with AM_CPPFLAGS

### DIFF
--- a/libmisc/Makefile.am
+++ b/libmisc/Makefile.am
@@ -1,7 +1,7 @@
 
 EXTRA_DIST = .indent.pro xgetXXbyYY.c
 
-INCLUDES = -I$(top_srcdir)/lib
+AM_CPPFLAGS = -I$(top_srcdir)/lib
 
 noinst_LIBRARIES = libmisc.a
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,9 +7,10 @@ usbindir = ${prefix}/sbin
 suidperms = 4755
 sgidperms = 2755
 
-INCLUDES = \
+AM_CPPFLAGS = \
 	-I${top_srcdir}/lib \
-	-I$(top_srcdir)/libmisc
+	-I$(top_srcdir)/libmisc \
+	-DLOCALEDIR=\"$(datadir)/locale\"
 
 # XXX why are login and su in /bin anyway (other than for
 # historical reasons)?
@@ -69,7 +70,6 @@ LDADD          = $(INTLLIBS) \
 		 $(LIBTCB) \
 		 $(top_builddir)/libmisc/libmisc.a \
 		 $(top_builddir)/lib/libshadow.la
-AM_CPPFLAGS    = -DLOCALEDIR=\"$(datadir)/locale\"
 
 if ACCT_TOOLS_SETUID
 LIBPAM_SUID  = $(LIBPAM)


### PR DESCRIPTION
Catch up with [Automake](http://git.savannah.gnu.org/cgit/automake.git/commit/?id=1415d22f6203206bc393fc4ea233123ba579222d), where the deprecation notice landed in
[v1.6b, cut 2002-07-28](http://git.savannah.gnu.org/cgit/automake.git/tag/?id=Release-1-6b).  Avoids:

```
$ autoreconf -v -f --install
...
libmisc/Makefile.am:4: warning: 'INCLUDES' is the old name for 'AM_CPPFLAGS' (or '*_CPPFLAGS')
...
src/Makefile.am:10: warning: 'INCLUDES' is the old name for 'AM_CPPFLAGS' (or '*_CPPFLAGS')
...
```
