### PR TITLE
Don't crash on bogus keys in login.defs if PAM is enabled

### DIFF
--- a/lib/getdef.c
+++ b/lib/getdef.c
@@ -148,6 +148,7 @@ static struct itemdef knowndef_table[] = {
 #ifdef USE_PAM
 	PAMDEFS
 #endif
+	{NULL, NULL}
 };
 
 #ifndef LOGINDEFS


### PR DESCRIPTION
Without this patch, PAM enabled builds crash when encountering an
invalid key in login.defs or key overrides because of array overflows

To reproduce, simply
	useradd -K Windows=broken

Signed-off-by: Bernhard Rosenkränzer <bero@lindev.ch>