### PR TITLE
chfn: Prevent buffer overflow.

### DIFF
--- a/src/chfn.c
+++ b/src/chfn.c
@@ -61,7 +61,7 @@ static char fullnm[BUFSIZ];
 static char roomno[BUFSIZ];
 static char workph[BUFSIZ];
 static char homeph[BUFSIZ];
-static char slop[BUFSIZ];
+static char slop[BUFSIZ + 1 + 80];
 static bool amroot;
 /* Flags */
 static bool fflg = false;		/* -f - set full name                */
@@ -311,6 +311,11 @@ static void process_flags (int argc, char **argv)
 				exit (E_NOPERM);
 			}
 			oflg = true;
+			if (strlen (optarg) > (unsigned int) 80) {
+				fprintf (stderr,
+				         _("%s: fields too long\n"), Prog);
+				exit (E_NOPERM);
+			}
 			STRFCPY (slop, optarg);
 			break;
 		case 'r':


### PR DESCRIPTION
This is a stability fix, not a security fix, because the affected -o
option can only be used by root and it takes a modified passwd file.

If a gecos field for a user has BUFSIZ characters without commas and an
equals sign (i.e. a huge slop/extra field) and chfn is called with -o,
then a buffer overflow occurs.

It is not possible to trigger this with shadow tools. Therefore, the
passwd file must be modified manually.

I have fixed this unlikely case the easiest and cleanest way possible.
Since chfn bails out if more than 80 characters excluding commas are
supposed to be written into gecos field, we can stop processing early on
if -o argument is too long.

Signed-off-by: Tobias Stoeckmann <tobias@stoeckmann.org>