### PR TITLE
Btrfs subvolume

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -250,6 +250,9 @@ AC_ARG_WITH(audit,
 AC_ARG_WITH(libpam,
 	[AC_HELP_STRING([--with-libpam], [use libpam for PAM support @<:@default=yes if found@:>@])],
 	[with_libpam=$withval], [with_libpam=maybe])
+AC_ARG_WITH(btrfs,
+	[AC_HELP_STRING([--with-btrfs], [add BtrFS support @<:@default=yes if found@:>@])],
+	[with_selinux=$withval], [with_selinux=maybe])
 AC_ARG_WITH(selinux,
 	[AC_HELP_STRING([--with-selinux], [use SELinux support @<:@default=yes if found@:>@])],
 	[with_selinux=$withval], [with_selinux=maybe])
@@ -455,6 +458,20 @@ if test "$with_libcrack" = "yes"; then
 	AC_CHECK_LIB(crack, FascistHistoryPw,
 		AC_DEFINE(HAVE_LIBCRACK_PW, 1, [Defined if it includes *Pw functions.]))
 fi
+
+if test "$with_btrfs" != "no"; then
+	AC_CHECK_HEADERS([sys/statfs.h linux/magic.h linux/btrfs_tree.h], \
+		[btrfs_headers="yes"], [btrfs_headers="no"])
+	if test "$btrfs_headers$with_btrfs" = "noyes" ; then
+		AC_MSG_ERROR([One of sys/statfs.h linux/magic.h linux/btrfs_tree.h is missing])
+	fi
+
+	if test "$btrfs_headers" = "yes" ; then
+		AC_DEFINE(WITH_BTRFS, 1, [Build shadow with BtrFS support])
+		with_btrfs="yes"
+	fi
+fi
+AM_CONDITIONAL(WITH_BTRFS, test x$with_btrfs = xyes)
 
 AC_SUBST(LIBSELINUX)
 AC_SUBST(LIBSEMANAGE)
@@ -688,6 +705,7 @@ if test "$with_libpam" = "yes"; then
 echo "	suid account management tools:	$enable_acct_tools_setuid"
 fi
 echo "	SELinux support:		$with_selinux"
+echo "	BtrFS support:			$with_btrfs"
 echo "	ACL support:			$with_acl"
 echo "	Extended Attributes support:	$with_attr"
 echo "	tcb support (incomplete):	$with_tcb"

--- a/lib/prototypes.h
+++ b/lib/prototypes.h
@@ -73,10 +73,12 @@ extern int expire (const struct passwd *, /*@null@*/const struct spwd *);
 extern int isexpired (const struct passwd *, /*@null@*/const struct spwd *);
 
 /* btrfs.c */
+#ifdef WITH_BTRFS
 extern int btrfs_create_subvolume(const char *path);
 extern int btrfs_remove_subvolume(const char *path);
 extern int btrfs_is_subvolume(const char *path);
 extern int is_btrfs(const char *path);
+#endif
 
 /* basename() renamed to Basename() to avoid libc name space confusion */
 /* basename.c */

--- a/lib/prototypes.h
+++ b/lib/prototypes.h
@@ -72,6 +72,12 @@ extern int expire (const struct passwd *, /*@null@*/const struct spwd *);
 /* isexpired.c */
 extern int isexpired (const struct passwd *, /*@null@*/const struct spwd *);
 
+/* btrfs.c */
+extern int btrfs_create_subvolume(const char *path);
+extern int btrfs_remove_subvolume(const char *path);
+extern int btrfs_is_subvolume(const char *path);
+extern int is_btrfs(const char *path);
+
 /* basename() renamed to Basename() to avoid libc name space confusion */
 /* basename.c */
 extern /*@observer@*/const char *Basename (const char *str);

--- a/libmisc/Makefile.am
+++ b/libmisc/Makefile.am
@@ -10,7 +10,6 @@ libmisc_a_SOURCES = \
 	age.c \
 	audit_help.c \
 	basename.c \
-	btrfs.c \
 	chkname.c \
 	chkname.h \
 	chowndir.c \
@@ -73,3 +72,8 @@ libmisc_a_SOURCES = \
 	xgetspnam.c \
 	xmalloc.c \
 	yesno.c
+
+if WITH_BTRFS
+libmisc_a_SOURCES += btrfs.c
+endif
+

--- a/libmisc/Makefile.am
+++ b/libmisc/Makefile.am
@@ -10,6 +10,7 @@ libmisc_a_SOURCES = \
 	age.c \
 	audit_help.c \
 	basename.c \
+	btrfs.c \
 	chkname.c \
 	chkname.h \
 	chowndir.c \

--- a/libmisc/btrfs.c
+++ b/libmisc/btrfs.c
@@ -1,0 +1,94 @@
+#include <linux/btrfs_tree.h>
+#include <linux/magic.h>
+#include <sys/statfs.h>
+
+#include "prototypes.h"
+
+
+static int run_btrfs_subvolume_cmd(const char *subcmd, const char *arg1, const char *arg2)
+{
+	int status = 0;
+	const char *cmd = "/sbin/btrfs";
+	const char *argv[] = {
+		strrchr(cmd, '/'),
+		"subvolume",
+		subcmd,
+		arg1,
+		arg2,
+		NULL
+	};
+
+	if (argv[0] == NULL)
+		argv[0] = cmd;
+	else
+		argv[0] = argv[0] + 1;
+
+	if (access(cmd, X_OK)) {
+		return 1;
+	}
+
+	if (run_command(cmd, argv, NULL, &status))
+		return -1;
+	return status;
+}
+
+
+int btrfs_create_subvolume(const char *path)
+{
+	return run_btrfs_subvolume_cmd("create", path, NULL);
+}
+
+
+int btrfs_remove_subvolume(const char *path)
+{
+	return run_btrfs_subvolume_cmd("delete", "-C", path);
+}
+
+
+/* Adapted from btrfsprogs */
+/*
+ * This intentionally duplicates btrfs_util_is_subvolume_fd() instead of opening
+ * a file descriptor and calling it, because fstat() and fstatfs() don't accept
+ * file descriptors opened with O_PATH on old kernels (before v3.6 and before
+ * v3.12, respectively), but stat() and statfs() can be called on a path that
+ * the user doesn't have read or write permissions to.
+ *
+ * returns:
+ *   1 - btrfs subvolume
+ *   0 - not btrfs subvolume
+ *  -1 - error
+ */
+int btrfs_is_subvolume(const char *path)
+{
+	struct stat st;
+	int ret;
+
+	ret = is_btrfs(path);
+	if (ret <= 0)
+		return ret;
+
+	ret = stat(path, &st);
+	if (ret == -1)
+		return -1;
+
+	if (st.st_ino != BTRFS_FIRST_FREE_OBJECTID || !S_ISDIR(st.st_mode)) {
+		return 0;
+	}
+
+	return 1;
+}
+
+
+/* Adapted from btrfsprogs */
+int is_btrfs(const char *path)
+{
+	struct statfs sfs;
+	int ret;
+
+	ret = statfs(path, &sfs);
+	if (ret == -1)
+		return -1;
+
+	return sfs.f_type == BTRFS_SUPER_MAGIC;
+}
+

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -823,7 +823,9 @@ static void usage (int status)
 	                Prog, Prog, Prog);
 	(void) fputs (_("  -b, --base-dir BASE_DIR       base directory for the home directory of the\n"
 	                "                                new account\n"), usageout);
+#ifdef WITH_BTRFS
 	(void) fputs (_("      --btrfs-subvolume-home    use BTRFS subvolume for home directory\n"), usageout);
+#endif
 	(void) fputs (_("  -c, --comment COMMENT         GECOS field of the new account\n"), usageout);
 	(void) fputs (_("  -d, --home-dir HOME_DIR       home directory of the new account\n"), usageout);
 	(void) fputs (_("  -D, --defaults                print or change default useradd configuration\n"), usageout);
@@ -1104,7 +1106,9 @@ static void process_flags (int argc, char **argv)
 		int c;
 		static struct option long_options[] = {
 			{"base-dir",       required_argument, NULL, 'b'},
+#ifdef WITH_BTRFS
 			{"btrfs-subvolume-home", no_argument, NULL, 200},
+#endif
 			{"comment",        required_argument, NULL, 'c'},
 			{"home-dir",       required_argument, NULL, 'd'},
 			{"defaults",       no_argument,       NULL, 'D'},
@@ -2083,6 +2087,7 @@ static void create_home (void)
 				   subvolume but no BTRFS. The paths cound be different by the
 				   trailing slash
 				 */
+#if WITH_BTRFS
 				if (subvolflg && (strlen(prefix_user_home) - (int)strlen(path)) <= 1) {
 					char *btrfs_check = strdup(path);
 
@@ -2107,7 +2112,9 @@ static void create_home (void)
 						fail_exit (E_HOMEDIR);
 					}
 				}
-				else if (mkdir (path, 0) != 0) {
+				else
+#endif
+				if (mkdir (path, 0) != 0) {
 			fprintf (stderr,
 							_("%s: cannot create directory %s\n"),
 							Prog, path);

--- a/src/userdel.c
+++ b/src/userdel.c
@@ -1272,7 +1272,21 @@ int main (int argc, char **argv)
 #endif				/* EXTRA_CHECK_HOME_DIR */
 
 	if (rflg) {
-		if (remove_tree (user_home, true) != 0) {
+		int is_subvolume = btrfs_is_subvolume (user_home);
+		if (is_subvolume < 0) {
+		    errors++;
+		    /* continue */
+		}
+		else if (is_subvolume > 0) {
+			if (btrfs_remove_subvolume (user_home)) {
+				fprintf (stderr,
+				         _("%s: error removing subvolume %s\n"),
+				         Prog, user_home);
+				errors++;
+				/* continue */
+			}
+		}
+		else if (remove_tree (user_home, true) != 0) {
 			fprintf (stderr,
 			         _("%s: error removing directory %s\n"),
 			         Prog, user_home);

--- a/src/userdel.c
+++ b/src/userdel.c
@@ -1272,6 +1272,7 @@ int main (int argc, char **argv)
 #endif				/* EXTRA_CHECK_HOME_DIR */
 
 	if (rflg) {
+#ifdef WITH_BTRFS
 		int is_subvolume = btrfs_is_subvolume (user_home);
 		if (is_subvolume < 0) {
 		    errors++;
@@ -1286,7 +1287,9 @@ int main (int argc, char **argv)
 				/* continue */
 			}
 		}
-		else if (remove_tree (user_home, true) != 0) {
+		else
+#endif
+		if (remove_tree (user_home, true) != 0) {
 			fprintf (stderr,
 			         _("%s: error removing directory %s\n"),
 			         Prog, user_home);

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -1819,6 +1819,13 @@ static void move_home (void)
 			return;
 		} else {
 			if (EXDEV == errno) {
+				if (btrfs_is_subvolume (prefix_user_home) > 0) {
+					fprintf (stderr,
+					        _("%s: error: cannot move subvolume from %s to %s - different device\n"),
+					        Prog, prefix_user_home, prefix_user_newhome);
+					fail_exit (E_HOMEDIR);
+				}
+
 				if (copy_tree (prefix_user_home, prefix_user_newhome, true,
 				               true,
 				               user_id,

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -1819,12 +1819,14 @@ static void move_home (void)
 			return;
 		} else {
 			if (EXDEV == errno) {
+#ifdef WITH_BTRFS
 				if (btrfs_is_subvolume (prefix_user_home) > 0) {
 					fprintf (stderr,
 					        _("%s: error: cannot move subvolume from %s to %s - different device\n"),
 					        Prog, prefix_user_home, prefix_user_newhome);
 					fail_exit (E_HOMEDIR);
 				}
+#endif
 
 				if (copy_tree (prefix_user_home, prefix_user_newhome, true,
 				               true,


### PR DESCRIPTION
This adds support for using `btrfs` subvolumes as a user home instead of just a plain directory. These subvolumes allow for snapshots to be taken to allow users to rollback changes. A use-case is described at,

https://www.suse.com/c/menu-du-jour-vivaneau-vert-sur-lit-de-legumes-au-beurre-et-supremes-de-pamplemousse-2/

It also implements #131

I've only implemented this as a long option as this is kind of specialized situation. In default case, nothing changes for useradd. For `userdel`, it can now handle subvolumes on `btrfs` instead of just printing an error. `usermod` will also throw an error instead of doing a deep-copy of a subvolume for cross-device home moves, which is better than current attempt at deep-copy and failure.

subvolume creation and deletion is handled by `btrfs` program.

```
 configure.ac        | 18 ++++++++++++++
 lib/prototypes.h    |  8 ++++++
 libmisc/Makefile.am |  5 ++++
 libmisc/btrfs.c     | 94 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 src/useradd.c       | 41 ++++++++++++++++++++++++++++++
 src/userdel.c       | 17 +++++++++++++
 src/usermod.c       |  9 +++++++
 7 files changed, 192 insertions(+)
```
