### PR TITLE
passwd: handle NULL pw_passwd when printing password status

### DIFF
--- a/src/passwd.c
+++ b/src/passwd.c
@@ -490,9 +490,12 @@ static void print_status (const struct passwd *pw)
 		               ((long long)sp->sp_max * SCALE) / DAY,
 		               ((long long)sp->sp_warn * SCALE) / DAY,
 		               ((long long)sp->sp_inact * SCALE) / DAY);
-	} else {
+	} else if (NULL != pw->pw_passwd) {
 		(void) printf ("%s %s\n",
 		               pw->pw_name, pw_status (pw->pw_passwd));
+	} else {
+		(void) fprintf(stderr, _("%s: malformed password data obtained for user %s\n"),
+		               Prog, pw->pw_name);
 	}
 }
 


### PR DESCRIPTION
When the -S and -a options are used for passwd to list the status
of all passwords, there is a chance the pw_passwd field of struct
passwd will be NULL. This can be due to 'files compat' being set
for passwd in /etc/nsswitch.conf and the usage of some features
not available in the 'files' mode (e.g. a plus sign at the start
of a line).

Example:

germ161:~ # grep passwd /etc/nsswitch.conf
passwd: files compat
germ161:~ # rpm -qa shadow
shadow-4.2.1-34.20.x86_64
germ161:~ # grep passwd /etc/nsswitch.conf
passwd: files compat
germ161:~ # grep + /etc/passwd
+@nisgroup
germ161:~ # passwd -S -a > /dev/null
Segmentation fault (core dumped)

With this commit:

germ161:~ # passwd -S -a > /dev/null
passwd: malformed password data obtained for user +@nisgroup

This was reproduced on SLES12SP5 (shadow-4.2.1-34.20) and Ubuntu 20.4 (passwd-1:4.8.1-1ubuntu5.20.04.1). The option 'files compat' does not really make sense for passwd, but in any case simply segfaulting is in my opinion a bad way to handle such a case.

An alternative approach would be to check whether the argument to pw_status is not NULL and if so, ignore that entry, but I thought an explicit message was better than simply ignoring the problem.