### PR TITLE
Handle malformed lines in hushlogins file.

### DIFF
--- a/libmisc/hushed.c
+++ b/libmisc/hushed.c
@@ -90,7 +90,7 @@ bool hushed (const char *username)
 		return false;
 	}
 	for (found = false; !found && (fgets (buf, (int) sizeof buf, fp) == buf);) {
-		buf[strlen (buf) - 1] = '\0';
+		buf[strcspn (buf, "\n")] = '\0';
 		found = (strcmp (buf, pw->pw_shell) == 0) ||
 		        (strcmp (buf, pw->pw_name) == 0);
 	}


### PR DESCRIPTION
If a line in hushlogins file, e.g. /etc/hushlogins, starts with
'\0', then current code performs an out of boundary write.
If the line lacks a newline at the end, then another character is
overridden.

With strcspn both cases are solved.

Signed-off-by: Tobias Stoeckmann <tobias@stoeckmann.org>