### PR TITLE
man: use the consistent value 0 to disable PASS_MIN_DAYS restriction

### DIFF
--- a/man/login.defs.d/PASS_MIN_DAYS.xml
+++ b/man/login.defs.d/PASS_MIN_DAYS.xml
@@ -34,7 +34,7 @@
     <para>
       The minimum number of days allowed between password changes.  Any
       password changes attempted sooner than this will be rejected. If not
-      specified, -1 will be assumed (which disables the restriction).
+      specified, 0 will be assumed (which disables the restriction).
     </para>
   </listitem>
 </varlistentry>


### PR DESCRIPTION
This is a patch for #349.