### PR TITLE
useradd.c: Fix undeclared subuid_count when not using subids

### DIFF
--- a/src/useradd.c
+++ b/src/useradd.c
@@ -2418,9 +2418,9 @@ int main (int argc, char **argv)
 #ifdef ENABLE_SUBIDS
 	uid_t uid_min;
 	uid_t uid_max;
-	unsigned long subuid_count;
-	unsigned long subgid_count;
 #endif
+	unsigned long subuid_count = 0;
+	unsigned long subgid_count = 0;
 
 	/*
 	 * Get my name so that I can use it to report errors.


### PR DESCRIPTION
subuid_count won't get used by usr_update(), but since we're passing it
as an argument we have to make sure it's always defined.  So just define
it as pre-set to 0.

Closes #402

Signed-off-by: Serge Hallyn <serge@hallyn.com>