### PR TITLE
Revert "Honor --sbindir and --bindir for binary installation"

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,8 +2,8 @@
 EXTRA_DIST = \
 	.indent.pro
 
-ubindir = ${bindir}
-usbindir = ${sbindir}
+ubindir = ${prefix}/bin
+usbindir = ${prefix}/sbin
 suidperms = 4755
 sgidperms = 2755
 


### PR DESCRIPTION
This reverts commit e293aa9cfca0619a63616af75532637dab60d49d.

See https://github.com/shadow-maint/shadow/issues/196

Some distros still care about `/bin` vs `/usr/bin`. This commit makes
it so all binaries are always installed to `/bin`/`/sbin`. The only way to
restore the previous behaviour of installing some binaries to
`/usr/bin`/`/usr/sbin` is to revert the patch.