### PR TITLE
Add optional config directory /etc/login.defs.d/

### DIFF
--- a/lib/getdef.h
+++ b/lib/getdef.h
@@ -42,7 +42,10 @@ extern /*@observer@*/ /*@null@*/const char *getdef_str (const char *);
 extern int putdef_str (const char *, const char *);
 extern void setdef_config_file (const char* file);
 
-/* default UMASK value if not specified in /etc/login.defs */
+/*
+ * default UMASK value if not specified in /etc/login.defs or
+ * in /etc/login.defs.d/
+ */
 #define		GETDEF_DEFAULT_UMASK	022
 
 #endif				/* _GETDEF_H */

--- a/man/chage.1.xml
+++ b/man/chage.1.xml
@@ -272,8 +272,9 @@
     <title>CONFIGURATION</title>
     <para>
       The following configuration variables in
-      <filename>/etc/login.defs</filename> change the behavior of this
-      tool:
+      <filename>/etc/login.defs</filename> or
+      <filename>/etc/login.defs.d/*.defs</filename>
+      change the behavior of this tool:
     </para>
     <variablelist>
       &USE_TCB;

--- a/man/chfn.1.xml
+++ b/man/chfn.1.xml
@@ -89,7 +89,9 @@
       <citerefentry><refentrytitle>finger</refentrytitle><manvolnum>1</manvolnum>
       </citerefentry> and similar programs. A normal user may only change
       the fields for her own account, subject to the restrictions in
-      <filename>/etc/login.defs</filename>. (The default configuration is to
+      <filename>/etc/login.defs</filename> or
+      <filename>/etc/login.defs.d/*.defs</filename>.
+      (The default configuration is to
       prevent users from changing their fullname.) The superuser may change
       any field for any account. Additionally, only the superuser may use
       the <option>-o</option> option to change the undefined portions of the
@@ -193,8 +195,9 @@
     <title>CONFIGURATION</title>
     <para>
       The following configuration variables in
-      <filename>/etc/login.defs</filename> change the behavior of this
-      tool:
+      <filename>/etc/login.defs</filename> or
+      <filename>/etc/login.defs.d/*.defs</filename>
+      change the behavior of this tool:
     </para>
     <variablelist>
       &CHFN_AUTH;
@@ -211,6 +214,12 @@
 	<listitem>
 	  <para>Shadow password suite configuration.</para>
 	</listitem>
+      </varlistentry>
+      <varlistentry>
+  <term><filename>/etc/login.defs.d/*.defs</filename></term>
+  <listitem>
+    <para>Additional shadow password suite configuration.</para>
+  </listitem>
       </varlistentry>
       <varlistentry>
 	<term><filename>/etc/passwd</filename></term>

--- a/man/chgpasswd.8.xml
+++ b/man/chgpasswd.8.xml
@@ -91,7 +91,8 @@
     </para>
     <para>
       The default encryption algorithm can be defined for the system with
-      the <option>ENCRYPT_METHOD</option> variable of <filename>/etc/login.defs</filename>,
+      the <option>ENCRYPT_METHOD</option> variable of <filename>/etc/login.defs</filename>
+      or <filename>/etc/login.defs.d/*.defs</filename>,
       and can be overwritten with the <option>-e</option>,
       <option>-m</option>, or <option>-c</option> options.
     </para>
@@ -175,7 +176,8 @@
 	  <para>
 	    By default, the number of rounds is defined by the
 	    SHA_CRYPT_MIN_ROUNDS and SHA_CRYPT_MAX_ROUNDS variables in
-	    <filename>/etc/login.defs</filename>.
+	    <filename>/etc/login.defs</filename> or
+      <filename>/etc/login.defs.d/*.defs</filename>.
 	  </para>
 	</listitem>
       </varlistentry>
@@ -198,8 +200,9 @@
     <title>CONFIGURATION</title>
     <para>
       The following configuration variables in
-      <filename>/etc/login.defs</filename> change the behavior of this
-      tool:
+      <filename>/etc/login.defs</filename> or
+      <filename>/etc/login.defs.d/*.defs</filename>
+      change the behavior of this tool:
     </para>
     <variablelist>
       &ENCRYPT_METHOD;
@@ -229,6 +232,12 @@
 	<listitem>
 	  <para>Shadow password suite configuration.</para>
 	</listitem>
+      </varlistentry>
+      <varlistentry>
+  <term><filename>/etc/login.defs.d/*.defs</filename></term>
+  <listitem>
+    <para>Additional shadow password suite configuration.</para>
+  </listitem>
       </varlistentry>
     </variablelist>
   </refsect1>

--- a/man/chpasswd.8.xml
+++ b/man/chpasswd.8.xml
@@ -98,7 +98,8 @@
       The default encryption algorithm can be defined for the system with
       the <option>ENCRYPT_METHOD</option> or
       <option>MD5_CRYPT_ENAB</option> variables of
-      <filename>/etc/login.defs</filename>, and can be overwritten with the
+      <filename>/etc/login.defs</filename> or
+      <filename>/etc/login.defs.d/*.defs</filename>, and can be overwritten with the
       <option>-e</option>, <option>-m</option>, or <option>-c</option>
       options.
     </para>
@@ -155,7 +156,8 @@
 	    specified), the encryption method is defined by the 
 	    <option>ENCRYPT_METHOD</option> or
 	    <option>MD5_CRYPT_ENAB</option> variables of
-	    <filename>/etc/login.defs</filename>.
+	    <filename>/etc/login.defs</filename> or
+      <filename>/etc/login.defs.d/*.defs</filename>.
 	  </para>
 	</listitem>
       </varlistentry>
@@ -220,7 +222,8 @@
 	    By default, the number of rounds is defined by the
 	    <option>SHA_CRYPT_MIN_ROUNDS</option> and
 	    <option>SHA_CRYPT_MAX_ROUNDS</option> variables in
-	    <filename>/etc/login.defs</filename>.
+	    <filename>/etc/login.defs</filename> or
+      <filename>/etc/login.defs.d/*.defs</filename>.
 	  </para>
 	</listitem>
       </varlistentry>
@@ -239,8 +242,9 @@
     <title>CONFIGURATION</title>
     <para>
       The following configuration variables in
-      <filename>/etc/login.defs</filename> change the behavior of this
-      tool:
+      <filename>/etc/login.defs</filename> or
+      <filename>/etc/login.defs.d/*.defs</filename>
+      change the behavior of this tool:
     </para>
     <variablelist condition="no_pam">
       &ENCRYPT_METHOD;
@@ -271,6 +275,12 @@
 	<listitem>
 	  <para>Shadow password suite configuration.</para>
 	</listitem>
+      </varlistentry>
+      <varlistentry>
+  <term><filename>/etc/login.defs.d/*.defs</filename></term>
+  <listitem>
+    <para>Additional shadow password suite configuration.</para>
+  </listitem>
       </varlistentry>
       <varlistentry condition="pam">
 	<term><filename>/etc/pam.d/chpasswd</filename></term>

--- a/man/chsh.1.xml
+++ b/man/chsh.1.xml
@@ -154,8 +154,9 @@
     <title>CONFIGURATION</title>
     <para>
       The following configuration variables in
-      <filename>/etc/login.defs</filename> change the behavior of this
-      tool:
+      <filename>/etc/login.defs</filename> or
+      <filename>/etc/login.defs.d/*.defs</filename>
+      change the behavior of this tool:
     </para>
     <variablelist>
       &CHSH_AUTH;
@@ -183,6 +184,12 @@
 	<listitem>
 	  <para>Shadow password suite configuration.</para>
 	</listitem>
+      </varlistentry>
+      <varlistentry>
+  <term><filename>/etc/login.defs.d/*.defs</filename></term>
+  <listitem>
+    <para>Additional shadow password suite configuration.</para>
+  </listitem>
       </varlistentry>
     </variablelist>
   </refsect1>

--- a/man/gpasswd.1.xml
+++ b/man/gpasswd.1.xml
@@ -264,8 +264,9 @@
     <title>CONFIGURATION</title>
     <para>
       The following configuration variables in
-      <filename>/etc/login.defs</filename> change the behavior of this
-      tool:
+      <filename>/etc/login.defs</filename> or
+      <filename>/etc/login.defs.d/*.defs</filename>
+      change the behavior of this tool:
     </para>
     <variablelist>
       &ENCRYPT_METHOD;

--- a/man/groupadd.8.xml
+++ b/man/groupadd.8.xml
@@ -139,7 +139,8 @@
 	</term>
 	<listitem>
 	  <para>
-	    Overrides <filename>/etc/login.defs</filename> defaults 
+	    Overrides <filename>/etc/login.defs</filename> and
+	    <filename>/etc/login.defs.d/*.defs</filename> defaults
 	    (GID_MIN, GID_MAX and others). Multiple
 	    <option>-K</option> options can be specified.
 	  </para>
@@ -241,7 +242,8 @@
 	    The default behavior (if the <option>-g</option>,
 	    <option>-N</option>, and <option>-U</option> options are not
 	    specified) is defined by the <option>USERGROUPS_ENAB</option>
-	    variable in <filename>/etc/login.defs</filename>.
+	    variable in <filename>/etc/login.defs</filename> or
+	    <filename>/etc/login.defs.d/*.defs</filename>.
 	  </para>
 	</listitem>
       </varlistentry>
@@ -252,8 +254,9 @@
     <title>CONFIGURATION</title>
     <para>
       The following configuration variables in
-      <filename>/etc/login.defs</filename> change the behavior of this
-      tool:
+      <filename>/etc/login.defs</filename> or
+      <filename>/etc/login.defs.d/*.defs</filename>
+      change the behavior of this tool:
     </para>
     <variablelist>
       &GID_MAX; <!-- documents also GID_MIN -->
@@ -281,6 +284,12 @@
 	<term><filename>/etc/login.defs</filename></term>
 	<listitem>
 	  <para>Shadow password suite configuration.</para>
+	</listitem>
+      </varlistentry>
+      <varlistentry>
+	<term><filename>/etc/login.defs.d/*.defs</filename></term>
+	<listitem>
+	  <para>Additional shadow password suite configuration.</para>
 	</listitem>
       </varlistentry>
     </variablelist>

--- a/man/groupdel.8.xml
+++ b/man/groupdel.8.xml
@@ -156,8 +156,9 @@
     <title>CONFIGURATION</title>
     <para>
       The following configuration variables in
-      <filename>/etc/login.defs</filename> change the behavior of this
-      tool:
+      <filename>/etc/login.defs</filename> or
+      <filename>/etc/login.defs.d/*.defs</filename>
+      change the behavior of this tool:
     </para>
     <variablelist>
       &MAX_MEMBERS_PER_GROUP;

--- a/man/groupmems.8.xml
+++ b/man/groupmems.8.xml
@@ -199,8 +199,9 @@
     <title>CONFIGURATION</title>
     <para>
       The following configuration variables in
-      <filename>/etc/login.defs</filename> change the behavior of this
-      tool:
+      <filename>/etc/login.defs</filename> or
+      <filename>/etc/login.defs.d/*.defs</filename>
+      change the behavior of this tool:
     </para>
     <variablelist>
       &MAX_MEMBERS_PER_GROUP;

--- a/man/groupmod.8.xml
+++ b/man/groupmod.8.xml
@@ -130,7 +130,8 @@
 	    No checks will be performed with regard to the
 	    <option>GID_MIN</option>, <option>GID_MAX</option>,
 	    <option>SYS_GID_MIN</option>, or <option>SYS_GID_MAX</option>
-	    from <filename>/etc/login.defs</filename>.
+	    from <filename>/etc/login.defs</filename> or
+	    <filename>/etc/login.defs.d/*.defs</filename>.
 	  </para>
 	</listitem>
       </varlistentry>
@@ -224,7 +225,8 @@
 	    The default behavior (if the <option>-g</option>,
 	    <option>-N</option>, and <option>-U</option> options are not
 	    specified) is defined by the <option>USERGROUPS_ENAB</option>
-	    variable in <filename>/etc/login.defs</filename>.
+	    variable in <filename>/etc/login.defs</filename> or
+	    <filename>/etc/login.defs.d/*.defs</filename>.
 	  </para>
 	</listitem>
       </varlistentry>
@@ -235,8 +237,9 @@
     <title>CONFIGURATION</title>
     <para>
       The following configuration variables in
-      <filename>/etc/login.defs</filename> change the behavior of this
-      tool:
+      <filename>/etc/login.defs</filename> or
+      <filename>/etc/login.defs.d/*.defs</filename>
+      change the behavior of this tool:
     </para>
     <variablelist>
       &MAX_MEMBERS_PER_GROUP;
@@ -262,6 +265,12 @@
 	<term><filename>/etc/login.defs</filename></term>
 	<listitem>
 	  <para>Shadow password suite configuration.</para>
+	</listitem>
+      </varlistentry>
+      <varlistentry>
+	<term><filename>/etc/login.defs.d/*.defs</filename></term>
+	<listitem>
+	  <para>Additional shadow password suite configuration.</para>
 	</listitem>
       </varlistentry>
       <varlistentry>

--- a/man/grpck.8.xml
+++ b/man/grpck.8.xml
@@ -219,8 +219,9 @@
     <title>CONFIGURATION</title>
     <para>
       The following configuration variables in
-      <filename>/etc/login.defs</filename> change the behavior of this
-      tool:
+      <filename>/etc/login.defs</filename> or
+      <filename>/etc/login.defs.d/*.defs</filename>
+      change the behavior of this tool:
     </para>
     <variablelist>
       &MAX_MEMBERS_PER_GROUP;

--- a/man/lastlog.8.xml
+++ b/man/lastlog.8.xml
@@ -205,8 +205,9 @@
     <title>CONFIGURATION</title>
     <para>
       The following configuration variables in
-      <filename>/etc/login.defs</filename> change the behavior of this
-      tool:
+      <filename>/etc/login.defs</filename> or
+      <filename>/etc/login.defs.d/*.defs</filename>
+      change the behavior of this tool:
     </para>
     <variablelist>
       &LASTLOG_UID_MAX;

--- a/man/login.1.xml
+++ b/man/login.1.xml
@@ -294,8 +294,9 @@
     <title>CONFIGURATION</title>
     <para>
       The following configuration variables in
-      <filename>/etc/login.defs</filename> change the behavior of this
-      tool:
+      <filename>/etc/login.defs</filename> or
+      <filename>/etc/login.defs.d/*.defs</filename>
+      change the behavior of this tool:
     </para>
     <variablelist>
       &CONSOLE;
@@ -390,6 +391,12 @@
 	<listitem>
 	  <para>Shadow password suite configuration.</para>
 	</listitem>
+      </varlistentry>
+      <varlistentry>
+  <term><filename>/etc/login.defs.d/*.defs</filename></term>
+  <listitem>
+    <para>Additional shadow password suite configuration.</para>
+  </listitem>
       </varlistentry>
     </variablelist>
   </refsect1>

--- a/man/login.access.5.xml
+++ b/man/login.access.5.xml
@@ -126,6 +126,12 @@
 	  <para>Shadow password suite configuration.</para>
 	</listitem>
       </varlistentry>
+      <varlistentry>
+  <term><filename>/etc/login.defs.d/*.defs</filename></term>
+  <listitem>
+    <para>Additional shadow password suite configuration.</para>
+  </listitem>
+      </varlistentry>
     </variablelist>
   </refsect1>
 

--- a/man/login.defs.5.xml
+++ b/man/login.defs.5.xml
@@ -139,7 +139,9 @@
       The <filename>/etc/login.defs</filename> file defines the
       site-specific configuration for the shadow password suite. This file
       is required. Absence of this file will not prevent system operation,
-      but will probably result in undesirable operation.
+      but will probably result in undesirable operation. Configuration of
+      above file can be overwritten with
+      <filename>/etc/login.defs.d/*.defs</filename> files.
     </para>
 
     <para>

--- a/man/newgrp.1.xml
+++ b/man/newgrp.1.xml
@@ -109,8 +109,9 @@
     <title>CONFIGURATION</title>
     <para>
       The following configuration variables in
-      <filename>/etc/login.defs</filename> change the behavior of this
-      tool:
+      <filename>/etc/login.defs</filename> or
+      <filename>/etc/login.defs.d/*.defs</filename>
+      change the behavior of this tool:
     </para>
     <variablelist>
       &SYSLOG_SG_ENAB;

--- a/man/newusers.8.xml
+++ b/man/newusers.8.xml
@@ -360,7 +360,8 @@
 	  <para>
 	    By default, the number of rounds is defined by the
 	    SHA_CRYPT_MIN_ROUNDS and SHA_CRYPT_MAX_ROUNDS variables in
-	    <filename>/etc/login.defs</filename>.
+	    <filename>/etc/login.defs</filename> or
+	    <filename>/etc/login.defs.d/*.defs</filename>.
 	  </para>
 	</listitem>
       </varlistentry>
@@ -383,8 +384,9 @@
     <title>CONFIGURATION</title>
     <para>
       The following configuration variables in
-      <filename>/etc/login.defs</filename> change the behavior of this
-      tool:
+      <filename>/etc/login.defs</filename> or
+      <filename>/etc/login.defs.d/*.defs</filename>
+      change the behavior of this tool:
     </para>
     <variablelist condition="no_pam">
       &ENCRYPT_METHOD;
@@ -446,6 +448,12 @@
 	<term><filename>/etc/login.defs</filename></term>
 	<listitem>
 	  <para>Shadow password suite configuration.</para>
+	</listitem>
+      </varlistentry>
+      <varlistentry>
+	<term><filename>/etc/login.defs.d/*.defs</filename></term>
+	<listitem>
+	  <para>Additional shadow password suite configuration.</para>
 	</listitem>
       </varlistentry>
       <varlistentry condition="pam">

--- a/man/passwd.1.xml
+++ b/man/passwd.1.xml
@@ -381,8 +381,8 @@
       complex as he or she feels comfortable with.
     </para>
     <para>
-      Users may not be able to 
-      change their password on a system if NIS is enabled and they are not 
+      Users may not be able to
+      change their password on a system if NIS is enabled and they are not
       logged into the NIS server.
     </para>
     <para condition="pam">
@@ -395,8 +395,9 @@
     <title>CONFIGURATION</title>
     <para>
       The following configuration variables in
-      <filename>/etc/login.defs</filename> change the behavior of this
-      tool:
+      <filename>/etc/login.defs</filename> or
+      <filename>/etc/login.defs.d/*.defs</filename>
+      change the behavior of this tool:
     </para>
     <variablelist>
       &ENCRYPT_METHOD;
@@ -428,6 +429,12 @@
 	<term><filename>/etc/login.defs</filename></term>
 	<listitem>
 	  <para>Shadow password suite configuration.</para>
+	</listitem>
+      </varlistentry>
+      <varlistentry>
+	<term><filename>/etc/login.defs.d/*.defs</filename></term>
+	<listitem>
+	  <para>Additional shadow password suite configuration.</para>
 	</listitem>
       </varlistentry>
       <varlistentry condition="pam">

--- a/man/pwck.8.xml
+++ b/man/pwck.8.xml
@@ -263,8 +263,9 @@
     <title>CONFIGURATION</title>
     <para>
       The following configuration variables in
-      <filename>/etc/login.defs</filename> change the behavior of this
-      tool:
+      <filename>/etc/login.defs</filename> or
+      <filename>/etc/login.defs.d/*.defs</filename>
+      change the behavior of this tool:
     </para>
     <variablelist>
       &NONEXISTENT;

--- a/man/pwconv.8.xml
+++ b/man/pwconv.8.xml
@@ -169,7 +169,9 @@
       remap='I'>PASS_MIN_DAYS</emphasis>, <emphasis
       remap='I'>PASS_MAX_DAYS</emphasis>, and <emphasis
       remap='I'>PASS_WARN_AGE</emphasis> from
-      <filename>/etc/login.defs</filename> when adding new entries to
+      <filename>/etc/login.defs</filename> or
+      <filename>/etc/login.defs.d/*.defs</filename>
+      when adding new entries to
       <filename>/etc/shadow</filename>.
     </para>
 
@@ -227,7 +229,9 @@
     <title>CONFIGURATION</title>
     <para>
       The following configuration variable in
-      <filename>/etc/login.defs</filename> changes the behavior of
+      <filename>/etc/login.defs</filename> or
+      <filename>/etc/login.defs.d/*.defs</filename>
+      changes the behavior of
       <command>grpconv</command> and <command>grpunconv</command>:
     </para>
     <variablelist>
@@ -235,7 +239,9 @@
     </variablelist>
     <para>
       The following configuration variables in
-      <filename>/etc/login.defs</filename> change the behavior of
+      <filename>/etc/login.defs</filename> or
+      <filename>/etc/login.defs.d/*.defs</filename>
+      change the behavior of
       <command>pwconv</command>:
     </para>
     <variablelist>
@@ -254,6 +260,12 @@
 	<listitem>
 	  <para>Shadow password suite configuration.</para>
 	</listitem>
+      </varlistentry>
+      <varlistentry>
+  <term><filename>/etc/login.defs.d/*.defs</filename></term>
+  <listitem>
+    <para>Additional shadow password suite configuration.</para>
+  </listitem>
       </varlistentry>
     </variablelist>
   </refsect1>

--- a/man/sg.1.xml
+++ b/man/sg.1.xml
@@ -98,8 +98,9 @@
     <title>CONFIGURATION</title>
     <para>
       The following configuration variables in
-      <filename>/etc/login.defs</filename> change the behavior of this
-      tool:
+      <filename>/etc/login.defs</filename> or
+      <filename>/etc/login.defs.d/*.defs</filename>
+      change the behavior of this tool:
     </para>
     <variablelist>
       &SYSLOG_SG_ENAB;

--- a/man/su.1.xml
+++ b/man/su.1.xml
@@ -130,7 +130,8 @@
       for normal users, or <filename>/sbin:/bin:/usr/sbin:/usr/bin</filename>
       for the superuser. This may be changed with the
       <option>ENV_PATH</option> and <option>ENV_SUPATH</option>
-      definitions in <filename>/etc/login.defs</filename>.
+      definitions in <filename>/etc/login.defs</filename> or
+      <filename>/etc/login.defs.d/*.defs</filename>.
     </para>
 
     <para>
@@ -240,7 +241,8 @@
 		<listitem>
 		  <para>
 		    reset according to the
-		    <filename>/etc/login.defs</filename> options
+		    <filename>/etc/login.defs</filename> or
+		    <filename>/etc/login.defs.d/*.defs</filename> options
 		    <option>ENV_PATH</option> or
 		    <option>ENV_SUPATH</option> (see below);
 		  </para>
@@ -297,8 +299,9 @@
 		    If <option>--login</option> is used, the
 		    <envar>$TZ</envar>, <envar>$HZ</envar>, and
 		    <envar>$MAIL</envar> environment
-		    variables are set according to the 
-		    <filename>/etc/login.defs</filename>
+		    variables are set according to the
+		    <filename>/etc/login.defs</filename> or
+		    <filename>/etc/login.defs.d/*.defs</filename>
 		    options <option>ENV_TZ</option>,
 		    <option>ENV_HZ</option>, <option>MAIL_DIR</option>, and
 		    <option>MAIL_FILE</option> (see below).
@@ -338,8 +341,9 @@
     <title>CONFIGURATION</title>
     <para>
       The following configuration variables in
-      <filename>/etc/login.defs</filename> change the behavior of this
-      tool:
+      <filename>/etc/login.defs</filename> or
+      <filename>/etc/login.defs.d/*.defs</filename>
+      change the behavior of this tool:
     </para>
     <variablelist>
       &CONSOLE;
@@ -381,6 +385,12 @@
 	<term><filename>/etc/login.defs</filename></term>
 	<listitem>
 	  <para>Shadow password suite configuration.</para>
+	</listitem>
+      </varlistentry>
+      <varlistentry>
+	<term><filename>/etc/login.defs.d/*.defs</filename></term>
+	<listitem>
+	  <para>Additional shadow password suite configuration.</para>
 	</listitem>
       </varlistentry>
     </variablelist>

--- a/man/sulogin.8.xml
+++ b/man/sulogin.8.xml
@@ -134,8 +134,9 @@
     <title>CONFIGURATION</title>
     <para>
       The following configuration variables in
-      <filename>/etc/login.defs</filename> change the behavior of this
-      tool:
+      <filename>/etc/login.defs</filename> or
+      <filename>/etc/login.defs.d/*.defs</filename>
+      change the behavior of this tool:
     </para>
     <variablelist>
       &ENV_HZ;

--- a/man/useradd.8.xml
+++ b/man/useradd.8.xml
@@ -247,7 +247,8 @@
 	  <para>
 	    If not specified, the behavior of <command>useradd</command>
 	    will depend on the <option>USERGROUPS_ENAB</option> variable
-	    in <filename>/etc/login.defs</filename>. If this variable is
+	    in <filename>/etc/login.defs</filename> or
+	    <filename>/etc/login.defs.d/*.defs</filename>. If this variable is
 	    set to <replaceable>yes</replaceable> (or
 	    <option>-U/--user-group</option> is specified on the command
 	    line), a group will be created for the user, with the same
@@ -313,7 +314,8 @@
 	</term>
 	<listitem>
 	  <para>
-	    Overrides <filename>/etc/login.defs</filename> defaults
+	    Overrides <filename>/etc/login.defs</filename> and
+	    <filename>/etc/login.defs.d/*.defs</filename> defaults
 	    (<option>UID_MIN</option>, <option>UID_MAX</option>,
 	    <option>UMASK</option>, <option>PASS_MAX_DAYS</option>
 	    and others).
@@ -375,7 +377,8 @@
 	<listitem>
 	  <para>
 	    Do no create the user's home directory, even if the system
-	    wide setting from <filename>/etc/login.defs</filename>
+	    wide setting from <filename>/etc/login.defs</filename> or
+	    <filename>/etc/login.defs.d/*.defs</filename>
 	    (<option>CREATE_HOME</option>) is set to
 	    <replaceable>yes</replaceable>.
 	  </para>
@@ -396,7 +399,8 @@
 	    The default behavior (if the <option>-g</option>,
 	    <option>-N</option>, and <option>-U</option> options are not
 	    specified) is defined by the <option>USERGROUPS_ENAB</option>
-	    variable in <filename>/etc/login.defs</filename>.
+	    variable in <filename>/etc/login.defs</filename> or
+	    <filename>/etc/login.defs.d/*.defs</filename>.
 	  </para>
 	</listitem>
       </varlistentry>
@@ -446,14 +450,16 @@
 	    <filename>/etc/shadow</filename>, and their numeric
 	    identifiers are chosen in the
 	    <option>SYS_UID_MIN</option>-<option>SYS_UID_MAX</option>
-	    range, defined in <filename>/etc/login.defs</filename>, instead of
+	    range, defined in <filename>/etc/login.defs</filename> or
+	    <filename>/etc/login.defs.d/*.defs</filename>, instead of
 	    <option>UID_MIN</option>-<option>UID_MAX</option> (and their
 	    <option>GID</option> counterparts for the creation of groups).
 	  </para>
 	  <para>
 	    Note that <command>useradd</command> will not create a home
 	    directory for such a user, regardless of the default setting
-	    in <filename>/etc/login.defs</filename>
+	    in <filename>/etc/login.defs</filename> or
+	    <filename>/etc/login.defs.d/*.defs</filename>
 	    (<option>CREATE_HOME</option>). You have to specify the
 	    <option>-m</option> options if you want a home directory for a
 	    system account to be created.
@@ -534,7 +540,8 @@
 	    The default behavior (if the <option>-g</option>,
 	    <option>-N</option>, and <option>-U</option> options are not
 	    specified) is defined by the <option>USERGROUPS_ENAB</option>
-	    variable in <filename>/etc/login.defs</filename>.
+	    variable in <filename>/etc/login.defs</filename> or
+	    <filename>/etc/login.defs.d/*.defs</filename>.
 	  </para>
 	</listitem>
       </varlistentry>
@@ -617,7 +624,8 @@
 	      the <option>-N/--no-user-group</option> is used or when the
 	      <option>USERGROUPS_ENAB</option> variable is set to
 	      <replaceable>no</replaceable> in
-	      <filename>/etc/login.defs</filename>). The named
+	      <filename>/etc/login.defs</filename> or
+	      <filename>/etc/login.defs.d/*.defs</filename>). The named
 	      group must exist, and a numerical group ID must have an
 	      existing entry.
 	    </para>
@@ -683,8 +691,9 @@
     <title>CONFIGURATION</title>
     <para>
       The following configuration variables in
-      <filename>/etc/login.defs</filename> change the behavior of this
-      tool:
+      <filename>/etc/login.defs</filename> or
+      <filename>/etc/login.defs.d/*.defs</filename>
+      change the behavior of this tool:
     </para>
     <variablelist>
       &CREATE_HOME;
@@ -770,6 +779,12 @@
 	<term><filename>/etc/login.defs</filename></term>
 	<listitem>
 	  <para>Shadow password suite configuration.</para>
+	</listitem>
+      </varlistentry>
+      <varlistentry>
+	<term><filename>/etc/login.defs.d/*.defs</filename></term>
+	<listitem>
+	  <para>Additional shadow password suite configuration.</para>
 	</listitem>
       </varlistentry>
     </variablelist>

--- a/man/userdel.8.xml
+++ b/man/userdel.8.xml
@@ -109,6 +109,7 @@
 	    owned by the specified user.  If
 	    <option>USERGROUPS_ENAB</option> is defined to <emphasis
 	    remap='I'>yes</emphasis> in <filename>/etc/login.defs</filename>
+      or <filename>/etc/login.defs.d/*.conf</filename>
 	    and if a group exists with the same name as the deleted user,
 	    then this group will be removed, even if it is still the primary
 	    group of another user.
@@ -188,8 +189,9 @@
     <title>CONFIGURATION</title>
     <para>
       The following configuration variables in
-      <filename>/etc/login.defs</filename> change the behavior of this
-      tool:
+      <filename>/etc/login.defs</filename> or
+      <filename>/etc/login.defs.d/*.conf</filename>
+      change the behavior of this tool:
     </para>
     <variablelist>
       &MAIL_DIR; <!-- documents also MAIL_FILE -->
@@ -215,6 +217,12 @@
 	<listitem>
 	  <para>Shadow password suite configuration.</para>
 	</listitem>
+      </varlistentry>
+      <varlistentry>
+  <term><filename>/etc/login.defs.d/*.defs</filename></term>
+  <listitem>
+    <para>Additional shadow password suite configuration.</para>
+  </listitem>
       </varlistentry>
       <varlistentry>
 	<term><filename>/etc/passwd</filename></term>
@@ -317,7 +325,8 @@
       be performed on the NIS server.
     </para>
     <para>If <option>USERGROUPS_ENAB</option> is defined to <emphasis
-      remap='I'>yes</emphasis> in <filename>/etc/login.defs</filename>,
+      remap='I'>yes</emphasis> in <filename>/etc/login.defs</filename>
+      or <filename>/etc/login.defs.d/*.conf</filename>,
       <command>userdel</command> will delete the group with the same name
       as the user. To avoid inconsistencies in the passwd and group
       databases, <command>userdel</command> will check that this group is

--- a/man/usermod.8.xml
+++ b/man/usermod.8.xml
@@ -398,7 +398,8 @@
 	    No checks will be performed with regard to the
 	    <option>UID_MIN</option>, <option>UID_MAX</option>,
 	    <option>SYS_UID_MIN</option>, or <option>SYS_UID_MAX</option>
-	    from <filename>/etc/login.defs</filename>.
+	    from <filename>/etc/login.defs</filename> or
+	     <filename>/etc/login.defs.d/*.defs</filename>.
 	  </para>
 	</listitem>
       </varlistentry>
@@ -436,7 +437,8 @@
 	  <para>
 	     No checks will be performed with regard to
 	     <option>SUB_UID_MIN</option>, <option>SUB_UID_MAX</option>, or
-	     <option>SUB_UID_COUNT</option> from /etc/login.defs.
+	     <option>SUB_UID_COUNT</option> from <filename>/etc/login.defs</filename> or
+	     <filename>/etc/login.defs.d/*.defs</filename>.
 	  </para>
 	</listitem>
       </varlistentry>
@@ -456,7 +458,8 @@
 	  <para>
 	     No checks will be performed with regard to
 	     <option>SUB_UID_MIN</option>, <option>SUB_UID_MAX</option>, or
-	     <option>SUB_UID_COUNT</option> from /etc/login.defs.
+	     <option>SUB_UID_COUNT</option> from <filename>/etc/login.defs</filename> or
+	     <filename>/etc/login.defs.d/*.defs</filename>.
 	  </para>
 	</listitem>
       </varlistentry>
@@ -474,7 +477,8 @@
 	  <para>
 	     No checks will be performed with regard to
 	     <option>SUB_GID_MIN</option>, <option>SUB_GID_MAX</option>, or
-	     <option>SUB_GID_COUNT</option> from /etc/login.defs.
+	     <option>SUB_GID_COUNT</option> from <filename>/etc/login.defs</filename> or
+	     <filename>/etc/login.defs.d/*.defs</filename>.
 	  </para>
 	</listitem>
       </varlistentry>
@@ -494,7 +498,8 @@
 	  <para>
 	     No checks will be performed with regard to
 	     <option>SUB_GID_MIN</option>, <option>SUB_GID_MAX</option>, or
-	     <option>SUB_GID_COUNT</option> from /etc/login.defs.
+	     <option>SUB_GID_COUNT</option> from <filename>/etc/login.defs</filename> or
+	     <filename>/etc/login.defs.d/*.defs</filename>.
 	  </para>
 	</listitem>
       </varlistentry>
@@ -538,8 +543,9 @@
     <title>CONFIGURATION</title>
     <para>
       The following configuration variables in
-      <filename>/etc/login.defs</filename> change the behavior of this
-      tool:
+      <filename>/etc/login.defs</filename> or
+      <filename>/etc/login.defs.d/*.defs</filename>
+      change the behavior of this tool:
     </para>
     <variablelist>
       &LASTLOG_UID_MAX;
@@ -571,6 +577,12 @@
 	<term><filename>/etc/login.defs</filename></term>
 	<listitem>
 	  <para>Shadow password suite configuration.</para>
+	</listitem>
+      </varlistentry>
+      <varlistentry>
+	<term><filename>/etc/login.defs.d/*.defs</filename></term>
+	<listitem>
+	  <para>Additional shadow password suite configuration.</para>
 	</listitem>
       </varlistentry>
       <varlistentry>

--- a/man/vipw.8.xml
+++ b/man/vipw.8.xml
@@ -165,8 +165,9 @@
     <title>CONFIGURATION</title>
     <para>
       The following configuration variables in
-      <filename>/etc/login.defs</filename> change the behavior of this
-      tool:
+      <filename>/etc/login.defs</filename> or
+      <filename>/etc/login.defs.d/*.defs</filename>
+      change the behavior of this tool:
     </para>
     <variablelist>
       &USE_TCB;


### PR DESCRIPTION
Add support for optional config directory `/etc/login.defs.d/`. Some programs may create files in this directory, so if this directory exists, load all files with `.defs` suffix. If it doesn't exists, no change and load only default config file `/etc/login.defs`.