### PR TITLE
pwck: fix segfault when calling fprintf()

### DIFF
--- a/src/pwck.c
+++ b/src/pwck.c
@@ -857,6 +857,7 @@ int main (int argc, char **argv)
 	 * Get my name so that I can use it to report errors.
 	 */
 	Prog = Basename (argv[0]);
+	shadow_logfd = stderr;
 
 	(void) setlocale (LC_ALL, "");
 	(void) bindtextdomain (PACKAGE, LOCALEDIR);


### PR DESCRIPTION
As `shadow_logfd` variable is not set at the beginning of the program if
something fails and fprintf() is called a segmentation fault happens.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2021339