### PR TITLE
lib: check NULL before freeing passwd data

### DIFF
--- a/lib/pwmem.c
+++ b/lib/pwmem.c
@@ -93,14 +93,16 @@
 
 void pw_free (/*@out@*/ /*@only@*/struct passwd *pwent)
 {
-	free (pwent->pw_name);
-	if (pwent->pw_passwd) {
-		memzero (pwent->pw_passwd, strlen (pwent->pw_passwd));
-		free (pwent->pw_passwd);
+	if (pwent != NULL) {
+		free (pwent->pw_name);
+		if (pwent->pw_passwd) {
+			memzero (pwent->pw_passwd, strlen (pwent->pw_passwd));
+			free (pwent->pw_passwd);
+		}
+		free (pwent->pw_gecos);
+		free (pwent->pw_dir);
+		free (pwent->pw_shell);
+		free (pwent);
 	}
-	free (pwent->pw_gecos);
-	free (pwent->pw_dir);
-	free (pwent->pw_shell);
-	free (pwent);
 }
 

--- a/lib/shadowmem.c
+++ b/lib/shadowmem.c
@@ -79,11 +79,13 @@
 
 void spw_free (/*@out@*/ /*@only@*/struct spwd *spent)
 {
-	free (spent->sp_namp);
-	if (NULL != spent->sp_pwdp) {
-		memzero (spent->sp_pwdp, strlen (spent->sp_pwdp));
-		free (spent->sp_pwdp);
+	if (spent != NULL) {
+		free (spent->sp_namp);
+		if (NULL != spent->sp_pwdp) {
+			memzero (spent->sp_pwdp, strlen (spent->sp_pwdp));
+			free (spent->sp_pwdp);
+		}
+		free (spent);
 	}
-	free (spent);
 }
 


### PR DESCRIPTION
Add an additional NULL check condition in spw_free() and pw_free() to
avoid freeing an already empty pointer.

This is a follow-up to https://github.com/shadow-maint/shadow/pull/437#issuecomment-971622934