### PR TITLE
NOCONFIGURE=1 ./autogen.sh support added

### DIFF
--- a/README
+++ b/README
@@ -42,6 +42,7 @@ Alan Curry <pacman@tardis.mars.net>
 Aleksa Sarai <cyphar@cyphar.com>
 Alexander O. Yuriev <alex@bach.cis.temple.edu>
 Algis Rudys <arudys@rice.edu>
+Ali Rıza Keskin <parduscix@yandex.ru>
 Andreas Jaeger <aj@arthur.rhein-neckar.de>
 Aniello Del Sorbo <anidel@edu-gw.dia.unisa.it>
 Anton Gluck <gluc@midway.uchicago.edu>

--- a/autogen.sh
+++ b/autogen.sh
@@ -2,11 +2,13 @@
 
 autoreconf -v -f --install || exit 1
 
-./configure \
-	CFLAGS="-O2 -Wall" \
-	--enable-man \
-	--enable-maintainer-mode \
-	--enable-shared \
-	--without-libpam \
-	--with-selinux \
-	"$@"
+if test -z "$NOCONFIGURE"; then
+	./configure \
+		CFLAGS="-O2 -Wall" \
+		--enable-man \
+		--enable-maintainer-mode \
+		--enable-shared \
+		--without-libpam \
+		--with-selinux \
+		"$@"
+fi


### PR DESCRIPTION
most of build system need to this I think.

Most of build method look like this:
```bash
NOCONFIGURE=1 ./autogen.sh
./configure --prefix=/usr
make
make install DESTDIR="$pkgdir"

```
Autogen.sh script did not support noconfigude. I added it