### PR TITLE
buildsys: fix suidubins assignments

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -54,10 +54,10 @@ noinst_PROGRAMS = id sulogin
 suidbins       = su
 suidubins      = chage chfn chsh expiry gpasswd newgrp passwd
 if ACCT_TOOLS_SETUID
-	suidubins += chage chgpasswd chpasswd groupadd groupdel groupmod newusers useradd userdel usermod
+suidubins += chage chgpasswd chpasswd groupadd groupdel groupmod newusers useradd userdel usermod
 endif
 if ENABLE_SUBIDS
-	suidubins += newgidmap newuidmap
+suidubins += newgidmap newuidmap
 endif
 
 if WITH_TCB


### PR DESCRIPTION
These assignments were pasted as is into the Makefile and
ended up as part of a rule. (Usually the .PRECIOUS rule
which is why the build system never attempted to execute it
as commands, hiding the problem.)

Signed-off-by: Wolfgang Bumiller <wry.git@bumiller.com>
Reported-by: Rahel A <ra00177@surrey.ac.uk>