### PR TITLE
Add missing chmod() for shadowtcb_move()

### DIFF
--- a/lib/tcbfuncs.c
+++ b/lib/tcbfuncs.c
@@ -523,6 +523,12 @@ shadowtcb_status shadowtcb_move (/*@NULL@*/const char *user_newname, uid_t user_
 		         Prog, tcbdir, strerror (errno));
 		goto out_free;
 	}
+	if (chmod (tcbdir, dirmode.st_mode & 07777) != 0) {
+		fprintf (shadow_logfd,
+		         _("%s: Cannot change mode of %s: %s\n"),
+		         Prog, tcbdir, strerror (errno));
+		goto out_free;
+	}
 	ret = SHADOWTCB_SUCCESS;
 out_free:
 	free (tcbdir);


### PR DESCRIPTION
During shadowtcb_move() the directory is temporarily changed to be
owned by root:root with permissions 0700.  After the change is done,
the ownership and permissions were supposed to be restored.  The
call for chown() was there, but the chmod() call was missing.  This
resulted in the broken TCB functionality.  The added chmod() fixes
the issue.