### PR TITLE
selinux: include stdio

### DIFF
--- a/lib/selinux.c
+++ b/lib/selinux.c
@@ -31,12 +31,12 @@
 
 #ifdef WITH_SELINUX
 
+#include <stdio.h>
 #include "defines.h"
 
 #include <selinux/selinux.h>
 #include <selinux/context.h>
 #include "prototypes.h"
-
 
 static bool selinux_checked = false;
 static bool selinux_enabled;


### PR DESCRIPTION
We use fprintf(), stderr etc, so we should include stdio.h.