### PR TITLE
Adding logging of SSH_ORIGINAL_COMMAND to nologin.

### DIFF
--- a/man/nologin.8.xml
+++ b/man/nologin.8.xml
@@ -72,6 +72,9 @@
       <citerefentry><refentrytitle>nologin</refentrytitle><manvolnum>5</manvolnum>
       </citerefentry>.
     </para>
+    <para>
+      If <command>SSH_ORIGINAL_COMMAND</command> is populated it will be logged.
+    </para>
   </refsect1>
 
   <refsect1 id='see_also'>

--- a/src/nologin.c
+++ b/src/nologin.c
@@ -45,9 +45,14 @@ int main (void)
 	if (NULL == user) {
 		user = "UNKNOWN";
 	}
+
+	char *ssh_origcmd = getenv("SSH_ORIGINAL_COMMAND");
 	uid = getuid (); /* getuid() is always successful */
 	openlog ("nologin", LOG_CONS, LOG_AUTH);
-	syslog (LOG_CRIT, "Attempted login by %s (UID: %d) on %s", user, uid, tty);
+	syslog (LOG_CRIT, "Attempted login by %s (UID: %d) on %s%s%s",
+	        user, uid, tty,
+		(ssh_origcmd ? " SSH_ORIGINAL_COMMAND=" : ""),
+		(ssh_origcmd ? ssh_origcmd : ""));
 	closelog ();
 
 	printf ("%s", "This account is currently not available.\n");


### PR DESCRIPTION
If SSH_ORIGINAL_COMMAND is set, it will be added to the syslog entry.

Closes #123.