### PR TITLE
Deleted a misplaced semicolon.

### DIFF
--- a/src/useradd.c
+++ b/src/useradd.c
@@ -1825,7 +1825,7 @@ static void tallylog_reset (char *user_name)
 		break;
 	}
 
-	if (failed);
+	if (failed)
 	{
 		fprintf (stderr,
 		         _("%s: failed to reset the tallylog entry of user \"%s\"\n"),


### PR DESCRIPTION
There is a misplaced semicolon which causes an error message to be generated despite the fact that the clearing of the error log was successful.