### PR TITLE
fix newusers when nss provides subids

### DIFF
--- a/lib/nss.c
+++ b/lib/nss.c
@@ -116,14 +116,6 @@ void nss_init(char *nsswitch_path) {
 				subid_nss = NULL;
 				goto done;
 			}
-			subid_nss->has_any_range = dlsym(h, "shadow_subid_has_any_range");
-			if (!subid_nss->has_any_range) {
-				fprintf(shadow_logfd, "%s did not provide @has_any_range@\n", libname);
-				dlclose(h);
-				free(subid_nss);
-				subid_nss = NULL;
-				goto done;
-			}
 			subid_nss->find_subid_owners = dlsym(h, "shadow_subid_find_subid_owners");
 			if (!subid_nss->find_subid_owners) {
 				fprintf(shadow_logfd, "%s did not provide @find_subid_owners@\n", libname);

--- a/lib/prototypes.h
+++ b/lib/prototypes.h
@@ -270,18 +270,6 @@ extern bool nss_is_initialized();
 
 struct subid_nss_ops {
 	/*
-	 * nss_has_any_range: does a user own any subid range
-	 *
-	 * @owner: username
-	 * @idtype: subuid or subgid
-	 * @result: true if a subid allocation was found for @owner
-	 *
-	 * returns success if the module was able to determine an answer (true or false),
-	 * else an error status.
-	 */
-	enum subid_status (*has_any_range)(const char *owner, enum subid_type idtype, bool *result);
-
-	/*
 	 * nss_has_range: does a user own a given subid range
 	 *
 	 * @owner: username

--- a/lib/subordinateio.c
+++ b/lib/subordinateio.c
@@ -598,19 +598,8 @@ int sub_uid_open (int mode)
 	return commonio_open (&subordinate_uid_db, mode);
 }
 
-bool sub_uid_assigned(const char *owner)
+bool local_sub_uid_assigned(const char *owner)
 {
-	struct subid_nss_ops *h;
-	bool found;
-	enum subid_status status;
-	h = get_subid_nss_handle();
-	if (h) {
-		status = h->has_any_range(owner, ID_TYPE_UID, &found);
-		if (status == SUBID_STATUS_SUCCESS && found)
-			return true;
-		return false;
-	}
-
 	return range_exists (&subordinate_uid_db, owner);
 }
 
@@ -720,18 +709,8 @@ bool have_sub_gids(const char *owner, gid_t start, unsigned long count)
 	return have_range(&subordinate_gid_db, owner, start, count);
 }
 
-bool sub_gid_assigned(const char *owner)
+bool local_sub_gid_assigned(const char *owner)
 {
-	struct subid_nss_ops *h;
-	bool found;
-	enum subid_status status;
-	h = get_subid_nss_handle();
-	if (h) {
-		status = h->has_any_range(owner, ID_TYPE_GID, &found);
-		if (status == SUBID_STATUS_SUCCESS && found)
-			return true;
-		return false;
-	}
 	return range_exists (&subordinate_gid_db, owner);
 }
 

--- a/lib/subordinateio.h
+++ b/lib/subordinateio.h
@@ -16,7 +16,7 @@
 extern int sub_uid_close(void);
 extern bool have_sub_uids(const char *owner, uid_t start, unsigned long count);
 extern bool sub_uid_file_present (void);
-extern bool sub_uid_assigned(const char *owner);
+extern bool local_sub_uid_assigned(const char *owner);
 extern int sub_uid_lock (void);
 extern int sub_uid_setdbname (const char *filename);
 extern /*@observer@*/const char *sub_uid_dbname (void);
@@ -34,7 +34,7 @@ extern void free_subordinate_ranges(struct subordinate_range **ranges, int count
 extern int sub_gid_close(void);
 extern bool have_sub_gids(const char *owner, gid_t start, unsigned long count);
 extern bool sub_gid_file_present (void);
-extern bool sub_gid_assigned(const char *owner);
+extern bool local_sub_gid_assigned(const char *owner);
 extern int sub_gid_lock (void);
 extern int sub_gid_setdbname (const char *filename);
 extern /*@observer@*/const char *sub_gid_dbname (void);

--- a/src/newusers.c
+++ b/src/newusers.c
@@ -1033,6 +1033,24 @@ static void close_files (void)
 #endif				/* ENABLE_SUBIDS */
 }
 
+static bool want_subuids(void)
+{
+	if (get_subid_nss_handle() != NULL)
+		return false;
+	if (getdef_ulong ("SUB_UID_COUNT", 65536) == 0)
+		return false;
+	return true;
+}
+
+static bool want_subgids(void)
+{
+	if (get_subid_nss_handle() != NULL)
+		return false;
+	if (getdef_ulong ("SUB_GID_COUNT", 65536) == 0)
+		return false;
+	return true;
+}
+
 int main (int argc, char **argv)
 {
 	char buf[BUFSIZ];
@@ -1262,7 +1280,7 @@ int main (int argc, char **argv)
 		/*
 		 * Add subordinate uids if the user does not have them.
 		 */
-		if (is_sub_uid && !sub_uid_assigned(fields[0])) {
+		if (is_sub_uid && want_subuids() && !local_sub_uid_assigned(fields[0])) {
 			uid_t sub_uid_start = 0;
 			unsigned long sub_uid_count = 0;
 			if (find_new_sub_uids(&sub_uid_start, &sub_uid_count) == 0) {
@@ -1282,7 +1300,7 @@ int main (int argc, char **argv)
 		/*
 		 * Add subordinate gids if the user does not have them.
 		 */
-		if (is_sub_gid && !sub_gid_assigned(fields[0])) {
+		if (is_sub_gid && want_subgids() && !local_sub_gid_assigned(fields[0])) {
 			gid_t sub_gid_start = 0;
 			unsigned long sub_gid_count = 0;
 			if (find_new_sub_gids(&sub_gid_start, &sub_gid_count) == 0) {


### PR DESCRIPTION
Closes #331

1. drop 'has_any_range' nss method as it is not useful

2. do not try to create a subid range in newusers when using nss for
   subids, since that's not possible.

Signed-off-by: Serge Hallyn <serge@hallyn.com>
(cherry picked from commit 88a434adbdcf4a8640793fd58bcd2ba77598349d)