### PR TITLE
enable travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+sudo: false
+
+language: c
+
+compiler:
+  - gcc
+  - clang
+
+addons:
+  apt:
+    packages:
+      - autopoint
+      - xsltproc
+
+script:
+ - ./autogen.sh --without-selinux --disable-man
+ - grep ENABLE_ config.status
+ - make
+
+# vim:et:ts=2:sw=2

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -215,5 +215,4 @@ $(man_MANS):
 	@echo "Error: you need to run configure with '--enable-man'"
 	@echo "       in order to regenerate man pages."
 	@echo ""
-	@false
 endif

--- a/man/generate_mans.mak
+++ b/man/generate_mans.mak
@@ -47,7 +47,6 @@ clean-local:
 else
 $(man_MANS):
 	@echo you need to run configure with --enable-man to generate man pages
-	@false
 endif
 
 man8/grpconv.8 man8/grpunconv.8 man8/pwunconv.8: man8/pwconv.8

--- a/man/generate_translations.mak
+++ b/man/generate_translations.mak
@@ -14,7 +14,6 @@ include ../generate_mans.mak
 else
 $(man_MANS):
 	@echo you need to run configure with --enable-man to generate man pages
-	@false
 endif
 
 CLEANFILES = .xml2po.mo $(EXTRA_DIST) $(addsuffix .xml,$(EXTRA_DIST)) config.xml


### PR DESCRIPTION
kickstart travis integration

currently fails because:
- #50 added invalid `po/pl.po` with fatal errors - it should be reverted (#50) or fixed (#56) (example build with reverted po: https://travis-ci.org/glensc/shadow/builds/181503106)

also removes `false` calls from `$(MAN_mans)` targets because it was not possible to disable man generation, it always invoked those targets regardless of `--disable-man` option

does not enable all features:
```
shadow will be compiled with the following features:
	auditing support:		no
	CrackLib support:		no
	PAM support:			no
	SELinux support:		no
	ACL support:			no
	Extended Attributes support:	no
	tcb support (incomplete):	no
	shadow group support:		yes
	S/Key support:			no
	SHA passwords encryption:	yes
	nscd support:			yes
	subordinate IDs support:	yes
```

appropriate debian dev packages need to be figured out, but that can be done in subsequent PRs

also `make distcheck` should be added to travis, but it's currently broken, should be fixed first.

after being merged, repo owner needs to enable travis integration from https://travis-ci.org/shadow-maint/shadow