### PR TITLE
Make the sp_lstchg shadow field reproducible (re. #71)

### DIFF
--- a/README
+++ b/README
@@ -51,6 +51,7 @@ Brian R. Gaeke <brg@dgate.org>
 Calle Karlsson <ckn@kash.se>
 Chip Rosenthal <chip@unicom.com>
 Chris Evans <lady0110@sable.ox.ac.uk>
+Chris Lamb <chris@chris-lamb.co.uk>
 Cristian Gafton <gafton@sorosis.ro>
 Dan Walsh <dwalsh@redhat.com>
 Darcy Boese <possum@chardonnay.niagara.com>

--- a/configure.ac
+++ b/configure.ac
@@ -110,6 +110,9 @@ AC_REPLACE_FUNCS(sgetgrent sgetpwent sgetspent)
 AC_REPLACE_FUNCS(snprintf strcasecmp strdup strerror strstr)
 
 AC_CHECK_FUNC(setpgrp)
+AC_CHECK_FUNC(secure_getenv, [AC_DEFINE(HAS_SECURE_GETENV,
+                                        1,
+                                        [Defined to 1 if you have the declaration of 'secure_getenv'])])
 
 if test "$ac_cv_header_shadow_h" = "yes"; then
 	AC_CACHE_CHECK(for working shadow group support,

--- a/lib/defines.h
+++ b/lib/defines.h
@@ -382,4 +382,10 @@ extern char *strerror ();
 # endif
 #endif
 
+#ifdef HAVE_SECURE_GETENV
+#  define shadow_getenv(name) secure_getenv(name)
+# else
+#  define shadow_getenv(name) getenv(name)
+#endif
+
 #endif				/* _DEFINES_H_ */

--- a/libmisc/gettime.c
+++ b/libmisc/gettime.c
@@ -52,7 +52,7 @@
 	unsigned long long epoch;
 
 	fallback = time (NULL);
-	source_date_epoch = getenv ("SOURCE_DATE_EPOCH");
+	source_date_epoch = shadow_getenv ("SOURCE_DATE_EPOCH");
 
 	if (!source_date_epoch)
 		return fallback;

--- a/libmisc/pwd2spwd.c
+++ b/libmisc/pwd2spwd.c
@@ -40,7 +40,6 @@
 #include "prototypes.h"
 #include "defines.h"
 #include <pwd.h>
-extern time_t time (time_t *);
 
 /*
  * pwd_to_spwd - create entries for new spwd structure
@@ -66,7 +65,7 @@ struct spwd *pwd_to_spwd (const struct passwd *pw)
 		 */
 		sp.sp_min = 0;
 		sp.sp_max = (10000L * DAY) / SCALE;
-		sp.sp_lstchg = (long) time ((time_t *) 0) / SCALE;
+		sp.sp_lstchg = (long) gettime () / SCALE;
 		if (0 == sp.sp_lstchg) {
 			/* Better disable aging than requiring a password
 			 * change */

--- a/src/pwck.c
+++ b/src/pwck.c
@@ -609,7 +609,7 @@ static void check_pw_file (int *errors, bool *changed)
 					sp.sp_inact  = -1;
 					sp.sp_expire = -1;
 					sp.sp_flag   = SHADOW_SP_FLAG_UNSET;
-					sp.sp_lstchg = (long) time ((time_t *) 0) / SCALE;
+					sp.sp_lstchg = (long) gettime () / SCALE;
 					if (0 == sp.sp_lstchg) {
 						/* Better disable aging than
 						 * requiring a password change

--- a/src/pwconv.c
+++ b/src/pwconv.c
@@ -267,7 +267,7 @@ int main (int argc, char **argv)
 			spent.sp_flag   = SHADOW_SP_FLAG_UNSET;
 		}
 		spent.sp_pwdp = pw->pw_passwd;
-		spent.sp_lstchg = (long) time ((time_t *) 0) / SCALE;
+		spent.sp_lstchg = (long) gettime () / SCALE;
 		if (0 == spent.sp_lstchg) {
 			/* Better disable aging than requiring a password
 			 * change */


### PR DESCRIPTION
From <https://github.com/shadow-maint/shadow/pull/71>:

```
The third field in the /etc/shadow file (sp_lstchg) contains the date of
the last password change expressed as the number of days since Jan 1, 1970.
As this is a relative time, creating a user today will result in:

username:17238:0:99999:7:::
whilst creating the same user tomorrow will result in:

username:17239:0:99999:7:::
This has an impact for the Reproducible Builds[0] project where we aim to
be independent of as many elements the build environment as possible,
including the current date.

This patch changes the behaviour to use the SOURCE_DATE_EPOCH[1]
environment variable (instead of Jan 1, 1970) if valid.
```

This updated PR adds some missing calls to gettime (). This was originally
filed by Johannes Schauer in Debian as #917773 [2].

[0] https://reproducible-builds.org/
[1] https://reproducible-builds.org/specs/source-date-epoch/
[2] https://bugs.debian.org/917773