### PR TITLE
Fix regression in useradd not loading defaults properly.

### DIFF
--- a/src/useradd.c
+++ b/src/useradd.c
@@ -2027,6 +2027,8 @@ int main (int argc, char **argv)
 	is_shadow_grp = sgr_file_present ();
 #endif
 
+	get_defaults ();
+
 	process_flags (argc, argv);
 
 #ifdef ENABLE_SUBIDS
@@ -2035,8 +2037,6 @@ int main (int argc, char **argv)
 	is_sub_gid = sub_gid_file_present () && !rflg &&
 	    (!user_id || (user_id <= uid_max && user_id >= uid_min));
 #endif				/* ENABLE_SUBIDS */
-
-	get_defaults ();
 
 #ifdef ACCT_TOOLS_SETUID
 #ifdef USE_PAM


### PR DESCRIPTION
The get_defaults() has to be called before processing the flags.

Signed-off-by: Tomáš Mráz <tmraz@fedoraproject.org>