### PR TITLE
Install subid.h

### DIFF
--- a/libsubid/Makefile.am
+++ b/libsubid/Makefile.am
@@ -3,6 +3,8 @@ libsubid_la_LDFLAGS = -Wl,-soname,libsubid.so.@LIBSUBID_ABI@ \
 	-shared -version-info @LIBSUBID_ABI_MAJOR@
 libsubid_la_SOURCES = api.c
 
+pkginclude_HEADERS = subid.h
+
 MISCLIBS = \
 	$(LIBAUDIT) \
 	$(LIBSELINUX) \


### PR DESCRIPTION
Now subid.h gets installed under /usr/include/shadow/subid.h

Signed-off-by: Serge Hallyn <serge@hallyn.com>