### PR TITLE
build: Port to itstool

### DIFF
--- a/man/README.md
+++ b/man/README.md
@@ -7,4 +7,4 @@ pre-built ones might not fit your version of shadow.  To build them yourself use
 - xsltproc
 - docbook 4
 - docbook stylesheets
-- xml2po
+- itstool

--- a/man/generate_translations.mak
+++ b/man/generate_translations.mak
@@ -5,8 +5,9 @@ config.xml: ../config.xml.in
 	$(MAKE) -C .. config.xml
 	cp ../config.xml $@
 
-%.xml: ../%.xml ../po/$(LANG).po
-	xml2po --expand-all-entities -l $(LANG) -p ../po/$(LANG).po -o $@ ../$@
+%.xml: ../%.xml-config ../po/$(LANG).po
+	msgfmt -o $(LANG).mo ../po/$(LANG).po
+	itstool -l $(LANG) -m $(LANG).mo -o $@ $<
 	sed -i 's:\(^<refentry .*\)>:\1 lang="$(LANG)">:' $@
 
 include ../generate_mans.mak
@@ -16,4 +17,4 @@ $(man_MANS):
 	@echo you need to run configure with --enable-man to generate man pages
 endif
 
-CLEANFILES = .xml2po.mo $(EXTRA_DIST) $(addsuffix .xml,$(EXTRA_DIST)) config.xml
+CLEANFILES = $(EXTRA_DIST) $(addsuffix .xml,$(EXTRA_DIST)) config.xml


### PR DESCRIPTION
gnome-doc-utils are basically abandoned.

I am not sure this is correct as I am not very familiar with autotools. For example, what does remove the `.xml-config` files? Currently it is failing on

```
make[3]: *** No rule to make target 'man1/chfn.1', needed by 'all-am'.  Stop.
```