### PR TITLE
newgidmap: enforce setgroups=deny if self-mapping a group

### DIFF
--- a/README
+++ b/README
@@ -44,6 +44,7 @@ a lot of mail...
 
 Adam Rudnicki <adam@v-lo.krakow.pl>
 Alan Curry <pacman@tardis.mars.net>
+Aleksa Sarai <cyphar@cyphar.com>
 Alexander O. Yuriev <alex@bach.cis.temple.edu>
 Algis Rudys <arudys@rice.edu>
 Andreas Jaeger <aj@arthur.rhein-neckar.de>


### PR DESCRIPTION
This is necessary to match the kernel-side policy of "self-mapping in a
user namespace is fine, but you cannot drop groups" -- a policy that was
created in order to stop user namespaces from allowing trivial privilege
escalation by dropping supplementary groups that were "blacklisted" from
certain paths.

This is the simplest fix for the underlying issue, and effectively makes
it so that unless a user has a valid mapping set in /etc/subgid (which
only administrators can modify) -- and they are currently trying to use
that mapping -- then /proc/$pid/setgroups will be set to deny. This
workaround is only partial, because ideally it should be possible to set
an "allow_setgroups" or "deny_setgroups" flag in /etc/subgid to allow
administrators to further restrict newgidmap(1).

Ref: https://bugs.launchpad.net/ubuntu/+source/shadow/+bug/1729357
Fixes: CVE-2018-7169
Reported-by: Craig Furman <craig.furman89@gmail.com>
Signed-off-by: Aleksa Sarai <asarai@suse.de>