### PR TITLE
useradd: create /etc/default saving defaults.

### DIFF
--- a/src/useradd.c
+++ b/src/useradd.c
@@ -567,6 +567,14 @@ static int set_defaults (void)
 		assert (wlen == (int) len -1);
 	}
 
+	ret = mkdir(dirname(NEW_USER_FILE), 0755);
+	if (-1 == ret && EEXIST != errno) {
+		fprintf (stderr,
+			_("%s: cannot create directory for defaults file\n"),
+			Prog);
+		goto setdef_err;
+	}
+
 	/*
 	 * Create a temporary file to copy the new output to.
 	 */


### PR DESCRIPTION
Since bbf4b79, we stopped shipping /etc/default/useradd, and therefore
install of shadow does not auto-create /etc/default.  So when useradd
tries to save a new default, it needs to create the directory.

Closes #390.

Signed-off-by: Serge Hallyn <serge@hallyn.com>