### PR TITLE
Fix hurd build

### DIFF
--- a/libmisc/idmapping.c
+++ b/libmisc/idmapping.c
@@ -36,8 +36,8 @@
 #include <stdio.h>
 #include "prototypes.h"
 #include "idmapping.h"
-#include <sys/prctl.h>
 #if HAVE_SYS_CAPABILITY_H
+#include <sys/prctl.h>
 #include <sys/capability.h>
 #endif
 


### PR DESCRIPTION
Do not include <sys/prctl.h> we don't have <sys/capability.h>, we don't
need prctl in that case anyway.

Signed-off-by: Samuel Thibault <samuel.thibault@ens-lyon.org>