### PR TITLE
usermod, newusers, prefix: enforce absolute paths for homedir

### DIFF
--- a/libmisc/prefix_flag.c
+++ b/libmisc/prefix_flag.c
@@ -109,6 +109,12 @@ extern const char* process_prefix_flag (const char* short_opt, int argc, char **
 			return ""; /* if prefix is "/" then we ignore the flag option */
 		/* should we prevent symbolic link from being used as a prefix? */
 
+		if ( prefix[0] != '/') {
+			fprintf (shadow_logfd,
+				 _("%s: prefix must be an absolute path\n"),
+				 Prog);
+			exit (E_BAD_ARG);
+		}
 		size_t len;
 		len = strlen(prefix) + strlen(PASSWD_FILE) + 2;
 		passwd_db_file = xmalloc(len);

--- a/src/newusers.c
+++ b/src/newusers.c
@@ -1250,6 +1250,13 @@ int main (int argc, char **argv)
 /* FIXME: should check for directory */
 			mode_t mode = getdef_num ("HOME_MODE",
 			                          0777 & ~getdef_num ("UMASK", GETDEF_DEFAULT_UMASK));
+			if (newpw.pw_dir[0] != '/') {
+				fprintf(stderr,
+					_("%s: line %d: homedir must be an absolute path\n"),
+					Prog, line);
+				errors++;
+				continue;
+			};
 			if (mkdir (newpw.pw_dir, mode) != 0) {
 				fprintf (stderr,
 				         _("%s: line %d: mkdir %s failed: %s\n"),

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -1110,6 +1110,12 @@ static void process_flags (int argc, char **argv)
 				}
 				dflg = true;
 				user_newhome = optarg;
+				if (user_newhome[0] != '/') {
+					fprintf (stderr,
+					         _("%s: homedir must be an absolute path\n"),
+					         Prog);
+					exit (E_BAD_ARG);
+				}
 				break;
 			case 'e':
 				if ('\0' != *optarg) {


### PR DESCRIPTION
useradd already was enforcing this, but these were not.

Signed-off-by: Serge Hallyn <serge@hallyn.com>