### PR TITLE
Don't return owner in list_owner_ranges API call.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 dnl Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.69])
-m4_define([libsubid_abi_major], 2)
+m4_define([libsubid_abi_major], 3)
 m4_define([libsubid_abi_minor], 0)
 m4_define([libsubid_abi_micro], 0)
 m4_define([libsubid_abi], [libsubid_abi_major.libsubid_abi_minor.libsubid_abi_micro])

--- a/lib/prototypes.h
+++ b/lib/prototypes.h
@@ -300,8 +300,8 @@ struct subid_nss_ops {
 	 *
 	 * @owner - string representing username being queried
 	 * @id_type - subuid or subgid
-	 * @ranges - pointer to an array of struct subordinate_range pointers, or
-	 *           NULL.  The returned array of struct subordinate_range and its
+	 * @ranges - pointer to an array of struct subid_range pointers, or
+	 *           NULL.  The returned array of struct subid_range and its
 	 *           members must be freed by the caller.
 	 * @count - pointer to an integer into which the number of returned ranges
 	 *          is written.
@@ -309,7 +309,7 @@ struct subid_nss_ops {
 	 * returns success if the module was able to determine an answer,
 	 * else an error status.
 	 */
-	enum subid_status (*list_owner_ranges)(const char *owner, enum subid_type id_type, struct subordinate_range ***ranges, int *count);
+	enum subid_status (*list_owner_ranges)(const char *owner, enum subid_type id_type, struct subid_range ***ranges, int *count);
 
 	/*
 	 * nss_find_subid_owners: find uids who own a given subuid or subgid.

--- a/lib/prototypes.h
+++ b/lib/prototypes.h
@@ -300,16 +300,15 @@ struct subid_nss_ops {
 	 *
 	 * @owner - string representing username being queried
 	 * @id_type - subuid or subgid
-	 * @ranges - pointer to an array of struct subid_range pointers, or
-	 *           NULL.  The returned array of struct subid_range and its
-	 *           members must be freed by the caller.
+	 * @ranges - pointer to an array of struct subid_range, or NULL.  The
+	 *           returned array must be freed by the caller.
 	 * @count - pointer to an integer into which the number of returned ranges
 	 *          is written.
 
 	 * returns success if the module was able to determine an answer,
 	 * else an error status.
 	 */
-	enum subid_status (*list_owner_ranges)(const char *owner, enum subid_type id_type, struct subid_range ***ranges, int *count);
+	enum subid_status (*list_owner_ranges)(const char *owner, enum subid_type id_type, struct subid_range **ranges, int *count);
 
 	/*
 	 * nss_find_subid_owners: find uids who own a given subuid or subgid.

--- a/lib/subordinateio.h
+++ b/lib/subordinateio.h
@@ -25,7 +25,7 @@ extern int sub_uid_unlock (void);
 extern int sub_uid_add (const char *owner, uid_t start, unsigned long count);
 extern int sub_uid_remove (const char *owner, uid_t start, unsigned long count);
 extern uid_t sub_uid_find_free_range(uid_t min, uid_t max, unsigned long count);
-extern int list_owner_ranges(const char *owner, enum subid_type id_type, struct subid_range ***ranges);
+extern int list_owner_ranges(const char *owner, enum subid_type id_type, struct subid_range **ranges);
 extern bool new_subid_range(struct subordinate_range *range, enum subid_type id_type, bool reuse);
 extern bool release_subid_range(struct subordinate_range *range, enum subid_type id_type);
 extern int find_subid_owners(unsigned long id, enum subid_type id_type, uid_t **uids);

--- a/lib/subordinateio.h
+++ b/lib/subordinateio.h
@@ -25,7 +25,7 @@ extern int sub_uid_unlock (void);
 extern int sub_uid_add (const char *owner, uid_t start, unsigned long count);
 extern int sub_uid_remove (const char *owner, uid_t start, unsigned long count);
 extern uid_t sub_uid_find_free_range(uid_t min, uid_t max, unsigned long count);
-extern int list_owner_ranges(const char *owner, enum subid_type id_type, struct subordinate_range ***ranges);
+extern int list_owner_ranges(const char *owner, enum subid_type id_type, struct subid_range ***ranges);
 extern bool new_subid_range(struct subordinate_range *range, enum subid_type id_type, bool reuse);
 extern bool release_subid_range(struct subordinate_range *range, enum subid_type id_type);
 extern int find_subid_owners(unsigned long id, enum subid_type id_type, uid_t **uids);

--- a/libsubid/api.c
+++ b/libsubid/api.c
@@ -66,17 +66,17 @@ bool libsubid_init(const char *progname, FILE * logfd)
 }
 
 static
-int get_subid_ranges(const char *owner, enum subid_type id_type, struct subid_range ***ranges)
+int get_subid_ranges(const char *owner, enum subid_type id_type, struct subid_range **ranges)
 {
 	return list_owner_ranges(owner, id_type, ranges);
 }
 
-int get_subuid_ranges(const char *owner, struct subid_range ***ranges)
+int get_subuid_ranges(const char *owner, struct subid_range **ranges)
 {
 	return get_subid_ranges(owner, ID_TYPE_UID, ranges);
 }
 
-int get_subgid_ranges(const char *owner, struct subid_range ***ranges)
+int get_subgid_ranges(const char *owner, struct subid_range **ranges)
 {
 	return get_subid_ranges(owner, ID_TYPE_GID, ranges);
 }

--- a/libsubid/api.c
+++ b/libsubid/api.c
@@ -66,24 +66,19 @@ bool libsubid_init(const char *progname, FILE * logfd)
 }
 
 static
-int get_subid_ranges(const char *owner, enum subid_type id_type, struct subordinate_range ***ranges)
+int get_subid_ranges(const char *owner, enum subid_type id_type, struct subid_range ***ranges)
 {
 	return list_owner_ranges(owner, id_type, ranges);
 }
 
-int get_subuid_ranges(const char *owner, struct subordinate_range ***ranges)
+int get_subuid_ranges(const char *owner, struct subid_range ***ranges)
 {
 	return get_subid_ranges(owner, ID_TYPE_UID, ranges);
 }
 
-int get_subgid_ranges(const char *owner, struct subordinate_range ***ranges)
+int get_subgid_ranges(const char *owner, struct subid_range ***ranges)
 {
 	return get_subid_ranges(owner, ID_TYPE_GID, ranges);
-}
-
-void subid_free_ranges(struct subordinate_range **ranges, int count)
-{
-	return free_subordinate_ranges(ranges, count);
 }
 
 static

--- a/libsubid/subid.h
+++ b/libsubid/subid.h
@@ -50,32 +50,27 @@ bool libsubid_init(const char *progname, FILE *logfd);
  * get_subuid_ranges: return a list of UID ranges for a user
  *
  * @owner: username being queried
- * @ranges: a pointer to a subordinate range ** in which the result will be
- *          returned.
+ * @ranges: a pointer to an array of subid_range structs in which the result
+ *          will be returned.
+ *
+ * The caller must free(ranges) when done.
  *
  * returns: number of ranges found, ir < 0 on error.
  */
-int get_subuid_ranges(const char *owner, struct subid_range ***ranges);
+int get_subuid_ranges(const char *owner, struct subid_range **ranges);
 
 /*
  * get_subgid_ranges: return a list of GID ranges for a user
  *
  * @owner: username being queried
- * @ranges: a pointer to a subordinate range ** in which the result will be
- *          returned.
+ * @ranges: a pointer to an array of subid_range structs in which the result
+ *          will be returned.
+ *
+ * The caller must free(ranges) when done.
  *
  * returns: number of ranges found, ir < 0 on error.
  */
-int get_subgid_ranges(const char *owner, struct subid_range ***ranges);
-
-/*
- * subid_free_ranges: free an array of subordinate_ranges returned by either
- *                    get_subuid_ranges() or get_subgid_ranges().
- *
- * @ranges: the ranges to free
- * @count: the number of ranges in @ranges
- */
-void subid_free_ranges(struct subid_range **ranges, int count);
+int get_subgid_ranges(const char *owner, struct subid_range **ranges);
 
 /*
  * get_subuid_owners: return a list of uids to which the given uid has been

--- a/libsubid/subid.h
+++ b/libsubid/subid.h
@@ -3,6 +3,15 @@
 
 #ifndef SUBID_RANGE_DEFINED
 #define SUBID_RANGE_DEFINED 1
+
+/* subid_range is just a starting point and size of a range */
+struct subid_range {
+	unsigned long start;
+	unsigned long count;
+};
+
+/* subordinage_range is a subid_range plus an owner, representing
+ * a range in /etc/subuid or /etc/subgid */
 struct subordinate_range {
 	const char *owner;
 	unsigned long start;
@@ -46,7 +55,7 @@ bool libsubid_init(const char *progname, FILE *logfd);
  *
  * returns: number of ranges found, ir < 0 on error.
  */
-int get_subuid_ranges(const char *owner, struct subordinate_range ***ranges);
+int get_subuid_ranges(const char *owner, struct subid_range ***ranges);
 
 /*
  * get_subgid_ranges: return a list of GID ranges for a user
@@ -57,7 +66,7 @@ int get_subuid_ranges(const char *owner, struct subordinate_range ***ranges);
  *
  * returns: number of ranges found, ir < 0 on error.
  */
-int get_subgid_ranges(const char *owner, struct subordinate_range ***ranges);
+int get_subgid_ranges(const char *owner, struct subid_range ***ranges);
 
 /*
  * subid_free_ranges: free an array of subordinate_ranges returned by either
@@ -66,7 +75,7 @@ int get_subgid_ranges(const char *owner, struct subordinate_range ***ranges);
  * @ranges: the ranges to free
  * @count: the number of ranges in @ranges
  */
-void subid_free_ranges(struct subordinate_range **ranges, int count);
+void subid_free_ranges(struct subid_range **ranges, int count);
 
 /*
  * get_subuid_owners: return a list of uids to which the given uid has been

--- a/src/list_subid_ranges.c
+++ b/src/list_subid_ranges.c
@@ -17,7 +17,7 @@ void usage(void)
 int main(int argc, char *argv[])
 {
 	int i, count=0;
-	struct subid_range **ranges;
+	struct subid_range *ranges;
 	const char *owner;
 
 	Prog = Basename (argv[0]);
@@ -39,8 +39,7 @@ int main(int argc, char *argv[])
 	}
 	for (i = 0; i < count; i++) {
 		printf("%d: %s %lu %lu\n", i, owner,
-			ranges[i]->start, ranges[i]->count);
+			ranges[i].start, ranges[i].count);
 	}
-	subid_free_ranges(ranges, count);
 	return 0;
 }

--- a/src/list_subid_ranges.c
+++ b/src/list_subid_ranges.c
@@ -17,25 +17,28 @@ void usage(void)
 int main(int argc, char *argv[])
 {
 	int i, count=0;
-	struct subordinate_range **ranges;
+	struct subid_range **ranges;
+	const char *owner;
 
 	Prog = Basename (argv[0]);
 	shadow_logfd = stderr;
-	if (argc < 2) {
+	if (argc < 2)
 		usage();
+	owner = argv[1];
+	if (argc == 3 && strcmp(argv[1], "-g") == 0) {
+		owner = argv[2];
+		count = get_subgid_ranges(owner, &ranges);
+	} else if (argc == 2 && strcmp(argv[1], "-h") == 0) {
+		usage();
+	} else {
+		count = get_subuid_ranges(owner, &ranges);
 	}
-	if (argc == 3 && strcmp(argv[1], "-g") == 0)
-		count = get_subgid_ranges(argv[2], &ranges);
-	else if (argc == 2 && strcmp(argv[1], "-h") == 0)
-		usage();
-	else
-		count = get_subuid_ranges(argv[1], &ranges);
 	if (!ranges) {
 		fprintf(stderr, "Error fetching ranges\n");
 		exit(1);
 	}
 	for (i = 0; i < count; i++) {
-		printf("%d: %s %lu %lu\n", i, ranges[i]->owner,
+		printf("%d: %s %lu %lu\n", i, owner,
 			ranges[i]->start, ranges[i]->count);
 	}
 	subid_free_ranges(ranges, count);

--- a/tests/libsubid/04_nss/libsubid_zzz.c
+++ b/tests/libsubid/04_nss/libsubid_zzz.c
@@ -101,9 +101,9 @@ enum subid_status shadow_subid_find_subid_owners(unsigned long id, enum subid_ty
 	return SUBID_STATUS_SUCCESS;
 }
 
-enum subid_status shadow_subid_list_owner_ranges(const char *owner, enum subid_type id_type, struct subid_range ***in_ranges, int *count)
+enum subid_status shadow_subid_list_owner_ranges(const char *owner, enum subid_type id_type, struct subid_range **in_ranges, int *count)
 {
-	struct subid_range **ranges;
+	struct subid_range *ranges;
 
 	*count = 0;
 	if (strcmp(owner, "error") == 0)
@@ -113,7 +113,7 @@ enum subid_status shadow_subid_list_owner_ranges(const char *owner, enum subid_t
 	if (strcmp(owner, "conn") == 0)
 		return SUBID_STATUS_ERROR_CONN;
 
-	*ranges = NULL;
+	*in_ranges = NULL;
 	if (strcmp(owner, "user1") != 0 && strcmp(owner, "ubuntu") != 0 &&
 	    strcmp(owner, "group1") != 0)
 		return SUBID_STATUS_SUCCESS;
@@ -121,21 +121,15 @@ enum subid_status shadow_subid_list_owner_ranges(const char *owner, enum subid_t
 		return SUBID_STATUS_SUCCESS;
 	if (id_type == ID_TYPE_UID && strcmp(owner, "group1") == 0)
 		return SUBID_STATUS_SUCCESS;
-	ranges = (struct subid_range **)malloc(sizeof(struct subid_range *));
+	ranges = (struct subid_range *)malloc(sizeof(struct subid_range));
 	if (!*ranges)
 		return SUBID_STATUS_ERROR;
-	ranges[0] = (struct subid_range *)malloc(sizeof(struct subid_range));
-	if (!ranges[0]) {
-		free(*ranges);
-		*ranges = NULL;
-		return SUBID_STATUS_ERROR;
-	}
 	if (strcmp(owner, "user1") == 0 || strcmp(owner, "group1") == 0) {
-		ranges[0]->start = 100000;
-		ranges[0]->count = 65536;
+		ranges[0].start = 100000;
+		ranges[0].count = 65536;
 	} else {
-		ranges[0]->start = 200000;
-		ranges[0]->count = 100000;
+		ranges[0].start = 200000;
+		ranges[0].count = 100000;
 	}
 
 	*count = 1;

--- a/tests/libsubid/04_nss/libsubid_zzz.c
+++ b/tests/libsubid/04_nss/libsubid_zzz.c
@@ -101,9 +101,9 @@ enum subid_status shadow_subid_find_subid_owners(unsigned long id, enum subid_ty
 	return SUBID_STATUS_SUCCESS;
 }
 
-enum subid_status shadow_subid_list_owner_ranges(const char *owner, enum subid_type id_type, struct subordinate_range ***in_ranges, int *count)
+enum subid_status shadow_subid_list_owner_ranges(const char *owner, enum subid_type id_type, struct subid_range ***in_ranges, int *count)
 {
-	struct subordinate_range **ranges;
+	struct subid_range **ranges;
 
 	*count = 0;
 	if (strcmp(owner, "error") == 0)
@@ -121,16 +121,15 @@ enum subid_status shadow_subid_list_owner_ranges(const char *owner, enum subid_t
 		return SUBID_STATUS_SUCCESS;
 	if (id_type == ID_TYPE_UID && strcmp(owner, "group1") == 0)
 		return SUBID_STATUS_SUCCESS;
-	ranges = (struct subordinate_range **)malloc(sizeof(struct subordinate_range *));
+	ranges = (struct subid_range **)malloc(sizeof(struct subid_range *));
 	if (!*ranges)
 		return SUBID_STATUS_ERROR;
-	ranges[0] = (struct subordinate_range *)malloc(sizeof(struct subordinate_range));
+	ranges[0] = (struct subid_range *)malloc(sizeof(struct subid_range));
 	if (!ranges[0]) {
 		free(*ranges);
 		*ranges = NULL;
 		return SUBID_STATUS_ERROR;
 	}
-	ranges[0]->owner = strdup(owner);
 	if (strcmp(owner, "user1") == 0 || strcmp(owner, "group1") == 0) {
 		ranges[0]->start = 100000;
 		ranges[0]->count = 65536;


### PR DESCRIPTION
Closes: 339

struct subordinate_range is pretty closely tied to the existing
subid code and /etc/subuid format, so it includes an owner.  Dropping
that or even renaming it is more painful than I'd first thought.
So introduce a 'struct subid_range' which is only the start and
count, leaving 'struct subordinate_range' as the owner, start and
count.

Signed-off-by: Serge Hallyn <serge@hallyn.com>