### PR TITLE
useradd: change SELinux labels for home files

### DIFF
--- a/src/useradd.c
+++ b/src/useradd.c
@@ -2704,7 +2704,7 @@ int main (int argc, char **argv)
 	if (mflg) {
 		create_home ();
 		if (home_added) {
-			copy_tree (def_template, prefix_user_home, false, false,
+			copy_tree (def_template, prefix_user_home, false, true,
 			           (uid_t)-1, user_id, (gid_t)-1, user_gid);
 		} else {
 			fprintf (stderr,


### PR DESCRIPTION
Change SELinux labels for files copied from the skeleton directory to
the home directory.

This could cause gnome's graphical user adding to fail without copying
the full skeleton files.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2022658