### PR TITLE
usermod: check if shell is know

### DIFF
--- a/man/po/de.po
+++ b/man/po/de.po
@@ -1005,10 +1005,10 @@ msgstr ""
 
 #: usermod.8.xml:327(para) chsh.1.xml:123(para)
 msgid ""
-"The name of the user's new login shell. Setting this field to blank causes "
+"The path of the user's new login shell. Setting this field to blank causes "
 "the system to select the default login shell."
 msgstr ""
-"Der Name der neuen Anmelde-Shell des Benutzers. Falls dieses Feld leer "
+"Der Pfad der neuen Anmelde-Shell des Benutzers. Falls dieses Feld leer "
 "gelassen wird, verwendet das System die Standard-Anmelde-Shell."
 
 #: usermod.8.xml:334(term) useradd.8.xml:471(term)

--- a/man/usermod.8.xml
+++ b/man/usermod.8.xml
@@ -353,7 +353,7 @@
 	</term>
 	<listitem>
 	  <para>
-	    The name of the user's new login shell. Setting this field to
+	    The path of the user's new login shell. Setting this field to
 	    blank causes the system to select the default login shell.
 	  </para>
 	</listitem>

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -1032,7 +1032,7 @@ static void grp_update (void)
 static void process_flags (int argc, char **argv)
 {
 	const struct group *grp;
-
+	struct stat st;
 	bool anyflag = false;
 
 	{
@@ -1180,11 +1180,24 @@ static void process_flags (int argc, char **argv)
 			case 'P': /* no-op, handled in process_prefix_flag () */
 				break;
 			case 's':
-				if (!VALID (optarg)) {
+				if (   ( !VALID (optarg) )
+				    || (   ('\0' != optarg[0])
+				        && ('/'  != optarg[0])
+				        && ('*'  != optarg[0]) )) {
 					fprintf (stderr,
-					         _("%s: invalid field '%s'\n"),
+					         _("%s: invalid shell '%s'\n"),
 					         Prog, optarg);
 					exit (E_BAD_ARG);
+				}
+				if (    '\0' != optarg[0]
+				     && '*'  != optarg[0]
+				     && strcmp(optarg, "/sbin/nologin") != 0
+				     && (   stat(optarg, &st) != 0
+				         || S_ISDIR(st.st_mode)
+				         || access(optarg, X_OK) != 0)) {
+					fprintf (stderr,
+					         _("%s: Warning: missing or non-executable shell '%s'\n"),
+					         Prog, optarg);
 				}
 				user_newshell = optarg;
 				sflg = true;


### PR DESCRIPTION
The man page for usermod says:
> -s, --shell SHELL
> The name of the user's new login shell. ...

This is wrong, usermod just set whatever was given as the new shell. So
if you pass `bash` instead of the path of bash a login afterwards might
not work.

The behaviour in chsh was different, it checked if the argument was on
of the known shells and only then set it[0]. To make it easier for
users, the behaviour should be similar in both programms.

To still allow for a user to run without a real shell (e.g. a daemon
user) and not change the old behaviour too much (while still helping
users) check if the new shell looks like a path and then just set it,
w/o further validation

[0] However root was allowed to set any value, no matter if it was a
known shell or not.