### PR TITLE
Make userdel to work with -R.

### DIFF
--- a/src/userdel.c
+++ b/src/userdel.c
@@ -96,6 +96,7 @@ static char *user_home;
 static bool fflg = false;
 static bool rflg = false;
 static bool Zflg = false;
+static bool Rflg = false;
 
 static bool is_shadow_pwd;
 
@@ -1029,6 +1030,7 @@ int main (int argc, char **argv)
 				rflg = true;
 				break;
 			case 'R': /* no-op, handled in process_root_flag () */
+				Rflg = true;
 				break;
 #ifdef WITH_SELINUX             
 			case 'Z':
@@ -1103,9 +1105,12 @@ int main (int argc, char **argv)
 	 */
 	user_name = argv[argc - 1];
 	{
-		struct passwd *pwd;
-		pwd = getpwnam (user_name); /* local, no need for xgetpwnam */
+		const struct passwd *pwd;
+
+		pw_open(O_RDONLY);
+		pwd = pw_locate (user_name); /* we care only about local users */
 		if (NULL == pwd) {
+			pw_close();
 			fprintf (stderr, _("%s: user '%s' does not exist\n"),
 				 Prog, user_name);
 #ifdef WITH_AUDIT
@@ -1119,6 +1124,7 @@ int main (int argc, char **argv)
 		user_id = pwd->pw_uid;
 		user_gid = pwd->pw_gid;
 		user_home = xstrdup (pwd->pw_dir);
+		pw_close();
 	}
 #ifdef WITH_TCB
 	if (shadowtcb_set_user (user_name) == SHADOWTCB_FAILURE) {
@@ -1150,7 +1156,7 @@ int main (int argc, char **argv)
 	 * Note: This is a best effort basis. The user may log in between,
 	 * a cron job may be started on her behalf, etc.
 	 */
-	if (user_busy (user_name, user_id) != 0) {
+	if (!Rflg && user_busy (user_name, user_id) != 0) {
 		if (!fflg) {
 #ifdef WITH_AUDIT
 			audit_logger (AUDIT_DEL_USER, Prog,


### PR DESCRIPTION
The userdel checks for users with getpwnam() which might not work
properly in chroot. Check for the user's presence in local files only.
Fixes issue #89 