### PR TITLE
Makefile: bail out on error in for-loops

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -136,17 +136,17 @@ install-am: all-am
 	$(MAKE) $(AM_MAKEFLAGS) install-exec-am install-data-am
 	ln -sf newgrp	$(DESTDIR)$(ubindir)/sg
 	ln -sf vipw	$(DESTDIR)$(usbindir)/vigr
-	for i in $(suidbins); do \
+	set -e; for i in $(suidbins); do \
 		chmod $(suidperms) $(DESTDIR)$(bindir)/$$i; \
 	done
-	for i in $(suidubins); do \
+	set -e; for i in $(suidubins); do \
 		chmod $(suidperms) $(DESTDIR)$(ubindir)/$$i; \
 	done
-	for i in $(suidusbins); do \
+	set -e; for i in $(suidusbins); do \
 		chmod $(suidperms) $(DESTDIR)$(usbindir)/$$i; \
 	done
 if WITH_TCB
-	for i in $(shadowsgidubins); do \
+	set -e; for i in $(shadowsgidubins); do \
 		chown root:shadow $(DESTDIR)$(ubindir)/$$i; \
 		chmod $(sgidperms) $(DESTDIR)$(ubindir)/$$i; \
 	done


### PR DESCRIPTION
`make` runs each line in a shell and bails out on error,
however, the shell is not started with `-e`, so commands in
`for` loops can fail without the error actually causing
`make` to bail out with a failure status.

For instance, the following make snippet will end
successfully, printing 'SUCCESS', despite the first `chmod`
failing:

    all:
        touch a b
        for i in a-missing-file a b; do \
            chmod 666 $$i; \
        done
        @echo SUCCESS

To prevent wrong paths in install scripts from remaining
unnoticed, let's activate `set -e` in the `for` loop
subshells.

Signed-off-by: Wolfgang Bumiller <w.bumiller@proxmox.com>