### PR TITLE
useradd: check return value from chmod and log it

### DIFF
--- a/src/useradd.c
+++ b/src/useradd.c
@@ -2247,7 +2247,10 @@ static void create_home (void)
 		(void) chown (prefix_user_home, user_id, user_gid);
 		mode_t mode = getdef_num ("HOME_MODE",
 		                          0777 & ~getdef_num ("UMASK", GETDEF_DEFAULT_UMASK));
-		chmod (prefix_user_home, mode);
+		if (chmod (prefix_user_home, mode)) {
+			fprintf (stderr, _("%s: warning: chown on '%s' failed: %m\n"),
+			                 Prog, path);
+		}
 		home_added = true;
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_ADD_USER, Prog,


### PR DESCRIPTION
covscan was complaining abot calling chmod and ignoring the return value:
Error: CHECKED_RETURN (CWE-252):
shadow-4.6/src/useradd.c:2084: check_return: Calling "chmod(prefix_user_home, mode)" without checking return value. This library function may fail and return an error code.
<pre>
2082|   		mode_t mode = getdef_num ("HOME_MODE",
2083|   		                          0777 & ~getdef_num ("UMASK", GETDEF_DEFAULT_UMASK));
2084|-> 		chmod (prefix_user_home, mode);
2085|   		home_added = true;
2086|   #ifdef WITH_AUDIT
</pre>