### PR TITLE
libmisc: fix default value in SHA_get_salt_rounds()

### DIFF
--- a/libmisc/salt.c
+++ b/libmisc/salt.c
@@ -223,20 +223,21 @@ static /*@observer@*/const unsigned long SHA_get_salt_rounds (/*@null@*/int *pre
 		if ((-1 == min_rounds) && (-1 == max_rounds)) {
 			rounds = SHA_ROUNDS_DEFAULT;
 		}
+		else {
+			if (-1 == min_rounds) {
+				min_rounds = max_rounds;
+			}
 
-		if (-1 == min_rounds) {
-			min_rounds = max_rounds;
+			if (-1 == max_rounds) {
+				max_rounds = min_rounds;
+			}
+
+			if (min_rounds > max_rounds) {
+				max_rounds = min_rounds;
+			}
+
+			rounds = (unsigned long) shadow_random (min_rounds, max_rounds);
 		}
-
-		if (-1 == max_rounds) {
-			max_rounds = min_rounds;
-		}
-
-		if (min_rounds > max_rounds) {
-			max_rounds = min_rounds;
-		}
-
-		rounds = (unsigned long) shadow_random (min_rounds, max_rounds);
 	} else if (0 == *prefered_rounds) {
 		rounds = SHA_ROUNDS_DEFAULT;
 	} else {


### PR DESCRIPTION
If SHA_CRYPT_MIN_ROUNDS and SHA_CRYPT_MAX_ROUNDS are both unspecified,
use SHA_ROUNDS_DEFAULT.

Previously, the code fell through, calling shadow_random(-1, -1). This
ultimately set rounds = (unsigned long) -1, which ends up being a very
large number! This then got capped to SHA_ROUNDS_MAX later in the
function.

The new behavior matches BCRYPT_get_salt_rounds().

Bug: https://bugs.gentoo.org/808195
Fixes: https://github.com/shadow-maint/shadow/issues/393