### PR TITLE
Reset pid_child only if waitpid was successful.

### DIFF
--- a/src/su.c
+++ b/src/su.c
@@ -379,7 +379,7 @@ static void prepare_pam_close_session (void)
 				/* wake child when resumed */
 				kill (pid, SIGCONT);
 				stop = false;
-			} else {
+			} else if (   (pid_t)-1 != pid) {
 				pid_child = 0;
 			}
 		} while (!stop);


### PR DESCRIPTION
Do not reset the pid_child to 0 if the child process is still
running. This else-condition can be reached with pid being -1,
therefore explicitly test this condition.

This is a regression fix for CVE-2017-2616. If su receives a
signal like SIGTERM, it is not propagated to the child.

Reported-by: Radu Duta <raduduta@gmail.com>
Signed-off-by: Tobias Stoeckmann <tobias@stoeckmann.org>