### PR TITLE
Add support for ambient capabilities

### DIFF
--- a/src/login.c
+++ b/src/login.c
@@ -1288,6 +1288,7 @@ int main (int argc, char **argv)
 			env++;
 		}
 	}
+	(void) pam_end (pamh, PAM_SUCCESS | PAM_DATA_SILENT);
 #endif
 
 	(void) setlocale (LC_ALL, "");

--- a/src/su.c
+++ b/src/su.c
@@ -1156,12 +1156,9 @@ int main (int argc, char **argv)
 		}
 	}
 
-	/*
-	 * PAM_DATA_SILENT is not supported by some modules, and
-	 * there is no strong need to clean up the process space's
-	 * memory since we will either call exec or exit.
-	pam_end (pamh, PAM_SUCCESS | PAM_DATA_SILENT);
-	 */
+#ifdef USE_PAM
+	(void) pam_end (pamh, PAM_SUCCESS | PAM_DATA_SILENT);
+#endif
 
 	endpwent ();
 	endspent ();


### PR DESCRIPTION
**Caveat: This is for discussion, mostly. Still need to have a policy for bounded capabilities.**

## Enhance login(1) and su(1) to support ambient capabilities

### How things work without ambient capabilities

POSIX capabilities have been supported by Linux for quite some time now. Most distributions allow to set inheritable capabilities:

Activate `pam_cap.so` (comes with PAM enabled **libcap**)  in your PAM config...
```
auth		required	pam_env.so
auth		optional	pam_cap.so
auth		requisite	pam_faillock.so preauth
[...]
```
...add capabilities to users in `/etc/security/capability.conf`...
```
[...]
cap_net_raw      joeuser
[...]
```
...and enable that capability on an executable:
```
[βελλεροφων ~]# setcap cap_net_raw=ei /usr/bin/traceroute
[βελλεροφων ~]# getcap /usr/bin/traceroute
/usr/bin/traceroute cap_net_raw=ei
[βελλεροφων ~]#
```
Now **joeuser** can perform traceroutes that require raw sockets without using sudo, e.g.
```
traceroute -T -p 22 10.11.12.13
```
**While this already works on most Linux distributions, you have to set the inherited capabilities on every applicable executable, and you will have to set it again after that executable has been updated. It may be the case that _joeuser_ is your network admin and should be allowed to use raw sockets in *any* application. This is where *ambient capabilities* come into play.**

### Ambient Capabilities: Granting privileges on *any application*

Users with _ambient capabilities_ can use these without having them set on an executable with `setcap`. If **joeuser** has the ambient capability **cap_net_raw**, he would be able to use raw sockets in any application, even in scripting languages.

Unfortunately ambient capabilities are more or less unsupported in current distributions. The main reason for this is lacking support in applications that grant access to Linux systems (like **login(1)** and **su(1)**). Those applications usually run with root privileges and drop these with the **setuid()** system call which clears all ambient capabilities. Generally this is a good idea, because there are many applications out there that rely on setuid() to drop _all_ privileges.

To include support for ambient capabilities into **login** and **su**, the application has to set the "keep capabilities" flag and save the set of ambient capabilities before calling **setuid()**, and restore them afterwards. Since version 2.50 libcap's pam_cap.so module supports the "keepcaps" argument, which takes care of the "keep capabilities" flag. So each PAM enabled application just needs to save and restore the capabilities during setuid(). Old and new behavior can be controlled at runtime by changing the PAM configuration.

Signed-off-by: Björn Fischer <bf@CeBiTec.Uni-Bielefeld.DE>