### PR TITLE
libmisc: Accept --root=path and --prefix=path option syntax

### DIFF
--- a/libmisc/prefix_flag.c
+++ b/libmisc/prefix_flag.c
@@ -74,10 +74,13 @@ extern const char* process_prefix_flag (const char* short_opt, int argc, char **
 	 * Parse the command line options.
 	 */
 	int i;
-	const char *prefix = NULL;
+	const char *prefix = NULL, *val;
 
 	for (i = 0; i < argc; i++) {
+		val = NULL;
 		if (   (strcmp (argv[i], "--prefix") == 0)
+		    || ((strncmp (argv[i], "--prefix=", 9) == 0)
+			&& (val = argv[i] + 9))
 		    || (strcmp (argv[i], short_opt) == 0)) {
 			if (NULL != prefix) {
 				fprintf (stderr,
@@ -86,13 +89,16 @@ extern const char* process_prefix_flag (const char* short_opt, int argc, char **
 				exit (E_BAD_ARG);
 			}
 
-			if (i + 1 == argc) {
+			if (val) {
+				prefix = val;
+			} else if (i + 1 == argc) {
 				fprintf (stderr,
 				         _("%s: option '%s' requires an argument\n"),
 				         Prog, argv[i]);
 				exit (E_BAD_ARG);
+			} else {
+				prefix = argv[++ i];
 			}
-			prefix = argv[i + 1];
 		}
 	}
 

--- a/libmisc/root_flag.c
+++ b/libmisc/root_flag.c
@@ -56,10 +56,13 @@ extern void process_root_flag (const char* short_opt, int argc, char **argv)
 	 * Parse the command line options.
 	 */
 	int i;
-	const char *newroot = NULL;
+	const char *newroot = NULL, *val;
 
 	for (i = 0; i < argc; i++) {
+		val = NULL;
 		if (   (strcmp (argv[i], "--root") == 0)
+		    || ((strncmp (argv[i], "--root=", 7) == 0)
+			&& (val = argv[i] + 7))
 		    || (strcmp (argv[i], short_opt) == 0)) {
 			if (NULL != newroot) {
 				fprintf (stderr,
@@ -68,13 +71,16 @@ extern void process_root_flag (const char* short_opt, int argc, char **argv)
 				exit (E_BAD_ARG);
 			}
 
-			if (i + 1 == argc) {
+			if (val) {
+				newroot = val;
+			} else if (i + 1 == argc) {
 				fprintf (stderr,
 				         _("%s: option '%s' requires an argument\n"),
 				         Prog, argv[i]);
 				exit (E_BAD_ARG);
+			} else {
+				newroot = argv[++ i];
 			}
-			newroot = argv[i + 1];
 		}
 	}
 


### PR DESCRIPTION
Recognise --root=path in addition to --root path (and similarly for
--prefix) to match the syntax accepted by getopt_long.

Fixes #218