### PR TITLE
libsubid: fix defining SONAME version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -321,8 +321,6 @@ if test "$with_sha_crypt" = "yes"; then
 	AC_DEFINE(USE_SHA_CRYPT, 1, [Define to allow the SHA256 and SHA512 password encryption algorithms])
 fi
 
-AM_CONDITIONAL(ENABLE_SHARED, test "x$enable_shared" = "xyes")
-
 AM_CONDITIONAL(USE_BCRYPT, test "x$with_bcrypt" = "xyes")
 if test "$with_bcrypt" = "yes"; then
 	AC_DEFINE(USE_BCRYPT, 1, [Define to allow the bcrypt password encryption algorithm])

--- a/libsubid/Makefile.am
+++ b/libsubid/Makefile.am
@@ -1,10 +1,6 @@
 lib_LTLIBRARIES = libsubid.la
-if ENABLE_SHARED
-libsubid_la_LDFLAGS = -Wl,-soname,libsubid.so.@LIBSUBID_ABI@ \
-	-shared -version-info @LIBSUBID_ABI_MAJOR@
-endif
 libsubid_la_SOURCES = api.c
-libsubid_la_LDFLAGS = -export-symbols-regex '^subid_'
+libsubid_la_LDFLAGS = -version-info @LIBSUBID_ABI_MAJOR@ -export-symbols-regex '^subid_'
 
 pkginclude_HEADERS = subid.h
 


### PR DESCRIPTION
We were overriding this when --enable-shared was passed. We can actually
just dump the conditional logic as libtool will do the right thing for
us here anyway.

Without this patch, libsubid is installed as .0.

Signed-off-by: Sam James <sam@gentoo.org>