### PR TITLE
Don't auto-enable ACCT_TOOLS_SETUID if PAM is detected

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -226,7 +226,7 @@ AC_ARG_ENABLE(account-tools-setuid,
 	   *) AC_MSG_ERROR(bad value ${enableval} for --enable-account-tools-setuid)
 	   ;;
 	 esac],
-	[enable_acct_tools_setuid="maybe"]
+	[enable_acct_tools_setuid="no"]
 )
 
 AC_ARG_ENABLE(utmpx,


### PR DESCRIPTION
Here's a sad story:

* 70971457 is merged into shadow, allowing newgidmap/newuidmap to be
installed with file caps rather than setuid.
* https://bugs.archlinux.org/task/63248 is filed to take advantage of
this.
* The arch maintainer of the 'shadow' package notices that this doesn't
work, and submits a pull request to fix this in shadow.
* edf7547ad5 is merged, fixing the post install hooks.

The problem here is that distros have been building shadow with PAM for
O(years), but the install hooks have silently failed due to the
combination of the directory mismatch (suidubins vs suidsbins) and later
success with setuid'ing newgidmap/newuidmap.

With the install hooks fixed, those of us (Arch[1] and Gentoo[2] so far)
who never built shadow explicitly with --enable-account-tools-setuid are
now getting setuid account tools, and don't have PAM configuration
suitable for use with setuid account management tools.

It's entirely unclear to me why you'd want this, but I assume there's
some reason out there for it existing. Regardless, setuid binaries are
dangerous and shouldn't be enabled by default without good reason.

[1] https://bugs.archlinux.org/task/64836
[2] https://bugs.gentoo.org/702252