### PR TITLE
Use lckpwdf() again if prefix is not set and fix a possible DoS in locking

### DIFF
--- a/lib/commonio.c
+++ b/lib/commonio.c
@@ -141,7 +141,7 @@ static int do_lock_file (const char *file, const char *lock, bool log)
 	int retval;
 	char buf[32];
 
-	fd = open (file, O_CREAT | O_EXCL | O_WRONLY, 0600);
+	fd = open (file, O_CREAT | O_TRUNC | O_WRONLY, 0600);
 	if (-1 == fd) {
 		if (log) {
 			(void) fprintf (stderr,

--- a/lib/commonio.h
+++ b/lib/commonio.h
@@ -143,6 +143,7 @@ struct commonio_db {
 	bool isopen:1;
 	bool locked:1;
 	bool readonly:1;
+	bool setname:1;
 };
 
 extern int commonio_setname (struct commonio_db *, const char *);

--- a/lib/groupio.c
+++ b/lib/groupio.c
@@ -139,7 +139,8 @@ static /*@owned@*/struct commonio_db group_db = {
 	false,			/* changed */
 	false,			/* isopen */
 	false,			/* locked */
-	false			/* readonly */
+	false,			/* readonly */
+	false			/* setname */
 };
 
 int gr_setdbname (const char *filename)

--- a/lib/pwio.c
+++ b/lib/pwio.c
@@ -114,7 +114,8 @@ static struct commonio_db passwd_db = {
 	false,			/* changed */
 	false,			/* isopen */
 	false,			/* locked */
-	false			/* readonly */
+	false,			/* readonly */
+	false			/* setname */
 };
 
 int pw_setdbname (const char *filename)

--- a/lib/sgroupio.c
+++ b/lib/sgroupio.c
@@ -238,7 +238,8 @@ static struct commonio_db gshadow_db = {
 	false,			/* changed */
 	false,			/* isopen */
 	false,			/* locked */
-	false			/* readonly */
+	false,			/* readonly */
+	false			/* setname */
 };
 
 int sgr_setdbname (const char *filename)

--- a/lib/shadowio.c
+++ b/lib/shadowio.c
@@ -114,7 +114,8 @@ static struct commonio_db shadow_db = {
 	false,			/* changed */
 	false,			/* isopen */
 	false,			/* locked */
-	false			/* readonly */
+	false,			/* readonly */
+	false			/* setname */
 };
 
 int spw_setdbname (const char *filename)

--- a/lib/subordinateio.c
+++ b/lib/subordinateio.c
@@ -550,7 +550,8 @@ static struct commonio_db subordinate_uid_db = {
 	false,			/* changed */
 	false,			/* isopen */
 	false,			/* locked */
-	false			/* readonly */
+	false,			/* readonly */
+	false			/* setname */
 };
 
 int sub_uid_setdbname (const char *filename)
@@ -631,7 +632,8 @@ static struct commonio_db subordinate_gid_db = {
 	false,			/* changed */
 	false,			/* isopen */
 	false,			/* locked */
-	false			/* readonly */
+	false,			/* readonly */
+	false			/* setname */
 };
 
 int sub_gid_setdbname (const char *filename)


### PR DESCRIPTION
This PR fixes two issues related to the locking of the databases.
