### PR TITLE
login.defs: Add LASTLOG_UID_MAX variable to limit lastlog to small uids.

### DIFF
--- a/lib/getdef.c
+++ b/lib/getdef.c
@@ -92,6 +92,7 @@ static struct itemdef def_table[] = {
 	{"GID_MIN", NULL},
 	{"HUSHLOGIN_FILE", NULL},
 	{"KILLCHAR", NULL},
+	{"LASTLOG_UID_MAX", NULL},
 	{"LOGIN_RETRIES", NULL},
 	{"LOGIN_TIMEOUT", NULL},
 	{"LOG_OK_LOGINS", NULL},

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -137,6 +137,7 @@ login_defs_v = \
 	ISSUE_FILE.xml \
 	KILLCHAR.xml \
 	LASTLOG_ENAB.xml \
+	LASTLOG_UID_MAX.xml \
 	LOGIN_RETRIES.xml \
 	LOGIN_STRING.xml \
 	LOGIN_TIMEOUT.xml \

--- a/man/lastlog.8.xml
+++ b/man/lastlog.8.xml
@@ -31,6 +31,7 @@
 -->
 <!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook V4.5//EN"
   "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [
+<!ENTITY LASTLOG_UID_MAX       SYSTEM "login.defs.d/LASTLOG_UID_MAX.xml">
 <!-- SHADOW-CONFIG-HERE -->
 ]>
 <refentry id='lastlog.8'>
@@ -198,6 +199,18 @@
       you have in <filename>passwd</filename> users with a high UID). You can
       display its real size with "<command>ls -s</command>".
     </para>
+  </refsect1>
+
+  <refsect1 id='configuration'>
+    <title>CONFIGURATION</title>
+    <para>
+      The following configuration variables in
+      <filename>/etc/login.defs</filename> change the behavior of this
+      tool:
+    </para>
+    <variablelist>
+      &LASTLOG_UID_MAX;
+    </variablelist>
   </refsect1>
 
   <refsect1 id='files'>

--- a/man/login.defs.5.xml
+++ b/man/login.defs.5.xml
@@ -54,6 +54,7 @@
 <!ENTITY ISSUE_FILE            SYSTEM "login.defs.d/ISSUE_FILE.xml">
 <!ENTITY KILLCHAR              SYSTEM "login.defs.d/KILLCHAR.xml">
 <!ENTITY LASTLOG_ENAB          SYSTEM "login.defs.d/LASTLOG_ENAB.xml">
+<!ENTITY LASTLOG_UID_MAX       SYSTEM "login.defs.d/LASTLOG_UID_MAX.xml">
 <!ENTITY LOG_OK_LOGINS         SYSTEM "login.defs.d/LOG_OK_LOGINS.xml">
 <!ENTITY LOG_UNKFAIL_ENAB      SYSTEM "login.defs.d/LOG_UNKFAIL_ENAB.xml">
 <!ENTITY LOGIN_RETRIES         SYSTEM "login.defs.d/LOGIN_RETRIES.xml">
@@ -188,6 +189,7 @@
       &ISSUE_FILE;
       &KILLCHAR;
       &LASTLOG_ENAB;
+      &LASTLOG_UID_MAX;
       &LOG_OK_LOGINS;
       &LOG_UNKFAIL_ENAB;
       &LOGIN_RETRIES;
@@ -349,7 +351,12 @@
 	</listitem>
       </varlistentry>
       <!-- id: no variables -->
-      <!-- lastlog: no variables -->
+      <varlistentry>
+	<term>lastlog</term>
+	<listitem>
+	  <para>LASTLOG_UID_MAX</para>
+	</listitem>
+      </varlistentry>
       <varlistentry>
 	<term>login</term>
 	<listitem>
@@ -365,7 +372,7 @@
 	    HUSHLOGIN_FILE
 	    <phrase condition="no_pam">ISSUE_FILE</phrase>
 	    KILLCHAR
-	    <phrase condition="no_pam">LASTLOG_ENAB</phrase>
+	    <phrase condition="no_pam">LASTLOG_ENAB LASTLOG_UID_MAX</phrase>
 	    LOGIN_RETRIES
 	    <phrase condition="no_pam">LOGIN_STRING</phrase>
 	    LOGIN_TIMEOUT LOG_OK_LOGINS LOG_UNKFAIL_ENAB
@@ -474,6 +481,7 @@
 	  <para>
 	    CREATE_HOME
 	    GID_MAX GID_MIN
+	    LASTLOG_UID_MAX
 	    MAIL_DIR MAX_MEMBERS_PER_GROUP
 	    PASS_MAX_DAYS PASS_MIN_DAYS PASS_WARN_AGE
 	    SUB_GID_COUNT SUB_GID_MAX SUB_GID_MIN
@@ -498,6 +506,7 @@
 	<term>usermod</term>
 	<listitem>
 	  <para>
+	    LASTLOG_UID_MAX
 	    MAIL_DIR MAIL_FILE MAX_MEMBERS_PER_GROUP
 	    <phrase condition="tcb">TCB_SYMLINKS USE_TCB</phrase>
 	  </para>

--- a/man/login.defs.d/LASTLOG_UID_MAX.xml
+++ b/man/login.defs.d/LASTLOG_UID_MAX.xml
@@ -1,0 +1,45 @@
+<!--
+   Copyright (c) 1991 - 1993, Julianne Frances Haugh
+   Copyright (c) 1991 - 1993, Chip Rosenthal
+   Copyright (c) 2007 - 2008, Nicolas François
+   Copyright (c) 2018, Red Hat, inc.
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+   3. The name of the copyright holders or contributors may not be used to
+      endorse or promote products derived from this software without
+      specific prior written permission.
+  
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+   PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT
+   HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+<varlistentry>
+  <term><option>LASTLOG_UID_MAX</option> (number)</term>
+  <listitem>
+    <para>
+      Highest user ID number for which the lastlog entries should be
+      updated. As higher user IDs are usually tracked by remote user
+      identity and authentication services there is no need to create
+      a huge sparse lastlog file for them.
+    </para>
+    <para>
+      The default value for <option>LASTLOG_UID_MAX</option> is 99999.
+    </para>
+  </listitem>
+</varlistentry>

--- a/man/login.defs.d/LASTLOG_UID_MAX.xml
+++ b/man/login.defs.d/LASTLOG_UID_MAX.xml
@@ -39,7 +39,8 @@
       a huge sparse lastlog file for them.
     </para>
     <para>
-      The default value for <option>LASTLOG_UID_MAX</option> is 99999.
+      No <option>LASTLOG_UID_MAX</option> option present in the configuration
+      means that there is no user ID limit for writing lastlog entries.
     </para>
   </listitem>
 </varlistentry>

--- a/man/useradd.8.xml
+++ b/man/useradd.8.xml
@@ -32,6 +32,7 @@
   "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [
 <!ENTITY CREATE_HOME           SYSTEM "login.defs.d/CREATE_HOME.xml">
 <!ENTITY GID_MAX               SYSTEM "login.defs.d/GID_MAX.xml">
+<!ENTITY LASTLOG_UID_MAX       SYSTEM "login.defs.d/LASTLOG_UID_MAX.xml">
 <!ENTITY MAIL_DIR              SYSTEM "login.defs.d/MAIL_DIR.xml">
 <!ENTITY MAX_MEMBERS_PER_GROUP SYSTEM "login.defs.d/MAX_MEMBERS_PER_GROUP.xml">
 <!ENTITY PASS_MAX_DAYS         SYSTEM "login.defs.d/PASS_MAX_DAYS.xml">
@@ -670,6 +671,7 @@
     <variablelist>
       &CREATE_HOME;
       &GID_MAX; <!-- documents also GID_MIN -->
+      &LASTLOG_UID_MAX;
       &MAIL_DIR;
       &MAX_MEMBERS_PER_GROUP;
       &PASS_MAX_DAYS;

--- a/man/usermod.8.xml
+++ b/man/usermod.8.xml
@@ -30,6 +30,7 @@
 -->
 <!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook V4.5//EN"
   "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [
+<!ENTITY LASTLOG_UID_MAX       SYSTEM "login.defs.d/LASTLOG_UID_MAX.xml">
 <!ENTITY MAIL_DIR              SYSTEM "login.defs.d/MAIL_DIR.xml">
 <!ENTITY MAX_MEMBERS_PER_GROUP SYSTEM "login.defs.d/MAX_MEMBERS_PER_GROUP.xml">
 <!ENTITY SUB_GID_COUNT         SYSTEM "login.defs.d/SUB_GID_COUNT.xml">
@@ -517,6 +518,7 @@
       tool:
     </para>
     <variablelist>
+      &LASTLOG_UID_MAX;
       &MAIL_DIR; <!-- documents also MAIL_FILE -->
       &MAX_MEMBERS_PER_GROUP;
       &SUB_GID_COUNT; <!-- documents also SUB_GID_MAX and SUB_GID_MIN -->

--- a/src/lastlog.c
+++ b/src/lastlog.c
@@ -185,7 +185,7 @@ static void print (void)
 	const struct passwd *pwent;
 	unsigned long lastlog_uid_max;
 
-	lastlog_uid_max = getdef_ulong ("LASTLOG_UID_MAX", 99999UL);
+	lastlog_uid_max = getdef_ulong ("LASTLOG_UID_MAX", 0xFFFFFFFFUL);
 	if (   (has_umin && umin > lastlog_uid_max)
 	    || (has_umax && umax > lastlog_uid_max)) {
 		fprintf (stderr, _("%s: Selected uid(s) are higher than LASTLOG_UID_MAX (%lu),\n"
@@ -263,7 +263,7 @@ static void update (void)
 	if (!uflg) /* safety measure */
 		return;
 
-	lastlog_uid_max = getdef_ulong ("LASTLOG_UID_MAX", 99999UL);
+	lastlog_uid_max = getdef_ulong ("LASTLOG_UID_MAX", 0xFFFFFFFFUL);
 	if (   (has_umin && umin > lastlog_uid_max)
 	    || (has_umax && umax > lastlog_uid_max)) {
 		fprintf (stderr, _("%s: Selected uid(s) are higher than LASTLOG_UID_MAX (%lu),\n"

--- a/src/login.c
+++ b/src/login.c
@@ -1163,7 +1163,7 @@ int main (int argc, char **argv)
 
 #ifndef USE_PAM			/* pam_lastlog handles this */
 	if (   getdef_bool ("LASTLOG_ENAB")
-	    && pwd->pw_uid <= (uid_t) getdef_ulong ("LASTLOG_UID_MAX", 99999UL)) {
+	    && pwd->pw_uid <= (uid_t) getdef_ulong ("LASTLOG_UID_MAX", 0xFFFFFFFFUL)) {
 		/* give last login and log this one */
 		dolastlog (&ll, pwd, tty, hostname);
 	}
@@ -1300,7 +1300,7 @@ int main (int argc, char **argv)
 			}
 		}
 		if (   getdef_bool ("LASTLOG_ENAB")
-		    && pwd->pw_uid <= (uid_t) getdef_ulong ("LASTLOG_UID_MAX", 99999UL)
+		    && pwd->pw_uid <= (uid_t) getdef_ulong ("LASTLOG_UID_MAX", 0xFFFFFFFFUL)
 		    && (ll.ll_time != 0)) {
 			time_t ll_time = ll.ll_time;
 

--- a/src/login.c
+++ b/src/login.c
@@ -1162,7 +1162,9 @@ int main (int argc, char **argv)
 #endif				/* WITH_AUDIT */
 
 #ifndef USE_PAM			/* pam_lastlog handles this */
-	if (getdef_bool ("LASTLOG_ENAB")) {	/* give last login and log this one */
+	if (   getdef_bool ("LASTLOG_ENAB")
+	    && pwd->pw_uid <= (uid_t) getdef_ulong ("LASTLOG_UID_MAX", 99999UL)) {
+		/* give last login and log this one */
 		dolastlog (&ll, pwd, tty, hostname);
 	}
 #endif
@@ -1298,6 +1300,7 @@ int main (int argc, char **argv)
 			}
 		}
 		if (   getdef_bool ("LASTLOG_ENAB")
+		    && pwd->pw_uid <= (uid_t) getdef_ulong ("LASTLOG_UID_MAX", 99999UL)
 		    && (ll.ll_time != 0)) {
 			time_t ll_time = ll.ll_time;
 

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -1869,7 +1869,7 @@ static void lastlog_reset (uid_t uid)
 		return;
 	}
 
-	max_uid = (uid_t) getdef_ulong ("LASTLOG_UID_MAX", 99999UL);
+	max_uid = (uid_t) getdef_ulong ("LASTLOG_UID_MAX", 0xFFFFFFFFUL);
 	if (uid > max_uid) {
 		/* do not touch lastlog for large uids */
 		return;

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -1863,8 +1863,15 @@ static void lastlog_reset (uid_t uid)
 	struct lastlog ll;
 	int fd;
 	off_t offset_uid = (off_t) (sizeof ll) * uid;
+	uid_t max_uid;
 
 	if (access (LASTLOG_FILE, F_OK) != 0) {
+		return;
+	}
+
+	max_uid = (uid_t) getdef_ulong ("LASTLOG_UID_MAX", 99999UL);
+	if (uid > max_uid) {
+		/* do not touch lastlog for large uids */
 		return;
 	}
 

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -1864,8 +1864,15 @@ static void update_lastlog (void)
 	int fd;
 	off_t off_uid = (off_t) user_id * sizeof ll;
 	off_t off_newuid = (off_t) user_newid * sizeof ll;
+	uid_t max_uid;
 
 	if (access (LASTLOG_FILE, F_OK) != 0) {
+		return;
+	}
+
+	max_uid = (uid_t) getdef_ulong ("LASTLOG_MAX_UID", 99999UL);
+	if (user_newid > max_uid) {
+		/* do not touch lastlog for large uids */
 		return;
 	}
 

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -1870,7 +1870,7 @@ static void update_lastlog (void)
 		return;
 	}
 
-	max_uid = (uid_t) getdef_ulong ("LASTLOG_MAX_UID", 99999UL);
+	max_uid = (uid_t) getdef_ulong ("LASTLOG_MAX_UID", 0xFFFFFFFFUL);
 	if (user_newid > max_uid) {
 		/* do not touch lastlog for large uids */
 		return;


### PR DESCRIPTION
As the large uids are usually provided by remote user identity and
authentication service, which also provide user login tracking,
there is no need to create a huge sparse file for them on every local
machine.