### PR TITLE
sgetpwent.c/sgetgrent.c: check for additional data at end of line

### DIFF
--- a/lib/sgetgrent.c
+++ b/lib/sgetgrent.c
@@ -136,7 +136,7 @@ struct group *sgetgrent (const char *buf)
 			cp++;
 		}
 	}
-	if (i < (NFIELDS - 1) || *grpfields[2] == '\0') {
+	if (i < (NFIELDS - 1) || *grpfields[2] == '\0' || cp != NULL) {
 		return (struct group *) 0;
 	}
 	grent.gr_name = grpfields[0];

--- a/lib/sgetpwent.c
+++ b/lib/sgetpwent.c
@@ -90,6 +90,11 @@ struct passwd *sgetpwent (const char *buf)
 		}
 	}
 
+    /* something at the end, columns over shot */
+    if( cp != NULL ) {
+        return( NULL );
+    }
+
 	/*
 	 * There must be exactly NFIELDS colon separated fields or
 	 * the entry is invalid.  Also, the UID and GID must be non-blank.


### PR DESCRIPTION
Additional check to test for data at the end of passwd and group, fixes #94 