### PR TITLE
libmisc: don't free members variable

### DIFF
--- a/libmisc/list.c
+++ b/libmisc/list.c
@@ -263,8 +263,6 @@ bool is_on_list (char *const *list, const char *member)
 		}
 	}
 
-	free (members);
-
 	/*
 	 * Return the new array of pointers
 	 */


### PR DESCRIPTION
In 9eb191edc4a625bb68e827b18638f5b5816cb30c I included a free() that
frees the members variable, which in turn causes the comma_to_list()
function to return an array of empty elements. The array variable holds
a list of pointers that point to offsets of the members variable. When
the function succeeds freeing members variable causes the elements of
the array variable to point to an empty string.

This is causing several regressions in our internal testing environment.
So, I'm reverting the change.

Signed-off-by: Iker Pedrosa <ipedrosa@redhat.com>