### PR TITLE
Fix the default mentioned in man page for SUB_UID/GID_COUNT variables.

### DIFF
--- a/man/login.defs.d/SUB_GID_COUNT.xml
+++ b/man/login.defs.d/SUB_GID_COUNT.xml
@@ -42,7 +42,7 @@
     <para>
       The default values for <option>SUB_GID_MIN</option>,
       <option>SUB_GID_MAX</option>, <option>SUB_GID_COUNT</option>
-      are respectively 100000, 600100000 and 10000.
+      are respectively 100000, 600100000 and 65536.
     </para>
   </listitem>
 </varlistentry>

--- a/man/login.defs.d/SUB_UID_COUNT.xml
+++ b/man/login.defs.d/SUB_UID_COUNT.xml
@@ -42,7 +42,7 @@
     <para>
       The default values for <option>SUB_UID_MIN</option>,
       <option>SUB_UID_MAX</option>, <option>SUB_UID_COUNT</option>
-      are respectively 100000, 600100000 and 10000.
+      are respectively 100000, 600100000 and 65536.
     </para>
   </listitem>
 </varlistentry>


### PR DESCRIPTION
Subject says it all. A trivial fix.