### PR TITLE
Adding tty logging to the useradd command

### DIFF
--- a/src/useradd.c
+++ b/src/useradd.c
@@ -223,7 +223,7 @@ static void open_files (void);
 static void open_shadow (void);
 static void faillog_reset (uid_t);
 static void lastlog_reset (uid_t);
-static void tallylog_reset (char *);
+static void tallylog_reset (const char *);
 static void usr_update (void);
 static void create_home (void);
 static void create_mail (void);
@@ -1912,7 +1912,7 @@ static void lastlog_reset (uid_t uid)
 	}
 }
 
-static void tallylog_reset (char *user_name)
+static void tallylog_reset (const char *user_name)
 {
 	const char pam_tally2[] = "/sbin/pam_tally2";
 	const char *pname;
@@ -1968,6 +1968,7 @@ static void usr_update (void)
 {
 	struct passwd pwent;
 	struct spwd spent;
+	char *tty;
 
 	/*
 	 * Fill in the password structure with any new fields, making
@@ -1980,10 +1981,12 @@ static void usr_update (void)
 	 * Create a syslog entry. We need to do this now in case anything
 	 * happens so we know what we were trying to accomplish.
 	 */
+	tty=ttyname (STDIN_FILENO);
 	SYSLOG ((LOG_INFO,
-	         "new user: name=%s, UID=%u, GID=%u, home=%s, shell=%s",
+	         "new user: name=%s, UID=%u, GID=%u, home=%s, shell=%s, from=%s",
 	         user_name, (unsigned int) user_id,
-	         (unsigned int) user_gid, user_home, user_shell));
+	         (unsigned int) user_gid, user_home, user_shell,
+	         tty ? tty : "none" ));
 
 	/*
 	 * Initialize faillog and lastlog entries for this UID in case


### PR DESCRIPTION
This commit adds a from= field to the end of the useradd log entry.
Casting user_name to tallylog_reset to silence a compiler warning.

Closes #198.