### PR TITLE
useradd: Read defaults after changing root directories

### DIFF
--- a/src/useradd.c
+++ b/src/useradd.c
@@ -2047,8 +2047,8 @@ int main (int argc, char **argv)
 #endif				/* ACCT_TOOLS_SETUID */
 
 #ifdef ENABLE_SUBIDS
-	uid_t uid_min = (uid_t) getdef_ulong ("UID_MIN", 1000UL);
-	uid_t uid_max = (uid_t) getdef_ulong ("UID_MAX", 60000UL);
+	uid_t uid_min;
+	uid_t uid_max;
 #endif
 
 	/*
@@ -2085,6 +2085,8 @@ int main (int argc, char **argv)
 	process_flags (argc, argv);
 
 #ifdef ENABLE_SUBIDS
+	uid_min = (uid_t) getdef_ulong ("UID_MIN", 1000UL);
+	uid_max = (uid_t) getdef_ulong ("UID_MAX", 60000UL);
 	is_sub_uid = sub_uid_file_present () && !rflg &&
 	    (!user_id || (user_id <= uid_max && user_id >= uid_min));
 	is_sub_gid = sub_gid_file_present () && !rflg &&


### PR DESCRIPTION
There was an apparently unintentional change in behavior with 65c261714027d6d2bcf10cd103c5209ae9f7617f.  Previously, using the `--root` option with `useradd` would cause defaults to be loaded from the target root directory, but that commit caused defaults to be loaded before changing roots.  This was initially reported in coreos/bugs#1787.