### PR TITLE
Removed hard-coded default mail spool in useradd

### DIFF
--- a/src/useradd.c
+++ b/src/useradd.c
@@ -2203,8 +2203,13 @@ static void create_mail (void)
 		mode_t mode;
 
 		spool = getdef_str ("MAIL_DIR");
+#ifdef MAIL_SPOOL_DIR
+		if ((NULL == spool) && (getdef_str ("MAIL_FILE") == NULL)) {
+			spool = MAIL_SPOOL_DIR;
+		}
+#endif /* MAIL_SPOOL_DIR */
 		if (NULL == spool) {
-			spool = "/var/mail";
+			return;
 		}
 		file = alloca (strlen (prefix) + strlen (spool) + strlen (user_name) + 2);
 		if(prefix[0])


### PR DESCRIPTION
The useradd program should be consistent with userdel and usermod and use the
MAIL_SPOOL_DIR variable as the default spool, if it is defined. Otherwise,
don't create a new mailbox, because it won't be cleaned up by userdel when run
with the -r flag.