### PR TITLE
add new UMASK_HOME login.defs option

### DIFF
--- a/etc/login.defs
+++ b/etc/login.defs
@@ -195,11 +195,16 @@ KILLCHAR	025
 # Default initial "umask" value used by login(1) on non-PAM enabled systems.
 # Default "umask" value for pam_umask(8) on PAM enabled systems.
 # UMASK is also used by useradd(8) and newusers(8) to set the mode for new
-# home directories.
+# home directories if HOME_MODE is not set.
 # 022 is the default value, but 027, or even 077, could be considered
 # for increased privacy. There is no One True Answer here: each sysadmin
 # must make up their mind.
 UMASK		022
+
+# HOME_MODE is used by useradd(8) and newusers(8) to set the mode for new
+# home directories.
+# If HOME_MODE is not set, the value of UMASK is used to create the mode.
+#HOME_MODE	0700
 
 #
 # Password aging controls:

--- a/lib/getdef.c
+++ b/lib/getdef.c
@@ -93,6 +93,7 @@ static struct itemdef def_table[] = {
 	{"FAKE_SHELL", NULL},
 	{"GID_MAX", NULL},
 	{"GID_MIN", NULL},
+	{"HOME_MODE", NULL},
 	{"HUSHLOGIN_FILE", NULL},
 	{"KILLCHAR", NULL},
 	{"LASTLOG_UID_MAX", NULL},

--- a/man/login.defs.5.xml
+++ b/man/login.defs.5.xml
@@ -50,6 +50,7 @@
 <!ENTITY FAKE_SHELL            SYSTEM "login.defs.d/FAKE_SHELL.xml">
 <!ENTITY FTMP_FILE             SYSTEM "login.defs.d/FTMP_FILE.xml">
 <!ENTITY GID_MAX               SYSTEM "login.defs.d/GID_MAX.xml">
+<!ENTITY HOME_MODE             SYSTEM "login.defs.d/HOME_MODE.xml">
 <!ENTITY HUSHLOGIN_FILE        SYSTEM "login.defs.d/HUSHLOGIN_FILE.xml">
 <!ENTITY ISSUE_FILE            SYSTEM "login.defs.d/ISSUE_FILE.xml">
 <!ENTITY KILLCHAR              SYSTEM "login.defs.d/KILLCHAR.xml">
@@ -185,6 +186,7 @@
       &FAKE_SHELL;
       &FTMP_FILE;
       &GID_MAX; <!-- documents also GID_MIN -->
+      &HOME_MODE;
       &HUSHLOGIN_FILE;
       &ISSUE_FILE;
       &KILLCHAR;
@@ -401,6 +403,7 @@
 	    ENCRYPT_METHOD
 	    GID_MAX GID_MIN
 	    MAX_MEMBERS_PER_GROUP MD5_CRYPT_ENAB
+	    HOME_MODE
 	    PASS_MAX_DAYS PASS_MIN_DAYS PASS_WARN_AGE
 	    <phrase condition="sha_crypt">SHA_CRYPT_MAX_ROUNDS
 	    SHA_CRYPT_MIN_ROUNDS</phrase>
@@ -481,6 +484,7 @@
 	  <para>
 	    CREATE_HOME
 	    GID_MAX GID_MIN
+	    HOME_MODE
 	    LASTLOG_UID_MAX
 	    MAIL_DIR MAX_MEMBERS_PER_GROUP
 	    PASS_MAX_DAYS PASS_MIN_DAYS PASS_WARN_AGE

--- a/man/login.defs.d/UMASK.xml
+++ b/man/login.defs.d/UMASK.xml
@@ -37,7 +37,8 @@
     </para>
     <para>
       <command>useradd</command> and <command>newusers</command> use this
-      mask to set the mode of the home directory they create
+      mask to set the mode of the home directory they create if
+      <option>HOME_MODE</option> is not set.
     </para>
     <para condition="no_pam">
       It is also used by <command>login</command> to define users' initial

--- a/src/newusers.c
+++ b/src/newusers.c
@@ -1216,9 +1216,9 @@ int main (int argc, char **argv)
 		if (   ('\0' != fields[5][0])
 		    && (access (newpw.pw_dir, F_OK) != 0)) {
 /* FIXME: should check for directory */
-			mode_t msk = 0777 & ~getdef_num ("UMASK",
-			                                 GETDEF_DEFAULT_UMASK);
-			if (mkdir (newpw.pw_dir, msk) != 0) {
+			mode_t mode = getdef_num ("HOME_MODE",
+			                          0777 & ~getdef_num ("UMASK", GETDEF_DEFAULT_UMASK));
+			if (mkdir (newpw.pw_dir, mode) != 0) {
 				fprintf (stderr,
 				         _("%s: line %d: mkdir %s failed: %s\n"),
 				         Prog, line, newpw.pw_dir,

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -2152,8 +2152,9 @@ static void create_home (void)
 		}
 
 		(void) chown (prefix_user_home, user_id, user_gid);
-		chmod (prefix_user_home,
-		       0777 & ~getdef_num ("UMASK", GETDEF_DEFAULT_UMASK));
+		mode_t mode = getdef_num ("HOME_MODE",
+		                          0777 & ~getdef_num ("UMASK", GETDEF_DEFAULT_UMASK));
+		chmod (prefix_user_home, mode);
 		home_added = true;
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_ADD_USER, Prog,


### PR DESCRIPTION
This option can be used to set a separate mode for useradd(8) and
newusers(8) to create the home directories with.
If this option is not set, the current behavior of using UMASK
or the default umask is preserved.

There are many distributions that set UMASK to 077 by default just
to create home directories not readable by others and use things like
/etc/profile, bashrc or sudo configuration files to set a less restrictive
umask. This has always resulted in bug reports because it is hard
to follow as users tend to change files like bashrc and are not about
setting the umask to counteract the umask set in /etc/login.defs.

A recent change in sudo has also resulted in many bug reports about
this. sudo now tries to respect the umask set by pam modules and on
systems where pam does not set a umask, the login.defs UMASK value is
used.