### PR TITLE
login & su: Treat an empty passwd field as invalid

### DIFF
--- a/etc/login.defs
+++ b/etc/login.defs
@@ -444,3 +444,12 @@ USERGROUPS_ENAB yes
 # primary group.
 #
 #GRANT_AUX_GROUP_SUBIDS yes
+
+#
+# Prevents an empty password field to be interpreted as "no authentication
+# required".
+# Set to "yes" to prevent for all accounts
+# Set to "superuser" to prevent for UID 0 / root (default)
+# Set to "no" to not prevent for any account (dangerous, historical default)
+
+PREVENT_NO_AUTH superuser

--- a/lib/getdef.c
+++ b/lib/getdef.c
@@ -161,6 +161,7 @@ static struct itemdef def_table[] = {
 #endif
 	{"FORCE_SHADOW", NULL},
 	{"GRANT_AUX_GROUP_SUBIDS", NULL},
+	{"PREVENT_NO_AUTH", NULL},
 	{NULL, NULL}
 };
 

--- a/src/login.c
+++ b/src/login.c
@@ -978,9 +978,18 @@ int main (int argc, char **argv)
 			    || ('*' == user_passwd[0])) {
 				failed = true;
 			}
-			/* Treat empty password field as invalid */
+
 			if (strcmp (user_passwd, "") == 0) {
-				failed = true;
+				char *prevent_no_auth = getdef_str("PREVENT_NO_AUTH");
+				if(prevent_no_auth == NULL) {
+					prevent_no_auth = "superuser";
+				}
+				if(strcmp(prevent_no_auth, "yes") == 0) {
+					failed = true;
+				} else if( (pwd->pw_uid == 0)
+					&& (strcmp(prevent_no_auth, "superuser") == 0)) {
+					failed = true;
+				}
 			}
 		}
 

--- a/src/login.c
+++ b/src/login.c
@@ -978,6 +978,10 @@ int main (int argc, char **argv)
 			    || ('*' == user_passwd[0])) {
 				failed = true;
 			}
+			/* Treat empty password field as invalid */
+			if (strcmp (user_passwd, "") == 0) {
+				failed = true;
+			}
 		}
 
 		if (strcmp (user_passwd, SHADOW_PASSWD_STRING) == 0) {

--- a/src/su.c
+++ b/src/su.c
@@ -501,6 +501,11 @@ static void check_perms_nopam (const struct passwd *pw)
 	/*@observer@*/const char *password = pw->pw_passwd;
 	RETSIGTYPE (*oldsig) (int);
 
+	if (strcmp (pw->pw_passwd, "") == 0) {
+		fprintf(stderr, _("Password field is empty, this is invalid.\n"));
+		exit(1);
+	}
+
 	if (caller_is_root) {
 		return;
 	}

--- a/src/su.c
+++ b/src/su.c
@@ -501,13 +501,23 @@ static void check_perms_nopam (const struct passwd *pw)
 	/*@observer@*/const char *password = pw->pw_passwd;
 	RETSIGTYPE (*oldsig) (int);
 
-	if (strcmp (pw->pw_passwd, "") == 0) {
-		fprintf(stderr, _("Password field is empty, this is invalid.\n"));
-		exit(1);
-	}
-
 	if (caller_is_root) {
 		return;
+	}
+
+	if (strcmp (pw->pw_passwd, "") == 0) {
+		char *prevent_no_auth = getdef_str("PREVENT_NO_AUTH");
+		if(prevent_no_auth == NULL) {
+			prevent_no_auth = "superuser";
+		}
+		if(strcmp(prevent_no_auth, "yes") == 0) {
+			fprintf(stderr, _("Password field is empty, this is forbidden for all accounts.\n"));
+			exit(1);
+		} else if( (pw->pw_uid == 0)
+				&& (strcmp(prevent_no_auth, "superuser") == 0)) {
+			fprintf(stderr, _("Password field is empty, this is forbidden for super-user.\n"));
+			exit(1);
+		}
 	}
 
 	/*


### PR DESCRIPTION
Otherwise it's treated like the “require no password” clause while it probably
should be treated like a normal su that can't validate anyway.

A similar change should be done for USE_PAM.