### PR TITLE
Fix out of tree builds with respect to libsubid includes

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -10,6 +10,8 @@ if HAVE_VENDORDIR
 libshadow_la_CPPFLAGS += -DVENDORDIR=\"$(VENDORDIR)\"
 endif
 
+libshadow_la_CPPFLAGS += -I$(top_srcdir)
+
 libshadow_la_SOURCES = \
 	commonio.c \
 	commonio.h \

--- a/libmisc/Makefile.am
+++ b/libmisc/Makefile.am
@@ -1,7 +1,7 @@
 
 EXTRA_DIST = .indent.pro xgetXXbyYY.c
 
-AM_CPPFLAGS = -I$(top_srcdir)/lib $(ECONF_CPPFLAGS)
+AM_CPPFLAGS = -I$(top_srcdir)/lib -I$(top_srcdir) $(ECONF_CPPFLAGS)
 
 noinst_LTLIBRARIES = libmisc.la
 

--- a/libsubid/Makefile.am
+++ b/libsubid/Makefile.am
@@ -20,8 +20,8 @@ MISCLIBS = \
 	$(LIBPAM)
 
 libsubid_la_LIBADD = \
-	$(top_srcdir)/lib/libshadow.la \
-	$(top_srcdir)/libmisc/libmisc.la \
+	$(top_builddir)/lib/libshadow.la \
+	$(top_builddir)/libmisc/libmisc.la \
 	$(MISCLIBS) -ldl
 
 AM_CPPFLAGS = \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -10,6 +10,7 @@ sgidperms = 2755
 AM_CPPFLAGS = \
 	-I${top_srcdir}/lib \
 	-I$(top_srcdir)/libmisc \
+	-I$(top_srcdir) \
 	-DLOCALEDIR=\"$(datadir)/locale\"
 
 # XXX why are login and su in /bin anyway (other than for
@@ -183,6 +184,7 @@ list_subid_ranges_LDADD = \
 list_subid_ranges_CPPFLAGS = \
 	-I$(top_srcdir)/lib \
 	-I$(top_srcdir)/libmisc \
+	-I$(top_srcdir) \
 	-I$(top_srcdir)/libsubid
 
 get_subid_owners_LDADD = \
@@ -194,11 +196,13 @@ get_subid_owners_LDADD = \
 get_subid_owners_CPPFLAGS = \
 	-I$(top_srcdir)/lib \
 	-I$(top_srcdir)/libmisc \
+	-I$(top_srcdir) \
 	-I$(top_srcdir)/libsubid
 
 new_subid_range_CPPFLAGS = \
 	-I$(top_srcdir)/lib \
 	-I$(top_srcdir)/libmisc \
+	-I$(top_srcdir) \
 	-I$(top_srcdir)/libsubid
 
 new_subid_range_LDADD = \
@@ -210,6 +214,7 @@ new_subid_range_LDADD = \
 free_subid_range_CPPFLAGS = \
 	-I$(top_srcdir)/lib \
 	-I$(top_srcdir)/libmisc \
+	-I$(top_srcdir) \
 	-I$(top_srcdir)/libsubid
 
 free_subid_range_LDADD = \
@@ -220,6 +225,7 @@ free_subid_range_LDADD = \
 
 check_subid_range_CPPFLAGS = \
 	-I$(top_srcdir)/lib \
+	-I$(top_srcdir) \
 	-I$(top_srcdir)/libmisc
 
 check_subid_range_LDADD = \


### PR DESCRIPTION
There's a better way to do this, and I hope to clean that up,
but this fixes out of tree builds for me right now.

Closes #386

Signed-off-by: Serge Hallyn <serge@hallyn.com>