### PR TITLE
Do not flush nscd and sssd cache in read-only mode

### DIFF
--- a/src/grpck.c
+++ b/src/grpck.c
@@ -870,8 +870,10 @@ int main (int argc, char **argv)
 	/* Commit the change in the database if needed */
 	close_files (changed);
 
-	nscd_flush_cache ("group");
-	sssd_flush_cache (SSSD_DB_GROUP);
+	if (!read_only) {
+		nscd_flush_cache ("group");
+		sssd_flush_cache (SSSD_DB_GROUP);
+	}
 
 	/*
 	 * Tell the user what we did and exit.

--- a/src/pwck.c
+++ b/src/pwck.c
@@ -877,8 +877,10 @@ int main (int argc, char **argv)
 
 	close_files (changed);
 
-	nscd_flush_cache ("passwd");
-	sssd_flush_cache (SSSD_DB_PASSWD);
+	if (!read_only) {
+		nscd_flush_cache ("passwd");
+		sssd_flush_cache (SSSD_DB_PASSWD);
+	}
 
 	/*
 	 * Tell the user what we did and exit.


### PR DESCRIPTION
Fix #155

signed-off-by: Charlie Vuillemez <cvuillemez@users.noreply.github.com>