### PR TITLE
[WIP] libsubid: don't print error messages on stderr by default

### DIFF
--- a/lib/commonio.c
+++ b/lib/commonio.c
@@ -144,7 +144,7 @@ static int do_lock_file (const char *file, const char *lock, bool log)
 	fd = open (file, O_CREAT | O_TRUNC | O_WRONLY, 0600);
 	if (-1 == fd) {
 		if (log) {
-			(void) fprintf (stderr,
+			(void) fprintf (shadow_logfd,
 			                "%s: %s: %s\n",
 			                Prog, file, strerror (errno));
 		}
@@ -156,7 +156,7 @@ static int do_lock_file (const char *file, const char *lock, bool log)
 	len = (ssize_t) strlen (buf) + 1;
 	if (write (fd, buf, (size_t) len) != len) {
 		if (log) {
-			(void) fprintf (stderr,
+			(void) fprintf (shadow_logfd,
 			                "%s: %s file write error: %s\n",
 			                Prog, file, strerror (errno));
 		}
@@ -166,7 +166,7 @@ static int do_lock_file (const char *file, const char *lock, bool log)
 	}
 	if (fdatasync (fd) == -1) {
 		if (log) {
-			(void) fprintf (stderr,
+			(void) fprintf (shadow_logfd,
 			                "%s: %s file sync error: %s\n",
 			                Prog, file, strerror (errno));
 		}
@@ -179,7 +179,7 @@ static int do_lock_file (const char *file, const char *lock, bool log)
 	if (link (file, lock) == 0) {
 		retval = check_link_count (file);
 		if ((0==retval) && log) {
-			(void) fprintf (stderr,
+			(void) fprintf (shadow_logfd,
 			                "%s: %s: lock file already used\n",
 			                Prog, file);
 		}
@@ -190,7 +190,7 @@ static int do_lock_file (const char *file, const char *lock, bool log)
 	fd = open (lock, O_RDWR);
 	if (-1 == fd) {
 		if (log) {
-			(void) fprintf (stderr,
+			(void) fprintf (shadow_logfd,
 			                "%s: %s: %s\n",
 			                Prog, lock, strerror (errno));
 		}
@@ -202,7 +202,7 @@ static int do_lock_file (const char *file, const char *lock, bool log)
 	close (fd);
 	if (len <= 0) {
 		if (log) {
-			(void) fprintf (stderr,
+			(void) fprintf (shadow_logfd,
 			                "%s: existing lock file %s without a PID\n",
 			                Prog, lock);
 		}
@@ -213,7 +213,7 @@ static int do_lock_file (const char *file, const char *lock, bool log)
 	buf[len] = '\0';
 	if (get_pid (buf, &pid) == 0) {
 		if (log) {
-			(void) fprintf (stderr,
+			(void) fprintf (shadow_logfd,
 			                "%s: existing lock file %s with an invalid PID '%s'\n",
 			                Prog, lock, buf);
 		}
@@ -223,7 +223,7 @@ static int do_lock_file (const char *file, const char *lock, bool log)
 	}
 	if (kill (pid, 0) == 0) {
 		if (log) {
-			(void) fprintf (stderr,
+			(void) fprintf (shadow_logfd,
 			                "%s: lock %s already used by PID %lu\n",
 			                Prog, lock, (unsigned long) pid);
 		}
@@ -233,7 +233,7 @@ static int do_lock_file (const char *file, const char *lock, bool log)
 	}
 	if (unlink (lock) != 0) {
 		if (log) {
-			(void) fprintf (stderr,
+			(void) fprintf (shadow_logfd,
 			                "%s: cannot get lock %s: %s\n",
 			                Prog, lock, strerror (errno));
 		}
@@ -245,13 +245,13 @@ static int do_lock_file (const char *file, const char *lock, bool log)
 	if (link (file, lock) == 0) {
 		retval = check_link_count (file);
 		if ((0==retval) && log) {
-			(void) fprintf (stderr,
+			(void) fprintf (shadow_logfd,
 			                "%s: %s: lock file already used\n",
 			                Prog, file);
 		}
 	} else {
 		if (log) {
-			(void) fprintf (stderr,
+			(void) fprintf (shadow_logfd,
 			                "%s: cannot get lock %s: %s\n",
 			                Prog, lock, strerror (errno));
 		}
@@ -442,7 +442,7 @@ int commonio_lock (struct commonio_db *db)
 		if (0 == lock_count) {
 			if (lckpwdf () == -1) {
 				if (geteuid () != 0) {
-					(void) fprintf (stderr,
+					(void) fprintf (shadow_logfd,
 					                "%s: Permission denied.\n",
 					                Prog);
 				}
@@ -478,7 +478,7 @@ int commonio_lock (struct commonio_db *db)
 		}
 		/* no unnecessary retries on "permission denied" errors */
 		if (geteuid () != 0) {
-			(void) fprintf (stderr, "%s: Permission denied.\n",
+			(void) fprintf (shadow_logfd, "%s: Permission denied.\n",
 			                Prog);
 			return 0;
 		}
@@ -1109,7 +1109,7 @@ int commonio_update (struct commonio_db *db, const void *eptr)
 	p = find_entry_by_name (db, db->ops->getname (eptr));
 	if (NULL != p) {
 		if (next_entry_by_name (db, p->next, db->ops->getname (eptr)) != NULL) {
-			fprintf (stderr, _("Multiple entries named '%s' in %s. Please fix this with pwck or grpck.\n"), db->ops->getname (eptr), db->filename);
+			fprintf (shadow_logfd, _("Multiple entries named '%s' in %s. Please fix this with pwck or grpck.\n"), db->ops->getname (eptr), db->filename);
 			db->ops->free (nentry);
 			return 0;
 		}
@@ -1214,7 +1214,7 @@ int commonio_remove (struct commonio_db *db, const char *name)
 		return 0;
 	}
 	if (next_entry_by_name (db, p->next, name) != NULL) {
-		fprintf (stderr, _("Multiple entries named '%s' in %s. Please fix this with pwck or grpck.\n"), name, db->filename);
+		fprintf (shadow_logfd, _("Multiple entries named '%s' in %s. Please fix this with pwck or grpck.\n"), name, db->filename);
 		return 0;
 	}
 

--- a/lib/encrypt.c
+++ b/lib/encrypt.c
@@ -84,7 +84,7 @@
 				method = &nummethod[0];
 			}
 		}
-		(void) fprintf (stderr,
+		(void) fprintf (shadow_logfd,
 		                _("crypt method not supported by libcrypt? (%s)\n"),
 		                method);
 		exit (EXIT_FAILURE);

--- a/lib/getdef.c
+++ b/lib/getdef.c
@@ -266,7 +266,7 @@ int getdef_num (const char *item, int dflt)
 	if (   (getlong (d->value, &val) == 0)
 	    || (val > INT_MAX)
 	    || (val < INT_MIN)) {
-		fprintf (stderr,
+		fprintf (shadow_logfd,
 		         _("configuration error - cannot parse %s value: '%s'"),
 		         item, d->value);
 		return dflt;
@@ -301,7 +301,7 @@ unsigned int getdef_unum (const char *item, unsigned int dflt)
 	if (   (getlong (d->value, &val) == 0)
 	    || (val < 0)
 	    || (val > INT_MAX)) {
-		fprintf (stderr,
+		fprintf (shadow_logfd,
 		         _("configuration error - cannot parse %s value: '%s'"),
 		         item, d->value);
 		return dflt;
@@ -334,7 +334,7 @@ long getdef_long (const char *item, long dflt)
 	}
 
 	if (getlong (d->value, &val) == 0) {
-		fprintf (stderr,
+		fprintf (shadow_logfd,
 		         _("configuration error - cannot parse %s value: '%s'"),
 		         item, d->value);
 		return dflt;
@@ -367,7 +367,7 @@ unsigned long getdef_ulong (const char *item, unsigned long dflt)
 
 	if (getulong (d->value, &val) == 0) {
 		/* FIXME: we should have a getulong */
-		fprintf (stderr,
+		fprintf (shadow_logfd,
 		         _("configuration error - cannot parse %s value: '%s'"),
 		         item, d->value);
 		return dflt;
@@ -405,7 +405,7 @@ int putdef_str (const char *name, const char *value)
 	cp = strdup (value);
 	if (NULL == cp) {
 		(void) fputs (_("Could not allocate space for config info.\n"),
-		              stderr);
+		              shadow_logfd);
 		SYSLOG ((LOG_ERR, "could not allocate space for config info"));
 		return -1;
 	}
@@ -449,7 +449,7 @@ static /*@observer@*/ /*@null@*/struct itemdef *def_find (const char *name)
 			goto out;
 		}
 	}
-	fprintf (stderr,
+	fprintf (shadow_logfd,
 	         _("configuration error - unknown item '%s' (notify administrator)\n"),
 	         name);
 	SYSLOG ((LOG_CRIT, "unknown configuration item `%s'", name));

--- a/lib/nscd.c
+++ b/lib/nscd.c
@@ -25,13 +25,13 @@ int nscd_flush_cache (const char *service)
 
 	if (run_command (cmd, spawnedArgs, spawnedEnv, &status) != 0) {
 		/* run_command writes its own more detailed message. */
-		(void) fprintf (stderr, _(MSG_NSCD_FLUSH_CACHE_FAILED), Prog);
+		(void) fprintf (shadow_logfd, _(MSG_NSCD_FLUSH_CACHE_FAILED), Prog);
 		return -1;
 	}
 
 	code = WEXITSTATUS (status);
 	if (!WIFEXITED (status)) {
-		(void) fprintf (stderr,
+		(void) fprintf (shadow_logfd,
 		                _("%s: nscd did not terminate normally (signal %d)\n"),
 		                Prog, WTERMSIG (status));
 		return -1;
@@ -43,9 +43,9 @@ int nscd_flush_cache (const char *service)
 		/* nscd is installed, but it isn't active. */
 		return 0;
 	} else if (code != 0) {
-		(void) fprintf (stderr, _("%s: nscd exited with status %d\n"),
+		(void) fprintf (shadow_logfd, _("%s: nscd exited with status %d\n"),
 		                Prog, code);
-		(void) fprintf (stderr, _(MSG_NSCD_FLUSH_CACHE_FAILED), Prog);
+		(void) fprintf (shadow_logfd, _(MSG_NSCD_FLUSH_CACHE_FAILED), Prog);
 		return -1;
 	}
 

--- a/lib/prototypes.h
+++ b/lib/prototypes.h
@@ -59,7 +59,8 @@
 #include "defines.h"
 #include "commonio.h"
 
-extern /*@observer@*/ const char *Prog;
+extern /*@observer@*/ const char *Prog; /* Program name showed in error messages */
+extern FILE *shadow_logfd;  /* file descripter to which error messages are printed */
 
 /* addgrps.c */
 #if defined (HAVE_SETGROUPS) && ! defined (USE_PAM)

--- a/lib/run_part.c
+++ b/lib/run_part.c
@@ -7,6 +7,7 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <lib/prototypes.h>
 
 int run_part (char *script_path, char *name, char *action)
 {
@@ -83,7 +84,7 @@ int run_parts (char *directory, char *name, char *action)
 		free (s);
 
 		if (execute_result!=0) {
-			fprintf (stderr,
+			fprintf (shadow_logfd,
 				"%s: did not exit cleanly.\n",
 			    namelist[n]->d_name);
 			for (; n<scanlist; n++) {

--- a/lib/selinux.c
+++ b/lib/selinux.c
@@ -154,7 +154,7 @@ static int selinux_log_cb (int type, const char *fmt, ...) {
 			    && (errno != EAFNOSUPPORT)) {
 
 			    (void) fputs (_("Cannot open audit interface.\n"),
-			              stderr);
+			              shadow_logfd);
 			    SYSLOG ((LOG_WARN, "Cannot open audit interface."));
 			}
 		}
@@ -207,7 +207,7 @@ int check_selinux_permit (const char *perm_name)
 	selinux_set_callback (SELINUX_CB_LOG, (union selinux_callback) selinux_log_cb);
 
 	if (getprevcon_raw (&user_context_raw) != 0) {
-		fprintf (stderr,
+		fprintf (shadow_logfd,
 		    _("%s: can not get previous SELinux process context: %s\n"),
 		    Prog, strerror (errno));
 		SYSLOG ((LOG_WARN,

--- a/lib/semanage.c
+++ b/lib/semanage.c
@@ -69,7 +69,7 @@ static void semanage_error_callback (unused void *varg,
 	switch (semanage_msg_get_level (handle)) {
 	case SEMANAGE_MSG_ERR:
 	case SEMANAGE_MSG_WARN:
-		fprintf (stderr, _("[libsemanage]: %s\n"), message);
+		fprintf (shadow_logfd, _("[libsemanage]: %s\n"), message);
 		break;
 	case SEMANAGE_MSG_INFO:
 		/* nop */
@@ -87,7 +87,7 @@ static semanage_handle_t *semanage_init (void)
 
 	handle = semanage_handle_create ();
 	if (NULL == handle) {
-		fprintf (stderr,
+		fprintf (shadow_logfd,
 		         _("Cannot create SELinux management handle\n"));
 		return NULL;
 	}
@@ -96,26 +96,26 @@ static semanage_handle_t *semanage_init (void)
 
 	ret = semanage_is_managed (handle);
 	if (ret != 1) {
-		fprintf (stderr, _("SELinux policy not managed\n"));
+		fprintf (shadow_logfd, _("SELinux policy not managed\n"));
 		goto fail;
 	}
 
 	ret = semanage_access_check (handle);
 	if (ret < SEMANAGE_CAN_READ) {
-		fprintf (stderr, _("Cannot read SELinux policy store\n"));
+		fprintf (shadow_logfd, _("Cannot read SELinux policy store\n"));
 		goto fail;
 	}
 
 	ret = semanage_connect (handle);
 	if (ret != 0) {
-		fprintf (stderr,
+		fprintf (shadow_logfd,
 		         _("Cannot establish SELinux management connection\n"));
 		goto fail;
 	}
 
 	ret = semanage_begin_transaction (handle);
 	if (ret != 0) {
-		fprintf (stderr, _("Cannot begin SELinux transaction\n"));
+		fprintf (shadow_logfd, _("Cannot begin SELinux transaction\n"));
 		goto fail;
 	}
 
@@ -137,7 +137,7 @@ static int semanage_user_mod (semanage_handle_t *handle,
 
 	semanage_seuser_query (handle, key, &seuser);
 	if (NULL == seuser) {
-		fprintf (stderr,
+		fprintf (shadow_logfd,
 		         _("Could not query seuser for %s\n"), login_name);
 		ret = 1;
 		goto done;
@@ -145,7 +145,7 @@ static int semanage_user_mod (semanage_handle_t *handle,
 
 	ret = semanage_seuser_set_mlsrange (handle, seuser, DEFAULT_SERANGE);
 	if (ret != 0) {
-		fprintf (stderr,
+		fprintf (shadow_logfd,
 		         _("Could not set serange for %s\n"), login_name);
 		ret = 1;
 		goto done;
@@ -153,7 +153,7 @@ static int semanage_user_mod (semanage_handle_t *handle,
 
 	ret = semanage_seuser_set_sename (handle, seuser, seuser_name);
 	if (ret != 0) {
-		fprintf (stderr,
+		fprintf (shadow_logfd,
 		         _("Could not set sename for %s\n"),
 		         login_name);
 		ret = 1;
@@ -162,7 +162,7 @@ static int semanage_user_mod (semanage_handle_t *handle,
 
 	ret = semanage_seuser_modify_local (handle, key, seuser);
 	if (ret != 0) {
-		fprintf (stderr,
+		fprintf (shadow_logfd,
 		         _("Could not modify login mapping for %s\n"),
 		         login_name);
 		ret = 1;
@@ -186,7 +186,7 @@ static int semanage_user_add (semanage_handle_t *handle,
 
 	ret = semanage_seuser_create (handle, &seuser);
 	if (ret != 0) {
-		fprintf (stderr,
+		fprintf (shadow_logfd,
 		         _("Cannot create SELinux login mapping for %s\n"),
 		         login_name);
 		ret = 1;
@@ -195,14 +195,14 @@ static int semanage_user_add (semanage_handle_t *handle,
 
 	ret = semanage_seuser_set_name (handle, seuser, login_name);
 	if (ret != 0) {
-		fprintf (stderr, _("Could not set name for %s\n"), login_name);
+		fprintf (shadow_logfd, _("Could not set name for %s\n"), login_name);
 		ret = 1;
 		goto done;
 	}
 
 	ret = semanage_seuser_set_mlsrange (handle, seuser, DEFAULT_SERANGE);
 	if (ret != 0) {
-		fprintf (stderr,
+		fprintf (shadow_logfd,
 		         _("Could not set serange for %s\n"),
 		         login_name);
 		ret = 1;
@@ -211,7 +211,7 @@ static int semanage_user_add (semanage_handle_t *handle,
 
 	ret = semanage_seuser_set_sename (handle, seuser, seuser_name);
 	if (ret != 0) {
-		fprintf (stderr,
+		fprintf (shadow_logfd,
 		         _("Could not set SELinux user for %s\n"),
 		         login_name);
 		ret = 1;
@@ -220,7 +220,7 @@ static int semanage_user_add (semanage_handle_t *handle,
 
 	ret = semanage_seuser_modify_local (handle, key, seuser);
 	if (ret != 0) {
-		fprintf (stderr,
+		fprintf (shadow_logfd,
 		         _("Could not add login mapping for %s\n"),
 		         login_name);
 		ret = 1;
@@ -248,21 +248,21 @@ int set_seuser (const char *login_name, const char *seuser_name)
 
 	handle = semanage_init ();
 	if (NULL == handle) {
-		fprintf (stderr, _("Cannot init SELinux management\n"));
+		fprintf (shadow_logfd, _("Cannot init SELinux management\n"));
 		ret = 1;
 		goto done;
 	}
 
 	ret = semanage_seuser_key_create (handle, login_name, &key);
 	if (ret != 0) {
-		fprintf (stderr, _("Cannot create SELinux user key\n"));
+		fprintf (shadow_logfd, _("Cannot create SELinux user key\n"));
 		ret = 1;
 		goto done;
 	}
 
 	ret = semanage_seuser_exists (handle, key, &seuser_exists);
 	if (ret < 0) {
-		fprintf (stderr, _("Cannot verify the SELinux user\n"));
+		fprintf (shadow_logfd, _("Cannot verify the SELinux user\n"));
 		ret = 1;
 		goto done;
 	}
@@ -270,7 +270,7 @@ int set_seuser (const char *login_name, const char *seuser_name)
 	if (0 != seuser_exists) {
 		ret = semanage_user_mod (handle, key, login_name, seuser_name);
 		if (ret != 0) {
-			fprintf (stderr,
+			fprintf (shadow_logfd,
 			         _("Cannot modify SELinux user mapping\n"));
 			ret = 1;
 			goto done;
@@ -278,7 +278,7 @@ int set_seuser (const char *login_name, const char *seuser_name)
 	} else {
 		ret = semanage_user_add (handle, key, login_name, seuser_name);
 		if (ret != 0) {
-			fprintf (stderr,
+			fprintf (shadow_logfd,
 			         _("Cannot add SELinux user mapping\n"));
 			ret = 1;
 			goto done;
@@ -287,7 +287,7 @@ int set_seuser (const char *login_name, const char *seuser_name)
 
 	ret = semanage_commit (handle);
 	if (ret < 0) {
-		fprintf (stderr, _("Cannot commit SELinux transaction\n"));
+		fprintf (shadow_logfd, _("Cannot commit SELinux transaction\n"));
 		ret = 1;
 		goto done;
 	}
@@ -310,27 +310,27 @@ int del_seuser (const char *login_name)
 
 	handle = semanage_init ();
 	if (NULL == handle) {
-		fprintf (stderr, _("Cannot init SELinux management\n"));
+		fprintf (shadow_logfd, _("Cannot init SELinux management\n"));
 		ret = 1;
 		goto done;
 	}
 
 	ret = semanage_seuser_key_create (handle, login_name, &key);
 	if (ret != 0) {
-		fprintf (stderr, _("Cannot create SELinux user key\n"));
+		fprintf (shadow_logfd, _("Cannot create SELinux user key\n"));
 		ret = 1;
 		goto done;
 	}
 
 	ret = semanage_seuser_exists (handle, key, &exists);
 	if (ret < 0) {
-		fprintf (stderr, _("Cannot verify the SELinux user\n"));
+		fprintf (shadow_logfd, _("Cannot verify the SELinux user\n"));
 		ret = 1;
 		goto done;
 	}
 
 	if (0 == exists) {
-		fprintf (stderr,
+		fprintf (shadow_logfd,
 		         _("Login mapping for %s is not defined, OK if default mapping was used\n"), 
 		         login_name);
 		ret = 0;  /* probably default mapping */
@@ -339,13 +339,13 @@ int del_seuser (const char *login_name)
 
 	ret = semanage_seuser_exists_local (handle, key, &exists);
 	if (ret < 0) {
-		fprintf (stderr, _("Cannot verify the SELinux user\n"));
+		fprintf (shadow_logfd, _("Cannot verify the SELinux user\n"));
 		ret = 1;
 		goto done;
 	}
 
 	if (0 == exists) {
-		fprintf (stderr,
+		fprintf (shadow_logfd,
 		         _("Login mapping for %s is defined in policy, cannot be deleted\n"), 
 		         login_name);
 		ret = 0; /* Login mapping defined in policy can't be deleted */
@@ -354,7 +354,7 @@ int del_seuser (const char *login_name)
 
 	ret = semanage_seuser_del_local (handle, key);
 	if (ret != 0) {
-		fprintf (stderr,
+		fprintf (shadow_logfd,
 		         _("Could not delete login mapping for %s"),
 		         login_name);
 		ret = 1;
@@ -363,7 +363,7 @@ int del_seuser (const char *login_name)
 
 	ret = semanage_commit (handle);
 	if (ret < 0) {
-		fprintf (stderr, _("Cannot commit SELinux transaction\n"));
+		fprintf (shadow_logfd, _("Cannot commit SELinux transaction\n"));
 		ret = 1;
 		goto done;
 	}

--- a/lib/spawn.c
+++ b/lib/spawn.c
@@ -48,7 +48,7 @@ int run_command (const char *cmd, const char *argv[],
 	}
 
 	(void) fflush (stdout);
-	(void) fflush (stderr);
+	(void) fflush (shadow_logfd);
 
 	pid = fork ();
 	if (0 == pid) {
@@ -57,11 +57,11 @@ int run_command (const char *cmd, const char *argv[],
 		if (ENOENT == errno) {
 			exit (E_CMD_NOTFOUND);
 		}
-		fprintf (stderr, "%s: cannot execute %s: %s\n",
+		fprintf (shadow_logfd, "%s: cannot execute %s: %s\n",
 		         Prog, cmd, strerror (errno));
 		exit (E_CMD_NOEXEC);
 	} else if ((pid_t)-1 == pid) {
-		fprintf (stderr, "%s: cannot execute %s: %s\n",
+		fprintf (shadow_logfd, "%s: cannot execute %s: %s\n",
 		         Prog, cmd, strerror (errno));
 		return -1;
 	}
@@ -74,7 +74,7 @@ int run_command (const char *cmd, const char *argv[],
 	         || ((pid_t)-1 != wpid && wpid != pid));
 
 	if ((pid_t)-1 == wpid) {
-		fprintf (stderr, "%s: waitpid (status: %d): %s\n",
+		fprintf (shadow_logfd, "%s: waitpid (status: %d): %s\n",
 		         Prog, *status, strerror (errno));
 		return -1;
 	}

--- a/libmisc/addgrps.c
+++ b/libmisc/addgrps.c
@@ -93,7 +93,7 @@ int add_groups (const char *list)
 
 		grp = getgrnam (token); /* local, no need for xgetgrnam */
 		if (NULL == grp) {
-			fprintf (stderr, _("Warning: unknown group %s\n"),
+			fprintf (shadow_logfd, _("Warning: unknown group %s\n"),
 				 token);
 			continue;
 		}
@@ -105,7 +105,7 @@ int add_groups (const char *list)
 		}
 
 		if (ngroups >= sysconf (_SC_NGROUPS_MAX)) {
-			fputs (_("Warning: too many groups\n"), stderr);
+			fputs (_("Warning: too many groups\n"), shadow_logfd);
 			break;
 		}
 		tmp = (gid_t *) realloc (grouplist, (size_t)(ngroups + 1) * sizeof (GETGROUPS_T));

--- a/libmisc/audit_help.c
+++ b/libmisc/audit_help.c
@@ -59,7 +59,7 @@ void audit_help_open (void)
 			return;
 		}
 		(void) fputs (_("Cannot open audit interface - aborting.\n"),
-		              stderr);
+		              shadow_logfd);
 		exit (EXIT_FAILURE);
 	}
 }

--- a/libmisc/chowntty.c
+++ b/libmisc/chowntty.c
@@ -75,7 +75,7 @@ void chown_tty (const struct passwd *info)
 	    || (fchmod (STDIN_FILENO, (mode_t)getdef_num ("TTYPERM", 0600)) != 0)) {
 		int err = errno;
 
-		fprintf (stderr,
+		fprintf (shadow_logfd,
 		         _("Unable to change owner or mode of tty stdin: %s"),
 		         strerror (err));
 		SYSLOG ((LOG_WARN,

--- a/libmisc/cleanup_group.c
+++ b/libmisc/cleanup_group.c
@@ -203,7 +203,7 @@ void cleanup_report_del_group_gshadow (void *group_name)
 void cleanup_unlock_group (unused void *arg)
 {
 	if (gr_unlock () == 0) {
-		fprintf (stderr,
+		fprintf (shadow_logfd,
 		         _("%s: failed to unlock %s\n"),
 		         Prog, gr_dbname ());
 		SYSLOG ((LOG_ERR, "failed to unlock %s", gr_dbname ()));
@@ -223,7 +223,7 @@ void cleanup_unlock_group (unused void *arg)
 void cleanup_unlock_gshadow (unused void *arg)
 {
 	if (sgr_unlock () == 0) {
-		fprintf (stderr,
+		fprintf (shadow_logfd,
 		         _("%s: failed to unlock %s\n"),
 		         Prog, sgr_dbname ());
 		SYSLOG ((LOG_ERR, "failed to unlock %s", sgr_dbname ()));

--- a/libmisc/cleanup_user.c
+++ b/libmisc/cleanup_user.c
@@ -120,7 +120,7 @@ void cleanup_report_add_user_shadow (void *user_name)
 void cleanup_unlock_passwd (unused void *arg)
 {
 	if (pw_unlock () == 0) {
-		fprintf (stderr,
+		fprintf (shadow_logfd,
 		         _("%s: failed to unlock %s\n"),
 		         Prog, pw_dbname ());
 		SYSLOG ((LOG_ERR, "failed to unlock %s", pw_dbname ()));
@@ -139,7 +139,7 @@ void cleanup_unlock_passwd (unused void *arg)
 void cleanup_unlock_shadow (unused void *arg)
 {
 	if (spw_unlock () == 0) {
-		fprintf (stderr,
+		fprintf (shadow_logfd,
 		         _("%s: failed to unlock %s\n"),
 		         Prog, spw_dbname ());
 		SYSLOG ((LOG_ERR, "failed to unlock %s", spw_dbname ()));

--- a/libmisc/copydir.c
+++ b/libmisc/copydir.c
@@ -125,11 +125,11 @@ static void error_acl (struct error_context *ctx, const char *fmt, ...)
 	}
 
 	va_start (ap, fmt);
-	(void) fprintf (stderr, _("%s: "), Prog);
-	if (vfprintf (stderr, fmt, ap) != 0) {
-		(void) fputs (_(": "), stderr);
+	(void) fprintf (shadow_logfd, _("%s: "), Prog);
+	if (vfprintf (shadow_logfd, fmt, ap) != 0) {
+		(void) fputs (_(": "), shadow_logfd);
 	}
-	(void) fprintf (stderr, "%s\n", strerror (errno));
+	(void) fprintf (shadow_logfd, "%s\n", strerror (errno));
 	va_end (ap);
 }
 
@@ -248,7 +248,7 @@ int copy_tree (const char *src_root, const char *dst_root,
 		}
 
 		if (!S_ISDIR (sb.st_mode)) {
-			fprintf (stderr,
+			fprintf (shadow_logfd,
 			         "%s: %s is not a directory",
 			         Prog, src_root);
 			return -1;

--- a/libmisc/env.c
+++ b/libmisc/env.c
@@ -171,7 +171,7 @@ void addenv (const char *string, /*@null@*/const char *value)
 			}
 			newenvp = __newenvp;
 		} else {
-			(void) fputs (_("Environment overflow\n"), stderr);
+			(void) fputs (_("Environment overflow\n"), shadow_logfd);
 			newenvc--;
 			free (newenvp[newenvc]);
 		}

--- a/libmisc/find_new_gid.c
+++ b/libmisc/find_new_gid.c
@@ -74,7 +74,7 @@ static int get_ranges (bool sys_group, gid_t *min_id, gid_t *max_id,
 
 		/* Check that the ranges make sense */
 		if (*max_id < *min_id) {
-			(void) fprintf (stderr,
+			(void) fprintf (shadow_logfd,
                             _("%s: Invalid configuration: SYS_GID_MIN (%lu), "
                               "GID_MIN (%lu), SYS_GID_MAX (%lu)\n"),
                             Prog, (unsigned long) *min_id,
@@ -97,7 +97,7 @@ static int get_ranges (bool sys_group, gid_t *min_id, gid_t *max_id,
 
 		/* Check that the ranges make sense */
 		if (*max_id < *min_id) {
-			(void) fprintf (stderr,
+			(void) fprintf (shadow_logfd,
 					_("%s: Invalid configuration: GID_MIN (%lu), "
 					  "GID_MAX (%lu)\n"),
 					Prog, (unsigned long) *min_id,
@@ -213,7 +213,7 @@ int find_new_gid (bool sys_group,
 			 * more likely to want to stop and address the
 			 * issue.
 			 */
-			fprintf (stderr,
+			fprintf (shadow_logfd,
 				_("%s: Encountered error attempting to use "
 				  "preferred GID: %s\n"),
 				Prog, strerror (result));
@@ -243,7 +243,7 @@ int find_new_gid (bool sys_group,
 	/* Create an array to hold all of the discovered GIDs */
 	used_gids = malloc (sizeof (bool) * (gid_max +1));
 	if (NULL == used_gids) {
-		fprintf (stderr,
+		fprintf (shadow_logfd,
 			 _("%s: failed to allocate memory: %s\n"),
 			 Prog, strerror (errno));
 		return -1;
@@ -323,7 +323,7 @@ int find_new_gid (bool sys_group,
 				 *
 				 */
 				if (!nospam) {
-					fprintf (stderr,
+					fprintf (shadow_logfd,
 						_("%s: Can't get unique system GID (%s). "
 						  "Suppressing additional messages.\n"),
 						Prog, strerror (result));
@@ -366,7 +366,7 @@ int find_new_gid (bool sys_group,
 					 *
 					 */
 					if (!nospam) {
-						fprintf (stderr,
+						fprintf (shadow_logfd,
 							_("%s: Can't get unique system GID (%s). "
 							  "Suppressing additional messages.\n"),
 							Prog, strerror (result));
@@ -426,7 +426,7 @@ int find_new_gid (bool sys_group,
 				 *
 				 */
 				if (!nospam) {
-					fprintf (stderr,
+					fprintf (shadow_logfd,
 						_("%s: Can't get unique GID (%s). "
 						  "Suppressing additional messages.\n"),
 						Prog, strerror (result));
@@ -469,7 +469,7 @@ int find_new_gid (bool sys_group,
 					 *
 					 */
 					if (!nospam) {
-						fprintf (stderr,
+						fprintf (shadow_logfd,
 							_("%s: Can't get unique GID (%s). "
 							  "Suppressing additional messages.\n"),
 							Prog, strerror (result));
@@ -488,7 +488,7 @@ int find_new_gid (bool sys_group,
 	}
 
 	/* The code reached here and found no available IDs in the range */
-	fprintf (stderr,
+	fprintf (shadow_logfd,
 		_("%s: Can't get unique GID (no more available GIDs)\n"),
 		Prog);
 	SYSLOG ((LOG_WARN, "no more available GIDs on the system"));

--- a/libmisc/find_new_sub_gids.c
+++ b/libmisc/find_new_sub_gids.c
@@ -60,7 +60,7 @@ int find_new_sub_gids (gid_t *range_start, unsigned long *range_count)
 	count = getdef_ulong ("SUB_GID_COUNT", 65536);
 
 	if (min > max || count >= max || (min + count - 1) > max) {
-		(void) fprintf (stderr,
+		(void) fprintf (shadow_logfd,
 				_("%s: Invalid configuration: SUB_GID_MIN (%lu),"
 				  " SUB_GID_MAX (%lu), SUB_GID_COUNT (%lu)\n"),
 			Prog, min, max, count);
@@ -69,7 +69,7 @@ int find_new_sub_gids (gid_t *range_start, unsigned long *range_count)
 
 	start = sub_gid_find_free_range(min, max, count);
 	if (start == (gid_t)-1) {
-		fprintf (stderr,
+		fprintf (shadow_logfd,
 		         _("%s: Can't get unique subordinate GID range\n"),
 		         Prog);
 		SYSLOG ((LOG_WARN, "no more available subordinate GIDs on the system"));

--- a/libmisc/find_new_sub_uids.c
+++ b/libmisc/find_new_sub_uids.c
@@ -60,7 +60,7 @@ int find_new_sub_uids (uid_t *range_start, unsigned long *range_count)
 	count = getdef_ulong ("SUB_UID_COUNT", 65536);
 
 	if (min > max || count >= max || (min + count - 1) > max) {
-		(void) fprintf (stderr,
+		(void) fprintf (shadow_logfd,
 				_("%s: Invalid configuration: SUB_UID_MIN (%lu),"
 				  " SUB_UID_MAX (%lu), SUB_UID_COUNT (%lu)\n"),
 			Prog, min, max, count);
@@ -69,7 +69,7 @@ int find_new_sub_uids (uid_t *range_start, unsigned long *range_count)
 
 	start = sub_uid_find_free_range(min, max, count);
 	if (start == (uid_t)-1) {
-		fprintf (stderr,
+		fprintf (shadow_logfd,
 		         _("%s: Can't get unique subordinate UID range\n"),
 		         Prog);
 		SYSLOG ((LOG_WARN, "no more available subordinate UIDs on the system"));

--- a/libmisc/find_new_uid.c
+++ b/libmisc/find_new_uid.c
@@ -74,7 +74,7 @@ static int get_ranges (bool sys_user, uid_t *min_id, uid_t *max_id,
 
 		/* Check that the ranges make sense */
 		if (*max_id < *min_id) {
-			(void) fprintf (stderr,
+			(void) fprintf (shadow_logfd,
                             _("%s: Invalid configuration: SYS_UID_MIN (%lu), "
                               "UID_MIN (%lu), SYS_UID_MAX (%lu)\n"),
                             Prog, (unsigned long) *min_id,
@@ -97,7 +97,7 @@ static int get_ranges (bool sys_user, uid_t *min_id, uid_t *max_id,
 
 		/* Check that the ranges make sense */
 		if (*max_id < *min_id) {
-			(void) fprintf (stderr,
+			(void) fprintf (shadow_logfd,
 					_("%s: Invalid configuration: UID_MIN (%lu), "
 					  "UID_MAX (%lu)\n"),
 					Prog, (unsigned long) *min_id,
@@ -213,7 +213,7 @@ int find_new_uid(bool sys_user,
 			 * more likely to want to stop and address the
 			 * issue.
 			 */
-			fprintf (stderr,
+			fprintf (shadow_logfd,
 				_("%s: Encountered error attempting to use "
 				  "preferred UID: %s\n"),
 				Prog, strerror (result));
@@ -243,7 +243,7 @@ int find_new_uid(bool sys_user,
 	/* Create an array to hold all of the discovered UIDs */
 	used_uids = malloc (sizeof (bool) * (uid_max +1));
 	if (NULL == used_uids) {
-		fprintf (stderr,
+		fprintf (shadow_logfd,
 			 _("%s: failed to allocate memory: %s\n"),
 			 Prog, strerror (errno));
 		return -1;
@@ -323,7 +323,7 @@ int find_new_uid(bool sys_user,
 				 *
 				 */
 				if (!nospam) {
-					fprintf (stderr,
+					fprintf (shadow_logfd,
 						_("%s: Can't get unique system UID (%s). "
 						  "Suppressing additional messages.\n"),
 						Prog, strerror (result));
@@ -366,7 +366,7 @@ int find_new_uid(bool sys_user,
 					 *
 					 */
 					if (!nospam) {
-						fprintf (stderr,
+						fprintf (shadow_logfd,
 							_("%s: Can't get unique system UID (%s). "
 							  "Suppressing additional messages.\n"),
 							Prog, strerror (result));
@@ -426,7 +426,7 @@ int find_new_uid(bool sys_user,
 				 *
 				 */
 				if (!nospam) {
-					fprintf (stderr,
+					fprintf (shadow_logfd,
 						_("%s: Can't get unique UID (%s). "
 						  "Suppressing additional messages.\n"),
 						Prog, strerror (result));
@@ -469,7 +469,7 @@ int find_new_uid(bool sys_user,
 					 *
 					 */
 					if (!nospam) {
-						fprintf (stderr,
+						fprintf (shadow_logfd,
 							_("%s: Can't get unique UID (%s). "
 							  "Suppressing additional messages.\n"),
 							Prog, strerror (result));
@@ -488,7 +488,7 @@ int find_new_uid(bool sys_user,
 	}
 
 	/* The code reached here and found no available IDs in the range */
-	fprintf (stderr,
+	fprintf (shadow_logfd,
 		_("%s: Can't get unique UID (no more available UIDs)\n"),
 		Prog);
 	SYSLOG ((LOG_WARN, "no more available UIDs on the system"));

--- a/libmisc/gettime.c
+++ b/libmisc/gettime.c
@@ -61,23 +61,23 @@
 	epoch = strtoull (source_date_epoch, &endptr, 10);
 	if ((errno == ERANGE && (epoch == ULLONG_MAX || epoch == 0))
 			|| (errno != 0 && epoch == 0)) {
-		fprintf (stderr,
+		fprintf (shadow_logfd,
 			 _("Environment variable $SOURCE_DATE_EPOCH: strtoull: %s\n"),
 			 strerror(errno));
 	} else if (endptr == source_date_epoch) {
-		fprintf (stderr,
+		fprintf (shadow_logfd,
 			 _("Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"),
 			 endptr);
 	} else if (*endptr != '\0') {
-		fprintf (stderr,
+		fprintf (shadow_logfd,
 			 _("Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"),
 			 endptr);
 	} else if (epoch > ULONG_MAX) {
-		fprintf (stderr,
+		fprintf (shadow_logfd,
 			 _("Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal to %lu but was found to be: %llu\n"),
 			 ULONG_MAX, epoch);
 	} else if (epoch > fallback) {
-		fprintf (stderr,
+		fprintf (shadow_logfd,
 			 _("Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal to the current time (%lu) but was found to be: %llu\n"),
 			 fallback, epoch);
 	} else {

--- a/libmisc/limits.c
+++ b/libmisc/limits.c
@@ -548,7 +548,7 @@ void setup_limits (const struct passwd *info)
 #ifdef LIMITS
 		if (info->pw_uid != 0) {
 			if ((setup_user_limits (info->pw_name) & LOGIN_ERROR_LOGIN) != 0) {
-				(void) fputs (_("Too many logins.\n"), stderr);
+				(void) fputs (_("Too many logins.\n"), shadow_logfd);
 				(void) sleep (2); /* XXX: Should be FAIL_DELAY */
 				exit (EXIT_FAILURE);
 			}

--- a/libmisc/pam_pass.c
+++ b/libmisc/pam_pass.c
@@ -59,20 +59,20 @@ void do_pam_passwd (const char *user, bool silent, bool change_expired)
 
 	ret = pam_start ("passwd", user, &conv, &pamh);
 	if (ret != PAM_SUCCESS) {
-		fprintf (stderr,
+		fprintf (shadow_logfd,
 			 _("passwd: pam_start() failed, error %d\n"), ret);
 		exit (10);	/* XXX */
 	}
 
 	ret = pam_chauthtok (pamh, flags);
 	if (ret != PAM_SUCCESS) {
-		fprintf (stderr, _("passwd: %s\n"), pam_strerror (pamh, ret));
-		fputs (_("passwd: password unchanged\n"), stderr);
+		fprintf (shadow_logfd, _("passwd: %s\n"), pam_strerror (pamh, ret));
+		fputs (_("passwd: password unchanged\n"), shadow_logfd);
 		pam_end (pamh, ret);
 		exit (10);	/* XXX */
 	}
 
-	fputs (_("passwd: password updated successfully\n"), stderr);
+	fputs (_("passwd: password updated successfully\n"), shadow_logfd);
 	(void) pam_end (pamh, PAM_SUCCESS);
 }
 #else				/* !USE_PAM */

--- a/libmisc/pam_pass_non_interactive.c
+++ b/libmisc/pam_pass_non_interactive.c
@@ -76,7 +76,7 @@ static int ni_conv (int num_msg,
 
 		switch (msg[count]->msg_style) {
 		case PAM_PROMPT_ECHO_ON:
-			fprintf (stderr,
+			fprintf (shadow_logfd,
 			         _("%s: PAM modules requesting echoing are not supported.\n"),
 			         Prog);
 			goto failed_conversation;
@@ -88,7 +88,7 @@ static int ni_conv (int num_msg,
 			break;
 		case PAM_ERROR_MSG:
 			if (   (NULL == msg[count]->msg)
-			    || (fprintf (stderr, "%s\n", msg[count]->msg) <0)) {
+			    || (fprintf (shadow_logfd, "%s\n", msg[count]->msg) <0)) {
 				goto failed_conversation;
 			}
 			responses[count].resp = NULL;
@@ -101,7 +101,7 @@ static int ni_conv (int num_msg,
 			responses[count].resp = NULL;
 			break;
 		default:
-			(void) fprintf (stderr,
+			(void) fprintf (shadow_logfd,
 			                _("%s: conversation type %d not supported.\n"),
 			                Prog, msg[count]->msg_style);
 			goto failed_conversation;
@@ -143,7 +143,7 @@ int do_pam_passwd_non_interactive (const char *pam_service,
 
 	ret = pam_start (pam_service, username, &non_interactive_pam_conv, &pamh);
 	if (ret != PAM_SUCCESS) {
-		fprintf (stderr,
+		fprintf (shadow_logfd,
 		         _("%s: (user %s) pam_start failure %d\n"),
 		         Prog, username, ret);
 		return 1;
@@ -152,7 +152,7 @@ int do_pam_passwd_non_interactive (const char *pam_service,
 	non_interactive_password = password;
 	ret = pam_chauthtok (pamh, 0);
 	if (ret != PAM_SUCCESS) {
-		fprintf (stderr,
+		fprintf (shadow_logfd,
 		         _("%s: (user %s) pam_chauthtok() failed, error:\n"
 		           "%s\n"),
 		         Prog, username, pam_strerror (pamh, ret));

--- a/libmisc/prefix_flag.c
+++ b/libmisc/prefix_flag.c
@@ -83,7 +83,7 @@ extern const char* process_prefix_flag (const char* short_opt, int argc, char **
 			&& (val = argv[i] + 9))
 		    || (strcmp (argv[i], short_opt) == 0)) {
 			if (NULL != prefix) {
-				fprintf (stderr,
+				fprintf (shadow_logfd,
 				         _("%s: multiple --prefix options\n"),
 				         Prog);
 				exit (E_BAD_ARG);
@@ -92,7 +92,7 @@ extern const char* process_prefix_flag (const char* short_opt, int argc, char **
 			if (val) {
 				prefix = val;
 			} else if (i + 1 == argc) {
-				fprintf (stderr,
+				fprintf (shadow_logfd,
 				         _("%s: option '%s' requires an argument\n"),
 				         Prog, argv[i]);
 				exit (E_BAD_ARG);

--- a/libmisc/pwdcheck.c
+++ b/libmisc/pwdcheck.c
@@ -51,7 +51,7 @@ void passwd_check (const char *user, const char *passwd, unused const char *prog
 	if (pw_auth (passwd, user, PW_LOGIN, (char *) 0) != 0) {
 		SYSLOG ((LOG_WARN, "incorrect password for `%s'", user));
 		(void) sleep (1);
-		fprintf (stderr, _("Incorrect password for %s.\n"), user);
+		fprintf (shadow_logfd, _("Incorrect password for %s.\n"), user);
 		exit (EXIT_FAILURE);
 	}
 }

--- a/libmisc/root_flag.c
+++ b/libmisc/root_flag.c
@@ -65,7 +65,7 @@ extern void process_root_flag (const char* short_opt, int argc, char **argv)
 			&& (val = argv[i] + 7))
 		    || (strcmp (argv[i], short_opt) == 0)) {
 			if (NULL != newroot) {
-				fprintf (stderr,
+				fprintf (shadow_logfd,
 				         _("%s: multiple --root options\n"),
 				         Prog);
 				exit (E_BAD_ARG);
@@ -74,7 +74,7 @@ extern void process_root_flag (const char* short_opt, int argc, char **argv)
 			if (val) {
 				newroot = val;
 			} else if (i + 1 == argc) {
-				fprintf (stderr,
+				fprintf (shadow_logfd,
 				         _("%s: option '%s' requires an argument\n"),
 				         Prog, argv[i]);
 				exit (E_BAD_ARG);
@@ -94,34 +94,34 @@ static void change_root (const char* newroot)
 	/* Drop privileges */
 	if (   (setregid (getgid (), getgid ()) != 0)
 	    || (setreuid (getuid (), getuid ()) != 0)) {
-		fprintf (stderr, _("%s: failed to drop privileges (%s)\n"),
+		fprintf (shadow_logfd, _("%s: failed to drop privileges (%s)\n"),
 		         Prog, strerror (errno));
 		exit (EXIT_FAILURE);
 	}
 
 	if ('/' != newroot[0]) {
-		fprintf (stderr,
+		fprintf (shadow_logfd,
 		         _("%s: invalid chroot path '%s'\n"),
 		         Prog, newroot);
 		exit (E_BAD_ARG);
 	}
 
 	if (access (newroot, F_OK) != 0) {
-		fprintf(stderr,
+		fprintf(shadow_logfd,
 		        _("%s: cannot access chroot directory %s: %s\n"),
 		        Prog, newroot, strerror (errno));
 		exit (E_BAD_ARG);
 	}
 
 	if (chdir (newroot) != 0) {
-		fprintf(stderr,
+		fprintf(shadow_logfd,
 				_("%s: cannot chdir to chroot directory %s: %s\n"),
 				Prog, newroot, strerror (errno));
 		exit (E_BAD_ARG);
 	}
 
 	if (chroot (newroot) != 0) {
-		fprintf(stderr,
+		fprintf(shadow_logfd,
 		        _("%s: unable to chroot to directory %s: %s\n"),
 		        Prog, newroot, strerror (errno));
 		exit (E_BAD_ARG);

--- a/libmisc/salt.c
+++ b/libmisc/salt.c
@@ -426,7 +426,7 @@ static /*@observer@*/const char *gensalt (size_t salt_size)
 		salt_len = (size_t) shadow_random (8, 16);
 #endif /* USE_SHA_CRYPT */
 	} else if (0 != strcmp (method, "DES")) {
-		fprintf (stderr,
+		fprintf (shadow_logfd,
 			 _("Invalid ENCRYPT_METHOD value: '%s'.\n"
 			   "Defaulting to DES.\n"),
 			 method);

--- a/libmisc/setupenv.c
+++ b/libmisc/setupenv.c
@@ -219,7 +219,7 @@ void setup_env (struct passwd *info)
 		static char temp_pw_dir[] = "/";
 
 		if (!getdef_bool ("DEFAULT_HOME") || chdir ("/") == -1) {
-			fprintf (stderr, _("Unable to cd to '%s'\n"),
+			fprintf (shadow_logfd, _("Unable to cd to '%s'\n"),
 				 info->pw_dir);
 			SYSLOG ((LOG_WARN,
 				 "unable to cd to `%s' for user `%s'\n",

--- a/libmisc/user_busy.c
+++ b/libmisc/user_busy.c
@@ -96,7 +96,7 @@ static int user_busy_utmp (const char *name)
 			continue;
 		}
 
-		fprintf (stderr,
+		fprintf (shadow_logfd,
 		         _("%s: user %s is currently logged in\n"),
 		         Prog, name);
 		return 1;
@@ -249,7 +249,7 @@ static int user_busy_processes (const char *name, uid_t uid)
 #ifdef ENABLE_SUBIDS
 			sub_uid_close();
 #endif
-			fprintf (stderr,
+			fprintf (shadow_logfd,
 			         _("%s: user %s is currently used by process %d\n"),
 			         Prog, name, pid);
 			return 1;
@@ -272,7 +272,7 @@ static int user_busy_processes (const char *name, uid_t uid)
 #ifdef ENABLE_SUBIDS
 					sub_uid_close();
 #endif
-					fprintf (stderr,
+					fprintf (shadow_logfd,
 					         _("%s: user %s is currently used by process %d\n"),
 					         Prog, name, pid);
 					return 1;

--- a/libmisc/xgetXXbyYY.c
+++ b/libmisc/xgetXXbyYY.c
@@ -74,7 +74,7 @@
 
 	result = malloc(sizeof(LOOKUP_TYPE));
 	if (NULL == result) {
-		fprintf (stderr, _("%s: out of memory\n"),
+		fprintf (shadow_logfd, _("%s: out of memory\n"),
 		         "x" STRINGIZE(FUNCTION_NAME));
 		exit (13);
 	}
@@ -84,7 +84,7 @@
 		LOOKUP_TYPE *resbuf = NULL;
 		buffer = (char *)realloc (buffer, length);
 		if (NULL == buffer) {
-			fprintf (stderr, _("%s: out of memory\n"),
+			fprintf (shadow_logfd, _("%s: out of memory\n"),
 			         "x" STRINGIZE(FUNCTION_NAME));
 			exit (13);
 		}
@@ -132,7 +132,7 @@
 	if (result) {
 		result = DUP_FUNCTION(result);
 		if (NULL == result) {
-			fprintf (stderr, _("%s: out of memory\n"),
+			fprintf (shadow_logfd, _("%s: out of memory\n"),
 			         "x" STRINGIZE(FUNCTION_NAME));
 			exit (13);
 		}

--- a/libmisc/xmalloc.c
+++ b/libmisc/xmalloc.c
@@ -54,7 +54,7 @@
 
 	ptr = (char *) malloc (size);
 	if (NULL == ptr) {
-		(void) fprintf (stderr,
+		(void) fprintf (shadow_logfd,
 		                _("%s: failed to allocate memory: %s\n"),
 		                Prog, strerror (errno));
 		exit (13);

--- a/libsubid/api.c
+++ b/libsubid/api.c
@@ -32,11 +32,38 @@
 #include <stdio.h>
 #include <errno.h>
 #include <stdlib.h>
+#include <string.h>
 #include <pwd.h>
 #include <stdbool.h>
 #include "subordinateio.h"
 #include "idmapping.h"
 #include "subid.h"
+
+const char *Prog = "(libsubid)";
+extern FILE * shadow_logfd;
+
+bool libsubid_init(const char *progname, FILE * logfd)
+{
+	if (progname) {
+		progname = strdup(progname);
+		if (progname)
+			Prog = progname;
+		else
+			fprintf(stderr, "Out of memory");
+	}
+
+	if (logfd) {
+		shadow_logfd = logfd;
+		return true;
+	}
+	shadow_logfd = fopen("/dev/null", "w");
+	if (!shadow_logfd) {
+		fprintf(stderr, "ERROR opening /dev/null for error messages.  Using stderr.");
+		shadow_logfd = stderr;
+		return false;
+	}
+	return true;
+}
 
 static
 int get_subid_ranges(const char *owner, enum subid_type id_type, struct subordinate_range ***ranges)

--- a/libsubid/subid.h
+++ b/libsubid/subid.h
@@ -22,6 +22,22 @@ enum subid_status {
 };
 
 /*
+ * libsubid_init: initialize libsubid
+ *
+ * @progname: Name to display as program.  If NULL, then "(libsubid)" will be
+ *            shown in error messages.
+ * @logfd:    Open file pointer to pass error messages to.  If NULL, then
+ *            /dev/null will be opened and messages will be sent there.  The
+ *            default if libsubid_init() is not called is stderr (2).
+ *
+ * This function does not need to be called.  If not called, then the defaults
+ * will be used.
+ *
+ * Returns false if an error occurred.
+ */
+bool libsubid_init(const char *progname, FILE *logfd);
+
+/*
  * get_subuid_ranges: return a list of UID ranges for a user
  *
  * @owner: username being queried

--- a/src/chage.c
+++ b/src/chage.c
@@ -62,6 +62,7 @@
  * Global variables
  */
 const char *Prog;
+FILE *shadow_logfd = NULL;
 
 static bool
     dflg = false,		/* set last password change date */
@@ -814,6 +815,7 @@ int main (int argc, char **argv)
 	 * Get the program name so that error messages can use it.
 	 */
 	Prog = Basename (argv[0]);
+	shadow_logfd = stderr;
 
 	sanitize_env ();
 	(void) setlocale (LC_ALL, "");

--- a/src/check_subid_range.c
+++ b/src/check_subid_range.c
@@ -18,6 +18,7 @@
 #include "idmapping.h"
 
 const char *Prog;
+FILE *shadow_logfd = NULL;
 
 int main(int argc, char **argv)
 {
@@ -25,6 +26,7 @@ int main(int argc, char **argv)
 	unsigned long start, count;
 	bool check_uids;
 	Prog = Basename (argv[0]);
+	shadow_logfd = stderr;
 
 	if (argc != 5)
 		exit(1);

--- a/src/chfn.c
+++ b/src/chfn.c
@@ -57,6 +57,7 @@
  * Global variables.
  */
 const char *Prog;
+FILE *shadow_logfd = NULL;
 static char fullnm[BUFSIZ];
 static char roomno[BUFSIZ];
 static char workph[BUFSIZ];
@@ -639,6 +640,7 @@ int main (int argc, char **argv)
 	 * prefix to most error messages.
 	 */
 	Prog = Basename (argv[0]);
+	shadow_logfd = stderr;
 
 	sanitize_env ();
 	(void) setlocale (LC_ALL, "");

--- a/src/chgpasswd.c
+++ b/src/chgpasswd.c
@@ -59,6 +59,7 @@
  * Global variables
  */
 const char *Prog;
+FILE *shadow_logfd = NULL;
 static bool eflg   = false;
 static bool md5flg = false;
 #if defined(USE_SHA_CRYPT) || defined(USE_BCRYPT) || defined(USE_YESCRYPT)
@@ -437,6 +438,7 @@ int main (int argc, char **argv)
 	int line = 0;
 
 	Prog = Basename (argv[0]);
+	shadow_logfd = stderr;
 
 	(void) setlocale (LC_ALL, "");
 	(void) bindtextdomain (PACKAGE, LOCALEDIR);

--- a/src/chpasswd.c
+++ b/src/chpasswd.c
@@ -56,6 +56,7 @@
  * Global variables
  */
 const char *Prog;
+FILE *shadow_logfd = NULL;
 static bool eflg   = false;
 static bool md5flg = false;
 #if defined(USE_SHA_CRYPT) || defined(USE_BCRYPT) || defined(USE_YESCRYPT)
@@ -429,6 +430,7 @@ int main (int argc, char **argv)
 	int line = 0;
 
 	Prog = Basename (argv[0]);
+	shadow_logfd = stderr;
 
 	(void) setlocale (LC_ALL, "");
 	(void) bindtextdomain (PACKAGE, LOCALEDIR);

--- a/src/chsh.c
+++ b/src/chsh.c
@@ -59,6 +59,7 @@
  * Global variables
  */
 const char *Prog;		/* Program name */
+FILE *shadow_logfd = NULL;
 static bool amroot;		/* Real UID is root */
 static char loginsh[BUFSIZ];	/* Name of new login shell */
 /* command line options */
@@ -441,6 +442,7 @@ int main (int argc, char **argv)
 	 * most error messages.
 	 */
 	Prog = Basename (argv[0]);
+	shadow_logfd = stderr;
 
 	(void) setlocale (LC_ALL, "");
 	(void) bindtextdomain (PACKAGE, LOCALEDIR);

--- a/src/expiry.c
+++ b/src/expiry.c
@@ -46,6 +46,7 @@
 
 /* Global variables */
 const char *Prog;
+FILE *shadow_logfd = NULL;
 static bool cflg = false;
 
 /* local function prototypes */
@@ -144,6 +145,7 @@ int main (int argc, char **argv)
 	struct spwd *spwd;
 
 	Prog = Basename (argv[0]);
+	shadow_logfd = stderr;
 
 	sanitize_env ();
 

--- a/src/faillog.c
+++ b/src/faillog.c
@@ -62,6 +62,7 @@ static void reset (void);
  * Global variables
  */
 const char *Prog;		/* Program name */
+FILE *shadow_logfd = NULL;
 static FILE *fail;		/* failure file stream */
 static time_t seconds;		/* that number of days in seconds */
 static unsigned long umin;	/* if uflg and has_umin, only display users with uid >= umin */
@@ -573,6 +574,7 @@ int main (int argc, char **argv)
 	 * most error messages.
 	 */
 	Prog = Basename (argv[0]);
+	shadow_logfd = stderr;
 
 	(void) setlocale (LC_ALL, "");
 	(void) bindtextdomain (PACKAGE, LOCALEDIR);

--- a/src/free_subid_range.c
+++ b/src/free_subid_range.c
@@ -7,6 +7,7 @@
 /* Test program for the subid freeing routine */
 
 const char *Prog;
+FILE *shadow_logfd = NULL;
 
 void usage(void)
 {
@@ -23,6 +24,7 @@ int main(int argc, char *argv[])
 	bool group = false;   // get subuids by default
 
 	Prog = Basename (argv[0]);
+	shadow_logfd = stderr;
 	while ((c = getopt(argc, argv, "g")) != EOF) {
 		switch(c) {
 		case 'g': group = true; break;

--- a/src/get_subid_owners.c
+++ b/src/get_subid_owners.c
@@ -4,6 +4,7 @@
 #include "prototypes.h"
 
 const char *Prog;
+FILE *shadow_logfd = NULL;
 
 void usage(void)
 {
@@ -19,6 +20,7 @@ int main(int argc, char *argv[])
 	uid_t *uids;
 
 	Prog = Basename (argv[0]);
+	shadow_logfd = stderr;
 	if (argc < 2) {
 		usage();
 	}

--- a/src/gpasswd.c
+++ b/src/gpasswd.c
@@ -58,6 +58,7 @@
  */
 /* The name of this command, as it is invoked */
 const char *Prog;
+FILE *shadow_logfd = NULL;
 
 #ifdef SHADOWGRP
 /* Indicate if shadow groups are enabled on the system
@@ -988,6 +989,7 @@ int main (int argc, char **argv)
 	 */
 	bywho = getuid ();
 	Prog = Basename (argv[0]);
+	shadow_logfd = stderr;
 
 	OPENLOG ("gpasswd");
 	setbuf (stdout, NULL);

--- a/src/groupadd.c
+++ b/src/groupadd.c
@@ -72,6 +72,7 @@
  * Global variables
  */
 const char *Prog;
+FILE *shadow_logfd = NULL;
 
 static /*@null@*/char *group_name;
 static gid_t group_id;
@@ -598,6 +599,7 @@ int main (int argc, char **argv)
 	 * Get my name so that I can use it to report errors.
 	 */
 	Prog = Basename (argv[0]);
+	shadow_logfd = stderr;
 
 	(void) setlocale (LC_ALL, "");
 	(void) bindtextdomain (PACKAGE, LOCALEDIR);

--- a/src/groupdel.c
+++ b/src/groupdel.c
@@ -58,6 +58,7 @@
  * Global variables
  */
 const char *Prog;
+FILE *shadow_logfd = NULL;
 
 static char *group_name;
 static gid_t group_id = -1;
@@ -376,6 +377,7 @@ int main (int argc, char **argv)
 	 * Get my name so that I can use it to report errors.
 	 */
 	Prog = Basename (argv[0]);
+	shadow_logfd = stderr;
 
 	(void) setlocale (LC_ALL, "");
 	(void) bindtextdomain (PACKAGE, LOCALEDIR);

--- a/src/groupmems.c
+++ b/src/groupmems.c
@@ -65,6 +65,7 @@
  * Global variables
  */
 const char *Prog;
+FILE *shadow_logfd = NULL;
 
 static char *adduser = NULL;
 static char *deluser = NULL;
@@ -595,6 +596,7 @@ int main (int argc, char **argv)
 	 * Get my name so that I can use it to report errors.
 	 */
 	Prog = Basename (argv[0]);
+	shadow_logfd = stderr;
 
 	(void) setlocale (LC_ALL, "");
 	(void) bindtextdomain (PACKAGE, LOCALEDIR);

--- a/src/groupmod.c
+++ b/src/groupmod.c
@@ -76,6 +76,7 @@
  * Global variables
  */
 const char *Prog;
+FILE *shadow_logfd = NULL;
 
 #ifdef	SHADOWGRP
 static bool is_shadow_grp;
@@ -792,6 +793,7 @@ int main (int argc, char **argv)
 	 * Get my name so that I can use it to report errors.
 	 */
 	Prog = Basename (argv[0]);
+	shadow_logfd = stderr;
 
 	(void) setlocale (LC_ALL, "");
 	(void) bindtextdomain (PACKAGE, LOCALEDIR);

--- a/src/groups.c
+++ b/src/groups.c
@@ -43,6 +43,7 @@
  * Global variables
  */
 const char *Prog;
+FILE *shadow_logfd = NULL;
 
 /* local function prototypes */
 static void print_groups (const char *member);
@@ -126,6 +127,7 @@ int main (int argc, char **argv)
 	 * Get the program name so that error messages can use it.
 	 */
 	Prog = Basename (argv[0]);
+	shadow_logfd = stderr;
 
 	if (argc == 1) {
 

--- a/src/grpck.c
+++ b/src/grpck.c
@@ -66,6 +66,7 @@
  * Global variables
  */
 const char *Prog;
+FILE *shadow_logfd = NULL;
 
 static const char *grp_file = GROUP_FILE;
 static bool use_system_grp_file = true;
@@ -840,6 +841,7 @@ int main (int argc, char **argv)
 	 * Get my name so that I can use it to report errors.
 	 */
 	Prog = Basename (argv[0]);
+	shadow_logfd = stderr;
 
 	(void) setlocale (LC_ALL, "");
 	(void) bindtextdomain (PACKAGE, LOCALEDIR);

--- a/src/grpconv.c
+++ b/src/grpconv.c
@@ -59,6 +59,7 @@
  * Global variables
  */
 const char *Prog;
+FILE *shadow_logfd = NULL;
 
 static bool gr_locked  = false;
 static bool sgr_locked = false;
@@ -146,6 +147,7 @@ int main (int argc, char **argv)
 	struct sgrp sgent;
 
 	Prog = Basename (argv[0]);
+	shadow_logfd = stderr;
 
 	(void) setlocale (LC_ALL, "");
 	(void) bindtextdomain (PACKAGE, LOCALEDIR);

--- a/src/grpunconv.c
+++ b/src/grpunconv.c
@@ -59,6 +59,7 @@
  * Global variables
  */
 const char *Prog;
+FILE *shadow_logfd = NULL;
 
 static bool gr_locked  = false;
 static bool sgr_locked = false;
@@ -145,6 +146,7 @@ int main (int argc, char **argv)
 	const struct sgrp *sg;
 
 	Prog = Basename (argv[0]);
+	shadow_logfd = stderr;
 
 	(void) setlocale (LC_ALL, "");
 	(void) bindtextdomain (PACKAGE, LOCALEDIR);

--- a/src/lastlog.c
+++ b/src/lastlog.c
@@ -62,6 +62,7 @@
  * Global variables
  */
 const char *Prog;		/* Program name */
+FILE *shadow_logfd = NULL;
 static FILE *lastlogfile;	/* lastlog file stream */
 static unsigned long umin;	/* if uflg and has_umin, only display users with uid >= umin */
 static bool has_umin = false;
@@ -317,6 +318,7 @@ int main (int argc, char **argv)
 	 * most error messages.
 	 */
 	Prog = Basename (argv[0]);
+	shadow_logfd = stderr;
 
 	(void) setlocale (LC_ALL, "");
 	(void) bindtextdomain (PACKAGE, LOCALEDIR);

--- a/src/list_subid_ranges.c
+++ b/src/list_subid_ranges.c
@@ -4,6 +4,7 @@
 #include "prototypes.h"
 
 const char *Prog;
+FILE *shadow_logfd = NULL;
 
 void usage(void)
 {
@@ -19,6 +20,7 @@ int main(int argc, char *argv[])
 	struct subordinate_range **ranges;
 
 	Prog = Basename (argv[0]);
+	shadow_logfd = stderr;
 	if (argc < 2) {
 		usage();
 	}

--- a/src/login.c
+++ b/src/login.c
@@ -83,6 +83,7 @@ static pam_handle_t *pamh = NULL;
  * Global variables
  */
 const char *Prog;
+FILE *shadow_logfd = NULL;
 
 static const char *hostname = "";
 static /*@null@*/ /*@only@*/char *username = NULL;
@@ -577,6 +578,7 @@ int main (int argc, char **argv)
 
 	amroot = (getuid () == 0);
 	Prog = Basename (argv[0]);
+	shadow_logfd = stderr;
 
 	if (geteuid() != 0) {
 		fprintf (stderr, _("%s: Cannot possibly work without effective root\n"), Prog);

--- a/src/logoutd.c
+++ b/src/logoutd.c
@@ -44,6 +44,7 @@
  * Global variables
  */
 const char *Prog;
+FILE *shadow_logfd = NULL;
 
 #ifndef DEFAULT_HUP_MESG
 #define DEFAULT_HUP_MESG _("login time exceeded\n\n")
@@ -187,6 +188,7 @@ int main (int argc, char **argv)
 	 * Start syslogging everything
 	 */
 	Prog = Basename (argv[0]);
+	shadow_logfd = stderr;
 
 	OPENLOG ("logoutd");
 

--- a/src/new_subid_range.c
+++ b/src/new_subid_range.c
@@ -7,6 +7,7 @@
 /* Test program for the subid creation routine */
 
 const char *Prog;
+FILE *shadow_logfd = NULL;
 
 void usage(void)
 {
@@ -26,6 +27,7 @@ int main(int argc, char *argv[])
 	bool ok;
 
 	Prog = Basename (argv[0]);
+	shadow_logfd = stderr;
 	while ((c = getopt(argc, argv, "gn")) != EOF) {
 		switch(c) {
 		case 'n': makenew = true; break;

--- a/src/newgidmap.c
+++ b/src/newgidmap.c
@@ -46,6 +46,7 @@
  * Global variables
  */
 const char *Prog;
+FILE *shadow_logfd = NULL;
 
 
 static bool verify_range(struct passwd *pw, struct map_range *range, bool *allow_setgroups)
@@ -176,6 +177,7 @@ int main(int argc, char **argv)
 	bool allow_setgroups = false;
 
 	Prog = Basename (argv[0]);
+	shadow_logfd = stderr;
 
 	/*
 	 * The valid syntax are

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -49,6 +49,7 @@
  * Global variables
  */
 const char *Prog;
+FILE *shadow_logfd = NULL;
 
 extern char **newenvp;
 extern char **environ;
@@ -443,6 +444,7 @@ int main (int argc, char **argv)
 	 * don't need to re-exec anything.  -- JWP
 	 */
 	Prog = Basename (argv[0]);
+	shadow_logfd = stderr;
 	is_newgrp = (strcmp (Prog, "newgrp") == 0);
 	OPENLOG (is_newgrp ? "newgrp" : "sg");
 	argc--;

--- a/src/newuidmap.c
+++ b/src/newuidmap.c
@@ -46,6 +46,7 @@
  * Global variables
  */
 const char *Prog;
+FILE *shadow_logfd = NULL;
 
 static bool verify_range(struct passwd *pw, struct map_range *range)
 {
@@ -106,6 +107,7 @@ int main(int argc, char **argv)
 	int written;
 
 	Prog = Basename (argv[0]);
+	shadow_logfd = stderr;
 
 	/*
 	 * The valid syntax are

--- a/src/newusers.c
+++ b/src/newusers.c
@@ -75,6 +75,7 @@
  * Global variables
  */
 const char *Prog;
+FILE *shadow_logfd = NULL;
 
 static bool rflg = false;	/* create a system account */
 #ifndef USE_PAM
@@ -1052,6 +1053,7 @@ int main (int argc, char **argv)
 #endif				/* USE_PAM */
 
 	Prog = Basename (argv[0]);
+	shadow_logfd = stderr;
 
 	(void) setlocale (LC_ALL, "");
 	(void) bindtextdomain (PACKAGE, LOCALEDIR);

--- a/src/passwd.c
+++ b/src/passwd.c
@@ -66,6 +66,7 @@
  * Global variables
  */
 const char *Prog;		/* Program name */
+FILE *shadow_logfd = NULL;
 
 static char *name;		/* The name of user whose password is being changed */
 static char *myname;		/* The current user's name */
@@ -752,6 +753,7 @@ int main (int argc, char **argv)
 	 * most error messages.
 	 */
 	Prog = Basename (argv[0]);
+	shadow_logfd = stderr;
 
 	(void) setlocale (LC_ALL, "");
 	(void) bindtextdomain (PACKAGE, LOCALEDIR);

--- a/src/pwck.c
+++ b/src/pwck.c
@@ -70,6 +70,7 @@
  * Global variables
  */
 const char *Prog;
+FILE *shadow_logfd = NULL;
 
 static bool use_system_pw_file = true;
 static bool use_system_spw_file = true;

--- a/src/pwconv.c
+++ b/src/pwconv.c
@@ -89,6 +89,7 @@
  * Global variables
  */
 const char *Prog;
+FILE *shadow_logfd = NULL;
 
 static bool spw_locked = false;
 static bool pw_locked = false;
@@ -176,6 +177,7 @@ int main (int argc, char **argv)
 	struct spwd spent;
 
 	Prog = Basename (argv[0]);
+	shadow_logfd = stderr;
 
 	(void) setlocale (LC_ALL, "");
 	(void) bindtextdomain (PACKAGE, LOCALEDIR);

--- a/src/pwunconv.c
+++ b/src/pwunconv.c
@@ -53,6 +53,7 @@
  * Global variables
  */
 const char *Prog;
+FILE *shadow_logfd = NULL;
 
 static bool spw_locked = false;
 static bool pw_locked = false;
@@ -137,6 +138,7 @@ int main (int argc, char **argv)
 	const struct spwd *spwd;
 
 	Prog = Basename (argv[0]);
+	shadow_logfd = stderr;
 
 	(void) setlocale (LC_ALL, "");
 	(void) bindtextdomain (PACKAGE, LOCALEDIR);

--- a/src/su.c
+++ b/src/su.c
@@ -82,6 +82,7 @@
  * Global variables
  */
 const char *Prog;
+FILE *shadow_logfd = NULL;
 static /*@observer@*/const char *caller_tty = NULL;	/* Name of tty SU is run from */
 static bool caller_is_root = false;
 static uid_t caller_uid;
@@ -716,6 +717,7 @@ static void save_caller_context (char **argv)
 	 * most error messages.
 	 */
 	Prog = Basename (argv[0]);
+	shadow_logfd = stderr;
 
 	caller_uid = getuid ();
 	caller_is_root = (caller_uid == 0);

--- a/src/sulogin.c
+++ b/src/sulogin.c
@@ -50,6 +50,7 @@
  * Global variables
  */
 const char *Prog;
+FILE *shadow_logfd = NULL;
 
 static char name[BUFSIZ];
 static char pass[BUFSIZ];
@@ -106,6 +107,7 @@ static RETSIGTYPE catch_signals (unused int sig)
 #endif
 
 	Prog = Basename (argv[0]);
+	shadow_logfd = stderr;
 	(void) setlocale (LC_ALL, "");
 	(void) bindtextdomain (PACKAGE, LOCALEDIR);
 	(void) textdomain (PACKAGE);

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -96,6 +96,7 @@
  * Global variables
  */
 const char *Prog;
+FILE *shadow_logfd = NULL;
 
 /*
  * These defaults are used if there is no defaults file.
@@ -2391,6 +2392,7 @@ int main (int argc, char **argv)
 	 * Get my name so that I can use it to report errors.
 	 */
 	Prog = Basename (argv[0]);
+	shadow_logfd = stderr;
 
 	(void) setlocale (LC_ALL, "");
 	(void) bindtextdomain (PACKAGE, LOCALEDIR);

--- a/src/userdel.c
+++ b/src/userdel.c
@@ -91,6 +91,7 @@
  * Global variables
  */
 const char *Prog;
+FILE *shadow_logfd = NULL;
 
 static char *user_name;
 static uid_t user_id;
@@ -1015,6 +1016,7 @@ int main (int argc, char **argv)
 	 * Get my name so that I can use it to report errors.
 	 */
 	Prog = Basename (argv[0]);
+	shadow_logfd = stderr;
 	(void) setlocale (LC_ALL, "");
 	(void) bindtextdomain (PACKAGE, LOCALEDIR);
 	(void) textdomain (PACKAGE);

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -105,6 +105,7 @@
  * Global variables
  */
 const char *Prog;
+FILE *shadow_logfd = NULL;
 
 static char *user_name;
 static char *user_newname;
@@ -2200,6 +2201,7 @@ int main (int argc, char **argv)
 	 * Get my name so that I can use it to report errors.
 	 */
 	Prog = Basename (argv[0]);
+	shadow_logfd = stderr;
 
 	(void) setlocale (LC_ALL, "");
 	(void) bindtextdomain (PACKAGE, LOCALEDIR);

--- a/src/vipw.c
+++ b/src/vipw.c
@@ -63,6 +63,7 @@
  * Global variables
  */
 const char *Prog;
+FILE *shadow_logfd = NULL;
 
 static const char *filename, *fileeditname;
 static bool filelocked = false;
@@ -481,6 +482,7 @@ int main (int argc, char **argv)
 	bool do_vipw;
 
 	Prog = Basename (argv[0]);
+	shadow_logfd = stderr;
 
 	(void) setlocale (LC_ALL, "");
 	(void) bindtextdomain (PACKAGE, LOCALEDIR);


### PR DESCRIPTION
Closes #325

Add a new subid_init() function which can be used to specify the
stream on which error messages should be printed.  (If you want to
get fancy you can redirect that to memory :)  If subid_init() is
not called, use stderr.  If NULL is passed, then /dev/null will
be used.

This patch also fixes up the 'Prog', which previously had to be
defined by any program linking against libsubid.  Now, by default
in libsubid it will show (subid).  Once subid_init() is called,
it will use the first variable passed to subid_init().

Signed-off-by: Serge Hallyn <serge@hallyn.com>