### PR TITLE
Add missing size args to snprintf calls.

### DIFF
--- a/src/su.c
+++ b/src/su.c
@@ -373,8 +373,8 @@ static void prepare_pam_close_session (void)
 		              stderr);
 		(void) kill (-pid_child, caught);
 
-		snprintf (kill_msg, 256, _(" ...killed.\n"));
-		snprintf (wait_msg, 256, _(" ...waiting for child to terminate.\n"));
+		snprintf (kill_msg, sizeof kill_msg, _(" ...killed.\n"));
+		snprintf (wait_msg, sizeof wait_msg, _(" ...waiting for child to terminate.\n"));
 
 		(void) signal (SIGALRM, kill_child);
 		(void) alarm (2);


### PR DESCRIPTION
This code was added in dd50014055a36969153e83cf3675d9559fa6a200,
but both calls to snprintf were missing their size arguments, which is
obviously wrong (and fails to compile with GCC 6).

Rebased on top of the fix added later.