### PR TITLE
Man clarifications

### DIFF
--- a/man/chage.1.xml
+++ b/man/chage.1.xml
@@ -102,6 +102,9 @@
 	    Set the number of days since January 1st, 1970 when the password
 	    was last changed. The date may also be expressed in the format
 	    YYYY-MM-DD (or the format more commonly used in your area).
+	    If the <replaceable>LAST_DAY</replaceable> is set to
+	    <emphasis>0</emphasis> the user is forced to change his password
+	    on the next log on.
 	  </para>
 	</listitem>
       </varlistentry>
@@ -118,6 +121,13 @@
 	    contact the system administrator before being able to use the
 	    system again.
 	  </para>
+	  <para>
+	    For example the following can be used to set an account to expire
+	    in 180 days:
+	  </para>
+	  <programlisting>
+	    chage -E $(date -d +180days +%Y-%m-%d)
+	  </programlisting>
 	  <para>
 	    Passing the number <emphasis remap='I'>-1</emphasis> as the
 	    <replaceable>EXPIRE_DATE</replaceable> will remove an account
@@ -238,6 +248,18 @@
     <para>
       The <command>chage</command> program requires a shadow password file to
       be available.
+    </para>
+    <para>
+      The chage program will report only the information from the shadow
+      password file. This implies that configuration from other sources
+      (e.g. LDAP or empty password hash field from the passwd file) that
+      affect the user's login will not be shown in the chage output.
+    </para>
+    <para>
+      The <command>chage</command> program will also not report any
+      inconsistency between the shadow and passwd files (e.g. missing x in
+      the passwd file). The <command>pwck</command> can be used to check
+      for this kind of inconsistencies.
     </para>
     <para>The <command>chage</command> command is restricted to the root
       user, except for the <option>-l</option> option, which may be used by

--- a/man/groupadd.8.xml
+++ b/man/groupadd.8.xml
@@ -334,13 +334,13 @@
 	<varlistentry>
 	  <term><replaceable>4</replaceable></term>
 	  <listitem>
-	    <para>GID not unique (when <option>-o</option> not used)</para>
+	    <para>GID is already used (when called without <option>-o</option>)</para>
 	  </listitem>
 	</varlistentry>
 	<varlistentry>
 	  <term><replaceable>9</replaceable></term>
 	  <listitem>
-	    <para>group name not unique</para>
+	    <para>group name is already used</para>
 	  </listitem>
 	</varlistentry>
 	<varlistentry>

--- a/man/groupmod.8.xml
+++ b/man/groupmod.8.xml
@@ -299,7 +299,7 @@
 	<varlistentry>
 	  <term><replaceable>4</replaceable></term>
 	  <listitem>
-	    <para>E_GID_IN_USE: specified group doesn't exist</para>
+	    <para>E_GID_IN_USE: group id already in use</para>
 	  </listitem>
 	</varlistentry>
 	<varlistentry>

--- a/man/shadow.5.xml
+++ b/man/shadow.5.xml
@@ -129,7 +129,7 @@
 	<listitem>
 	  <para>
 	    The date of the last password change, expressed as the number
-	    of days since Jan 1, 1970.
+	    of days since Jan 1, 1970 00:00 UTC.
 	  </para>
 	  <para>
 	    The value 0 has a special meaning, which is that the user
@@ -208,8 +208,8 @@
 	  </para>
 	  <para>
 	    After expiration of the password and this expiration period is
-	    elapsed, no login is possible using the current user's
-	    password.  The user should contact her administrator.
+	    elapsed, no login is possible for the user. The user should contact
+	    her administrator.
 	  </para>
 	  <para>
 	    An empty field means that there are no enforcement of an
@@ -224,7 +224,7 @@
 	<listitem>
 	  <para>
 	    The date of expiration of the account, expressed as the number
-	    of days since Jan 1, 1970.
+	    of days since Jan 1, 1970 00:00 UTC.
 	  </para>
 	  <para>
 	    Note that an account expiration differs from a password

--- a/man/useradd.8.xml
+++ b/man/useradd.8.xml
@@ -361,6 +361,11 @@
 	    <option>CREATE_HOME</option> is not enabled, no home
 	    directories are created.
 	  </para>
+	  <para>
+	    The directory where the user's home directory is created must
+	    exist and have proper SELinux context and permissions. Otherwise
+	    the user's home directory cannot be created or accessed.
+	  </para>
 	</listitem>
       </varlistentry>
       <varlistentry>

--- a/man/usermod.8.xml
+++ b/man/usermod.8.xml
@@ -143,7 +143,8 @@
 	    If the <option>-m</option>
 	    option is given, the contents of the current home directory will
 	    be moved to the new home directory, which is created if it does
-	    not already exist.
+	    not already exist. If the current home directory does not exist
+	    the new home directory will not be created.
 	  </para>
 	</listitem>
       </varlistentry>
@@ -204,6 +205,12 @@
 	  <para>
 	    The group ownership of files outside of the user's home directory
 	    must be fixed manually.
+	  </para>
+	  <para>
+	    The change of the group ownership of files inside of the user's
+	    home directory is also not done if the home dir owner uid is
+	    different from the current or new user id. This is a safety measure
+	    for special home directories such as <filename>/</filename>.
 	  </para>
 	</listitem>
       </varlistentry>
@@ -267,7 +274,8 @@
 	<listitem>
 	  <para>
 	    Move the content of the user's home directory to the new
-	    location.
+	    location. If the current home directory does not exist
+	    the new home directory will not be created.
 	  </para>
 	  <para>
 	    This option is only valid in combination with the
@@ -379,6 +387,12 @@
 	  <para>
 	    The ownership of files outside of the user's home directory
 	    must be fixed manually.
+	  </para>
+	  <para>
+	    The change of the user ownership of files inside of the user's
+	    home directory is also not done if the home dir owner uid is
+	    different from the current or new user id. This is a safety measure
+	    for special home directories such as <filename>/</filename>.
 	  </para>
 	  <para>
 	    No checks will be performed with regard to the


### PR DESCRIPTION
man/chage.1.xml: Indicate that -d option with a value of 0 forces the
user to change his password. Besides, set an example on how to use -E
option. Finally, add a general note to clarify that chage only takes
charge of local users and another note to indicate that it doesn't check
inconsistencies between shadow and passwd files.

man/groupadd.8.xml: clarify the exit values meaning.

man/shadow.5.xml: indicate the exact time and timezone for the dates.
Moreover, clarify that when the password expires the user won't be able
to login.

man/useradd.8.xml: specify the SELinux requirements for -m option.

man/usermod.8.xml: specify what happens when the current home directory
doesn't exist if using -d and -m options. Moreover, specify what happens
when the group ownership is changed and the uid's don't match in -u and
-g options.