### PR TITLE
libsubid: link to PAM libraries

### DIFF
--- a/libsubid/Makefile.am
+++ b/libsubid/Makefile.am
@@ -16,7 +16,8 @@ MISCLIBS = \
 	$(LIBCRYPT) \
 	$(LIBACL) \
 	$(LIBATTR) \
-	$(LIBTCB)
+	$(LIBTCB) \
+	$(LIBPAM)
 
 libsubid_la_LIBADD = \
 	$(top_srcdir)/lib/libshadow.la \


### PR DESCRIPTION
libsubid.so links to libmisc.a, which contains several routines referring to
PAM functions.

Fixes #384.