### PR TITLE
treewide: remove trailing whitespaces

### DIFF
--- a/src/chfn.c
+++ b/src/chfn.c
@@ -277,7 +277,7 @@ static void process_flags (int argc, char **argv)
 		{NULL, 0, NULL, '\0'}
 	};
 
-	/* 
+	/*
 	 * The remaining arguments will be processed one by one and executed
 	 * by this command. The name is the last argument if it does not
 	 * begin with a "-", otherwise the name is determined from the
@@ -392,7 +392,7 @@ static void check_perms (const struct passwd *pw)
 	/*
 	 * Non-privileged users are optionally authenticated (must enter the
 	 * password of the user whose information is being changed) before
-	 * any changes can be made. Idea from util-linux chfn/chsh. 
+	 * any changes can be made. Idea from util-linux chfn/chsh.
 	 * --marekm
 	 */
 	if (!amroot && getdef_bool ("CHFN_AUTH")) {

--- a/src/chgpasswd.c
+++ b/src/chgpasswd.c
@@ -593,7 +593,7 @@ int main (int argc, char **argv)
 			newgr.gr_passwd = cp;
 		}
 
-		/* 
+		/*
 		 * The updated group file entry is then put back and will
 		 * be written to the group file later, after all the
 		 * other entries have been updated as well.

--- a/src/expiry.c
+++ b/src/expiry.c
@@ -133,7 +133,7 @@ static void process_flags (int argc, char **argv)
 	}
 }
 
-/* 
+/*
  * expiry - check and enforce password expiration policy
  *
  *	expiry checks (-c) the current password expiration and forces (-f)
@@ -149,7 +149,7 @@ int main (int argc, char **argv)
 
 	sanitize_env ();
 
-	/* 
+	/*
 	 * Start by disabling all of the keyboard signals.
 	 */
 	(void) signal (SIGHUP, catch_signals);

--- a/src/groupdel.c
+++ b/src/groupdel.c
@@ -358,7 +358,7 @@ static void process_flags (int argc, char **argv)
  * main - groupdel command
  *
  *	The syntax of the groupdel command is
- *	
+ *
  *	groupdel group
  *
  *	The named group will be deleted.

--- a/src/groupmems.c
+++ b/src/groupmems.c
@@ -85,7 +85,7 @@ static bool sgr_locked = false;
 static char *whoami (void);
 static void add_user (const char *user,
                       const struct group *grp);
-static void remove_user (const char *user, 
+static void remove_user (const char *user,
                          const struct group *grp);
 static void purge_members (const struct group *grp);
 static void display_members (const char *const *members);
@@ -197,7 +197,7 @@ static void add_user (const char *user,
 /*
  * remove_user - Remove an user from a given group
  */
-static void remove_user (const char *user, 
+static void remove_user (const char *user,
                          const struct group *grp)
 {
 	struct group *newgrp;
@@ -587,7 +587,7 @@ static void close_files (void)
 #endif
 }
 
-int main (int argc, char **argv) 
+int main (int argc, char **argv)
 {
 	char *name;
 	const struct group *grp;

--- a/src/grpck.c
+++ b/src/grpck.c
@@ -718,7 +718,7 @@ static void check_sgr_file (int *errors, bool *changed)
 			}
 
 			/*
-			 * All shadow group file deletions wind up here. 
+			 * All shadow group file deletions wind up here.
 			 * This code removes the current entry from the
 			 * linked list. When done, it skips back to the top
 			 * of the loop to try out the next list element.

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -10,7 +10,7 @@
 *
 * Redistribution and use in source and binary forms are permitted
 * provided that this entire copyright notice is duplicated in all such
-* copies.  
+* copies.
 *
 * This software is provided "as is" and without any expressed or implied
 * warranties, including, without limitation, the implied warranties of
@@ -30,7 +30,7 @@
      * control based on login names and on host (or domain) names, internet
      * addresses (or network numbers), or on terminal line names in case of
      * non-networked logins. Diagnostics are reported through syslog(3).
-     * 
+     *
      * Author: Wietse Venema, Eindhoven University of Technology, The Netherlands.
      */
 #include <sys/types.h>

--- a/src/logoutd.c
+++ b/src/logoutd.c
@@ -198,7 +198,7 @@ int main (int argc, char **argv)
 	 */
 	while (true) {
 
-		/* 
+		/*
 		 * Attempt to re-open the utmpx/utmp file. The file is only
 		 * open while it is being used.
 		 */

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -494,7 +494,7 @@ int main (int argc, char **argv)
 		initflag = true;
 	}
 	if (!is_newgrp) {
-		/* 
+		/*
 		 * Do the command line for everything that is
 		 * not "newgrp".
 		 */
@@ -533,7 +533,7 @@ int main (int argc, char **argv)
 			group = argv[0];
 		} else {
 			/*
-			 * get the group file entry for her login group id. 
+			 * get the group file entry for her login group id.
 			 * the entry must exist, simply to be annoying.
 			 *
 			 * Perhaps in the past, but the default behavior now depends on the
@@ -595,17 +595,17 @@ int main (int argc, char **argv)
 	 * now we put her in the new group. The password file entry for her
 	 * current user id has been gotten. If there was no optional group
 	 * argument she will have her real and effective group id set to the
-	 * set to the value from her password file entry.  
+	 * set to the value from her password file entry.
 	 *
 	 * If run as newgrp, or as sg with no command, this process exec's
-	 * an interactive subshell with the effective GID of the new group. 
+	 * an interactive subshell with the effective GID of the new group.
 	 * If run as sg with a command, that command is exec'ed in this
 	 * subshell. When this process terminates, either because the user
 	 * exits, or the command completes, the parent of this process
 	 * resumes with the current GID.
 	 *
 	 * If a group is explicitly specified on the command line, the
-	 * interactive shell or command is run with that effective GID. 
+	 * interactive shell or command is run with that effective GID.
 	 * Access will be denied if no entry for that group can be found in
 	 * /etc/group. If the current user name appears in the members list
 	 * for that group, access will be granted immediately; if not, the
@@ -650,7 +650,7 @@ int main (int argc, char **argv)
 	}
 #endif                          /* HAVE_SETGROUPS */
 	/*
-	 * For splitted groups (due to limitations of NIS), check all 
+	 * For splitted groups (due to limitations of NIS), check all
 	 * groups of the same GID like the requested group for
 	 * membership of the current user.
 	 */
@@ -698,7 +698,7 @@ int main (int argc, char **argv)
 #ifdef HAVE_SETGROUPS
 	/*
 	 * I am going to try to add her new group id to her concurrent group
-	 * set. If the group id is already present i'll just skip this part. 
+	 * set. If the group id is already present i'll just skip this part.
 	 * If the group doesn't fit, i'll complain loudly and skip this
 	 * part.
 	 */
@@ -854,7 +854,7 @@ int main (int argc, char **argv)
 
 	/*
 	 * The previous code, when run as newgrp, re-exec'ed the shell in
-	 * the current process with the original gid on error conditions. 
+	 * the current process with the original gid on error conditions.
 	 * See the comment above. This historical behavior now has the
 	 * effect of creating unlogged extraneous shell layers when the
 	 * command line has an error or there is an authentication failure.
@@ -867,7 +867,7 @@ int main (int argc, char **argv)
 	if (NULL != group) {
 		snprintf (audit_buf, sizeof(audit_buf),
 		          "changing new-group=%s", group);
-		audit_logger (AUDIT_CHGRP_ID, Prog, 
+		audit_logger (AUDIT_CHGRP_ID, Prog,
 		              audit_buf, NULL,
 		              (unsigned int) getuid (), 0);
 	} else {

--- a/src/newuidmap.c
+++ b/src/newuidmap.c
@@ -148,7 +148,7 @@ int main(int argc, char **argv)
 				(unsigned long) getuid ()));
 		return EXIT_FAILURE;
 	}
-	
+
 	/* Get the effective uid and effective gid of the target process */
 	if (fstat(proc_dir_fd, &st) < 0) {
 		fprintf(stderr, _("%s: Could not stat directory for target %u\n"),

--- a/src/newusers.c
+++ b/src/newusers.c
@@ -428,7 +428,7 @@ static int add_user (const char *name, uid_t uid, gid_t gid)
 }
 
 #ifndef USE_PAM
-/* 
+/*
  * update_passwd - update the password in the passwd entry
  *
  * Return 0 if successful.

--- a/src/passwd.c
+++ b/src/passwd.c
@@ -328,7 +328,7 @@ static int new_password (const struct passwd *pw)
 
 		/*
 		 * If enabled, warn about weak passwords even if you are
-		 * root (enter this password again to use it anyway). 
+		 * root (enter this password again to use it anyway).
 		 * --marekm
 		 */
 		if (amroot && !warned && getdef_bool ("PASS_ALWAYS_WARN")
@@ -1045,7 +1045,7 @@ int main (int argc, char **argv)
 		STRFCPY (crypt_passwd, cp);
 
 		/*
-		 * See if the user is permitted to change the password. 
+		 * See if the user is permitted to change the password.
 		 * Otherwise, go ahead and set a new password.
 		 */
 		check_password (pw, sp);

--- a/src/suauth.c
+++ b/src/suauth.c
@@ -50,7 +50,7 @@
 
 #ifdef SU_ACCESS
 
-/* Really, I could do with a few const char's here defining all the 
+/* Really, I could do with a few const char's here defining all the
  * strings output to the user or the syslog. -- chris
  */
 static int applies (const char *, char *);

--- a/src/sulogin.c
+++ b/src/sulogin.c
@@ -211,7 +211,7 @@ static RETSIGTYPE catch_signals (unused int sig)
 		/*
 		 * XXX - can't enter single user mode if root password is
 		 * empty.  I think this doesn't happen very often :-). But
-		 * it will work with standard getpass() (no NULL on EOF). 
+		 * it will work with standard getpass() (no NULL on EOF).
 		 * --marekm
 		 */
 		if ((NULL == cp) || ('\0' == *cp)) {


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>

---

This patch was generated using `sed -i 's/[ \t]*$//'`. I would suggest encouraging users to set up a pre-commit hook to fix these trivial code style issues.

@hallyn If you want, you can set up a pre-commit CI configuration to help you out on this and other trivial changes. Check https://pre-commit.ci/ for reference.