### PR TITLE
Remove HAVE_STRFTIME ifdefs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -115,7 +115,6 @@ dnl Checks for library functions.
 AC_TYPE_GETGROUPS
 AC_TYPE_SIGNAL
 AC_FUNC_UTIME_NULL
-AC_FUNC_STRFTIME
 AC_REPLACE_FUNCS(mkdir putgrent putpwent putspent rename rmdir)
 AC_REPLACE_FUNCS(sgetgrent sgetpwent sgetspent)
 AC_REPLACE_FUNCS(snprintf strcasecmp strdup strerror strstr)

--- a/libmisc/failure.c
+++ b/libmisc/failure.c
@@ -232,13 +232,8 @@ int failcheck (uid_t uid, struct faillog *fl, bool failed)
 void failprint (const struct faillog *fail)
 {
 	struct tm *tp;
-
-#if HAVE_STRFTIME
 	char lasttimeb[256];
 	char *lasttime = lasttimeb;
-#else
-	char *lasttime;
-#endif
 	time_t NOW;
 
 	if (0 == fail->fail_cnt) {
@@ -248,31 +243,11 @@ void failprint (const struct faillog *fail)
 	tp = localtime (&(fail->fail_time));
 	(void) time (&NOW);
 
-#if HAVE_STRFTIME
 	/*
 	 * Print all information we have.
 	 */
 	(void) strftime (lasttimeb, sizeof lasttimeb, "%c", tp);
-#else
 
-	/*
-	 * Do the same thing, but don't use strftime since it
-	 * probably doesn't exist on this system
-	 */
-	lasttime = asctime (tp);
-	lasttime[24] = '\0';
-
-	if ((NOW - fail->fail_time) < YEAR) {
-		lasttime[19] = '\0';
-	}
-	if ((NOW - fail->fail_time) < DAY) {
-		lasttime = lasttime + 11;
-	}
-
-	if (' ' == *lasttime) {
-		lasttime++;
-	}
-#endif
 	/*@-formatconst@*/
 	(void) printf (ngettext ("%d failure since last login.\n"
 	                         "Last was %s on %s.\n",

--- a/src/chage.c
+++ b/src/chage.c
@@ -244,7 +244,6 @@ static int new_fields (void)
 
 static void print_date (time_t date)
 {
-#ifdef HAVE_STRFTIME
 	struct tm *tp;
 	char buf[80];
 	char format[80];
@@ -263,20 +262,6 @@ static void print_date (time_t date)
 		(void) strftime (buf, sizeof buf, format, tp);
 		(void) puts (buf);
 	}
-#else
-	struct tm *tp;
-	char *cp = NULL;
-
-	tp = gmtime (&date);
-	if (NULL != tp) {
-		cp = asctime (tp);
-	}
-	if (NULL != cp) {
-		(void) printf ("%6.6s, %4.4s\n", cp + 4, cp + 20);
-	} else {
-		(void) printf ("time_t: %lu\n", date);
-	}
-#endif
 }
 
 /*

--- a/src/faillog.c
+++ b/src/faillog.c
@@ -111,11 +111,8 @@ static void print_one (/*@null@*/const struct passwd *pw, bool force)
 	off_t offset;
 	struct faillog fl;
 	time_t now;
-
-#ifdef HAVE_STRFTIME
 	char *cp;
 	char ptime[80];
-#endif
 
 	if (NULL == pw) {
 		return;
@@ -168,13 +165,11 @@ static void print_one (/*@null@*/const struct passwd *pw, bool force)
 		fprintf (stderr, "Cannot read time from faillog.\n");
 		return;
 	}
-#ifdef HAVE_STRFTIME
 	strftime (ptime, sizeof (ptime), "%D %H:%M:%S %z", tm);
 	cp = ptime;
-#endif
+
 	printf ("%-9s   %5d    %5d   ",
 	        pw->pw_name, fl.fail_cnt, fl.fail_max);
-	/* FIXME: cp is not defined ifndef HAVE_STRFTIME */
 	printf ("%s  %s", cp, fl.fail_line);
 	if (0 != fl.fail_locktime) {
 		if (   ((fl.fail_time + fl.fail_locktime) > now)

--- a/src/lastlog.c
+++ b/src/lastlog.c
@@ -108,10 +108,7 @@ static void print_one (/*@null@*/const struct passwd *pw)
 	time_t ll_time;
 	off_t offset;
 	struct lastlog ll;
-
-#ifdef HAVE_STRFTIME
 	char ptime[80];
-#endif
 
 #ifdef HAVE_LL_HOST
 	int maxIPv6Addrlen;
@@ -177,13 +174,8 @@ static void print_one (/*@null@*/const struct passwd *pw)
 
 	ll_time = ll.ll_time;
 	tm = localtime (&ll_time);
-#ifdef HAVE_STRFTIME
 	strftime (ptime, sizeof (ptime), "%a %b %e %H:%M:%S %z %Y", tm);
 	cp = ptime;
-#else
-	cp = asctime (tm);
-	cp[24] = '\0';
-#endif
 
 	if (ll.ll_time == (time_t) 0) {
 		cp = _("**Never logged in**\0");

--- a/src/login.c
+++ b/src/login.c
@@ -534,7 +534,7 @@ int main (int argc, char **argv)
 #ifdef RLOGIN
 	char term[128] = "";
 #endif				/* RLOGIN */
-#if defined(HAVE_STRFTIME) && !defined(USE_PAM)
+#if !defined(USE_PAM)
 	char ptime[80];
 #endif
 	unsigned int delay;
@@ -1321,16 +1321,11 @@ int main (int argc, char **argv)
 		    && (ll.ll_time != 0)) {
 			time_t ll_time = ll.ll_time;
 
-#ifdef HAVE_STRFTIME
 			(void) strftime (ptime, sizeof (ptime),
 			                 "%a %b %e %H:%M:%S %z %Y",
 			                 localtime (&ll_time));
 			printf (_("Last login: %s on %s"),
 			        ptime, ll.ll_line);
-#else
-			printf (_("Last login: %.19s on %s"),
-			        ctime (&ll_time), ll.ll_line);
-#endif
 #ifdef HAVE_LL_HOST		/* __linux__ || SUN4 */
 			if ('\0' != ll.ll_host[0]) {
 				printf (_(" from %.*s"),


### PR DESCRIPTION
strftime(3) has been in standard C since C89.  It is also in
POSIX.1-2001, and in SVr4 (see [`strftime(3)`](https://www.man7.org/linux/man-pages/man3/strftime.3.html) and [`strftime(3p)`](https://www.man7.org/linux/man-pages/man3/strftime.3p.html)).
We can assume that this function is always available.

Signed-off-by: Alejandro Colomar <alx.manpages@gmail.com>