### PR TITLE
commonio: force lock file sync

### DIFF
--- a/lib/commonio.c
+++ b/lib/commonio.c
@@ -157,7 +157,17 @@ static int do_lock_file (const char *file, const char *lock, bool log)
 	if (write (fd, buf, (size_t) len) != len) {
 		if (log) {
 			(void) fprintf (stderr,
-			                "%s: %s: %s\n",
+			                "%s: %s file write error: %s\n",
+			                Prog, file, strerror (errno));
+		}
+		(void) close (fd);
+		unlink (file);
+		return 0;
+	}
+	if (fdatasync (fd) == -1) {
+		if (log) {
+			(void) fprintf (stderr,
+			                "%s: %s file sync error: %s\n",
 			                Prog, file, strerror (errno));
 		}
 		(void) close (fd);


### PR DESCRIPTION
lib/commonio.c: after writing to the lock file, force a file sync to
the storage system.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1862056