### PR TITLE
build: Check correct DocBook version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -334,8 +334,8 @@ if test "$enable_man" = "yes"; then
 	fi
 
 	dnl check for DocBook DTD and stylesheets in the local catalog.
-	JH_CHECK_XML_CATALOG([-//OASIS//DTD DocBook XML V4.1.2//EN],
-		[DocBook XML DTD V4.1.2], [], enable_man=no)
+	JH_CHECK_XML_CATALOG([-//OASIS//DTD DocBook XML V4.5//EN],
+		[DocBook XML DTD V4.5], [], enable_man=no)
 	JH_CHECK_XML_CATALOG([http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl],
 		[DocBook XSL Stylesheets >= 1.70.1], [], enable_man=no)
 fi


### PR DESCRIPTION
The documentation uses DocBook 4.5 DOCTYPE but the configure script checked for 4.1.2.