### PR TITLE
Fix covscan RESOURCE_LEAK

### DIFF
--- a/lib/commonio.c
+++ b/lib/commonio.c
@@ -336,8 +336,12 @@ static int create_backup (const char *backup, FILE * fp)
 		/* FIXME: unlink the backup file? */
 		return -1;
 	}
-	if (   (fsync (fileno (bkfp)) != 0)
-	    || (fclose (bkfp) != 0)) {
+	if (fsync (fileno (bkfp)) != 0) {
+		(void) fclose (bkfp);
+		/* FIXME: unlink the backup file? */
+		return -1;
+	}
+	if (fclose (bkfp) != 0) {
 		/* FIXME: unlink the backup file? */
 		return -1;
 	}

--- a/libmisc/addgrps.c
+++ b/libmisc/addgrps.c
@@ -57,6 +57,7 @@ int add_groups (const char *list)
 	bool added;
 	char *token;
 	char buf[1024];
+	int ret;
 
 	if (strlen (list) >= sizeof (buf)) {
 		errno = EINVAL;
@@ -120,9 +121,12 @@ int add_groups (const char *list)
 	}
 
 	if (added) {
-		return setgroups ((size_t)ngroups, grouplist);
+		ret = setgroups ((size_t)ngroups, grouplist);
+		free (grouplist);
+		return ret;
 	}
 
+	free (grouplist);
 	return 0;
 }
 #else				/* HAVE_SETGROUPS && !USE_PAM */

--- a/libmisc/chowntty.c
+++ b/libmisc/chowntty.c
@@ -62,6 +62,7 @@ void chown_tty (const struct passwd *info)
 	grent = getgr_nam_gid (getdef_str ("TTYGROUP"));
 	if (NULL != grent) {
 		gid = grent->gr_gid;
+		gr_free (grent);
 	} else {
 		gid = info->pw_gid;
 	}

--- a/libmisc/copydir.c
+++ b/libmisc/copydir.c
@@ -745,6 +745,7 @@ static int copy_file (const char *src, const char *dst,
 	}
 #ifdef WITH_SELINUX
 	if (set_selinux_file_context (dst, S_IFREG) != 0) {
+		(void) close (ifd);
 		return -1;
 	}
 #endif				/* WITH_SELINUX */
@@ -771,12 +772,16 @@ static int copy_file (const char *src, const char *dst,
 	        && (errno != 0))
 #endif				/* WITH_ATTR */
 	   ) {
+		if (ofd >= 0) {
+			(void) close (ofd);
+		}
 		(void) close (ifd);
 		return -1;
 	}
 
 	while ((cnt = read (ifd, buf, sizeof buf)) > 0) {
 		if (write (ofd, buf, (size_t)cnt) != cnt) {
+			(void) close (ofd);
 			(void) close (ifd);
 			return -1;
 		}
@@ -786,6 +791,7 @@ static int copy_file (const char *src, const char *dst,
 
 #ifdef HAVE_FUTIMES
 	if (futimes (ofd, mt) != 0) {
+		(void) close (ofd);
 		return -1;
 	}
 #endif				/* HAVE_FUTIMES */

--- a/libmisc/idmapping.c
+++ b/libmisc/idmapping.c
@@ -241,4 +241,5 @@ void write_mapping(int proc_dir_fd, int ranges, struct map_range *mappings,
 		exit(EXIT_FAILURE);
 	}
 	close(fd);
+	free(buf);
 }

--- a/libmisc/list.c
+++ b/libmisc/list.c
@@ -241,6 +241,7 @@ bool is_on_list (char *const *list, const char *member)
 
 	if ('\0' == *members) {
 		*array = (char *) 0;
+		free (members);
 		return array;
 	}
 
@@ -261,6 +262,8 @@ bool is_on_list (char *const *list, const char *member)
 			break;
 		}
 	}
+
+	free (members);
 
 	/*
 	 * Return the new array of pointers

--- a/libmisc/myname.c
+++ b/libmisc/myname.c
@@ -62,6 +62,9 @@
 		if ((NULL != pw) && (pw->pw_uid == ruid)) {
 			return pw;
 		}
+		if (NULL != pw) {
+			pw_free (pw);
+		}
 	}
 
 	return xgetpwuid (ruid);

--- a/libmisc/user_busy.c
+++ b/libmisc/user_busy.c
@@ -269,6 +269,7 @@ static int user_busy_processes (const char *name, uid_t uid)
 				}
 				if (check_status (name, task_path+6, uid) != 0) {
 					(void) closedir (proc);
+					(void) closedir (task_dir);
 #ifdef ENABLE_SUBIDS
 					sub_uid_close();
 #endif

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -162,8 +162,9 @@ static void check_perms (const struct group *grp,
 	 */
 	spwd = xgetspnam (pwd->pw_name);
 	if (NULL != spwd) {
-		pwd->pw_passwd = spwd->sp_pwdp;
+		pwd->pw_passwd = xstrdup (spwd->sp_pwdp);
 	}
+	spw_free (spwd);
 
 	if ((pwd->pw_passwd[0] == '\0') && (grp->gr_passwd[0] != '\0')) {
 		needspasswd = true;

--- a/src/passwd.c
+++ b/src/passwd.c
@@ -553,6 +553,11 @@ static char *update_crypt_pw (char *cp)
 
 		strcpy (newpw, "!");
 		strcat (newpw, cp);
+#ifndef USE_PAM
+		if (do_update_pwd) {
+			free (cp);
+		}
+#endif /* USE_PAM */
 		cp = newpw;
 	}
 	return cp;


### PR DESCRIPTION
I'm not completely sure about the change I made in `libmisc/addgrps.c`, so it would be nice to have a thorough review of it.

Error: RESOURCE_LEAK (CWE-772): [#def1]
shadow-4.8.1/lib/commonio.c:320: alloc_fn: Storage is returned from allocation function "fopen_set_perms".
shadow-4.8.1/lib/commonio.c:320: var_assign: Assigning: "bkfp" = storage returned from "fopen_set_perms(backup, "w", &sb)".
shadow-4.8.1/lib/commonio.c:329: noescape: Resource "bkfp" is not freed or pointed-to in "putc".
shadow-4.8.1/lib/commonio.c:334: noescape: Resource "bkfp" is not freed or pointed-to in "fflush".
shadow-4.8.1/lib/commonio.c:339: noescape: Resource "bkfp" is not freed or pointed-to in "fileno".
shadow-4.8.1/lib/commonio.c:342: leaked_storage: Variable "bkfp" going out of scope leaks the storage it points to.
  340|   	    || (fclose (bkfp) != 0)) {
  341|   		/* FIXME: unlink the backup file? */
  342|-> 		return -1;
  343|   	}
  344|

Error: RESOURCE_LEAK (CWE-772): [#def2]
shadow-4.8.1/libmisc/addgrps.c:69: alloc_fn: Storage is returned from allocation function "malloc".
shadow-4.8.1/libmisc/addgrps.c:69: var_assign: Assigning: "grouplist" = storage returned from "malloc(i * 4UL)".
shadow-4.8.1/libmisc/addgrps.c:73: noescape: Resource "grouplist" is not freed or pointed-to in "getgroups". [Note: The source code implementation of the function has been overridden by a builtin model.]
shadow-4.8.1/libmisc/addgrps.c:126: leaked_storage: Variable "grouplist" going out of scope leaks the storage it points to.
  124|   	}
  125|
  126|-> 	return 0;
  127|   }
  128|   #else				/* HAVE_SETGROUPS && !USE_PAM */

Error: RESOURCE_LEAK (CWE-772): [#def3]
shadow-4.8.1/libmisc/chowntty.c:62: alloc_fn: Storage is returned from allocation function "getgr_nam_gid".
shadow-4.8.1/libmisc/chowntty.c:62: var_assign: Assigning: "grent" = storage returned from "getgr_nam_gid(getdef_str("TTYGROUP"))".
shadow-4.8.1/libmisc/chowntty.c:98: leaked_storage: Variable "grent" going out of scope leaks the storage it points to.
   96|   	 */
   97|   #endif
   98|-> }
   99|

Error: RESOURCE_LEAK (CWE-772): [#def4]
shadow-4.8.1/libmisc/copydir.c:742: open_fn: Returning handle opened by "open". [Note: The source code implementation of the function has been overridden by a user model.]
shadow-4.8.1/libmisc/copydir.c:742: var_assign: Assigning: "ifd" = handle returned from "open(src, 0)".
shadow-4.8.1/libmisc/copydir.c:748: leaked_handle: Handle variable "ifd" going out of scope leaks the handle.
  746|   #ifdef WITH_SELINUX
  747|   	if (set_selinux_file_context (dst, NULL) != 0) {
  748|-> 		return -1;
  749|   	}
  750|   #endif				/* WITH_SELINUX */

Error: RESOURCE_LEAK (CWE-772): [#def5]
shadow-4.8.1/libmisc/copydir.c:751: open_fn: Returning handle opened by "open". [Note: The source code implementation of the function has been overridden by a user model.]
shadow-4.8.1/libmisc/copydir.c:751: var_assign: Assigning: "ofd" = handle returned from "open(dst, 577, statp->st_mode & 0xfffU)".
shadow-4.8.1/libmisc/copydir.c:752: noescape: Resource "ofd" is not freed or pointed-to in "fchown_if_needed".
shadow-4.8.1/libmisc/copydir.c:775: leaked_handle: Handle variable "ofd" going out of scope leaks the handle.
  773|   	   ) {
  774|   		(void) close (ifd);
  775|-> 		return -1;
  776|   	}
  777|

Error: RESOURCE_LEAK (CWE-772): [#def7]
shadow-4.8.1/libmisc/idmapping.c:188: alloc_fn: Storage is returned from allocation function "xmalloc".
shadow-4.8.1/libmisc/idmapping.c:188: var_assign: Assigning: "buf" = storage returned from "xmalloc(bufsize)".
shadow-4.8.1/libmisc/idmapping.c:188: var_assign: Assigning: "pos" = "buf".
shadow-4.8.1/libmisc/idmapping.c:213: noescape: Resource "buf" is not freed or pointed-to in "write".
shadow-4.8.1/libmisc/idmapping.c:219: leaked_storage: Variable "pos" going out of scope leaks the storage it points to.
shadow-4.8.1/libmisc/idmapping.c:219: leaked_storage: Variable "buf" going out of scope leaks the storage it points to.
  217|   	}
  218|   	close(fd);
  219|-> }

Error: RESOURCE_LEAK (CWE-772): [#def8]
shadow-4.8.1/libmisc/list.c:211: alloc_fn: Storage is returned from allocation function "xstrdup".
shadow-4.8.1/libmisc/list.c:211: var_assign: Assigning: "members" = storage returned from "xstrdup(comma)".
shadow-4.8.1/libmisc/list.c:217: var_assign: Assigning: "cp" = "members".
shadow-4.8.1/libmisc/list.c:218: noescape: Resource "cp" is not freed or pointed-to in "strchr".
shadow-4.8.1/libmisc/list.c:244: leaked_storage: Variable "cp" going out of scope leaks the storage it points to.
shadow-4.8.1/libmisc/list.c:244: leaked_storage: Variable "members" going out of scope leaks the storage it points to.
  242|   	if ('\0' == *members) {
  243|   		*array = (char *) 0;
  244|-> 		return array;
  245|   	}
  246|

Error: RESOURCE_LEAK (CWE-772): [#def11]
shadow-4.8.1/libmisc/myname.c:61: alloc_fn: Storage is returned from allocation function "xgetpwnam".
shadow-4.8.1/libmisc/myname.c:61: var_assign: Assigning: "pw" = storage returned from "xgetpwnam(cp)".
shadow-4.8.1/libmisc/myname.c:67: leaked_storage: Variable "pw" going out of scope leaks the storage it points to.
   65|   	}
   66|
   67|-> 	return xgetpwuid (ruid);
   68|   }
   69|

Error: RESOURCE_LEAK (CWE-772): [#def12]
shadow-4.8.1/libmisc/user_busy.c:260: alloc_fn: Storage is returned from allocation function "opendir".
shadow-4.8.1/libmisc/user_busy.c:260: var_assign: Assigning: "task_dir" = storage returned from "opendir(task_path)".
shadow-4.8.1/libmisc/user_busy.c:262: noescape: Resource "task_dir" is not freed or pointed-to in "readdir".
shadow-4.8.1/libmisc/user_busy.c:278: leaked_storage: Variable "task_dir" going out of scope leaks the storage it points to.
  276|   					         _("%s: user %s is currently used by process %d\n"),
  277|   					         Prog, name, pid);
  278|-> 					return 1;
  279|   				}
  280|   			}

Error: RESOURCE_LEAK (CWE-772): [#def20]
shadow-4.8.1/src/newgrp.c:162: alloc_fn: Storage is returned from allocation function "xgetspnam".
shadow-4.8.1/src/newgrp.c:162: var_assign: Assigning: "spwd" = storage returned from "xgetspnam(pwd->pw_name)".
shadow-4.8.1/src/newgrp.c:234: leaked_storage: Variable "spwd" going out of scope leaks the storage it points to.
  232|   	}
  233|
  234|-> 	return;
  235|
  236|   failure:

Error: RESOURCE_LEAK (CWE-772): [#def21]
shadow-4.8.1/src/passwd.c:530: alloc_fn: Storage is returned from allocation function "xstrdup".
shadow-4.8.1/src/passwd.c:530: var_assign: Assigning: "cp" = storage returned from "xstrdup(crypt_passwd)".
shadow-4.8.1/src/passwd.c:551: noescape: Resource "cp" is not freed or pointed-to in "strlen".
shadow-4.8.1/src/passwd.c:554: noescape: Resource "cp" is not freed or pointed-to in "strcat". [Note: The source code implementation of the function has been overridden by a builtin model.]
shadow-4.8.1/src/passwd.c:555: overwrite_var: Overwriting "cp" in "cp = newpw" leaks the storage that "cp" points to.
  553|   		strcpy (newpw, "!");
  554|   		strcat (newpw, cp);
  555|-> 		cp = newpw;
  556|   	}
  557|   	return cp;