### PR TITLE
Adding new switch -rG to usermod

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -15,6 +15,7 @@ Aleksa Sarai <cyphar@cyphar.com>
 Alexander O. Yuriev <alex@bach.cis.temple.edu>
 Algis Rudys <arudys@rice.edu>
 Andreas Jaeger <aj@arthur.rhein-neckar.de>
+Andy Zaugg <andy.zaugg@gmail.com>
 Aniello Del Sorbo <anidel@edu-gw.dia.unisa.it>
 Anton Gluck <gluc@midway.uchicago.edu>
 Arkadiusz Miskiewicz <misiek@pld.org.pl>

--- a/man/usermod.8.xml
+++ b/man/usermod.8.xml
@@ -328,6 +328,17 @@
       </varlistentry>
       <varlistentry>
 	<term>
+	  <option>-r</option>, <option>--remove</option>
+	</term>
+	<listitem>
+	  <para>
+	    Remove the user from named supplementary group(s). Use only with the
+	    <option>-G</option> option.
+	  </para>
+	</listitem>
+      </varlistentry>
+      <varlistentry>
+	<term>
 	  <option>-R</option>, <option>--root</option>&nbsp;<replaceable>CHROOT_DIR</replaceable>
 	</term>
 	<listitem>


### PR DESCRIPTION
Adding a new switch -rG, which provides a similar feature set to -aG, allowing a person to list exactly what groups to remove a user from.

As we can see user tester is part of test[1..4]

[a@localhost src]$ tail /etc/group ; sudo tail /etc/gshadow
tester1:x:1003:
test1:x:1004:tester1
test2:x:1005:tester1
test3:x:1006:tester1
test4:x:1007:tester1
tester1:!::
test1:!::tester1
test2:!::tester1
test3:!::tester1
test4:!::tester1

Running with -rG, we can now see that we have removed user tester1 from the named groups, while leaving the unnamed groups untouched
[a@localhost src]$ sudo ./usermod -rG test1,test2 tester1
[a@localhost src]$ tail /etc/group ; sudo tail /etc/gshadow
tester1:x:1003:
test1:x:1004:
test2:x:1005:
test3:x:1006:tester1
test4:x:1007:tester1
tester1:!::
test1:!::
test2:!::
test3:!::tester1
test4:!::tester1

Testing -G flag to see if we broke anything,
[a@localhost src]$ sudo ./usermod -G test1,test2 tester1
[a@localhost src]$ tail /etc/group ; sudo tail /etc/gshadow
tester1:x:1003:
test1:x:1004:tester1
test2:x:1005:tester1
test3:x:1006:
test4:x:1007:
tester1:!::
test1:!::tester1
test2:!::tester1
test3:!::
test4:!::

Works as expected, lets test -aG see if we broke that
[a@localhost src]$ sudo ./usermod -aG test3,test4 tester1
[a@localhost src]$ tail /etc/group ; sudo tail /etc/gshadow
tester1:x:1003:
test1:x:1004:tester1
test2:x:1005:tester1
test3:x:1006:tester1
test4:x:1007:tester1
tester1:!::
test1:!::tester1
test2:!::tester1
test3:!::tester1
test4:!::tester1


Closes #337 