### PR TITLE
login.defs: include HMAC_CRYPTO_ALGO key

### DIFF
--- a/etc/login.defs
+++ b/etc/login.defs
@@ -467,3 +467,13 @@ USERGROUPS_ENAB yes
 # Set to "no" to not prevent for any account (dangerous, historical default)
 
 PREVENT_NO_AUTH superuser
+
+#
+# Select the HMAC cryptography algorithm.
+# Used in pam_timestamp module to calculate the keyed-hash message
+# authentication code.
+#
+# Note: It is recommended to check hmac(3) to see the possible algorithms
+# that are available in your system.
+#
+#HMAC_CRYPTO_ALGO SHA512

--- a/lib/getdef.c
+++ b/lib/getdef.c
@@ -61,6 +61,7 @@ struct itemdef {
 	{"ENV_TZ", NULL},			\
 	{"FAILLOG_ENAB", NULL},			\
 	{"FTMP_FILE", NULL},			\
+	{"HMAC_CRYPTO_ALGO", NULL},		\
 	{"ISSUE_FILE", NULL},			\
 	{"LASTLOG_ENAB", NULL},			\
 	{"LOGIN_STRING", NULL},			\

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -136,6 +136,7 @@ login_defs_v = \
 	FAKE_SHELL.xml \
 	FTMP_FILE.xml \
 	GID_MAX.xml \
+	HMAC_CRYPTO_ALGO.xml \
 	HOME_MODE.xml \
 	HUSHLOGIN_FILE.xml \
 	ISSUE_FILE.xml \

--- a/man/login.defs.5.xml
+++ b/man/login.defs.5.xml
@@ -50,6 +50,7 @@
 <!ENTITY FAKE_SHELL            SYSTEM "login.defs.d/FAKE_SHELL.xml">
 <!ENTITY FTMP_FILE             SYSTEM "login.defs.d/FTMP_FILE.xml">
 <!ENTITY GID_MAX               SYSTEM "login.defs.d/GID_MAX.xml">
+<!ENTITY HMAC_CRYPTO_ALGO      SYSTEM "login.defs.d/HMAC_CRYPTO_ALGO.xml">
 <!ENTITY HOME_MODE             SYSTEM "login.defs.d/HOME_MODE.xml">
 <!ENTITY HUSHLOGIN_FILE        SYSTEM "login.defs.d/HUSHLOGIN_FILE.xml">
 <!ENTITY ISSUE_FILE            SYSTEM "login.defs.d/ISSUE_FILE.xml">
@@ -187,6 +188,7 @@
       &FAKE_SHELL;
       &FTMP_FILE;
       &GID_MAX; <!-- documents also GID_MIN -->
+      &HMAC_CRYPTO_ALGO;
       &HOME_MODE;
       &HUSHLOGIN_FILE;
       &ISSUE_FILE;

--- a/man/login.defs.d/HMAC_CRYPTO_ALGO.xml
+++ b/man/login.defs.d/HMAC_CRYPTO_ALGO.xml
@@ -1,0 +1,44 @@
+<!--
+   Copyright (c) 1991 - 1993, Julianne Frances Haugh
+   Copyright (c) 1991 - 1993, Chip Rosenthal
+   Copyright (c) 2007 - 2008, Nicolas François
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+   3. The name of the copyright holders or contributors may not be used to
+      endorse or promote products derived from this software without
+      specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+   PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT
+   HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+<varlistentry condition="no_pam">
+  <term><option>HMAC_CRYPTO_ALGO</option> (string)</term>
+  <listitem>
+    <para>
+      Used to select the HMAC cryptography algorithm that the pam_timestamp
+      module is going to use to calculate the keyed-hash message authentication
+      code.
+    </para>
+    <para>
+      Note: Check <refentrytitle>hmac</refentrytitle><manvolnum>3</manvolnum>
+      to see the possible algorithms that are available in your system.
+    </para>
+  </listitem>
+</varlistentry>


### PR DESCRIPTION
Include the new HMAC_CRYPTO_ALGO key that is needed by pam_timestamp to
select the algorithm that is going to be used to calculate the message
authentication code.

pam_timestamp is currently using an embedded algorithm to calculate the
HMAC message, but the idea is to improve this behaviour by relying on
openssl's implementation. On top of that, the ability to change the
algorithm with a simple configuration change allows to simplify the
process of removing unsecure algorithms.

Reference to pam's pull-request: https://github.com/linux-pam/linux-pam/pull/342
Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1947294