### PR TITLE
lib/spawn.c run_command: don't loop forever if waitpid() is returning ECHILD

### DIFF
--- a/lib/spawn.c
+++ b/lib/spawn.c
@@ -68,6 +68,8 @@ int run_command (const char *cmd, const char *argv[],
 
 	do {
 		wpid = waitpid (pid, status, 0);
+		if ((pid_t)-1 == wpid && errno == ECHILD)
+			break;
 	} while (   ((pid_t)-1 == wpid && errno == EINTR)
 	         || ((pid_t)-1 != wpid && wpid != pid));
 

--- a/lib/spawn.c
+++ b/lib/spawn.c
@@ -68,8 +68,9 @@ int run_command (const char *cmd, const char *argv[],
 
 	do {
 		wpid = waitpid (pid, status, 0);
-	} while (   ((pid_t)-1 == wpid && errno == EINTR)
-	         || ((pid_t)-1 != wpid && wpid != pid));
+	} while ( ((pid_t)-1 == wpid && errno != ECHILD)  
+	         && (((pid_t)-1 == wpid && errno == EINTR)
+	         || ((pid_t)-1 != wpid && wpid != pid)));
 
 	if ((pid_t)-1 == wpid) {
 		fprintf (stderr, "%s: waitpid (status: %d): %s\n",

--- a/lib/spawn.c
+++ b/lib/spawn.c
@@ -68,9 +68,8 @@ int run_command (const char *cmd, const char *argv[],
 
 	do {
 		wpid = waitpid (pid, status, 0);
-	} while ( ((pid_t)-1 == wpid && errno != ECHILD)  
-	         && (((pid_t)-1 == wpid && errno == EINTR)
-	         || ((pid_t)-1 != wpid && wpid != pid)));
+	} while (   ((pid_t)-1 == wpid && errno == EINTR)
+	         || ((pid_t)-1 != wpid && wpid != pid));
 
 	if ((pid_t)-1 == wpid) {
 		fprintf (stderr, "%s: waitpid (status: %d): %s\n",


### PR DESCRIPTION
lib/spawn.c run_command: don't loop forever if waitpid() is returning ECHILD

If SIGCHILD is being ignored, waitpid() will forever error with ECHILD and
this loop with never end, so don't loop if it erros with ECHILD.