### PR TITLE
Fix covscan BUFFER_SIZE

### DIFF
--- a/libmisc/failure.c
+++ b/libmisc/failure.c
@@ -98,7 +98,7 @@ void failure (uid_t uid, const char *tty, struct faillog *fl)
 		fl->fail_cnt++;
 	}
 
-	strncpy (fl->fail_line, tty, sizeof fl->fail_line);
+	strncpy (fl->fail_line, tty, sizeof (fl->fail_line) - 1);
 	(void) time (&fl->fail_time);
 
 	/*

--- a/libmisc/log.c
+++ b/libmisc/log.c
@@ -100,9 +100,9 @@ void dolastlog (
 	ll_time = newlog.ll_time;
 	(void) time (&ll_time);
 	newlog.ll_time = ll_time;
-	strncpy (newlog.ll_line, line, sizeof newlog.ll_line);
+	strncpy (newlog.ll_line, line, sizeof (newlog.ll_line) - 1);
 #if HAVE_LL_HOST
-	strncpy (newlog.ll_host, host, sizeof newlog.ll_host);
+	strncpy (newlog.ll_host, host, sizeof (newlog.ll_host) - 1);
 #endif
 	if (   (lseek (fd, offset, SEEK_SET) != offset)
 	    || (write (fd, (const void *) &newlog, sizeof newlog) != (ssize_t) sizeof newlog)

--- a/libmisc/utmp.c
+++ b/libmisc/utmp.c
@@ -257,25 +257,25 @@ static void updwtmpx (const char *filename, const struct utmpx *utx)
 	utent->ut_type = USER_PROCESS;
 #endif				/* HAVE_STRUCT_UTMP_UT_TYPE */
 	utent->ut_pid = getpid ();
-	strncpy (utent->ut_line, line,      sizeof (utent->ut_line));
+	strncpy (utent->ut_line, line,      sizeof (utent->ut_line) - 1);
 #ifdef HAVE_STRUCT_UTMP_UT_ID
 	if (NULL != ut) {
 		strncpy (utent->ut_id, ut->ut_id, sizeof (utent->ut_id));
 	} else {
 		/* XXX - assumes /dev/tty?? */
-		strncpy (utent->ut_id, line + 3, sizeof (utent->ut_id));
+		strncpy (utent->ut_id, line + 3, sizeof (utent->ut_id) - 1);
 	}
 #endif				/* HAVE_STRUCT_UTMP_UT_ID */
 #ifdef HAVE_STRUCT_UTMP_UT_NAME
 	strncpy (utent->ut_name, name,      sizeof (utent->ut_name));
 #endif				/* HAVE_STRUCT_UTMP_UT_NAME */
 #ifdef HAVE_STRUCT_UTMP_UT_USER
-	strncpy (utent->ut_user, name,      sizeof (utent->ut_user));
+	strncpy (utent->ut_user, name,      sizeof (utent->ut_user) - 1);
 #endif				/* HAVE_STRUCT_UTMP_UT_USER */
 	if (NULL != hostname) {
 		struct addrinfo *info = NULL;
 #ifdef HAVE_STRUCT_UTMP_UT_HOST
-		strncpy (utent->ut_host, hostname, sizeof (utent->ut_host));
+		strncpy (utent->ut_host, hostname, sizeof (utent->ut_host) - 1);
 #endif				/* HAVE_STRUCT_UTMP_UT_HOST */
 #ifdef HAVE_STRUCT_UTMP_UT_SYSLEN
 		utent->ut_syslen = MIN (strlen (hostname),


### PR DESCRIPTION
Error: BUFFER_SIZE (CWE-170): [#def6]
shadow-4.8.1/libmisc/failure.c:101: buffer_size_warning: Calling "strncpy" with a maximum size argument of 12 bytes on destination array "fl->fail_line" of size 12 bytes might leave the destination string unterminated.
   99|   	}
  100|
  101|-> 	strncpy (fl->fail_line, tty, sizeof fl->fail_line);
  102|   	(void) time (&fl->fail_time);
  103|

Error: BUFFER_SIZE (CWE-170): [#def9]
shadow-4.8.1/libmisc/log.c:103: buffer_size_warning: Calling "strncpy" with a maximum size argument of 32 bytes on destination array "newlog.ll_line" of size 32 bytes might leave the destination string unterminated.
  101|   	(void) time (&ll_time);
  102|   	newlog.ll_time = ll_time;
  103|-> 	strncpy (newlog.ll_line, line, sizeof newlog.ll_line);
  104|   #if HAVE_LL_HOST
  105|   	strncpy (newlog.ll_host, host, sizeof newlog.ll_host);

Error: BUFFER_SIZE (CWE-170): [#def10]
shadow-4.8.1/libmisc/log.c:105: buffer_size_warning: Calling "strncpy" with a maximum size argument of 256 bytes on destination array "newlog.ll_host" of size 256 bytes might leave the destination string unterminated.
  103|   	strncpy (newlog.ll_line, line, sizeof newlog.ll_line);
  104|   #if HAVE_LL_HOST
  105|-> 	strncpy (newlog.ll_host, host, sizeof newlog.ll_host);
  106|   #endif
  107|   	if (   (lseek (fd, offset, SEEK_SET) != offset)

Error: BUFFER_SIZE (CWE-170): [#def13]
shadow-4.8.1/libmisc/utmp.c:260: buffer_size_warning: Calling "strncpy" with a maximum size argument of 32 bytes on destination array "utent->ut_line" of size 32 bytes might leave the destination string unterminated.
  258|   #endif				/* HAVE_STRUCT_UTMP_UT_TYPE */
  259|   	utent->ut_pid = getpid ();
  260|-> 	strncpy (utent->ut_line, line,      sizeof (utent->ut_line));
  261|   #ifdef HAVE_STRUCT_UTMP_UT_ID
  262|   	if (NULL != ut) {

Error: BUFFER_SIZE (CWE-170): [#def14]
shadow-4.8.1/libmisc/utmp.c:266: buffer_size_warning: Calling "strncpy" with a maximum size argument of 4 bytes on destination array "utent->ut_id" of size 4 bytes might leave the destination string unterminated.
  264|   	} else {
  265|   		/* XXX - assumes /dev/tty?? */
  266|-> 		strncpy (utent->ut_id, line + 3, sizeof (utent->ut_id));
  267|   	}
  268|   #endif				/* HAVE_STRUCT_UTMP_UT_ID */

Error: BUFFER_SIZE (CWE-170): [#def15]
shadow-4.8.1/libmisc/utmp.c:273: buffer_size_warning: Calling "strncpy" with a maximum size argument of 32 bytes on destination array "utent->ut_user" of size 32 bytes might leave the destination string unterminated.
  271|   #endif				/* HAVE_STRUCT_UTMP_UT_NAME */
  272|   #ifdef HAVE_STRUCT_UTMP_UT_USER
  273|-> 	strncpy (utent->ut_user, name,      sizeof (utent->ut_user));
  274|   #endif				/* HAVE_STRUCT_UTMP_UT_USER */
  275|   	if (NULL != hostname) {

Error: BUFFER_SIZE (CWE-170): [#def16]
shadow-4.8.1/libmisc/utmp.c:278: buffer_size_warning: Calling "strncpy" with a maximum size argument of 256 bytes on destination array "utent->ut_host" of size 256 bytes might leave the destination string unterminated.
  276|   		struct addrinfo *info = NULL;
  277|   #ifdef HAVE_STRUCT_UTMP_UT_HOST
  278|-> 		strncpy (utent->ut_host, hostname, sizeof (utent->ut_host));
  279|   #endif				/* HAVE_STRUCT_UTMP_UT_HOST */
  280|   #ifdef HAVE_STRUCT_UTMP_UT_SYSLEN

Signed-off-by: Iker Pedrosa <ipedrosa@redhat.com>