### PR TITLE
add -U option to groupadd and groupmod

### DIFF
--- a/lib/prototypes.h
+++ b/lib/prototypes.h
@@ -206,7 +206,9 @@ extern void __gr_set_changed (void);
 
 /* groupmem.c */
 extern /*@null@*/ /*@only@*/struct group *__gr_dup (const struct group *grent);
+extern void gr_free_members (struct group *grent);
 extern void gr_free (/*@out@*/ /*@only@*/struct group *grent);
+extern bool gr_append_member (struct group *grp, char *member);
 
 /* hushed.c */
 extern bool hushed (const char *username);

--- a/man/groupadd.8.xml
+++ b/man/groupadd.8.xml
@@ -229,6 +229,22 @@
 	  </para>
 	</listitem>
       </varlistentry>
+      <varlistentry>
+	<term>
+	  <option>-U</option>, <option>--users</option>
+	</term>
+	<listitem>
+	  <para>
+	    A list of usernames to add as members of the group.
+	  </para>
+	  <para>
+	    The default behavior (if the <option>-g</option>,
+	    <option>-N</option>, and <option>-U</option> options are not
+	    specified) is defined by the <option>USERGROUPS_ENAB</option>
+	    variable in <filename>/etc/login.defs</filename>.
+	  </para>
+	</listitem>
+      </varlistentry>
     </variablelist>
   </refsect1>
 

--- a/man/groupmod.8.xml
+++ b/man/groupmod.8.xml
@@ -94,6 +94,15 @@
     <variablelist remap='IP'>
       <varlistentry>
 	<term>
+	  <option>-a</option>, <option>--append</option>&nbsp;<replaceable>GID</replaceable>
+	</term>
+	<listitem>
+      <para>If group members are specified with -U, append them to the existing
+            member list, rather than replacing it.</para>
+    </listitem>
+    </varlistentry>
+    <varlistentry>
+	<term>
 	  <option>-g</option>, <option>--gid</option>&nbsp;<replaceable>GID</replaceable>
 	</term>
 	<listitem>
@@ -200,6 +209,22 @@
 		Some limitations: NIS and LDAP users/groups are not verified.
 		PAM authentication is using the host files.
 		No SELINUX support.
+	  </para>
+	</listitem>
+      </varlistentry>
+      <varlistentry>
+	<term>
+	  <option>-U</option>, <option>--users</option>
+	</term>
+	<listitem>
+	  <para>
+	    A list of usernames to add as members of the group.
+	  </para>
+	  <para>
+	    The default behavior (if the <option>-g</option>,
+	    <option>-N</option>, and <option>-U</option> options are not
+	    specified) is defined by the <option>USERGROUPS_ENAB</option>
+	    variable in <filename>/etc/login.defs</filename>.
 	  </para>
 	</listitem>
       </varlistentry>

--- a/src/groupadd.c
+++ b/src/groupadd.c
@@ -79,6 +79,7 @@ static /*@null@*/char *group_passwd;
 static /*@null@*/char *empty_list = NULL;
 
 static const char *prefix = "";
+static char *user_list;
 
 static bool oflg = false;	/* permit non-unique group ID to be specified with -g */
 static bool gflg = false;	/* ID value for the new group */
@@ -126,7 +127,8 @@ static /*@noreturn@*/void usage (int status)
 	(void) fputs (_("  -p, --password PASSWORD       use this encrypted password for the new group\n"), usageout);
 	(void) fputs (_("  -r, --system                  create a system account\n"), usageout);
 	(void) fputs (_("  -R, --root CHROOT_DIR         directory to chroot into\n"), usageout);
-	(void) fputs (_("  -P, --prefix PREFIX_DIR       directory prefix\n"), usageout);
+	(void) fputs (_("  -P, --prefix PREFIX_DI        directory prefix\n"), usageout);
+	(void) fputs (_("  -U, --users USERS             list of user members of this group\n"), usageout);
 	(void) fputs ("\n", usageout);
 	exit (status);
 }
@@ -206,6 +208,19 @@ static void grp_update (void)
 		grp.gr_passwd = SHADOW_PASSWD_STRING;	/* XXX warning: const */
 	}
 #endif				/* SHADOWGRP */
+
+	if (user_list) {
+		char *token;
+		token = strtok(user_list, ",");
+		while (token) {
+			if (prefix_getpwnam (token) == NULL) {
+				fprintf (stderr, _("Invalid member username %s\n"), token);
+				exit (E_GRP_UPDATE);
+			}
+			grp.gr_mem = add_list(grp.gr_mem, token);
+			token = strtok(NULL, ",");
+		}
+	}
 
 	/*
 	 * Write out the new group file entry.
@@ -391,10 +406,11 @@ static void process_flags (int argc, char **argv)
 		{"system",     no_argument,       NULL, 'r'},
 		{"root",       required_argument, NULL, 'R'},
 		{"prefix",     required_argument, NULL, 'P'},
+		{"users",      required_argument, NULL, 'U'},
 		{NULL, 0, NULL, '\0'}
 	};
 
-	while ((c = getopt_long (argc, argv, "fg:hK:op:rR:P:",
+	while ((c = getopt_long (argc, argv, "fg:hK:op:rR:P:U:",
 		                 long_options, NULL)) != -1) {
 		switch (c) {
 		case 'f':
@@ -452,6 +468,9 @@ static void process_flags (int argc, char **argv)
 		case 'R': /* no-op, handled in process_root_flag () */
 			break;
 		case 'P': /* no-op, handled in process_prefix_flag () */
+			break;
+		case 'U':
+			user_list = optarg;
 			break;
 		default:
 			usage (E_USAGE);


### PR DESCRIPTION
Add a -U option which adds new usernames as members.  For groupmod,
also add -a (append), without which existing members are removed.

Closes #265