### PR TITLE
bcrypt should use $2b$ as prefix for setting.

### DIFF
--- a/libmisc/salt.c
+++ b/libmisc/salt.c
@@ -34,7 +34,7 @@ static /*@observer@*/const char *BCRYPT_salt_rounds (/*@null@*/int *prefered_rou
 #endif /* USE_BCRYPT */
 #ifdef USE_YESCRYPT
 static /*@observer@*/const char *gensalt_yescrypt (void);
-static /*@observer@*/const char *YESCRYPT_salt_cost (/*@null@*/long *prefered_rounds);
+static /*@observer@*/const char *YESCRYPT_salt_cost (/*@null@*/int *prefered_cost);
 #endif /* USE_YESCRYPT */
 
 #ifndef HAVE_L64A
@@ -277,7 +277,7 @@ static /*@observer@*/const char *gensalt_bcrypt (void)
 /*
  * Return a salt prefix specifying the cost for the YESCRYPT method.
  */
-static /*@observer@*/const char *YESCRYPT_salt_cost (/*@null@*/long *prefered_cost)
+static /*@observer@*/const char *YESCRYPT_salt_cost (/*@null@*/int *prefered_cost)
 {
 	static char cost_prefix[5];
 	long cost;

--- a/libmisc/salt.c
+++ b/libmisc/salt.c
@@ -90,12 +90,8 @@ static void seedRNG (void)
  */
 #define MAGNUM(array,ch)	(array)[0]=(array)[2]='$',(array)[1]=(ch),(array)[3]='\0'
 #ifdef USE_BCRYPT
-/* 
- * Using the Prefix $2a$ to enable an anti-collision safety measure in musl libc.
- * Negatively affects a subset of passwords containing the '\xff' character,
- * which is not valid UTF-8 (so "unlikely to cause much annoyance").
- */
-#define BCRYPTMAGNUM(array)	(array)[0]=(array)[3]='$',(array)[1]='2',(array)[2]='a',(array)[4]='\0'
+/* Use $2b$ as prefix for compatibility with OpenBSD's bcrypt. */
+#define BCRYPTMAGNUM(array)	(array)[0]=(array)[3]='$',(array)[1]='2',(array)[2]='b',(array)[4]='\0'
 #endif /* USE_BCRYPT */
 
 #if defined(USE_SHA_CRYPT) || defined(USE_BCRYPT)


### PR DESCRIPTION
This prefix is the recommended one for new bcrypt hashes for a long time.