### PR TITLE
Fixes of LASTLOG_UID_MAX and login.defs

### DIFF
--- a/etc/login.defs
+++ b/etc/login.defs
@@ -341,8 +341,8 @@ CHFN_RESTRICT		rwh
 # If only one of the MIN or MAX values is set, then this value will be used.
 # If MIN > MAX, the highest value will be used.
 #
-# SHA_CRYPT_MIN_ROUNDS 5000
-# SHA_CRYPT_MAX_ROUNDS 5000
+#SHA_CRYPT_MIN_ROUNDS 5000
+#SHA_CRYPT_MAX_ROUNDS 5000
 
 #
 # List of groups to add to the user's supplementary group set

--- a/etc/login.defs
+++ b/etc/login.defs
@@ -32,6 +32,15 @@ LOG_OK_LOGINS		no
 LASTLOG_ENAB		yes
 
 #
+# Limit the highest user ID number for which the lastlog entries should
+# be updated.
+#
+# No LASTLOG_UID_MAX means that there is no user ID limit for writing
+# lastlog entries.
+#
+#LASTLOG_UID_MAX
+
+#
 # Enable checking and display of mailbox status upon login.
 #
 # Disable if the shell startup files already check for mail

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -1879,7 +1879,7 @@ static void update_lastlog (void)
 		return;
 	}
 
-	max_uid = (uid_t) getdef_ulong ("LASTLOG_MAX_UID", 0xFFFFFFFFUL);
+	max_uid = (uid_t) getdef_ulong ("LASTLOG_UID_MAX", 0xFFFFFFFFUL);
 	if (user_newid > max_uid) {
 		/* do not touch lastlog for large uids */
 		return;


### PR DESCRIPTION
46331648 introduced LASTLOG_UID_MAX and (probably by a mistake) LASTLOG_MAX_UID. The latter one is apparent typo unsupported by the parser.

46331648 also says LASTLOG_UID_MAX that LASTLOG_UID_MAX is going to be added to login.defs. But that change is missing.