### PR TITLE
Add warning when turning off man switch

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -324,6 +324,7 @@ if test "$enable_man" = "yes"; then
 	AC_PATH_PROG([XSLTPROC], [xsltproc])
 	if test -z "$XSLTPROC"; then
 		enable_man=no
+		AC_MSG_ERROR([xsltproc is missing.])
 	fi
 
 	dnl check for DocBook DTD and stylesheets in the local catalog.


### PR DESCRIPTION
Print a warning in case xsltproc is missing.