### PR TITLE
Respect --enable-static=no in libsubid

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -321,6 +321,8 @@ if test "$with_sha_crypt" = "yes"; then
 	AC_DEFINE(USE_SHA_CRYPT, 1, [Define to allow the SHA256 and SHA512 password encryption algorithms])
 fi
 
+AM_CONDITIONAL(ENABLE_SHARED, test "x$enable_shared" = "xyes")
+
 AM_CONDITIONAL(USE_BCRYPT, test "x$with_bcrypt" = "xyes")
 if test "$with_bcrypt" = "yes"; then
 	AC_DEFINE(USE_BCRYPT, 1, [Define to allow the bcrypt password encryption algorithm])

--- a/libsubid/Makefile.am
+++ b/libsubid/Makefile.am
@@ -1,6 +1,8 @@
 lib_LTLIBRARIES = libsubid.la
+if ENABLE_SHARED
 libsubid_la_LDFLAGS = -Wl,-soname,libsubid.so.@LIBSUBID_ABI@ \
 	-shared -version-info @LIBSUBID_ABI_MAJOR@
+endif
 libsubid_la_SOURCES = api.c
 
 pkginclude_HEADERS = subid.h


### PR DESCRIPTION
libsubid's Makefile.am was always setting enable-shared in its LDFLAGS.
Do that only if not building static.

Closes #387

Signed-off-by: Serge Hallyn <shallyn@cisco.com>