### PR TITLE
Default value for progname/logfd, and set progname in subid_init too

### DIFF
--- a/lib/shadowlog.c
+++ b/lib/shadowlog.c
@@ -2,8 +2,8 @@
 
 #include "lib/shadowlog_internal.h"
 
-const char *shadow_progname;
-FILE *shadow_logfd;
+const char *shadow_progname = "libshadow";
+FILE *shadow_logfd = NULL;
 
 void log_set_progname(const char *progname)
 {

--- a/libsubid/api.c
+++ b/libsubid/api.c
@@ -40,17 +40,16 @@
 #include "subid.h"
 #include "shadowlog.h"
 
-static const char *Prog = "(libsubid)";
-
 bool subid_init(const char *progname, FILE * logfd)
 {
 	FILE *shadow_logfd;
 	if (progname) {
 		progname = strdup(progname);
-		if (progname)
-			Prog = progname;
-		else
+		if (!progname)
 			return false;
+		log_set_progname(progname);
+	} else {
+		log_set_progname("(libsubid)");
 	}
 
 	if (logfd) {


### PR DESCRIPTION
Set the program name in `subid_init` too, as [suggested](https://github.com/shadow-maint/shadow/pull/472#issuecomment-1001205406) in #472.

The existing code here made me think that there should be a default value in lib if the user doesn't set it, so do that as well.