### PR TITLE
include getdef.h for getdef_bool prototype

### DIFF
--- a/lib/sgroupio.c
+++ b/lib/sgroupio.c
@@ -40,6 +40,7 @@
 #include "prototypes.h"
 #include "defines.h"
 #include "commonio.h"
+#include "getdef.h"
 #include "sgroupio.h"
 
 /*@null@*/ /*@only@*/struct sgrp *__sgr_dup (const struct sgrp *sgent)

--- a/lib/shadowio.c
+++ b/lib/shadowio.c
@@ -40,6 +40,7 @@
 #include <shadow.h>
 #include <stdio.h>
 #include "commonio.h"
+#include "getdef.h"
 #include "shadowio.h"
 #ifdef WITH_TCB
 #include <tcb.h>


### PR DESCRIPTION
Otherwise we get build warnings like:
sgroupio.c:255:6: warning: implicit declaration of function 'getdef_bool' [-Wimplicit-function-declaration]
shadowio.c:131:6: warning: implicit declaration of function 'getdef_bool' [-Wimplicit-function-declaration]