### PR TITLE
Two covscan issues

### DIFF
--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -445,7 +445,6 @@ int main (int argc, char **argv)
 	Prog = Basename (argv[0]);
 	is_newgrp = (strcmp (Prog, "newgrp") == 0);
 	OPENLOG (is_newgrp ? "newgrp" : "sg");
-	gid = getgid ();
 	argc--;
 	argv++;
 

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -729,7 +729,7 @@ static int set_defaults (void)
 static int get_groups (char *list)
 {
 	char *cp;
-	const struct group *grp;
+	struct group *grp;
 	int errors = 0;
 	int ngroups = 0;
 
@@ -808,6 +808,7 @@ static int get_groups (char *list)
 		 * Add the group name to the user's list of groups.
 		 */
 		user_groups[ngroups++] = xstrdup (grp->gr_name);
+		free (grp);
 	} while (NULL != list);
 
 	close_group_files ();


### PR DESCRIPTION
Error: CLANG_WARNING: [#def31]
src/newgrp.c:448:2: warning: Value stored to 'gid' is never read [deadcode.DeadStores]
```
	gid = getgid ();
```

Error: RESOURCE_LEAK (CWE-772): [#def39] [important]
src/useradd.c:728: alloc_fn: Storage is returned from allocation function "get_local_group".
src/useradd.c:728: var_assign: Assigning: "grp" = storage returned from "get_local_group(list)".
src/useradd.c:728: overwrite_var: Overwriting "grp" in "grp = get_local_group(list)" leaks the storage that "grp" points to.
```
726|   		 * GID values, otherwise the string is looked up as is.
727|   		 */
728|-> 		grp = get_local_group (list);
729|
730|   		/*
```