### PR TITLE
groupdel: fix SIGSEGV when passwd does not exist

### DIFF
--- a/libmisc/prefix_flag.c
+++ b/libmisc/prefix_flag.c
@@ -288,6 +288,9 @@ extern struct passwd* prefix_getpwent()
 	if (!passwd_db_file) {
 		return getpwent();
 	}
+	if (!fp_pwent) {
+		return NULL;
+	}
 	return fgetpwent(fp_pwent);
 }
 extern void prefix_endpwent()


### PR DESCRIPTION
When using groupdel with a prefix, groupdel will attempt to read a
passwd file to look for any user in the group. When the file does not
exist it cores with segmentation fault.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1986111