### PR TITLE
[WIP] Support systems that only have utmpx

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -74,12 +74,6 @@ AC_CHECK_MEMBERS([struct utmp.ut_type,
                   struct utmp.ut_time,
                   struct utmp.ut_xtime,
                   struct utmp.ut_tv],,,[[#include <utmp.h>]])
-dnl There are dependencies:
-dnl If UTMPX has to be used, the utmp structure shall have a ut_id field.
-if test "$ac_cv_header_utmpx_h" = "yes" &&
-   test "$ac_cv_member_struct_utmp_ut_id" != "yes"; then
-	AC_MSG_ERROR(Systems with UTMPX and no ut_id field in the utmp structure are not supported)
-fi
 
 AC_CHECK_MEMBERS([struct utmpx.ut_name,
                   struct utmpx.ut_host,

--- a/lib/prototypes.h
+++ b/lib/prototypes.h
@@ -416,17 +416,19 @@ extern int set_filesize_limit (int blocks);
 extern int user_busy (const char *name, uid_t uid);
 
 /* utmp.c */
+#ifndef USE_UTMPX
 extern /*@null@*/struct utmp *get_current_utmp (void);
 extern struct utmp *prepare_utmp (const char *name,
                                   const char *line,
                                   const char *host,
                                   /*@null@*/const struct utmp *ut);
 extern int setutmp (struct utmp *ut);
-#ifdef USE_UTMPX
+#else
+extern /*@null@*/struct utmpx *get_current_utmp (void);
 extern struct utmpx *prepare_utmpx (const char *name,
                                     const char *line,
                                     const char *host,
-                                    /*@null@*/const struct utmp *ut);
+                                    /*@null@*/const struct utmpx *ut);
 extern int setutmpx (struct utmpx *utx);
 #endif				/* USE_UTMPX */
 


### PR DESCRIPTION
This allows shadow-utils to build on systems like Adélie, which have no
<utmp.h> header or `struct utmp`.  We use a <utmpx.h>-based daemon,
[utmps], which uses `struct utmpx` only.

Tested both `login` and `logoutd` with utmps and both work correctly.

[utmps]: http://skarnet.org/software/utmps/

---

NOTE: This has not been tested on a glibc system yet (I don't have any outside of chroots; it is not possible for me to test `login` / `logoutd` functionality in a chroot.)