### PR TITLE
newgrp: fix segmentation fault

### DIFF
--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -163,8 +163,8 @@ static void check_perms (const struct group *grp,
 	spwd = xgetspnam (pwd->pw_name);
 	if (NULL != spwd) {
 		pwd->pw_passwd = xstrdup (spwd->sp_pwdp);
+		spw_free (spwd);
 	}
-	spw_free (spwd);
 
 	if ((pwd->pw_passwd[0] == '\0') && (grp->gr_passwd[0] != '\0')) {
 		needspasswd = true;


### PR DESCRIPTION
Fix segmentation fault in newgrp when xgetspnam() returns a NULL value
that is immediately freed.

The error was committed in
https://github.com/shadow-maint/shadow/commit/e65cc6aebcb4132fa413f00a905216a5b35b3d57

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2019553