### PR TITLE
Fixed typo in login.defs

### DIFF
--- a/tests/chage/15_chage-I_no_shadow_entry/config/etc/login.defs
+++ b/tests/chage/15_chage-I_no_shadow_entry/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chage/16_chage-m_no_shadow_entry/config/etc/login.defs
+++ b/tests/chage/16_chage-m_no_shadow_entry/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chage/17_chage-M_no_shadow_entry/config/etc/login.defs
+++ b/tests/chage/17_chage-M_no_shadow_entry/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chage/18_chage-d_no_shadow_entry/config/etc/login.defs
+++ b/tests/chage/18_chage-d_no_shadow_entry/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chage/19_chage-W_no_shadow_entry/config/etc/login.defs
+++ b/tests/chage/19_chage-W_no_shadow_entry/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chage/20_chage-E_no_shadow_entry/config/etc/login.defs
+++ b/tests/chage/20_chage-E_no_shadow_entry/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chage/25_chage_interactive/config/etc/login.defs
+++ b/tests/chage/25_chage_interactive/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chage/26_chage_interactive_date_0/config/etc/login.defs
+++ b/tests/chage/26_chage_interactive_date_0/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chage/27_chage_interactive_date_-1/config/etc/login.defs
+++ b/tests/chage/27_chage_interactive_date_-1/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chage/28_chage_interactive_date_EPOCH/config/etc/login.defs
+++ b/tests/chage/28_chage_interactive_date_EPOCH/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chage/29_chage_interactive_date_pre-EPOCH/config/etc/login.defs
+++ b/tests/chage/29_chage_interactive_date_pre-EPOCH/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chage/30_chage_interactive_date_pre-EPOCH2/config/etc/login.defs
+++ b/tests/chage/30_chage_interactive_date_pre-EPOCH2/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chage/31_chage_interactive_date_invalid/config/etc/login.defs
+++ b/tests/chage/31_chage_interactive_date_invalid/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chage/32_chage_interactive_date_invalid2/config/etc/login.defs
+++ b/tests/chage/32_chage_interactive_date_invalid2/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chage/33_chage_interactive-W_invalid1/config/etc/login.defs
+++ b/tests/chage/33_chage_interactive-W_invalid1/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chage/34_chage_interactive-W_invalid2/config/etc/login.defs
+++ b/tests/chage/34_chage_interactive-W_invalid2/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chage/35_chage_interactive-W-1/config/etc/login.defs
+++ b/tests/chage/35_chage_interactive-W-1/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chage/36_chage_interactive-I_invalid1/config/etc/login.defs
+++ b/tests/chage/36_chage_interactive-I_invalid1/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chage/37_chage_interactive-I_invalid2/config/etc/login.defs
+++ b/tests/chage/37_chage_interactive-I_invalid2/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chage/38_chage_interactive-I-1/config/etc/login.defs
+++ b/tests/chage/38_chage_interactive-I-1/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chage/39_chage_interactive-d-1/config/etc/login.defs
+++ b/tests/chage/39_chage_interactive-d-1/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chroot/chage/01_chage--root/config_chroot/etc/login.defs
+++ b/tests/chroot/chage/01_chage--root/config_chroot/etc/login.defs
@@ -197,7 +197,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chroot/chgpasswd/01_chgpasswd--root/config_chroot/etc/login.defs
+++ b/tests/chroot/chgpasswd/01_chgpasswd--root/config_chroot/etc/login.defs
@@ -197,7 +197,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chroot/chpasswd/01_chpasswd--root_nopam/config_chroot/etc/login.defs
+++ b/tests/chroot/chpasswd/01_chpasswd--root_nopam/config_chroot/etc/login.defs
@@ -197,7 +197,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chroot/chpasswd/02_chpasswd--root_pam/config_chroot/etc/login.defs
+++ b/tests/chroot/chpasswd/02_chpasswd--root_pam/config_chroot/etc/login.defs
@@ -197,7 +197,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chroot/chsh/01_chsh--root/config_chroot/etc/login.defs
+++ b/tests/chroot/chsh/01_chsh--root/config_chroot/etc/login.defs
@@ -197,7 +197,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chroot/gpasswd/01_gpasswd--root/config_chroot/etc/login.defs
+++ b/tests/chroot/gpasswd/01_gpasswd--root/config_chroot/etc/login.defs
@@ -197,7 +197,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chroot/groupadd/01_groupadd--root/config_chroot/etc/login.defs
+++ b/tests/chroot/groupadd/01_groupadd--root/config_chroot/etc/login.defs
@@ -197,7 +197,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chroot/groupdel/01_groupdel--root/config_chroot/etc/login.defs
+++ b/tests/chroot/groupdel/01_groupdel--root/config_chroot/etc/login.defs
@@ -197,7 +197,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chroot/groupmod/01_groupmod--root/config_chroot/etc/login.defs
+++ b/tests/chroot/groupmod/01_groupmod--root/config_chroot/etc/login.defs
@@ -197,7 +197,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chroot/grpck/01_grpck--root/config_chroot/etc/login.defs
+++ b/tests/chroot/grpck/01_grpck--root/config_chroot/etc/login.defs
@@ -197,7 +197,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chroot/grpconv/01_grpconv--root/config_chroot/etc/login.defs
+++ b/tests/chroot/grpconv/01_grpconv--root/config_chroot/etc/login.defs
@@ -197,7 +197,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chroot/grpunconv/01_grpunconv--root/config_chroot/etc/login.defs
+++ b/tests/chroot/grpunconv/01_grpunconv--root/config_chroot/etc/login.defs
@@ -197,7 +197,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chroot/lastlog/01_lastlog--root/config_chroot/etc/login.defs
+++ b/tests/chroot/lastlog/01_lastlog--root/config_chroot/etc/login.defs
@@ -197,7 +197,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chroot/login/01_login_sublogin/config/etc/login.defs
+++ b/tests/chroot/login/01_login_sublogin/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chroot/login/01_login_sublogin/config_chroot/etc/login.defs
+++ b/tests/chroot/login/01_login_sublogin/config_chroot/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chroot/pwck/01_pwck--root/config_chroot/etc/login.defs
+++ b/tests/chroot/pwck/01_pwck--root/config_chroot/etc/login.defs
@@ -197,7 +197,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chroot/pwconv/01_pwconv--root/config_chroot/etc/login.defs
+++ b/tests/chroot/pwconv/01_pwconv--root/config_chroot/etc/login.defs
@@ -197,7 +197,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chroot/pwunconv/01_pwunconv--root/config_chroot/etc/login.defs
+++ b/tests/chroot/pwunconv/01_pwunconv--root/config_chroot/etc/login.defs
@@ -197,7 +197,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chroot/useradd/01_useradd--root/config_chroot/etc/login.defs
+++ b/tests/chroot/useradd/01_useradd--root/config_chroot/etc/login.defs
@@ -197,7 +197,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chroot/useradd/02_useradd--root_login.defs/config_chroot/etc/login.defs
+++ b/tests/chroot/useradd/02_useradd--root_login.defs/config_chroot/etc/login.defs
@@ -197,7 +197,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chroot/useradd/03_useradd--root_useradd.default/config_chroot/etc/login.defs
+++ b/tests/chroot/useradd/03_useradd--root_useradd.default/config_chroot/etc/login.defs
@@ -197,7 +197,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chroot/useradd/04_useradd--root_useradd-D/config_chroot/etc/login.defs
+++ b/tests/chroot/useradd/04_useradd--root_useradd-D/config_chroot/etc/login.defs
@@ -197,7 +197,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chroot/useradd/05_useradd--root_useradd-D-e-g/config_chroot/etc/login.defs
+++ b/tests/chroot/useradd/05_useradd--root_useradd-D-e-g/config_chroot/etc/login.defs
@@ -197,7 +197,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chroot/userdel/01_userdel--root/config_chroot/etc/login.defs
+++ b/tests/chroot/userdel/01_userdel--root/config_chroot/etc/login.defs
@@ -197,7 +197,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/chroot/usermod/01_usermod--root/config_chroot/etc/login.defs
+++ b/tests/chroot/usermod/01_usermod--root/config_chroot/etc/login.defs
@@ -197,7 +197,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/crypt/login.defs_DES-MD5_CRYPT_ENAB/config/etc/login.defs
+++ b/tests/crypt/login.defs_DES-MD5_CRYPT_ENAB/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/crypt/login.defs_DES/config/etc/login.defs
+++ b/tests/crypt/login.defs_DES/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/crypt/login.defs_MD5/config/etc/login.defs
+++ b/tests/crypt/login.defs_MD5/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/crypt/login.defs_MD5_CRYPT_ENAB/config/etc/login.defs
+++ b/tests/crypt/login.defs_MD5_CRYPT_ENAB/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/crypt/login.defs_SHA256-round-max/config/etc/login.defs
+++ b/tests/crypt/login.defs_SHA256-round-max/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/crypt/login.defs_SHA256-round-min-max/config/etc/login.defs
+++ b/tests/crypt/login.defs_SHA256-round-min-max/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/crypt/login.defs_SHA256-round-min/config/etc/login.defs
+++ b/tests/crypt/login.defs_SHA256-round-min/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/crypt/login.defs_SHA256/config/etc/login.defs
+++ b/tests/crypt/login.defs_SHA256/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/crypt/login.defs_SHA512/config/etc/login.defs
+++ b/tests/crypt/login.defs_SHA512/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/crypt/login.defs_none/config/etc/login.defs
+++ b/tests/crypt/login.defs_none/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/chage/01_chage_openRW_passwd_failure/config/etc/login.defs
+++ b/tests/failures/chage/01_chage_openRW_passwd_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/chage/02_chage_openRO_passwd_failure/config/etc/login.defs
+++ b/tests/failures/chage/02_chage_openRO_passwd_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/chage/03_chage_openRW_shadow_failure/config/etc/login.defs
+++ b/tests/failures/chage/03_chage_openRW_shadow_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/chage/04_chage_openRO_shadow_failure/config/etc/login.defs
+++ b/tests/failures/chage/04_chage_openRO_shadow_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/chage/05_chage_rename_shadow_failure/config/etc/login.defs
+++ b/tests/failures/chage/05_chage_rename_shadow_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/chage/06_chage_rename_passwd_failure/config/etc/login.defs
+++ b/tests/failures/chage/06_chage_rename_passwd_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/chgpasswd/01_chgpasswd-e_open_group_failure/config/etc/login.defs
+++ b/tests/failures/chgpasswd/01_chgpasswd-e_open_group_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/chgpasswd/02_chgpasswd-e_open_gshadow_failure/config/etc/login.defs
+++ b/tests/failures/chgpasswd/02_chgpasswd-e_open_gshadow_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/chgpasswd/03_chgpasswd-e_rename_group_failure/config/etc/login.defs
+++ b/tests/failures/chgpasswd/03_chgpasswd-e_rename_group_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/chgpasswd/04_chgpasswd-e_rename_gshadow_failure/config/etc/login.defs
+++ b/tests/failures/chgpasswd/04_chgpasswd-e_rename_gshadow_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/chpasswd-PAM/01_chpasswd-e_open_passwd_failure/config/etc/login.defs
+++ b/tests/failures/chpasswd-PAM/01_chpasswd-e_open_passwd_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/chpasswd-PAM/02_chpasswd-e_open_shadow_failure/config/etc/login.defs
+++ b/tests/failures/chpasswd-PAM/02_chpasswd-e_open_shadow_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/chpasswd-PAM/03_chpasswd-e_rename_passwd_failure/config/etc/login.defs
+++ b/tests/failures/chpasswd-PAM/03_chpasswd-e_rename_passwd_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/chpasswd-PAM/04_chpasswd-e_rename_shadow_failure/config/etc/login.defs
+++ b/tests/failures/chpasswd-PAM/04_chpasswd-e_rename_shadow_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/chsh/01_chsh_open_passwd_failure/config/etc/login.defs
+++ b/tests/failures/chsh/01_chsh_open_passwd_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/chsh/02_chsh_rename_passwd_failure/config/etc/login.defs
+++ b/tests/failures/chsh/02_chsh_rename_passwd_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/cppw/01_cppw_open_passwd_in_failure/config/etc/login.defs
+++ b/tests/failures/cppw/01_cppw_open_passwd_in_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/cppw/02_cppw_open_passwd_backup_failure/config/etc/login.defs
+++ b/tests/failures/cppw/02_cppw_open_passwd_backup_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/cppw/03_cppw_rename_passwd_failure/config/etc/login.defs
+++ b/tests/failures/cppw/03_cppw_rename_passwd_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/gpasswd/01_gpasswd_group_open_failure/config/etc/login.defs
+++ b/tests/failures/gpasswd/01_gpasswd_group_open_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/gpasswd/02_gpasswd_gshadow_open_failure/config/etc/login.defs
+++ b/tests/failures/gpasswd/02_gpasswd_gshadow_open_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/gpasswd/03_gpasswd-a_group_open_failure/config/etc/login.defs
+++ b/tests/failures/gpasswd/03_gpasswd-a_group_open_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/gpasswd/04_gpasswd-d_group_open_failure/config/etc/login.defs
+++ b/tests/failures/gpasswd/04_gpasswd-d_group_open_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/gpasswd/05_gpasswd-r_group_open_failure/config/etc/login.defs
+++ b/tests/failures/gpasswd/05_gpasswd-r_group_open_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/gpasswd/06_gpasswd-R_gshadow_open_failure/config/etc/login.defs
+++ b/tests/failures/gpasswd/06_gpasswd-R_gshadow_open_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/gpasswd/07_gpasswd-A_gshadow_open_failure/config/etc/login.defs
+++ b/tests/failures/gpasswd/07_gpasswd-A_gshadow_open_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/gpasswd/08_gpasswd_group_openRO_failure/config/etc/login.defs
+++ b/tests/failures/gpasswd/08_gpasswd_group_openRO_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/gpasswd/09_gpasswd_gshadow_openRO_failure/config/etc/login.defs
+++ b/tests/failures/gpasswd/09_gpasswd_gshadow_openRO_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/gpasswd/10_gpasswd_group_rename_failure/config/etc/login.defs
+++ b/tests/failures/gpasswd/10_gpasswd_group_rename_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/gpasswd/11_gpasswd_gshadow_rename_failure/config/etc/login.defs
+++ b/tests/failures/gpasswd/11_gpasswd_gshadow_rename_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/groupadd/01_groupadd_gshadow_rename_failure/config/etc/login.defs
+++ b/tests/failures/groupadd/01_groupadd_gshadow_rename_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/groupadd/02_groupadd_group_rename_failure/config/etc/login.defs
+++ b/tests/failures/groupadd/02_groupadd_group_rename_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/groupadd/03_groupadd_gshadow_open_failure/config/etc/login.defs
+++ b/tests/failures/groupadd/03_groupadd_gshadow_open_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/groupadd/04_groupadd_group_open_failure/config/etc/login.defs
+++ b/tests/failures/groupadd/04_groupadd_group_open_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/groupdel/01_groupdel_gshadow_rename_failure/config/etc/login.defs
+++ b/tests/failures/groupdel/01_groupdel_gshadow_rename_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/groupdel/02_groupdel_group_rename_failure/config/etc/login.defs
+++ b/tests/failures/groupdel/02_groupdel_group_rename_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/groupdel/03_groupdel_gshadow_open_failure/config/etc/login.defs
+++ b/tests/failures/groupdel/03_groupdel_gshadow_open_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/groupdel/04_groupdel_group_open_failure/config/etc/login.defs
+++ b/tests/failures/groupdel/04_groupdel_group_open_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/groupmod/01_groupmod_change_group_name_gshadow_rename_failure/config/etc/login.defs
+++ b/tests/failures/groupmod/01_groupmod_change_group_name_gshadow_rename_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/groupmod/02_groupmod_change_gid_change_primary_group_passwd_rename_failure/config/etc/login.defs
+++ b/tests/failures/groupmod/02_groupmod_change_gid_change_primary_group_passwd_rename_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/groupmod/03_groupmod_change_group_name_group_rename_failure/config/etc/login.defs
+++ b/tests/failures/groupmod/03_groupmod_change_group_name_group_rename_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/groupmod/04_groupmod_group_open_failure/config/etc/login.defs
+++ b/tests/failures/groupmod/04_groupmod_group_open_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/groupmod/05_groupmod_gshadow_open_failure/config/etc/login.defs
+++ b/tests/failures/groupmod/05_groupmod_gshadow_open_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/groupmod/06_groupmod_-g_no_gshadow_open_failure/config/etc/login.defs
+++ b/tests/failures/groupmod/06_groupmod_-g_no_gshadow_open_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/groupmod/07_groupmod_passwd_open_failure/config/etc/login.defs
+++ b/tests/failures/groupmod/07_groupmod_passwd_open_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/groupmod/08_groupmod_-g_same_gid_no_passwd_open_failure/config/etc/login.defs
+++ b/tests/failures/groupmod/08_groupmod_-g_same_gid_no_passwd_open_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/groupmod/09_groupmod_-n_no_passwd_open_failure/config/etc/login.defs
+++ b/tests/failures/groupmod/09_groupmod_-n_no_passwd_open_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/grpck/01_grpck_system_group_open_failure/config/etc/login.defs
+++ b/tests/failures/grpck/01_grpck_system_group_open_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/grpck/02_grpck_group_open_failure/config/etc/login.defs
+++ b/tests/failures/grpck/02_grpck_group_open_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/grpck/03_grpck_system_gshadow_open_failure/config/etc/login.defs
+++ b/tests/failures/grpck/03_grpck_system_gshadow_open_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/grpck/04_grpck_gshadow_open_failure/config/etc/login.defs
+++ b/tests/failures/grpck/04_grpck_gshadow_open_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/grpck/05_grpck_sort_group_rename_failure/config/etc/login.defs
+++ b/tests/failures/grpck/05_grpck_sort_group_rename_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/grpck/06_grpck_sort_gshadow_rename_failure/config/etc/login.defs
+++ b/tests/failures/grpck/06_grpck_sort_gshadow_rename_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/grpconv/01_grpconv_open_group_failure/config/etc/login.defs
+++ b/tests/failures/grpconv/01_grpconv_open_group_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/grpconv/02_grpconv_open_gshadow_failure/config/etc/login.defs
+++ b/tests/failures/grpconv/02_grpconv_open_gshadow_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/grpconv/03_grpconv_rename_group_failure/config/etc/login.defs
+++ b/tests/failures/grpconv/03_grpconv_rename_group_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/grpconv/04_grpconv_rename_gshadow_failure/config/etc/login.defs
+++ b/tests/failures/grpconv/04_grpconv_rename_gshadow_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/grpunconv/01_grpunconv_group_rename_failure/config/etc/login.defs
+++ b/tests/failures/grpunconv/01_grpunconv_group_rename_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/grpunconv/02_grpunconv_open_group_failure/config/etc/login.defs
+++ b/tests/failures/grpunconv/02_grpunconv_open_group_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/grpunconv/03_grpunconv_open_gshadow_failure/config/etc/login.defs
+++ b/tests/failures/grpunconv/03_grpunconv_open_gshadow_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/grpunconv/04_grpunconv_unlink_gshadow_failure/config/etc/login.defs
+++ b/tests/failures/grpunconv/04_grpunconv_unlink_gshadow_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/newusers/01_newusers_open_passwd_failure/config/etc/login.defs
+++ b/tests/failures/newusers/01_newusers_open_passwd_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/newusers/02_newusers_open_shadow_failure/config/etc/login.defs
+++ b/tests/failures/newusers/02_newusers_open_shadow_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/newusers/03_newusers_open_group_failure/config/etc/login.defs
+++ b/tests/failures/newusers/03_newusers_open_group_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/newusers/04_newusers_open_gshadow_failure/config/etc/login.defs
+++ b/tests/failures/newusers/04_newusers_open_gshadow_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/newusers/05_newusers_rename_passwd_failure/config/etc/login.defs
+++ b/tests/failures/newusers/05_newusers_rename_passwd_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/newusers/06_newusers_rename_shadow_failure/config/etc/login.defs
+++ b/tests/failures/newusers/06_newusers_rename_shadow_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/newusers/07_newusers_rename_group_failure/config/etc/login.defs
+++ b/tests/failures/newusers/07_newusers_rename_group_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/newusers/08_newusers_rename_gshadow_failure/config/etc/login.defs
+++ b/tests/failures/newusers/08_newusers_rename_gshadow_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/newusers/09_newusers_rename_shadow_failure_PAM/config/etc/login.defs
+++ b/tests/failures/newusers/09_newusers_rename_shadow_failure_PAM/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/pwconv/01_pwconv_open_passwd_failure/config/etc/login.defs
+++ b/tests/failures/pwconv/01_pwconv_open_passwd_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/pwconv/02_pwconv_open_shadow_failure/config/etc/login.defs
+++ b/tests/failures/pwconv/02_pwconv_open_shadow_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/pwconv/03_pwconv_rename_passwd_failure/config/etc/login.defs
+++ b/tests/failures/pwconv/03_pwconv_rename_passwd_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/pwconv/04_pwconv_rename_shadow_failure/config/etc/login.defs
+++ b/tests/failures/pwconv/04_pwconv_rename_shadow_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/pwunconv/01_pwunconv_passwd_rename_failure/config/etc/login.defs
+++ b/tests/failures/pwunconv/01_pwunconv_passwd_rename_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/pwunconv/02_pwunconv_open_passwd_failure/config/etc/login.defs
+++ b/tests/failures/pwunconv/02_pwunconv_open_passwd_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/pwunconv/03_pwunconv_open_shadow_failure/config/etc/login.defs
+++ b/tests/failures/pwunconv/03_pwunconv_open_shadow_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/pwunconv/04_pwunconv_unlink_shadow_failure/config/etc/login.defs
+++ b/tests/failures/pwunconv/04_pwunconv_unlink_shadow_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/useradd/01_useradd_open_passwd_failure/config/etc/login.defs
+++ b/tests/failures/useradd/01_useradd_open_passwd_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/useradd/02_useradd_open_shadow_failure/config/etc/login.defs
+++ b/tests/failures/useradd/02_useradd_open_shadow_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/useradd/03_useradd_open_group_failure/config/etc/login.defs
+++ b/tests/failures/useradd/03_useradd_open_group_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/useradd/04_useradd_open_gshadow_failure/config/etc/login.defs
+++ b/tests/failures/useradd/04_useradd_open_gshadow_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/useradd/05_useradd_rename_passwd_failure/config/etc/login.defs
+++ b/tests/failures/useradd/05_useradd_rename_passwd_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/useradd/06_useradd_rename_shadow_failure/config/etc/login.defs
+++ b/tests/failures/useradd/06_useradd_rename_shadow_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/useradd/07_useradd_rename_group_failure/config/etc/login.defs
+++ b/tests/failures/useradd/07_useradd_rename_group_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/useradd/08_useradd_rename_gshadow_failure/config/etc/login.defs
+++ b/tests/failures/useradd/08_useradd_rename_gshadow_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/useradd/09_useradd_rename_defaults_failure/config/etc/login.defs
+++ b/tests/failures/useradd/09_useradd_rename_defaults_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/useradd/10_useradd_rename_defaults_backup_failure/config/etc/login.defs
+++ b/tests/failures/useradd/10_useradd_rename_defaults_backup_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/useradd/12_useradd_open_subuid_failure/config/etc/login.defs
+++ b/tests/failures/useradd/12_useradd_open_subuid_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/useradd/13_useradd_open_subgid_failure/config/etc/login.defs
+++ b/tests/failures/useradd/13_useradd_open_subgid_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/useradd/14_username_rename_subuid_failure/config/etc/login.defs
+++ b/tests/failures/useradd/14_username_rename_subuid_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/useradd/15_username_rename_subgid_failure/config/etc/login.defs
+++ b/tests/failures/useradd/15_username_rename_subgid_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/userdel/01_userdel_gshadow_rename_failure/config/etc/login.defs
+++ b/tests/failures/userdel/01_userdel_gshadow_rename_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/userdel/02_userdel_group_rename_failure/config/etc/login.defs
+++ b/tests/failures/userdel/02_userdel_group_rename_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/userdel/03_userdel_shadow_rename_failure/config/etc/login.defs
+++ b/tests/failures/userdel/03_userdel_shadow_rename_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/userdel/04_userdel_passwd_rename_failure/config/etc/login.defs
+++ b/tests/failures/userdel/04_userdel_passwd_rename_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/userdel/05_userdel_failure_remove_mailbox/config/etc/login.defs
+++ b/tests/failures/userdel/05_userdel_failure_remove_mailbox/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/userdel/06_userdel_failure_remove_file_homedir/config/etc/login.defs
+++ b/tests/failures/userdel/06_userdel_failure_remove_file_homedir/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/userdel/07_userdel_failure_remove_homedir/config/etc/login.defs
+++ b/tests/failures/userdel/07_userdel_failure_remove_homedir/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/userdel/08_userdel_open_passwd_failure/config/etc/login.defs
+++ b/tests/failures/userdel/08_userdel_open_passwd_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/userdel/09_userdel_open_shadow_failure/config/etc/login.defs
+++ b/tests/failures/userdel/09_userdel_open_shadow_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/userdel/10_userdel_open_group_failure/config/etc/login.defs
+++ b/tests/failures/userdel/10_userdel_open_group_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/userdel/11_userdel_open_gshadow_failure/config/etc/login.defs
+++ b/tests/failures/userdel/11_userdel_open_gshadow_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/userdel/12_userdel_open_subuid_failure/config/etc/login.defs
+++ b/tests/failures/userdel/12_userdel_open_subuid_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/userdel/13_userdel_open_subgid_failure/config/etc/login.defs
+++ b/tests/failures/userdel/13_userdel_open_subgid_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/userdel/14_userdel_rename_subuid_failure/config/etc/login.defs
+++ b/tests/failures/userdel/14_userdel_rename_subuid_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/userdel/15_userdel_rename_subgid_failure/config/etc/login.defs
+++ b/tests/failures/userdel/15_userdel_rename_subgid_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/usermod/01_usermod_change_user_name_gshadow_rename_failure/config/etc/login.defs
+++ b/tests/failures/usermod/01_usermod_change_user_name_gshadow_rename_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/usermod/02_usermod_change_uid_passwd_rename_failure/config/etc/login.defs
+++ b/tests/failures/usermod/02_usermod_change_uid_passwd_rename_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/usermod/03_usermod_change_user_name_group_rename_failure/config/etc/login.defs
+++ b/tests/failures/usermod/03_usermod_change_user_name_group_rename_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/usermod/04_usermod_change_user_name_gshadow_rename_no_failure/config/etc/login.defs
+++ b/tests/failures/usermod/04_usermod_change_user_name_gshadow_rename_no_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/usermod/05_usermod_change_uid_shadow_rename_failure/config/etc/login.defs
+++ b/tests/failures/usermod/05_usermod_change_uid_shadow_rename_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/usermod/06_usermod_change_user_name_open_passwd_failure/config/etc/login.defs
+++ b/tests/failures/usermod/06_usermod_change_user_name_open_passwd_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/usermod/07_usermod_change_user_name_open_shadow_failure/config/etc/login.defs
+++ b/tests/failures/usermod/07_usermod_change_user_name_open_shadow_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/usermod/08_usermod_change_user_name_open_group_failure/config/etc/login.defs
+++ b/tests/failures/usermod/08_usermod_change_user_name_open_group_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/usermod/09_usermod_change_user_name_open_gshadow_failure/config/etc/login.defs
+++ b/tests/failures/usermod/09_usermod_change_user_name_open_gshadow_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/usermod/12_usermod_change_uid_passwd_unlock_passwd_failure/config/etc/login.defs
+++ b/tests/failures/usermod/12_usermod_change_uid_passwd_unlock_passwd_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/usermod/13_usermod_-v_open_subuid_failure/config/etc/login.defs
+++ b/tests/failures/usermod/13_usermod_-v_open_subuid_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/usermod/14_usermod_-V_open_subuid_failure/config/etc/login.defs
+++ b/tests/failures/usermod/14_usermod_-V_open_subuid_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/usermod/15_usermod_-w_open_subgid_failure/config/etc/login.defs
+++ b/tests/failures/usermod/15_usermod_-w_open_subgid_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/usermod/16_usermod_-W_open_subgid_failure/config/etc/login.defs
+++ b/tests/failures/usermod/16_usermod_-W_open_subgid_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/usermod/17_usermod_-v_rename_subuid_failure/config/etc/login.defs
+++ b/tests/failures/usermod/17_usermod_-v_rename_subuid_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/failures/usermod/18_usermod_-w_rename_subgid_failure/config/etc/login.defs
+++ b/tests/failures/usermod/18_usermod_-w_rename_subgid_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/chgpasswd/01_chgpasswd_invalid_group/config/etc/login.defs
+++ b/tests/grouptools/chgpasswd/01_chgpasswd_invalid_group/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/chgpasswd/02_chgpasswd_multiple_groups/config/etc/login.defs
+++ b/tests/grouptools/chgpasswd/02_chgpasswd_multiple_groups/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/chgpasswd/03_chgpasswd_no_gshadow_file/config/etc/login.defs
+++ b/tests/grouptools/chgpasswd/03_chgpasswd_no_gshadow_file/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/chgpasswd/04_chgpasswd_no_gshadow_entry/config/etc/login.defs
+++ b/tests/grouptools/chgpasswd/04_chgpasswd_no_gshadow_entry/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/chgpasswd/05_chgpasswd_error_no_password/config/etc/login.defs
+++ b/tests/grouptools/chgpasswd/05_chgpasswd_error_no_password/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/gpasswd/19_gpasswd_change_passwd-root/config/etc/login.defs
+++ b/tests/grouptools/gpasswd/19_gpasswd_change_passwd-root/config/etc/login.defs
@@ -197,7 +197,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/gpasswd/20_gpasswd_change_passwd-root-no_shadow_group/config/etc/login.defs
+++ b/tests/grouptools/gpasswd/20_gpasswd_change_passwd-root-no_shadow_group/config/etc/login.defs
@@ -197,7 +197,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/gpasswd/21_gpasswd_change_passwd-root-no_gshadow_file/config/etc/login.defs
+++ b/tests/grouptools/gpasswd/21_gpasswd_change_passwd-root-no_gshadow_file/config/etc/login.defs
@@ -197,7 +197,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/gpasswd/22_gpasswd_change_passwd-myuser/config/etc/login.defs
+++ b/tests/grouptools/gpasswd/22_gpasswd_change_passwd-myuser/config/etc/login.defs
@@ -197,7 +197,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/gpasswd/69_gpasswd_change_passwd_2_tries/config/etc/login.defs
+++ b/tests/grouptools/gpasswd/69_gpasswd_change_passwd_2_tries/config/etc/login.defs
@@ -197,7 +197,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/gpasswd/70_gpasswd_change_passwd_3_tries/config/etc/login.defs
+++ b/tests/grouptools/gpasswd/70_gpasswd_change_passwd_3_tries/config/etc/login.defs
@@ -197,7 +197,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/gpasswd/71_gpasswd_change_passwd_4_tries/config/etc/login.defs
+++ b/tests/grouptools/gpasswd/71_gpasswd_change_passwd_4_tries/config/etc/login.defs
@@ -197,7 +197,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupadd/01_groupadd_add_group/config/etc/login.defs
+++ b/tests/grouptools/groupadd/01_groupadd_add_group/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupadd/02_groupadd_add_group_GID_MIN/config/etc/login.defs
+++ b/tests/grouptools/groupadd/02_groupadd_add_group_GID_MIN/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupadd/03_groupadd_add_group_-K_GID_MIN/config/etc/login.defs
+++ b/tests/grouptools/groupadd/03_groupadd_add_group_-K_GID_MIN/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupadd/04_groupadd_set_password/config/etc/login.defs
+++ b/tests/grouptools/groupadd/04_groupadd_set_password/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupadd/05_groupadd_set_GID/config/etc/login.defs
+++ b/tests/grouptools/groupadd/05_groupadd_set_GID/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupadd/06_groupadd_-f_add_existing_group/config/etc/login.defs
+++ b/tests/grouptools/groupadd/06_groupadd_-f_add_existing_group/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupadd/07_groupadd_-f_add_existing_GID/config/etc/login.defs
+++ b/tests/grouptools/groupadd/07_groupadd_-f_add_existing_GID/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupadd/10_groupadd_-o_add_existing_GID/config/etc/login.defs
+++ b/tests/grouptools/groupadd/10_groupadd_-o_add_existing_GID/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupadd/17_groupadd_add_systemgroup/config/etc/login.defs
+++ b/tests/grouptools/groupadd/17_groupadd_add_systemgroup/config/etc/login.defs
@@ -207,7 +207,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupadd/18_groupadd_no_more_GID/config/etc/login.defs
+++ b/tests/grouptools/groupadd/18_groupadd_no_more_GID/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupadd/19_groupadd_-r_no_more_system_GID/config/etc/login.defs
+++ b/tests/grouptools/groupadd/19_groupadd_-r_no_more_system_GID/config/etc/login.defs
@@ -208,7 +208,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupadd/25_groupadd_no_gshadow/config/etc/login.defs
+++ b/tests/grouptools/groupadd/25_groupadd_no_gshadow/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupdel/01_groupdel_delete_group/config/etc/login.defs
+++ b/tests/grouptools/groupdel/01_groupdel_delete_group/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupdel/02_groupdel_delete_group_no_gshadow_group/config/etc/login.defs
+++ b/tests/grouptools/groupdel/02_groupdel_delete_group_no_gshadow_group/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupdel/03_groupdel_delete_group_no_gshadow_file/config/etc/login.defs
+++ b/tests/grouptools/groupdel/03_groupdel_delete_group_no_gshadow_file/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupdel/04_groupdel_delete_group_error_busy_group/config/etc/login.defs
+++ b/tests/grouptools/groupdel/04_groupdel_delete_group_error_busy_group/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupdel/05_groupdel_delete_group_error_unknown_group/config/etc/login.defs
+++ b/tests/grouptools/groupdel/05_groupdel_delete_group_error_unknown_group/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupdel/06_groupdel_delete_group_error_locked_group/config/etc/login.defs
+++ b/tests/grouptools/groupdel/06_groupdel_delete_group_error_locked_group/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupdel/07_groupdel_delete_group_error_locked_gshadow/config/etc/login.defs
+++ b/tests/grouptools/groupdel/07_groupdel_delete_group_error_locked_gshadow/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupdel/08_groupdel_delete_group_error_no_group_parameter/config/etc/login.defs
+++ b/tests/grouptools/groupdel/08_groupdel_delete_group_error_no_group_parameter/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupdel/09_groupdel_delete_group_error_two_group_parameter/config/etc/login.defs
+++ b/tests/grouptools/groupdel/09_groupdel_delete_group_error_two_group_parameter/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupdel/10_groupdel_usage/config/etc/login.defs
+++ b/tests/grouptools/groupdel/10_groupdel_usage/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupdel/11_groupdel_invalid_option/config/etc/login.defs
+++ b/tests/grouptools/groupdel/11_groupdel_invalid_option/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupmems/54_groupmems_usage_invalid_option/config/etc/login.defs
+++ b/tests/grouptools/groupmems/54_groupmems_usage_invalid_option/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupmems/55_groupmems_usage-a-d/config/etc/login.defs
+++ b/tests/grouptools/groupmems/55_groupmems_usage-a-d/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupmems/56_groupmems_usage_extra_arg/config/etc/login.defs
+++ b/tests/grouptools/groupmems/56_groupmems_usage_extra_arg/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupmod/01_groupmod_change_gid/config/etc/login.defs
+++ b/tests/grouptools/groupmod/01_groupmod_change_gid/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupmod/02_groupmod_change_gid_change_primary_group/config/etc/login.defs
+++ b/tests/grouptools/groupmod/02_groupmod_change_gid_change_primary_group/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupmod/03_groupmod_change_gid_no_gshadow_group/config/etc/login.defs
+++ b/tests/grouptools/groupmod/03_groupmod_change_gid_no_gshadow_group/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupmod/04_groupmod_change_gid_no_gshadow_file/config/etc/login.defs
+++ b/tests/grouptools/groupmod/04_groupmod_change_gid_no_gshadow_file/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupmod/05_groupmod_change_gid_-o_override_used_GID/config/etc/login.defs
+++ b/tests/grouptools/groupmod/05_groupmod_change_gid_-o_override_used_GID/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupmod/06_groupmod_change_group_name/config/etc/login.defs
+++ b/tests/grouptools/groupmod/06_groupmod_change_group_name/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupmod/07_groupmod_change_group_name_no_gshadow_group/config/etc/login.defs
+++ b/tests/grouptools/groupmod/07_groupmod_change_group_name_no_gshadow_group/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupmod/08_groupmod_change_group_name_no_gshadow_file/config/etc/login.defs
+++ b/tests/grouptools/groupmod/08_groupmod_change_group_name_no_gshadow_file/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupmod/09_groupmod_set_password/config/etc/login.defs
+++ b/tests/grouptools/groupmod/09_groupmod_set_password/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupmod/10_groupmod_set_password_no_gshadow_group/config/etc/login.defs
+++ b/tests/grouptools/groupmod/10_groupmod_set_password_no_gshadow_group/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupmod/11_groupmod_set_password_no_gshadow_file/config/etc/login.defs
+++ b/tests/grouptools/groupmod/11_groupmod_set_password_no_gshadow_file/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupmod/12_groupmod_change_gid_error_unknown_group/config/etc/login.defs
+++ b/tests/grouptools/groupmod/12_groupmod_change_gid_error_unknown_group/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupmod/13_groupmod_change_gid_error_used_GID/config/etc/login.defs
+++ b/tests/grouptools/groupmod/13_groupmod_change_gid_error_used_GID/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupmod/14_groupmod_change_group_name_error_used_name/config/etc/login.defs
+++ b/tests/grouptools/groupmod/14_groupmod_change_group_name_error_used_name/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupmod/15_groupmod_change_group_name_error_invalid_name/config/etc/login.defs
+++ b/tests/grouptools/groupmod/15_groupmod_change_group_name_error_invalid_name/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupmod/16_groupmod_change_group_name_no_changes/config/etc/login.defs
+++ b/tests/grouptools/groupmod/16_groupmod_change_group_name_no_changes/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupmod/17_groupmod_change_gid_error_locked_group/config/etc/login.defs
+++ b/tests/grouptools/groupmod/17_groupmod_change_gid_error_locked_group/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupmod/18_groupmod_change_gid_no_error_locked_gshadow/config/etc/login.defs
+++ b/tests/grouptools/groupmod/18_groupmod_change_gid_no_error_locked_gshadow/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupmod/19_groupmod_change_gid_error_invalid_GID/config/etc/login.defs
+++ b/tests/grouptools/groupmod/19_groupmod_change_gid_error_invalid_GID/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupmod/20_groupmod_change_gid_error_negative_GID/config/etc/login.defs
+++ b/tests/grouptools/groupmod/20_groupmod_change_gid_error_negative_GID/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupmod/21_groupmod_change_gid_error_no_group/config/etc/login.defs
+++ b/tests/grouptools/groupmod/21_groupmod_change_gid_error_no_group/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupmod/22_groupmod_change_gid_and_group_name/config/etc/login.defs
+++ b/tests/grouptools/groupmod/22_groupmod_change_gid_and_group_name/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupmod/23_groupmod_change_gid_and_group_name_and_password/config/etc/login.defs
+++ b/tests/grouptools/groupmod/23_groupmod_change_gid_and_group_name_and_password/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupmod/24_groupmod_change_gid_and_name_error_locked_gshadow/config/etc/login.defs
+++ b/tests/grouptools/groupmod/24_groupmod_change_gid_and_name_error_locked_gshadow/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupmod/25_groupmod_change_gid_change_primary_group_error_locked_passwd/config/etc/login.defs
+++ b/tests/grouptools/groupmod/25_groupmod_change_gid_change_primary_group_error_locked_passwd/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupmod/26_groupmod_change_group_name_no_error_locked_passwd/config/etc/login.defs
+++ b/tests/grouptools/groupmod/26_groupmod_change_group_name_no_error_locked_passwd/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupmod/27_groupmod_change_gid_error_GID_4294967295/config/etc/login.defs
+++ b/tests/grouptools/groupmod/27_groupmod_change_gid_error_GID_4294967295/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupmod/29_groupmod_-g_same_gid_new_name/config/etc/login.defs
+++ b/tests/grouptools/groupmod/29_groupmod_-g_same_gid_new_name/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupmod/30_groupmod_-g_same_gid_same_name/config/etc/login.defs
+++ b/tests/grouptools/groupmod/30_groupmod_-g_same_gid_same_name/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupmod/31_groupmod_-g_same_gid/config/etc/login.defs
+++ b/tests/grouptools/groupmod/31_groupmod_-g_same_gid/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupmod/33_groupmod_set_password_no_gshadow_file_with_group_pwd_x/config/etc/login.defs
+++ b/tests/grouptools/groupmod/33_groupmod_set_password_no_gshadow_file_with_group_pwd_x/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupmod/34_groupmod_set_password_group_without_shadow_pwd/config/etc/login.defs
+++ b/tests/grouptools/groupmod/34_groupmod_set_password_group_without_shadow_pwd/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupmod/35_groupmod_set_password_group_without_shadow_pwd_no_gshadow_group/config/etc/login.defs
+++ b/tests/grouptools/groupmod/35_groupmod_set_password_group_without_shadow_pwd_no_gshadow_group/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupmod/36_groupmod_set_password_group_with_shadow_pwd_no_gshadow_group/config/etc/login.defs
+++ b/tests/grouptools/groupmod/36_groupmod_set_password_group_with_shadow_pwd_no_gshadow_group/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/grouptools/groupmod/37_groupmod_invalid_option/config/etc/login.defs
+++ b/tests/grouptools/groupmod/37_groupmod_invalid_option/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/login/01_login_prompt/config/etc/login.defs
+++ b/tests/login/01_login_prompt/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/login/02_login_user/config/etc/login.defs
+++ b/tests/login/02_login_user/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/login/03_login_check_tty/config/etc/login.defs
+++ b/tests/login/03_login_check_tty/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/newgidmap/01_newgidmap/config/etc/login.defs
+++ b/tests/newgidmap/01_newgidmap/config/etc/login.defs
@@ -202,7 +202,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/newgidmap/02_newgidmap_relaxed_gid_check/config/etc/login.defs
+++ b/tests/newgidmap/02_newgidmap_relaxed_gid_check/config/etc/login.defs
@@ -202,7 +202,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/newuidmap/01_newuidmap/config/etc/login.defs
+++ b/tests/newuidmap/01_newuidmap/config/etc/login.defs
@@ -202,7 +202,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/newuidmap/02_newuidmap_relaxed_gid_check/config/etc/login.defs
+++ b/tests/newuidmap/02_newuidmap_relaxed_gid_check/config/etc/login.defs
@@ -202,7 +202,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/newusers/25_create_user_error_no_remaining_UID/config/etc/login.defs
+++ b/tests/newusers/25_create_user_error_no_remaining_UID/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/newusers/26_create_user_error_no_remaining_GID/config/etc/login.defs
+++ b/tests/newusers/26_create_user_error_no_remaining_GID/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/split_groups/01_useradd_split_group/config/etc/login.defs
+++ b/tests/split_groups/01_useradd_split_group/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/split_groups/02_useradd_no_split_group/config/etc/login.defs
+++ b/tests/split_groups/02_useradd_no_split_group/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/split_groups/03_useradd_split_group_already_split/config/etc/login.defs
+++ b/tests/split_groups/03_useradd_split_group_already_split/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/split_groups/04_useradd_split_group_already_full/config/etc/login.defs
+++ b/tests/split_groups/04_useradd_split_group_already_full/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/split_groups/05_useradd_split_group_already_split_passwd_differ/config/etc/login.defs
+++ b/tests/split_groups/05_useradd_split_group_already_split_passwd_differ/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/split_groups/06_useradd_split_group_already_split_GID_differ/config/etc/login.defs
+++ b/tests/split_groups/06_useradd_split_group_already_split_GID_differ/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/split_groups/07_useradd_split_group_already_split_user_in_both_lines/config/etc/login.defs
+++ b/tests/split_groups/07_useradd_split_group_already_split_user_in_both_lines/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/split_groups/08_useradd_no_split_group_already_split/config/etc/login.defs
+++ b/tests/split_groups/08_useradd_no_split_group_already_split/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/split_groups/09_groupdel_split_group_already_split/config/etc/login.defs
+++ b/tests/split_groups/09_groupdel_split_group_already_split/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/split_groups/10_groupdel_no_split_group_already_split/config/etc/login.defs
+++ b/tests/split_groups/10_groupdel_no_split_group_already_split/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/su/04/config/etc/login.defs
+++ b/tests/su/04/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/su/05/config/etc/login.defs
+++ b/tests/su/05/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/su/06/config/etc/login.defs
+++ b/tests/su/06/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/su/07/config/etc/login.defs
+++ b/tests/su/07/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/su/08/config/etc/login.defs
+++ b/tests/su/08/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/su/09/config/etc/login.defs
+++ b/tests/su/09/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/su/10_su_sulog_success/config/etc/login.defs
+++ b/tests/su/10_su_sulog_success/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/su/11_su_sulog_failure/config/etc/login.defs
+++ b/tests/su/11_su_sulog_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/su/12_su_child_failure/config/etc/login.defs
+++ b/tests/su/12_su_child_failure/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/su/13_su_child_success/config/etc/login.defs
+++ b/tests/su/13_su_child_success/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/subids/12_useradd_invalid_subuid_configuration1/config/etc/login.defs
+++ b/tests/subids/12_useradd_invalid_subuid_configuration1/config/etc/login.defs
@@ -205,7 +205,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/subids/13_useradd_invalid_subuid_configuration2/config/etc/login.defs
+++ b/tests/subids/13_useradd_invalid_subuid_configuration2/config/etc/login.defs
@@ -205,7 +205,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/subids/14_useradd_invalid_subuid_configuration3/config/etc/login.defs
+++ b/tests/subids/14_useradd_invalid_subuid_configuration3/config/etc/login.defs
@@ -205,7 +205,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/subids/15_useradd_invalid_subgid_configuration1/config/etc/login.defs
+++ b/tests/subids/15_useradd_invalid_subgid_configuration1/config/etc/login.defs
@@ -205,7 +205,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/subids/16_useradd_invalid_subgid_configuration2/config/etc/login.defs
+++ b/tests/subids/16_useradd_invalid_subgid_configuration2/config/etc/login.defs
@@ -205,7 +205,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/subids/17_useradd_invalid_subgid_configuration3/config/etc/login.defs
+++ b/tests/subids/17_useradd_invalid_subgid_configuration3/config/etc/login.defs
@@ -205,7 +205,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/subids/18_useradd_min=max/config/etc/login.defs
+++ b/tests/subids/18_useradd_min=max/config/etc/login.defs
@@ -205,7 +205,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/usertools/chpasswd/01_chpasswd_invalid_user/config/etc/login.defs
+++ b/tests/usertools/chpasswd/01_chpasswd_invalid_user/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/usertools/chpasswd/02_chpasswd_multiple_users/config/etc/login.defs
+++ b/tests/usertools/chpasswd/02_chpasswd_multiple_users/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/usertools/chpasswd/03_chpasswd_no_shadow_file/config/etc/login.defs
+++ b/tests/usertools/chpasswd/03_chpasswd_no_shadow_file/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/usertools/chpasswd/04_chpasswd_no_shadow_entry/config/etc/login.defs
+++ b/tests/usertools/chpasswd/04_chpasswd_no_shadow_entry/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/usertools/chpasswd/05_chpasswd_error_no_password/config/etc/login.defs
+++ b/tests/usertools/chpasswd/05_chpasswd_error_no_password/config/etc/login.defs
@@ -206,7 +206,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/usertools/userdel/05_userdel_no_USERGROUPS_ENAB/config/etc/login.defs
+++ b/tests/usertools/userdel/05_userdel_no_USERGROUPS_ENAB/config/etc/login.defs
@@ -197,7 +197,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/usertools/userdel/06_userdel_no_usergroup/config/etc/login.defs
+++ b/tests/usertools/userdel/06_userdel_no_usergroup/config/etc/login.defs
@@ -197,7 +197,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/usertools/userdel/07_userdel_usergroup_not_primary/config/etc/login.defs
+++ b/tests/usertools/userdel/07_userdel_usergroup_not_primary/config/etc/login.defs
@@ -197,7 +197,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/usertools/userdel/08_userdel_usergroup_with_other_members/config/etc/login.defs
+++ b/tests/usertools/userdel/08_userdel_usergroup_with_other_members/config/etc/login.defs
@@ -197,7 +197,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/usertools/userdel/09_userdel_usergroup_no_other_members_in_gshadow/config/etc/login.defs
+++ b/tests/usertools/userdel/09_userdel_usergroup_no_other_members_in_gshadow/config/etc/login.defs
@@ -197,7 +197,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/usertools/usermod/47_usermod-u_default_maildir/config/etc/login.defs
+++ b/tests/usertools/usermod/47_usermod-u_default_maildir/config/etc/login.defs
@@ -197,7 +197,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 

--- a/tests/usertools/usermod/48_usermod-u_MAIL_FILE/config/etc/login.defs
+++ b/tests/usertools/usermod/48_usermod-u_MAIL_FILE/config/etc/login.defs
@@ -197,7 +197,7 @@ CHFN_RESTRICT		rwh
 
 #
 # Should login be allowed if we can't cd to the home directory?
-# Default in no.
+# Default is no.
 #
 DEFAULT_HOME	yes
 


### PR DESCRIPTION
Replaced using: `grep -rl "Default in no." | sort -u | xargs -I@ gsed -i 's/Default in no./Default is no./g' @`

Sorry for the hassle.