### PR TITLE
add parsing support for advertised force long opt

### DIFF
--- a/man/groupdel.8.xml
+++ b/man/groupdel.8.xml
@@ -92,6 +92,17 @@
     </para>
     <variablelist remap='IP'>
       <varlistentry>
+	<term>
+	  <option>-f</option>, <option>--force</option>
+	</term>
+	<listitem>
+	  <para>
+      This option forces the removal of the group, even if there's some user
+      having the group as the primary one.
+	  </para>
+	</listitem>
+      </varlistentry>
+      <varlistentry>
 	<term><option>-h</option>, <option>--help</option></term>
 	<listitem>
 	  <para>Display help message and exit.</para>

--- a/src/groupdel.c
+++ b/src/groupdel.c
@@ -323,6 +323,7 @@ static void process_flags (int argc, char **argv)
 	int c;
 	static struct option long_options[] = {
 		{"help", no_argument,       NULL, 'h'},
+		{"force", no_argument,      NULL, 'f'},
 		{"root", required_argument, NULL, 'R'},
 		{"prefix", required_argument, NULL, 'P'},
 		{NULL, 0, NULL, '\0'}


### PR DESCRIPTION
Existing help output advertises --force as a long opt.

  -f, --force                   delete group even if it is the primary group of a user

But errors when the long opt is used.

groupdel: unrecognized option '--force'

Signed-off-by: Jamin W. Collins <jamin.collins@gmail.com>