### PR TITLE
useradd: use built-in settings by default

### DIFF
--- a/etc/Makefile.am
+++ b/etc/Makefile.am
@@ -4,8 +4,7 @@
 sysconf_DATA = login.defs
 
 defaultdir = $(sysconfdir)/default
-default_DATA = \
-	useradd
+default_DATA =
 
 nonpam_files = \
 	limits \

--- a/etc/useradd
+++ b/etc/useradd
@@ -1,8 +1,0 @@
-# useradd defaults file
-GROUP=1000
-HOME=/home
-INACTIVE=-1
-EXPIRE=
-SHELL=/bin/bash
-SKEL=/etc/skel
-CREATE_MAIL_SPOOL=yes

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -97,12 +97,12 @@ const char *Prog;
 /*
  * These defaults are used if there is no defaults file.
  */
-static gid_t def_group = 100;
+static gid_t def_group = 1000;
 static const char *def_gname = "other";
 static const char *def_home = "/home";
-static const char *def_shell = "";
+static const char *def_shell = "/bin/bash";
 static const char *def_template = SKEL_DIR;
-static const char *def_create_mail_spool = "no";
+static const char *def_create_mail_spool = "yes";
 
 static long def_inactive = -1;
 static const char *def_expire = "";


### PR DESCRIPTION
Avoids installing inconsistent settings. The correct ones would be
written as soon as an admin uses useradd -D to modify the defaults.