### PR TITLE
Fixed suid bit for subuid tools

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -57,7 +57,7 @@ if ACCT_TOOLS_SETUID
 	suidubins += chage chgpasswd chpasswd groupadd groupdel groupmod newusers useradd userdel usermod
 endif
 if ENABLE_SUBIDS
-	suidubins += newgidmap newuidmap
+suidubins += newgidmap newuidmap
 endif
 
 if WITH_TCB


### PR DESCRIPTION
We detect that our containerization tool stopped working with `newuidmap` and `newgidmap` utilities from `shadow` 4.4: https://github.com/tailhook/vagga/issues/362

Also the same typo is present for the account tools: https://github.com/shadow-maint/shadow/blob/master/src/Makefile.am#L57
But possibly to fix it there should be changed default value for the `--enable-account-tools-setuid` flag. Because account utilities never have had suid bit due to the typo.