### PR TITLE
newsubgid: add deny_setgroups option to /etc/subgid

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,10 +1,11 @@
 
 AUTOMAKE_OPTIONS = 1.0 foreign
 
-DEFS = 
+DEFS =
 
 noinst_LTLIBRARIES = libshadow.la
 
+libshadow_la_LIBADD = ../libmisc/libmisc.la
 libshadow_la_LDFLAGS = -version-info 0:0:0
 
 libshadow_la_SOURCES = \

--- a/lib/prototypes.h
+++ b/lib/prototypes.h
@@ -229,8 +229,10 @@ extern void setup_limits (const struct passwd *);
 extern /*@only@*/ /*@out@*/char **add_list (/*@returned@*/ /*@only@*/char **, const char *);
 extern /*@only@*/ /*@out@*/char **del_list (/*@returned@*/ /*@only@*/char **, const char *);
 extern /*@only@*/ /*@out@*/char **dup_list (char *const *);
+extern /*@only@*/ /*@out@*/void free_list (char *const *);
 extern bool is_on_list (char *const *list, const char *member);
 extern /*@only@*/char **comma_to_list (const char *);
+extern /*@only@*/char *comma_from_list (char *const *);
 
 /* log.c */
 extern void dolastlog (

--- a/lib/subordinateio.h
+++ b/lib/subordinateio.h
@@ -13,6 +13,7 @@
 
 extern int sub_uid_close(void);
 extern bool have_sub_uids(const char *owner, uid_t start, unsigned long count);
+extern char **sub_uid_options(const char *owner, uid_t start, unsigned long count);
 extern bool sub_uid_file_present (void);
 extern bool sub_uid_assigned(const char *owner);
 extern int sub_uid_lock (void);
@@ -26,6 +27,7 @@ extern uid_t sub_uid_find_free_range(uid_t min, uid_t max, unsigned long count);
 
 extern int sub_gid_close(void);
 extern bool have_sub_gids(const char *owner, gid_t start, unsigned long count);
+extern char **sub_gid_options(const char *owner, uid_t start, unsigned long count);
 extern bool sub_gid_file_present (void);
 extern bool sub_gid_assigned(const char *owner);
 extern int sub_gid_lock (void);

--- a/libmisc/Makefile.am
+++ b/libmisc/Makefile.am
@@ -3,9 +3,9 @@ EXTRA_DIST = .indent.pro xgetXXbyYY.c
 
 AM_CPPFLAGS = -I$(top_srcdir)/lib
 
-noinst_LIBRARIES = libmisc.a
+noinst_LTLIBRARIES = libmisc.la
 
-libmisc_a_SOURCES = \
+libmisc_la_SOURCES = \
 	addgrps.c \
 	age.c \
 	audit_help.c \

--- a/libmisc/list.c
+++ b/libmisc/list.c
@@ -152,7 +152,8 @@
 	int i;
 	char **tmp;
 
-	assert (NULL != list);
+	if (NULL == list)
+		return NULL;
 
 	for (i = 0; NULL != list[i]; i++);
 
@@ -168,6 +169,23 @@
 	tmp[i] = (char *) 0;
 	return tmp;
 }
+
+/*
+ * Free a list.
+ * The output list isn't modified, but the memory is freed.
+ */
+void free_list (char *const *list)
+{
+	int i;
+
+	if (NULL == list)
+		return;
+
+	for (i = 0; NULL != list[i]; i++)
+		free(list[i]);
+	free((void *)list);
+}
+
 
 /*
  * Check if member is part of the input list
@@ -269,3 +287,30 @@ bool is_on_list (char *const *list, const char *member)
 	return array;
 }
 
+/*
+ * comma_from_list - inverse of comma_to_list
+ */
+
+/*@only@*/char *comma_from_list (char *const *list)
+{
+	char *comma;
+	int i, commalen = 0;
+
+	if (NULL == list)
+		return NULL;
+
+	for (i = 0; NULL != list[i]; i++)
+		commalen += strlen(list[i]) + 1;
+
+	comma = xmalloc(commalen + 1);
+	memset(comma, '\0', commalen + 1);
+
+	for (i = 0; NULL != list[i]; i++) {
+		int j = strlen(comma);
+		if (j > 0)
+			comma[j++] = ',';
+		strncat(comma, list[i], commalen - j);
+	}
+
+	return comma;
+}

--- a/man/groupmod.8.xml
+++ b/man/groupmod.8.xml
@@ -3,7 +3,7 @@
    Copyright (c) 1991       , Julianne Frances Haugh
    Copyright (c) 2007 - 2011, Nicolas François
    All rights reserved.
-  
+
    Redistribution and use in source and binary forms, with or without
    modification, are permitted provided that the following conditions
    are met:
@@ -15,7 +15,7 @@
    3. The name of the copyright holders or contributors may not be used to
       endorse or promote products derived from this software without
       specific prior written permission.
-  
+
    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
    ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -136,7 +136,7 @@
 	  <option>-n</option>, <option>--new-name</option>&nbsp;<replaceable>NEW_GROUP</replaceable>
 	</term>
 	<listitem>
-	  <para> 
+	  <para>
 	    The name of the group will be changed from <replaceable>GROUP</replaceable>
 	    to <replaceable>NEW_GROUP</replaceable> name.
 	  </para>
@@ -278,16 +278,19 @@
 	    <para>E_GRP_UPDATE: can't update group file</para>
 	  </listitem>
 	</varlistentry>
+	<varlistentry>
 	  <term><replaceable>11</replaceable></term>
 	  <listitem>
 	    <para>E_CLEANUP_SERVICE: can't setup cleanup service</para>
 	  </listitem>
 	</varlistentry>
+	<varlistentry>
 	  <term><replaceable>12</replaceable></term>
 	  <listitem>
 	    <para>E_PAM_USERNAME: can't determine your username for use with pam</para>
 	  </listitem>
 	</varlistentry>
+	<varlistentry>
 	  <term><replaceable>13</replaceable></term>
 	  <listitem>
 	    <para>E_PAM_ERROR: pam returned an error, see syslog facility id groupmod for the PAM error message</para>

--- a/man/newgidmap.1.xml
+++ b/man/newgidmap.1.xml
@@ -2,7 +2,7 @@
 <!--
    Copyright (c) 2013 Eric W. Biederman
    All rights reserved.
-  
+
    Redistribution and use in source and binary forms, with or without
    modification, are permitted provided that the following conditions
    are met:
@@ -14,7 +14,7 @@
    3. The name of the copyright holders or contributors may not be used to
       endorse or promote products derived from this software without
       specific prior written permission.
-  
+
    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
    ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -122,10 +122,27 @@
       of the above sets, each of the GIDs in the range [lowergid,
       lowergid+count] is allowed to the caller according to
       <filename>/etc/subgid</filename> before setting
+      <filename>/proc/[pid]/setgroups</filename> and
       <filename>/proc/[pid]/gid_map</filename>.
     </para>
+
     <para>
       Note that newgidmap may be used only once for a given process.
+    </para>
+
+    <para>
+      <command>newgidmap</command> also allows you to map a user's own
+      effective group ID without it being specified in
+      <filename>/etc/subgid</filename> (in order to match the "unprivileged
+      user namespaces" feature in Linux 3.8). If this is the only mapping
+      requested (in order to match the security protections from Linux 3.19),
+      <command>newgidmap</command> will ensure that
+      <filename>/proc/[pid]/setgroups</filename> is set to "deny" (either by
+      writing "deny" itself or seeing that it is already set to "deny"), and
+      will fail if writing "deny" failed. This restriction is also applied if
+      any of the mappings given to <command>newgidmap</command> has the
+      <option>deny_setgroups</option> option set in
+      <filename>/etc/subgid</filename>.
     </para>
 
   </refsect1>

--- a/man/subgid.5.xml
+++ b/man/subgid.5.xml
@@ -2,7 +2,7 @@
 <!--
    Copyright (c) 2013 Eric W. Biederman
    All rights reserved.
-  
+
    Redistribution and use in source and binary forms, with or without
    modification, are permitted provided that the following conditions
    are met:
@@ -14,7 +14,7 @@
    3. The name of the copyright holders or contributors may not be used to
       endorse or promote products derived from this software without
       specific prior written permission.
-  
+
    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
    ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -51,7 +51,7 @@
       a user name and a range of subordinate group ids that user
       is allowed to use.
 
-      This is specified with three fields delimited by colons
+      This is specified with four fields delimited by colons
       (<quote>:</quote>).
       These fields are:
     </para>
@@ -64,6 +64,9 @@
       </listitem>
       <listitem>
 	<para>numerical subordinate group ID count</para>
+      </listitem>
+      <listitem>
+	<para>comma-separated list of options (optional)</para>
       </listitem>
     </itemizedlist>
 
@@ -83,6 +86,42 @@
       become noticeable. In this case it is recommended to use UIDs
       instead of login names. Benchmarks have shown speed-ups up to 20x.
     </para>
+
+  </refsect1>
+
+  <refsect1 id='options'>
+    <title>OPTIONS</title>
+
+    <para>
+      Options are comma-separated. Empty options are ignored, and if the
+      field is missing entirely it is treated as an empty string. Attempting
+      to use an unknown option will cause <command>newgidmap</command> to emit
+      an error. Setting options from the same option-set multiple times in a
+      single entry will result in the last option specified taking precedence.
+    </para>
+
+    <variablelist>
+      <varlistentry>
+        <term><option>allow_setgroups</option> (default),
+              <option>deny_setgroups</option></term>
+        <listitem>
+          <para>
+            Specify whether
+            <citerefentry>
+              <refentrytitle>setgroups</refentrytitle><manvolnum>2</manvolnum>
+            </citerefentry>
+            will be disabled by <command>newgidmap</command>. If more than one
+            mapping is given to <command>newgidmap</command>, and they have
+            different <option>*_setgroups</option> options set,
+            <option>deny_setgroups</option> always takes precedence. See
+            <citerefentry>
+              <refentrytitle>newgidmap</refentrytitle><manvolnum>1</manvolnum>
+            </citerefentry>
+            for more details.
+          </para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
 
   </refsect1>
 

--- a/man/subuid.5.xml
+++ b/man/subuid.5.xml
@@ -2,7 +2,7 @@
 <!--
    Copyright (c) 2013 Eric W. Biederman
    All rights reserved.
-  
+
    Redistribution and use in source and binary forms, with or without
    modification, are permitted provided that the following conditions
    are met:
@@ -14,7 +14,7 @@
    3. The name of the copyright holders or contributors may not be used to
       endorse or promote products derived from this software without
       specific prior written permission.
-  
+
    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
    ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -51,7 +51,7 @@
       a user name and a range of subordinate user ids that user
       is allowed to use.
 
-      This is specified with three fields delimited by colons
+      This is specified with four fields delimited by colons
       (<quote>:</quote>).
       These fields are:
     </para>
@@ -64,6 +64,9 @@
       </listitem>
       <listitem>
 	<para>numerical subordinate user ID count</para>
+      </listitem>
+      <listitem>
+	<para>comma-separated list of options (optional)</para>
       </listitem>
     </itemizedlist>
 
@@ -82,6 +85,24 @@
       <filename>/etc/subuid</filename>, parsing performance penalty will
       become noticeable. In this case it is recommended to use UIDs
       instead of login names. Benchmarks have shown speed-ups up to 20x.
+    </para>
+
+  </refsect1>
+
+  <refsect1 id='options'>
+    <title>OPTIONS</title>
+
+    <para>
+      Options are comma-separated. Empty options are ignored, and if the
+      field is missing entirely it is treated as an empty string. Attempting
+      to use an unknown option will cause <command>newuidmap</command> to emit
+      an error. Setting options from the same option-set multiple times in a
+      single entry will result in the last option specified taking precedence.
+    </para>
+
+    <para>
+      At the moment, no options are defined for
+      <filename>/etc/subuid</filename>.
     </para>
 
   </refsect1>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -68,7 +68,7 @@ endif
 
 LDADD          = $(INTLLIBS) \
 		 $(LIBTCB) \
-		 $(top_builddir)/libmisc/libmisc.a \
+		 $(top_builddir)/libmisc/libmisc.la \
 		 $(top_builddir)/lib/libshadow.la
 
 if ACCT_TOOLS_SETUID

--- a/src/newgidmap.c
+++ b/src/newgidmap.c
@@ -46,6 +46,27 @@
  */
 const char *Prog;
 
+static void parse_gid_options(char **options)
+{
+	int i;
+
+	if (NULL == options)
+		return;
+
+	for (i = 0; NULL != options[i]; i++) {
+		char *option = options[i];
+
+		if (strlen(option) < 1)
+			continue;
+
+		/* No options are currently valid for /etc/subgid, so error out. */
+
+		fprintf(stderr, _("%s: option '%s' is not understood\n"),
+			Prog,
+			option);
+		exit(EXIT_FAILURE);
+	}
+}
 
 static bool verify_range(struct passwd *pw, struct map_range *range, bool *allow_setgroups)
 {
@@ -55,7 +76,11 @@ static bool verify_range(struct passwd *pw, struct map_range *range, bool *allow
 
 	/* Test /etc/subgid. If the mapping is valid then we allow setgroups. */
 	if (have_sub_gids(pw->pw_name, range->lower, range->count)) {
+		char **options = sub_gid_options(pw->pw_name, range->lower, range->count);
+
 		*allow_setgroups = true;
+		parse_gid_options(options);
+		free_list(options);
 		return true;
 	}
 


### PR DESCRIPTION
Add a new deny_setgroups (and corresponding allow_setgroups) flag to
/etc/subgid. The purpose of this flag is to extend the security
protections against CVE-2018-7169, so that even group mapping configured
in /etc/subgid by an administrator can still disable setgroups.

However, rather than the fairly lenient semantics for self-mapping, the
semantics of /etc/subgid are stronger. If a mapping is encountered where
"deny_setgroups" is set, then no other mapping can "undo" this
restriction. The reason for this is that "deny_setgroups" indicates that
(according to the administrator) the mapping is unsafe to allow setgroups
in, and adding more mappings will not change this fact. "allow_setgroups"
is the default, and setting it is a noop. The logic used when applying
setgroups policies is unchanged (only denies are written, and we don't
write anything if it's already denied).

Signed-off-by: Aleksa Sarai <asarai@suse.de>