### PR TITLE
configure.ac: fix configure error with dash

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -500,7 +500,7 @@ if test "$with_selinux" != "no"; then
 			AC_MSG_ERROR([libsemanage not found])
 		fi
 
-		if test "$selinux_lib$semanage_lib" == "yesyes" ; then
+		if test "$selinux_lib$semanage_lib" = "yesyes" ; then
 			AC_DEFINE(WITH_SELINUX, 1,
 			          [Build shadow with SELinux support])
 			LIBSELINUX="-lselinux"


### PR DESCRIPTION
A configure error occurs when /bin/sh -> dash:
  checking for is_selinux_enabled in -lselinux... yes
  checking for semanage_connect in -lsemanage... yes
  configure: 16322: test: yesyes: unexpected operator

Use "=" instead of "==" since dash doesn't support this operator.

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>