### PR TITLE
Fix chpasswd long line handling

### DIFF
--- a/src/chpasswd.c
+++ b/src/chpasswd.c
@@ -432,6 +432,15 @@ int main (int argc, char **argv)
 			*cp = '\0';
 		} else {
 			if (feof (stdin) == 0) {
+
+				// Drop all remaining characters on this line.
+				while (fgets (buf, (int) sizeof buf, stdin) != (char *) 0) {
+					cp = strchr (buf, '\n');
+					if (cp != NULL) {
+						break;
+					}
+				}
+
 				fprintf (stderr,
 				         _("%s: line %d: line too long\n"),
 				         Prog, line);


### PR DESCRIPTION
When a line that goes over the size of the buffer is read in, an error message is display, but the remaining characters at the end of the line aren't ignored. This can result in the following output:

```
$ (seq 8500 | tr -d '\n' && echo user:password) | sudo src/chpasswd
chpasswd: line 1: line too long
chpasswd: line 2: line too long
chpasswd: line 3: line too long
chpasswd: line 4: line too long
chpasswd: line 5: user '884698470847184728473847484758476847784788479848084818482848384848485848684878488848984908491849284938494849584968497849884998500user' does not exist
chpasswd: error detected, changes ignored
```

This change reads of the remaining output until the next newline, or EOF character.