### PR TITLE
Fixes the linking issues when libsubid is static and linked to

### DIFF
--- a/libsubid/api.c
+++ b/libsubid/api.c
@@ -39,8 +39,8 @@
 #include "idmapping.h"
 #include "subid.h"
 
-const char *Prog = "(libsubid)";
-FILE *shadow_logfd;
+static const char *Prog = "(libsubid)";
+static FILE *shadow_logfd;
 
 bool libsubid_init(const char *progname, FILE * logfd)
 {


### PR DESCRIPTION
binaries that also define the Prog and shadow_logfd variables.

Fixes #406 and #407 .