### PR TITLE
Fix typo in access of shell command

### DIFF
--- a/src/useradd.c
+++ b/src/useradd.c
@@ -1331,7 +1331,7 @@ static void process_flags (int argc, char **argv)
 				        && ('*'  != optarg[0]) )
 				    || (stat(optarg, &st) != 0)
 				    || (S_ISDIR(st.st_mode))
-				    || (access(optarg, X_OK != 0))) {
+				    || (access(optarg, X_OK) != 0)) {
 					fprintf (stderr,
 					         _("%s: invalid shell '%s'\n"),
 					         Prog, optarg);


### PR DESCRIPTION
Fix typo in 88fa0651bfa4be0c819da0027456f5046a3b4967.
For some reason my git push -f seems not to have worked.