### PR TITLE
usermod: Remove special case for ""

### DIFF
--- a/src/usermod.c
+++ b/src/usermod.c
@@ -1073,18 +1073,14 @@ static void process_flags (int argc, char **argv)
 				}
 				break;
 			case 'e':
-				if ('\0' != *optarg) {
-					user_newexpire = strtoday (optarg);
-					if (user_newexpire < -1) {
-						fprintf (stderr,
-						         _("%s: invalid date '%s'\n"),
-						         Prog, optarg);
-						exit (E_BAD_ARG);
-					}
-					user_newexpire *= DAY / SCALE;
-				} else {
-					user_newexpire = -1;
+				user_newexpire = strtoday (optarg);
+				if (user_newexpire < -1) {
+					fprintf (stderr,
+						 _("%s: invalid date '%s'\n"),
+						 Prog, optarg);
+					exit (E_BAD_ARG);
 				}
+				user_newexpire *= DAY / SCALE;
 				eflg = true;
 				break;
 			case 'f':


### PR DESCRIPTION
That special case is already handled by the called function: strtoday()
so we can simplify the calling code.

Link: <https://github.com/shadow-maint/shadow/issues/454>
Signed-off-by: Alejandro Colomar <alx.manpages@gmail.com>

--

**NOTE**: I didn't test the change, since I couldn't find instructions on how to build it in the README, and there's no `Makefile`.