### PR TITLE
Double freeing up pointers , Causing Segmentation fault

### DIFF
--- a/src/newusers.c
+++ b/src/newusers.c
@@ -291,7 +291,7 @@ static int add_group (const char *name, const char *gid, gid_t *ngid, uid_t uid)
 		         _("%s: invalid group name '%s'\n"),
 		         Prog, grent.gr_name);
 		if (grent.gr_name)
-		free (grent.gr_name);
+			free (grent.gr_name);
 		return -1;
 	}
 

--- a/src/newusers.c
+++ b/src/newusers.c
@@ -290,6 +290,7 @@ static int add_group (const char *name, const char *gid, gid_t *ngid, uid_t uid)
 		fprintf (stderr,
 		         _("%s: invalid group name '%s'\n"),
 		         Prog, grent.gr_name);
+		if (grent.gr_name)
 		free (grent.gr_name);
 		return -1;
 	}


### PR DESCRIPTION
Edited to code to avoid freeing up of NULL pointer which is causing the Segmentation fault. 

` newusers newusers.txt 

*** Error in `newusers': double free or corruption (!prev): 0x000055aa28dc8030 ***
======= Backtrace: =========
/lib/x86_64-linux-gnu/libc.so.6(+0x777e5)[0x7f45a98aa7e5]
/lib/x86_64-linux-gnu/libc.so.6(+0x8037a)[0x7f45a98b337a]
/lib/x86_64-linux-gnu/libc.so.6(cfree+0x4c)[0x7f45a98b753c]
newusers(+0xaa97)[0x55aa271efa97]
newusers(+0x8825)[0x55aa271ed825]
newusers(+0x89de)[0x55aa271ed9de]
newusers(+0x5ea9)[0x55aa271eaea9]
newusers(+0x3eb7)[0x55aa271e8eb7]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf0)[0x7f45a9853830]
newusers(+0x4fd9)[0x55aa271e9fd9]
======= Memory map: ========
55aa271e5000-55aa271f5000 r-xp 00000000 08:01 134366                     /usr/sbin/newusers
55aa273f4000-55aa273f5000 r--p 0000f000 08:01 134366                     /usr/sbin/newusers
55aa273f5000-55aa273f7000 rw-p 00010000 08:01 134366                     /usr/sbin/newusers
55aa273f7000-55aa273f8000 rw-p 00000000 00:00 0 
55aa28d89000-55aa28df6000 rw-p 00000000 00:00 0                          [heap]
7f45a4000000-7f45a4021000 rw-p 00000000 00:00 0 
7f45a4021000-7f45a8000000 ---p 00000000 00:00 0 
7f45a8525000-7f45a853b000 r-xp 00000000 08:01 132883                     /lib/x86_64-linux-gnu/libgcc_s.so.1
7f45a853b000-7f45a873a000 ---p 00016000 08:01 132883                     /lib/x86_64-linux-gnu/libgcc_s.so.1
7f45a873a000-7f45a873b000 rw-p 00015000 08:01 132883                     /lib/x86_64-linux-gnu/libgcc_s.so.1
7f45a873b000-7f45a8746000 r-xp 00000000 08:01 132911                     /lib/x86_64-linux-gnu/libnss_files-2.23.so
7f45a8746000-7f45a8945000 ---p 0000b000 08:01 132911                     /lib/x86_64-linux-gnu/libnss_files-2.23.so
7f45a8945000-7f45a8946000 r--p 0000a000 08:01 132911                     /lib/x86_64-linux-gnu/libnss_files-2.23.so
7f45a8946000-7f45a8947000 rw-p 0000b000 08:01 132911                     /lib/x86_64-linux-gnu/libnss_files-2.23.so
7f45a8947000-7f45a894d000 rw-p 00000000 00:00 0 
7f45a894d000-7f45a8958000 r-xp 00000000 08:01 132915                     /lib/x86_64-linux-gnu/libnss_nis-2.23.so
7f45a8958000-7f45a8b57000 ---p 0000b000 08:01 132915                     /lib/x86_64-linux-gnu/libnss_nis-2.23.so
7f45a8b57000-7f45a8b58000 r--p 0000a000 08:01 132915                     /lib/x86_64-linux-gnu/libnss_nis-2.23.so
7f45a8b58000-7f45a8b59000 rw-p 0000b000 08:01 132915                     /lib/x86_64-linux-gnu/libnss_nis-2.23.so
7f45a8b59000-7f45a8b6f000 r-xp 00000000 08:01 132905                     /lib/x86_64-linux-gnu/libnsl-2.23.so
7f45a8b6f000-7f45a8d6e000 ---p 00016000 08:01 132905                     /lib/x86_64-linux-gnu/libnsl-2.23.so
7f45a8d6e000-7f45a8d6f000 r--p 00015000 08:01 132905                     /lib/x86_64-linux-gnu/libnsl-2.23.so
7f45a8d6f000-7f45a8d70000 rw-p 00016000 08:01 132905                     /lib/x86_64-linux-gnu/libnsl-2.23.so
7f45a8d70000-7f45a8d72000 rw-p 00000000 00:00 0 
7f45a8d72000-7f45a8d7a000 r-xp 00000000 08:01 132907                     /lib/x86_64-linux-gnu/libnss_compat-2.23.so
7f45a8d7a000-7f45a8f79000 ---p 00008000 08:01 132907                     /lib/x86_64-linux-gnu/libnss_compat-2.23.so
7f45a8f79000-7f45a8f7a000 r--p 00007000 08:01 132907                     /lib/x86_64-linux-gnu/libnss_compat-2.23.so
7f45a8f7a000-7f45a8f7b000 rw-p 00008000 08:01 132907                     /lib/x86_64-linux-gnu/libnss_compat-2.23.so
7f45a8f7b000-7f45a8f93000 r-xp 00000000 08:01 132930                     /lib/x86_64-linux-gnu/libpthread-2.23.so
7f45a8f93000-7f45a9192000 ---p 00018000 08:01 132930                     /lib/x86_64-linux-gnu/libpthread-2.23.so
7f45a9192000-7f45a9193000 r--p 00017000 08:01 132930                     /lib/x86_64-linux-gnu/libpthread-2.23.so
7f45a9193000-7f45a9194000 rw-p 00018000 08:01 132930                     /lib/x86_64-linux-gnu/libpthread-2.23.so
7f45a9194000-7f45a9198000 rw-p 00000000 00:00 0 
7f45a9198000-7f45a9206000 r-xp 00000000 08:01 132927                     /lib/x86_64-linux-gnu/libpcre.so.3.13.2
7f45a9206000-7f45a9406000 ---p 0006e000 08:01 132927                     /lib/x86_64-linux-gnu/libpcre.so.3.13.2
7f45a9406000-7f45a9407000 r--p 0006e000 08:01 132927                     /lib/x86_64-linux-gnu/libpcre.so.3.13.2
7f45a9407000-7f45a9408000 rw-p 0006f000 08:01 132927                     /lib/x86_64-linux-gnu/libpcre.so.3.13.2
7f45a9408000-7f45a940b000 r-xp 00000000 08:01 132875                     /lib/x86_64-linux-gnu/libdl-2.23.so
7f45a940b000-7f45a960a000 ---p 00003000 08:01 132875                     /lib/x86_64-linux-gnu/libdl-2.23.so
7f45a960a000-7f45a960b000 r--p 00002000 08:01 132875                     /lib/x86_64-linux-gnu/libdl-2.23.so
7f45a960b000-7f45a960c000 rw-p 00003000 08:01 132875                     /lib/x86_64-linux-gnu/libdl-2.23.so
7f45a960c000-7f45a9628000 r-xp 00000000 08:01 132856                     /lib/x86_64-linux-gnu/libaudit.so.1.0.0
7f45a9628000-7f45a9827000 ---p 0001c000 08:01 132856                     /lib/x86_64-linux-gnu/libaudit.so.1.0.0
7f45a9827000-7f45a9828000 r--p 0001b000 08:01 132856                     /lib/x86_64-linux-gnu/libaudit.so.1.0.0
7f45a9828000-7f45a9829000 rw-p 0001c000 08:01 132856                     /lib/x86_64-linux-gnu/libaudit.so.1.0.0
7f45a9829000-7f45a9833000 rw-p 00000000 00:00 0 
7f45a9833000-7f45a99f3000 r-xp 00000000 08:01 132862                     /lib/x86_64-linux-gnu/libc-2.23.so
7f45a99f3000-7f45a9bf3000 ---p 001c0000 08:01 132862                     /lib/x86_64-linux-gnu/libc-2.23.so
7f45a9bf3000-7f45a9bf7000 r--p 001c0000 08:01 132862                     /lib/x86_64-linux-gnu/libc-2.23.so
7f45a9bf7000-7f45a9bf9000 rw-p 001c4000 08:01 132862                     /lib/x86_64-linux-gnu/libc-2.23.so
7f45a9bf9000-7f45a9bfd000 rw-p 00000000 00:00 0 
7f45a9bfd000-7f45a9c1c000 r-xp 00000000 08:01 132940                     /lib/x86_64-linux-gnu/libselinux.so.1
7f45a9c1c000-7f45a9e1b000 ---p 0001f000 08:01 132940                     /lib/x86_64-linux-gnu/libselinux.so.1
7f45a9e1b000-7f45a9e1c000 r--p 0001e000 08:01 132940                     /lib/x86_64-linux-gnu/libselinux.so.1
7f45a9e1c000-7f45a9e1d000 rw-p 0001f000 08:01 132940                     /lib/x86_64-linux-gnu/libselinux.so.1
7f45a9e1d000-7f45a9e1f000 rw-p 00000000 00:00 0 
7f45a9e1f000-7f45a9e2c000 r-xp 00000000 08:01 132920                     /lib/x86_64-linux-gnu/libpam.so.0.83.1
7f45a9e2c000-7f45aa02b000 ---p 0000d000 08:01 132920                     /lib/x86_64-linux-gnu/libpam.so.0.83.1
7f45aa02b000-7f45aa02c000 r--p 0000c000 08:01 132920                     /lib/x86_64-linux-gnu/libpam.so.0.83.1
7f45aa02c000-7f45aa02d000 rw-p 0000d000 08:01 132920                     /lib/x86_64-linux-gnu/libpam.so.0.83.1
7f45aa02d000-7f45aa053000 r-xp 00000000 08:01 132842                     /lib/x86_64-linux-gnu/ld-2.23.so
7f45aa244000-7f45aa249000 rw-p 00000000 00:00 0 
7f45aa24f000-7f45aa252000 rw-p 00000000 00:00 0 
7f45aa252000-7f45aa253000 r--p 00025000 08:01 132842                     /lib/x86_64-linux-gnu/ld-2.23.so
7f45aa253000-7f45aa254000 rw-p 00026000 08:01 132842                     /lib/x86_64-linux-gnu/ld-2.23.so
7f45aa254000-7f45aa255000 rw-p 00000000 00:00 0 
7ffd9d4bc000-7ffd9d4dd000 rw-p 00000000 00:00 0                          [stack]
7ffd9d5ab000-7ffd9d5ad000 r--p 00000000 00:00 0                          [vvar]
7ffd9d5ad000-7ffd9d5af000 r-xp 00000000 00:00 0                          [vdso]
ffffffffff600000-ffffffffff601000 r-xp 00000000 00:00 0                  [vsyscall]
Aborted (core dumped)
`