### PR TITLE
Reset user in tallylog

### DIFF
--- a/src/useradd.c
+++ b/src/useradd.c
@@ -51,7 +51,9 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/wait.h>
 #include <time.h>
+#include <unistd.h>
 #include "chkname.h"
 #include "defines.h"
 #include "faillog.h"
@@ -213,6 +215,7 @@ static void open_files (void);
 static void open_shadow (void);
 static void faillog_reset (uid_t);
 static void lastlog_reset (uid_t);
+static void tallylog_reset (char *);
 static void usr_update (void);
 static void create_home (void);
 static void create_mail (void);
@@ -1789,6 +1792,50 @@ static void lastlog_reset (uid_t uid)
 	}
 }
 
+static void tallylog_reset (char *user_name)
+{
+	static const char pam_tally2[] = "/sbin/pam_tally2";
+	const char *pname;
+	pid_t childpid;
+	int failed;
+	int status;
+
+	if (access(pam_tally2, X_OK) == -1)
+		return;
+
+	failed = 0;
+	switch (childpid = fork())
+	{
+	case -1: /* error */
+		failed = 1;
+		break;
+	case 0: /* child */
+		pname = strrchr(pam_tally2, '/');
+		if (pname == NULL)
+			pname = pam_tally2;
+		else
+			pname++;        /* Skip the '/' */
+		execl(pam_tally2, pname, "--user", user_name, "--reset", "--quiet", NULL);
+		/* If we come here, something has gone terribly wrong */
+		failed = 1;
+		break;
+	default: /* parent */
+		if (waitpid(childpid, &status, 0) == -1 || !WIFEXITED(status) || WEXITSTATUS(status) != 0)
+			failed = 1;
+		break;
+	}
+
+	if (failed);
+	{
+		fprintf (stderr,
+		         _("%s: failed to reset the tallylog entry of user \"%s\"\n"),
+		         Prog, user_name);
+		SYSLOG ((LOG_WARN, "failed to reset the tallylog entry of user \"%s\"", user_name));
+	}
+
+	return;
+}
+
 /*
  * usr_update - create the user entries
  *
@@ -2224,6 +2271,15 @@ int main (int argc, char **argv)
 	}
 
 	close_files ();
+
+	/*
+	 * tallylog_reset needs to be able to lookup
+	 * a valid existing user name,
+	 * so we canot call it before close_files()
+	 */
+	if ((!lflg) && (getpwuid (user_id) != NULL)) {
+		tallylog_reset (user_name);
+	}
 
 #ifdef WITH_SELINUX
 	if (Zflg) {


### PR DESCRIPTION
The useradd application resets the user data in /var/log/faillog, if it
exists and a new user is created.

pam_tally2 is used in many distributions.

Check for /var/log/tallylog and reset the user there.

Patch was written by Josef Moellers <jmoellers@suse.de>.

https://bugzilla.suse.com/show_bug.cgi?id=980486