### PR TITLE
libmisc/salt.c: Use secure system ressources to obtain random bytes.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -44,18 +44,19 @@ AC_HEADER_STDBOOL
 
 AC_CHECK_HEADERS(errno.h fcntl.h limits.h unistd.h sys/time.h utmp.h \
 	utmpx.h termios.h termio.h sgtty.h sys/ioctl.h syslog.h paths.h \
-	utime.h ulimit.h sys/capability.h sys/resource.h gshadow.h lastlog.h \
-	locale.h rpc/key_prot.h netdb.h acl/libacl.h attr/libattr.h \
-	attr/error_context.h)
+	utime.h ulimit.h sys/capability.h sys/random.h sys/resource.h \
+	gshadow.h lastlog.h locale.h rpc/key_prot.h netdb.h acl/libacl.h \
+	attr/libattr.h attr/error_context.h)
 
 dnl shadow now uses the libc's shadow implementation
 AC_CHECK_HEADER([shadow.h],,[AC_MSG_ERROR([You need a libc with shadow.h])])
 
-AC_CHECK_FUNCS(l64a fchmod fchown fsync futimes getgroups gethostname getspnam \
-	gettimeofday getusershell getutent initgroups lchown lckpwdf lstat \
-	lutimes memcpy memset setgroups sigaction strchr updwtmp updwtmpx innetgr \
-	getpwnam_r getpwuid_r getgrnam_r getgrgid_r getspnam_r getaddrinfo \
-	ruserok dlopen)
+AC_CHECK_FUNCS(arc4random_buf l64a fchmod fchown fsync futimes getgroups \
+	gethostname getentropy getrandom getspnam gettimeofday getusershell \
+	getutent initgroups lchown lckpwdf lstat lutimes memcpy memset \
+	setgroups sigaction strchr updwtmp updwtmpx innetgr getpwnam_r \
+	getpwuid_r getgrnam_r getgrgid_r getspnam_r getaddrinfo ruserok \
+	dlopen)
 AC_SYS_LARGEFILE
 
 dnl Checks for typedefs, structures, and compiler characteristics.


### PR DESCRIPTION
In a previous commit we introduced `/dev/urandom` as a source to obtain random bytes from.  This may not be available on all systems, or when operating inside of a chroot.

Almost all systems provide functions to obtain random bytes from secure system ressources.  Thus we should prefer to use these, and fall back to `/dev/urandom`, if there is no such function present, as a last resort.

***

See:  https://github.com/shadow-maint/shadow/pull/377#issuecomment-873534049

@AdamWill: This PR will likely fix your issue.