### PR TITLE
useradd: clarify the useradd -d parameter behavior in man page

### DIFF
--- a/man/useradd.8.xml
+++ b/man/useradd.8.xml
@@ -181,8 +181,10 @@
 	    login directory. The default is to append the
 	    <replaceable>LOGIN</replaceable> name to
 	    <replaceable>BASE_DIR</replaceable> and use that as the login
-	    directory name. The directory <replaceable>HOME_DIR</replaceable>
-	    does not have to exist but will not be created if it is missing.
+	    directory name.  If the directory
+	    <replaceable>HOME_DIR</replaceable> does not exist, then it
+	    will be created unless the <option>-M</option> option is
+	    specified.
 	  </para>
 	</listitem>
       </varlistentry>


### PR DESCRIPTION
Explanation: clarify the useradd -d parameter as it does create directory HOME_DIR if it doesn't exit.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1677005