### PR TITLE
lib: rename Prog to shadow_progname, with only one definition

### DIFF
--- a/lib/commonio.c
+++ b/lib/commonio.c
@@ -147,7 +147,7 @@ static int do_lock_file (const char *file, const char *lock, bool log)
 		if (log) {
 			(void) fprintf (shadow_logfd,
 			                "%s: %s: %s\n",
-			                Prog, file, strerror (errno));
+			                shadow_progname, file, strerror (errno));
 		}
 		return 0;
 	}
@@ -159,7 +159,7 @@ static int do_lock_file (const char *file, const char *lock, bool log)
 		if (log) {
 			(void) fprintf (shadow_logfd,
 			                "%s: %s file write error: %s\n",
-			                Prog, file, strerror (errno));
+			                shadow_progname, file, strerror (errno));
 		}
 		(void) close (fd);
 		unlink (file);
@@ -169,7 +169,7 @@ static int do_lock_file (const char *file, const char *lock, bool log)
 		if (log) {
 			(void) fprintf (shadow_logfd,
 			                "%s: %s file sync error: %s\n",
-			                Prog, file, strerror (errno));
+			                shadow_progname, file, strerror (errno));
 		}
 		(void) close (fd);
 		unlink (file);
@@ -182,7 +182,7 @@ static int do_lock_file (const char *file, const char *lock, bool log)
 		if ((0==retval) && log) {
 			(void) fprintf (shadow_logfd,
 			                "%s: %s: lock file already used\n",
-			                Prog, file);
+			                shadow_progname, file);
 		}
 		unlink (file);
 		return retval;
@@ -193,7 +193,7 @@ static int do_lock_file (const char *file, const char *lock, bool log)
 		if (log) {
 			(void) fprintf (shadow_logfd,
 			                "%s: %s: %s\n",
-			                Prog, lock, strerror (errno));
+			                shadow_progname, lock, strerror (errno));
 		}
 		unlink (file);
 		errno = EINVAL;
@@ -205,7 +205,7 @@ static int do_lock_file (const char *file, const char *lock, bool log)
 		if (log) {
 			(void) fprintf (shadow_logfd,
 			                "%s: existing lock file %s without a PID\n",
-			                Prog, lock);
+			                shadow_progname, lock);
 		}
 		unlink (file);
 		errno = EINVAL;
@@ -216,7 +216,7 @@ static int do_lock_file (const char *file, const char *lock, bool log)
 		if (log) {
 			(void) fprintf (shadow_logfd,
 			                "%s: existing lock file %s with an invalid PID '%s'\n",
-			                Prog, lock, buf);
+			                shadow_progname, lock, buf);
 		}
 		unlink (file);
 		errno = EINVAL;
@@ -226,7 +226,7 @@ static int do_lock_file (const char *file, const char *lock, bool log)
 		if (log) {
 			(void) fprintf (shadow_logfd,
 			                "%s: lock %s already used by PID %lu\n",
-			                Prog, lock, (unsigned long) pid);
+			                shadow_progname, lock, (unsigned long) pid);
 		}
 		unlink (file);
 		errno = EEXIST;
@@ -236,7 +236,7 @@ static int do_lock_file (const char *file, const char *lock, bool log)
 		if (log) {
 			(void) fprintf (shadow_logfd,
 			                "%s: cannot get lock %s: %s\n",
-			                Prog, lock, strerror (errno));
+			                shadow_progname, lock, strerror (errno));
 		}
 		unlink (file);
 		return 0;
@@ -248,13 +248,13 @@ static int do_lock_file (const char *file, const char *lock, bool log)
 		if ((0==retval) && log) {
 			(void) fprintf (shadow_logfd,
 			                "%s: %s: lock file already used\n",
-			                Prog, file);
+			                shadow_progname, file);
 		}
 	} else {
 		if (log) {
 			(void) fprintf (shadow_logfd,
 			                "%s: cannot get lock %s: %s\n",
-			                Prog, lock, strerror (errno));
+			                shadow_progname, lock, strerror (errno));
 		}
 	}
 
@@ -449,7 +449,7 @@ int commonio_lock (struct commonio_db *db)
 				if (geteuid () != 0) {
 					(void) fprintf (shadow_logfd,
 					                "%s: Permission denied.\n",
-					                Prog);
+					                shadow_progname);
 				}
 				return 0;	/* failure */
 			}
@@ -484,7 +484,7 @@ int commonio_lock (struct commonio_db *db)
 		/* no unnecessary retries on "permission denied" errors */
 		if (geteuid () != 0) {
 			(void) fprintf (shadow_logfd, "%s: Permission denied.\n",
-			                Prog);
+			                shadow_progname);
 			return 0;
 		}
 	}

--- a/lib/nscd.c
+++ b/lib/nscd.c
@@ -26,7 +26,7 @@ int nscd_flush_cache (const char *service)
 
 	if (run_command (cmd, spawnedArgs, spawnedEnv, &status) != 0) {
 		/* run_command writes its own more detailed message. */
-		(void) fprintf (shadow_logfd, _(MSG_NSCD_FLUSH_CACHE_FAILED), Prog);
+		(void) fprintf (shadow_logfd, _(MSG_NSCD_FLUSH_CACHE_FAILED), shadow_progname);
 		return -1;
 	}
 
@@ -34,7 +34,7 @@ int nscd_flush_cache (const char *service)
 	if (!WIFEXITED (status)) {
 		(void) fprintf (shadow_logfd,
 		                _("%s: nscd did not terminate normally (signal %d)\n"),
-		                Prog, WTERMSIG (status));
+		                shadow_progname, WTERMSIG (status));
 		return -1;
 	} else if (code == E_CMD_NOTFOUND) {
 		/* nscd is not installed, or it is installed but uses an
@@ -45,8 +45,8 @@ int nscd_flush_cache (const char *service)
 		return 0;
 	} else if (code != 0) {
 		(void) fprintf (shadow_logfd, _("%s: nscd exited with status %d\n"),
-		                Prog, code);
-		(void) fprintf (shadow_logfd, _(MSG_NSCD_FLUSH_CACHE_FAILED), Prog);
+		                shadow_progname, code);
+		(void) fprintf (shadow_logfd, _(MSG_NSCD_FLUSH_CACHE_FAILED), shadow_progname);
 		return -1;
 	}
 

--- a/lib/selinux.c
+++ b/lib/selinux.c
@@ -216,7 +216,7 @@ int check_selinux_permit (const char *perm_name)
 	if (getprevcon_raw (&user_context_raw) != 0) {
 		fprintf (shadow_logfd,
 		    _("%s: can not get previous SELinux process context: %s\n"),
-		    Prog, strerror (errno));
+		    shadow_progname, strerror (errno));
 		SYSLOG ((LOG_WARN,
 		    "can not get previous SELinux process context: %s",
 		    strerror (errno)));

--- a/lib/shadowlog.c
+++ b/lib/shadowlog.c
@@ -2,14 +2,17 @@
 
 #include "lib/shadowlog_internal.h"
 
+const char *shadow_progname;
+FILE *shadow_logfd;
+
 void log_set_progname(const char *progname)
 {
-	Prog = progname;
+	shadow_progname = progname;
 }
 
 const char *log_get_progname(void)
 {
-	return Prog;
+	return shadow_progname;
 }
 
 void log_set_logfd(FILE *fd)

--- a/lib/shadowlog_internal.h
+++ b/lib/shadowlog_internal.h
@@ -1,2 +1,2 @@
-const char *Prog; /* Program name showed in error messages */
-FILE *shadow_logfd;  /* file descripter to which error messages are printed */
+extern const char *shadow_progname; /* Program name showed in error messages */
+extern FILE *shadow_logfd;  /* file descripter to which error messages are printed */

--- a/lib/spawn.c
+++ b/lib/spawn.c
@@ -60,11 +60,11 @@ int run_command (const char *cmd, const char *argv[],
 			exit (E_CMD_NOTFOUND);
 		}
 		fprintf (shadow_logfd, "%s: cannot execute %s: %s\n",
-		         Prog, cmd, strerror (errno));
+		         shadow_progname, cmd, strerror (errno));
 		exit (E_CMD_NOEXEC);
 	} else if ((pid_t)-1 == pid) {
 		fprintf (shadow_logfd, "%s: cannot execute %s: %s\n",
-		         Prog, cmd, strerror (errno));
+		         shadow_progname, cmd, strerror (errno));
 		return -1;
 	}
 
@@ -77,7 +77,7 @@ int run_command (const char *cmd, const char *argv[],
 
 	if ((pid_t)-1 == wpid) {
 		fprintf (shadow_logfd, "%s: waitpid (status: %d): %s\n",
-		         Prog, *status, strerror (errno));
+		         shadow_progname, *status, strerror (errno));
 		return -1;
 	}
 

--- a/lib/sssd.c
+++ b/lib/sssd.c
@@ -48,22 +48,22 @@ int sssd_flush_cache (int dbflags)
 	free(sss_cache_args);
 	if (rv != 0) {
 		/* run_command writes its own more detailed message. */
-		SYSLOG ((LOG_WARN, MSG_SSSD_FLUSH_CACHE_FAILED, Prog));
+		SYSLOG ((LOG_WARN, MSG_SSSD_FLUSH_CACHE_FAILED, shadow_progname));
 		return -1;
 	}
 
 	code = WEXITSTATUS (status);
 	if (!WIFEXITED (status)) {
 		SYSLOG ((LOG_WARN, "%s: sss_cache did not terminate normally (signal %d)",
-			Prog, WTERMSIG (status)));
+			shadow_progname, WTERMSIG (status)));
 		return -1;
 	} else if (code == E_CMD_NOTFOUND) {
 		/* sss_cache is not installed, or it is installed but uses an
 		   interpreter that is missing.  Probably the former. */
 		return 0;
 	} else if (code != 0) {
-		SYSLOG ((LOG_WARN, "%s: sss_cache exited with status %d", Prog, code));
-		SYSLOG ((LOG_WARN, MSG_SSSD_FLUSH_CACHE_FAILED, Prog));
+		SYSLOG ((LOG_WARN, "%s: sss_cache exited with status %d", shadow_progname, code));
+		SYSLOG ((LOG_WARN, MSG_SSSD_FLUSH_CACHE_FAILED, shadow_progname));
 		return -1;
 	}
 

--- a/lib/tcbfuncs.c
+++ b/lib/tcbfuncs.c
@@ -74,7 +74,7 @@ shadowtcb_status shadowtcb_gain_priv (void)
  * to exit soon.
  */
 #define OUT_OF_MEMORY do { \
-	fprintf (shadow_logfd, _("%s: out of memory\n"), Prog); \
+	fprintf (shadow_logfd, _("%s: out of memory\n"), shadow_progname); \
 	(void) fflush (shadow_logfd); \
 } while (false)
 
@@ -120,7 +120,7 @@ static /*@null@*/ char *shadowtcb_path_rel_existing (const char *name)
 	if (lstat (path, &st) != 0) {
 		fprintf (shadow_logfd,
 		         _("%s: Cannot stat %s: %s\n"),
-		         Prog, path, strerror (errno));
+		         shadow_progname, path, strerror (errno));
 		free (path);
 		return NULL;
 	}
@@ -136,7 +136,7 @@ static /*@null@*/ char *shadowtcb_path_rel_existing (const char *name)
 	if (!S_ISLNK (st.st_mode)) {
 		fprintf (shadow_logfd,
 		         _("%s: %s is neither a directory, nor a symlink.\n"),
-		         Prog, path);
+		         shadow_progname, path);
 		free (path);
 		return NULL;
 	}
@@ -144,7 +144,7 @@ static /*@null@*/ char *shadowtcb_path_rel_existing (const char *name)
 	if (-1 == ret) {
 		fprintf (shadow_logfd,
 		         _("%s: Cannot read symbolic link %s: %s\n"),
-		         Prog, path, strerror (errno));
+		         shadow_progname, path, strerror (errno));
 		free (path);
 		return NULL;
 	}
@@ -153,7 +153,7 @@ static /*@null@*/ char *shadowtcb_path_rel_existing (const char *name)
 		link[sizeof(link) - 1] = '\0';
 		fprintf (shadow_logfd,
 		         _("%s: Suspiciously long symlink: %s\n"),
-		         Prog, link);
+		         shadow_progname, link);
 		return NULL;
 	}
 	link[(size_t)ret] = '\0';
@@ -211,7 +211,7 @@ static shadowtcb_status mkdir_leading (const char *name, uid_t uid)
 	if (stat (TCB_DIR, &st) != 0) {
 		fprintf (shadow_logfd,
 		         _("%s: Cannot stat %s: %s\n"),
-		         Prog, TCB_DIR, strerror (errno));
+		         shadow_progname, TCB_DIR, strerror (errno));
 		goto out_free_path;
 	}
 	while ((ind = strchr (ptr, '/'))) {
@@ -223,19 +223,19 @@ static shadowtcb_status mkdir_leading (const char *name, uid_t uid)
 		if ((mkdir (dir, 0700) != 0) && (errno != EEXIST)) {
 			fprintf (shadow_logfd,
 			         _("%s: Cannot create directory %s: %s\n"),
-			         Prog, dir, strerror (errno));
+			         shadow_progname, dir, strerror (errno));
 			goto out_free_dir;
 		}
 		if (chown (dir, 0, st.st_gid) != 0) {
 			fprintf (shadow_logfd,
 			         _("%s: Cannot change owner of %s: %s\n"),
-			         Prog, dir, strerror (errno));
+			         shadow_progname, dir, strerror (errno));
 			goto out_free_dir;
 		}
 		if (chmod (dir, 0711) != 0) {
 			fprintf (shadow_logfd,
 			         _("%s: Cannot change mode of %s: %s\n"),
-			         Prog, dir, strerror (errno));
+			         shadow_progname, dir, strerror (errno));
 			goto out_free_dir;
 		}
 		free (dir);
@@ -265,7 +265,7 @@ static shadowtcb_status unlink_suffs (const char *user)
 		if ((unlink (tmp) != 0) && (errno != ENOENT)) {
 			fprintf (shadow_logfd,
 			         _("%s: unlink: %s: %s\n"),
-			         Prog, tmp, strerror (errno));
+			         shadow_progname, tmp, strerror (errno));
 			free (tmp);
 			return SHADOWTCB_FAILURE;
 		}
@@ -290,7 +290,7 @@ static shadowtcb_status rmdir_leading (char *path)
 			if (errno != ENOTEMPTY) {
 				fprintf (shadow_logfd,
 				         _("%s: Cannot remove directory %s: %s\n"),
-				         Prog, dir, strerror (errno));
+				         shadow_progname, dir, strerror (errno));
 				ret = SHADOWTCB_FAILURE;
 			}
 			free (dir);
@@ -319,7 +319,7 @@ static shadowtcb_status move_dir (const char *user_newname, uid_t user_newid)
 	if (stat (olddir, &oldmode) != 0) {
 		fprintf (shadow_logfd,
 		         _("%s: Cannot stat %s: %s\n"),
-		         Prog, olddir, strerror (errno));
+		         shadow_progname, olddir, strerror (errno));
 		goto out_free;
 	}
 	old_uid = oldmode.st_uid;
@@ -346,7 +346,7 @@ static shadowtcb_status move_dir (const char *user_newname, uid_t user_newid)
 	if (rename (real_old_dir, real_new_dir) != 0) {
 		fprintf (shadow_logfd,
 		         _("%s: Cannot rename %s to %s: %s\n"),
-		         Prog, real_old_dir, real_new_dir, strerror (errno));
+		         shadow_progname, real_old_dir, real_new_dir, strerror (errno));
 		goto out_free;
 	}
 	if (rmdir_leading (real_old_dir_rel) == SHADOWTCB_FAILURE) {
@@ -355,7 +355,7 @@ static shadowtcb_status move_dir (const char *user_newname, uid_t user_newid)
 	if ((unlink (olddir) != 0) && (errno != ENOENT)) {
 		fprintf (shadow_logfd,
 		         _("%s: Cannot remove %s: %s\n"),
-		         Prog, olddir, strerror (errno));
+		         shadow_progname, olddir, strerror (errno));
 		goto out_free;
 	}
 	if (asprintf (&newdir, TCB_DIR "/%s", user_newname) == -1) {
@@ -369,7 +369,7 @@ static shadowtcb_status move_dir (const char *user_newname, uid_t user_newid)
 	    && (symlink (real_new_dir_rel, newdir) != 0)) {
 		fprintf (shadow_logfd,
 		         _("%s: Cannot create symbolic link %s: %s\n"),
-		         Prog, real_new_dir_rel, strerror (errno));
+		         shadow_progname, real_new_dir_rel, strerror (errno));
 		goto out_free;
 	}
 	ret = SHADOWTCB_SUCCESS;
@@ -468,31 +468,31 @@ shadowtcb_status shadowtcb_move (/*@NULL@*/const char *user_newname, uid_t user_
 	if (stat (tcbdir, &dirmode) != 0) {
 		fprintf (shadow_logfd,
 		         _("%s: Cannot stat %s: %s\n"),
-		         Prog, tcbdir, strerror (errno));
+		         shadow_progname, tcbdir, strerror (errno));
 		goto out_free;
 	}
 	if (chown (tcbdir, 0, 0) != 0) {
 		fprintf (shadow_logfd,
 		         _("%s: Cannot change owners of %s: %s\n"),
-		         Prog, tcbdir, strerror (errno));
+		         shadow_progname, tcbdir, strerror (errno));
 		goto out_free;
 	}
 	if (chmod (tcbdir, 0700) != 0) {
 		fprintf (shadow_logfd,
 		         _("%s: Cannot change mode of %s: %s\n"),
-		         Prog, tcbdir, strerror (errno));
+		         shadow_progname, tcbdir, strerror (errno));
 		goto out_free;
 	}
 	if (lstat (shadow, &filemode) != 0) {
 		if (errno != ENOENT) {
 			fprintf (shadow_logfd,
 			         _("%s: Cannot lstat %s: %s\n"),
-			         Prog, shadow, strerror (errno));
+			         shadow_progname, shadow, strerror (errno));
 			goto out_free;
 		}
 		fprintf (shadow_logfd,
 		         _("%s: Warning, user %s has no tcb shadow file.\n"),
-		         Prog, user_newname);
+		         shadow_progname, user_newname);
 	} else {
 		if (!S_ISREG (filemode.st_mode) ||
 			filemode.st_nlink != 1) {
@@ -500,19 +500,19 @@ shadowtcb_status shadowtcb_move (/*@NULL@*/const char *user_newname, uid_t user_
 			         _("%s: Emergency: %s's tcb shadow is not a "
 			           "regular file with st_nlink=1.\n"
 			           "The account is left locked.\n"),
-			         Prog, user_newname);
+			         shadow_progname, user_newname);
 			goto out_free;
 		}
 		if (chown (shadow, user_newid, filemode.st_gid) != 0) {
 			fprintf (shadow_logfd,
 			         _("%s: Cannot change owner of %s: %s\n"),
-			         Prog, shadow, strerror (errno));
+			         shadow_progname, shadow, strerror (errno));
 			goto out_free;
 		}
 		if (chmod (shadow, filemode.st_mode & 07777) != 0) {
 			fprintf (shadow_logfd,
 			         _("%s: Cannot change mode of %s: %s\n"),
-			         Prog, shadow, strerror (errno));
+			         shadow_progname, shadow, strerror (errno));
 			goto out_free;
 		}
 	}
@@ -522,13 +522,13 @@ shadowtcb_status shadowtcb_move (/*@NULL@*/const char *user_newname, uid_t user_
 	if (chown (tcbdir, user_newid, dirmode.st_gid) != 0) {
 		fprintf (shadow_logfd,
 		         _("%s: Cannot change owner of %s: %s\n"),
-		         Prog, tcbdir, strerror (errno));
+		         shadow_progname, tcbdir, strerror (errno));
 		goto out_free;
 	}
 	if (chmod (tcbdir, dirmode.st_mode & 07777) != 0) {
 		fprintf (shadow_logfd,
 		         _("%s: Cannot change mode of %s: %s\n"),
-		         Prog, tcbdir, strerror (errno));
+		         shadow_progname, tcbdir, strerror (errno));
 		goto out_free;
 	}
 	ret = SHADOWTCB_SUCCESS;
@@ -553,7 +553,7 @@ shadowtcb_status shadowtcb_create (const char *name, uid_t uid)
 	if (stat (TCB_DIR, &tcbdir_stat) != 0) {
 		fprintf (shadow_logfd,
 		         _("%s: Cannot stat %s: %s\n"),
-		         Prog, TCB_DIR, strerror (errno));
+		         shadow_progname, TCB_DIR, strerror (errno));
 		return SHADOWTCB_FAILURE;
 	}
 	shadowgid = tcbdir_stat.st_gid;
@@ -573,39 +573,39 @@ shadowtcb_status shadowtcb_create (const char *name, uid_t uid)
 	if (mkdir (dir, 0700) != 0) {
 		fprintf (shadow_logfd,
 		         _("%s: mkdir: %s: %s\n"),
-		         Prog, dir, strerror (errno));
+		         shadow_progname, dir, strerror (errno));
 		goto out_free;
 	}
 	fd = open (shadow, O_RDWR | O_CREAT | O_TRUNC, 0600);
 	if (fd < 0) {
 		fprintf (shadow_logfd,
 		         _("%s: Cannot open %s: %s\n"),
-		         Prog, shadow, strerror (errno));
+		         shadow_progname, shadow, strerror (errno));
 		goto out_free;
 	}
 	close (fd);
 	if (chown (shadow, 0, authgid) != 0) {
 		fprintf (shadow_logfd,
 		         _("%s: Cannot change owner of %s: %s\n"),
-		         Prog, shadow, strerror (errno));
+		         shadow_progname, shadow, strerror (errno));
 		goto out_free;
 	}
 	if (chmod (shadow, (mode_t) ((authgid == shadowgid) ? 0600 : 0640)) != 0) {
 		fprintf (shadow_logfd,
 		         _("%s: Cannot change mode of %s: %s\n"),
-		         Prog, shadow, strerror (errno));
+		         shadow_progname, shadow, strerror (errno));
 		goto out_free;
 	}
 	if (chown (dir, 0, authgid) != 0) {
 		fprintf (shadow_logfd,
 		         _("%s: Cannot change owner of %s: %s\n"),
-		         Prog, dir, strerror (errno));
+		         shadow_progname, dir, strerror (errno));
 		goto out_free;
 	}
 	if (chmod (dir, (mode_t) ((authgid == shadowgid) ? 02700 : 02710)) != 0) {
 		fprintf (shadow_logfd,
 		         _("%s: Cannot change mode of %s: %s\n"),
-		         Prog, dir, strerror (errno));
+		         shadow_progname, dir, strerror (errno));
 		goto out_free;
 	}
 	if (   (shadowtcb_set_user (name) == SHADOWTCB_FAILURE)


### PR DESCRIPTION
After #471, the build fails with duplicate symbol errors with `-fno-common`:

```
/gar/bin/ld: ../lib/.libs/libshadow.a(libshadow_la-encrypt.o):/src/sys/shadow/work/6761cf2d7e9defeed7f915c668a87b84bac2c9c3/lib/shadowlog_internal.h:2: multiple definition of `shadow_logfd'; ../lib/.libs/libshadow.a(libshadow_la-commonio.o):/src/sys/shadow/work/6761cf2d7e9defeed7f915c668a87b84bac2c9c3/lib/shadowlog_internal.h:2: first defined here
/gar/bin/ld: ../lib/.libs/libshadow.a(libshadow_la-encrypt.o):/src/sys/shadow/work/6761cf2d7e9defeed7f915c668a87b84bac2c9c3/lib/shadowlog_internal.h:1: multiple definition of `Prog'; ../lib/.libs/libshadow.a(libshadow_la-commonio.o):/src/sys/shadow/work/6761cf2d7e9defeed7f915c668a87b84bac2c9c3/lib/shadowlog_internal.h:1: first defined here
```
(etc.)

`-fcommon` is the default in GCC 10 and later, and explicitly enabled in some distributions to catch problems like this. There were two causes:

- `Prog` and `shadow_logfd` were defined in a header file that was included in multiple other files. Fix this by defining them once in `shadowlog.c`, and having `extern` declarations in the header.

- Most of the tools (except `id`/`nologin`) also define a `Prog` variable, which is not intended to alias the one in the library. Fix this by renaming `Prog` in the library to `shadow_progname`, which also matches the new accessor functions for it.

I think this should still be OK in terms of what #465 wanted, i.e. the shared library doesn't require users to define these symbols.