### PR TITLE
Remove HAVE_GETGROUPS ifdefs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -51,7 +51,7 @@ AC_CHECK_HEADERS(crypt.h errno.h fcntl.h limits.h unistd.h sys/time.h utmp.h \
 dnl shadow now uses the libc's shadow implementation
 AC_CHECK_HEADER([shadow.h],,[AC_MSG_ERROR([You need a libc with shadow.h])])
 
-AC_CHECK_FUNCS(arc4random_buf l64a fchmod fchown fsync futimes getgroups \
+AC_CHECK_FUNCS(arc4random_buf l64a fchmod fchown fsync futimes \
 	gethostname getentropy getrandom getspnam gettimeofday getusershell \
 	getutent initgroups lchown lckpwdf lstat lutimes memcpy memset \
 	setgroups sigaction strchr updwtmp updwtmpx innetgr getpwnam_r \

--- a/src/groups.c
+++ b/src/groups.c
@@ -107,18 +107,12 @@ static void print_groups (const char *member)
  */
 int main (int argc, char **argv)
 {
-#ifdef HAVE_GETGROUPS
 	long sys_ngroups;
 	GETGROUPS_T *groups;
-#else
-	char *logname;
-	char *getlogin ();
-#endif
 
-#ifdef HAVE_GETGROUPS
 	sys_ngroups = sysconf (_SC_NGROUPS_MAX);
 	groups = (GETGROUPS_T *) malloc (sizeof (GETGROUPS_T) * sys_ngroups);
-#endif
+
 	(void) setlocale (LC_ALL, "");
 	(void) bindtextdomain (PACKAGE, LOCALEDIR);
 	(void) textdomain (PACKAGE);
@@ -137,7 +131,6 @@ int main (int argc, char **argv)
 		 * current user.
 		 */
 
-#ifdef HAVE_GETGROUPS
 		int i;
 		int pri_grp; /* TODO: should be GETGROUPS_T */
 		/*
@@ -196,18 +189,6 @@ int main (int argc, char **argv)
 			}
 		}
 		(void) putchar ('\n');
-#else
-		/*
-		 * This system does not have the getgroups() system call, so
-		 * I must check the groups file directly.
-		 */
-		logname = getlogin ();
-		if (NULL != logname) {
-			print_groups (logname);
-		} else {
-			exit (EXIT_FAILURE);
-		}
-#endif
 	} else {
 
 		/*

--- a/src/id.c
+++ b/src/id.c
@@ -52,11 +52,7 @@ static void usage (void);
 
 static void usage (void)
 {
-#ifdef HAVE_GETGROUPS
 	(void) fputs (_("Usage: id [-a]\n"), stderr);
-#else
-	(void) fputs (_("Usage: id\n"), stderr);
-#endif
 	exit (EXIT_FAILURE);
 }
 
@@ -73,11 +69,9 @@ static void usage (void)
  * gid_t for everything. Some systems have a small and fixed NGROUPS,
  * usually about 16 or 32. Others use bigger values.
  */
-#ifdef HAVE_GETGROUPS
 	GETGROUPS_T *groups;
 	int ngroups;
 	bool aflg = 0;
-#endif
 	struct passwd *pw;
 	struct group *gr;
 
@@ -92,8 +86,8 @@ static void usage (void)
 	 * work if the system library is recompiled.
 	 */
 	sys_ngroups = sysconf (_SC_NGROUPS_MAX);
-#ifdef HAVE_GETGROUPS
 	groups = (GETGROUPS_T *) malloc (sizeof (GETGROUPS_T) * sys_ngroups);
+
 	/*
 	 * See if the -a flag has been given to print out the concurrent
 	 * group set.
@@ -106,11 +100,6 @@ static void usage (void)
 			aflg = true;
 		}
 	}
-#else
-	if (argc > 1) {
-		usage ();
-	}
-#endif
 
 	ruid = getuid ();
 	euid = geteuid ();
@@ -161,7 +150,7 @@ static void usage (void)
 			(void) printf (" EGID=%lu", (unsigned long) egid);
 		}
 	}
-#ifdef HAVE_GETGROUPS
+
 	/*
 	 * Print out the concurrent group set if the user has requested it.
 	 * The group numbers will be printed followed by their names.
@@ -195,7 +184,6 @@ static void usage (void)
 		}
 	}
 	free (groups);
-#endif
 
 	/*
 	 * Finish off the line.


### PR DESCRIPTION
getgroups(2) has been in POSIX since POSIX.1-2001.  It is also in
in SVr4 and in 4.3BSD (see [`getgroups(2)`](https://man7.org/linux/man-pages/man2/getgroups.2.html) and [`getgroups(3p)`](https://www.man7.org/linux/man-pages/man3/getgroups.3p.html)).
We can assume that this function is always available.

Signed-off-by: Alejandro Colomar <alx.manpages@gmail.com>