### PR TITLE
Make the check for non-executable shell only a warning.

### DIFF
--- a/src/useradd.c
+++ b/src/useradd.c
@@ -1328,14 +1328,21 @@ static void process_flags (int argc, char **argv)
 				if (   ( !VALID (optarg) )
 				    || (   ('\0' != optarg[0])
 				        && ('/'  != optarg[0])
-				        && ('*'  != optarg[0]) )
-				    || (stat(optarg, &st) != 0)
-				    || (S_ISDIR(st.st_mode))
-				    || (access(optarg, X_OK) != 0)) {
+				        && ('*'  != optarg[0]) )) {
 					fprintf (stderr,
 					         _("%s: invalid shell '%s'\n"),
 					         Prog, optarg);
 					exit (E_BAD_ARG);
+				}
+				if (    '\0' != optarg[0]
+				     && '*'  != optarg[0]
+				     && strcmp(optarg, "/sbin/nologin") != 0
+				     && (   stat(optarg, &st) != 0
+				         || S_ISDIR(st.st_mode)
+				         || access(optarg, X_OK) != 0)) {
+					fprintf (stderr,
+					         _("%s: Warning: missing or non-executable shell '%s'\n"),
+					         Prog, optarg);
 				}
 				user_shell = optarg;
 				def_shell = optarg;


### PR DESCRIPTION
Although it is a good idea to check for an inadvertent typo
in the shell name it is possible that the shell might not be present
on the system yet when the user is added.