### PR TITLE
Deduplicate usermod manual (fixes #202)

### DIFF
--- a/man/usermod.8.xml
+++ b/man/usermod.8.xml
@@ -120,16 +120,6 @@
       </varlistentry>
       <varlistentry>
 	<term>
-	  <option>-b</option>, <option>--badnames</option>
-	</term>
-	<listitem>
-	  <para>
-	    Allow names that do not conform to standards.
-	  </para>
-	</listitem>
-      </varlistentry>
-      <varlistentry>
-	<term>
 	  <option>-c</option>, <option>--comment</option>&nbsp;<replaceable>COMMENT</replaceable>
 	</term>
 	<listitem>


### PR DESCRIPTION
Changelog:
1) modified:   man/usermod.8.xml
   Removed duplicate "badnames" options entry.