### PR TITLE
Honor --sbindir and --bindir for binary installation

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -52,13 +52,14 @@ usbin_PROGRAMS = \
 # id and groups are from gnu, sulogin from sysvinit
 noinst_PROGRAMS = id sulogin
 
+suidusbins     =
 suidbins       = su
 suidubins      = chage chfn chsh expiry gpasswd newgrp
 if !WITH_TCB
 suidubins += passwd
 endif
 if ACCT_TOOLS_SETUID
-suidubins += chgpasswd chpasswd groupadd groupdel groupmod newusers useradd userdel usermod
+suidusbins += chgpasswd chpasswd groupadd groupdel groupmod newusers useradd userdel usermod
 endif
 if ENABLE_SUBIDS
 if !FCAPS
@@ -133,6 +134,9 @@ install-am: all-am
 	done
 	for i in $(suidubins); do \
 		chmod $(suidperms) $(DESTDIR)$(ubindir)/$$i; \
+	done
+	for i in $(suidusbins); do \
+		chmod $(suidperms) $(DESTDIR)$(usbindir)/$$i; \
 	done
 if WITH_TCB
 	for i in $(shadowsgidubins); do \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,8 +2,8 @@
 EXTRA_DIST = \
 	.indent.pro
 
-ubindir = ${prefix}/bin
-usbindir = ${prefix}/sbin
+ubindir = ${bindir}
+usbindir = ${sbindir}
 suidperms = 4755
 sgidperms = 2755
 


### PR DESCRIPTION
Some distros don't care about the split between /bin, /sbin, /usr/bin,
and /usr/sbin, so let them easily stuff binaries wherever they want.

This also fixes a problem during installation where-in a loop of 'chmod
4755' calls will mostly fail (regardless of configuration). However, because
the last two succeed (newuidmap/newgidmap), make considers the command to be a
success. Somewhat not-amusingly, configuring shadow with --with-fcaps will
cause installation to fail because the final chmod call is now a failing one.