### PR TITLE
Remove HAVE_MEMCPY and HAVE_MEMSET ifdefs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -53,7 +53,7 @@ AC_CHECK_HEADER([shadow.h],,[AC_MSG_ERROR([You need a libc with shadow.h])])
 
 AC_CHECK_FUNCS(arc4random_buf l64a fchmod fchown fsync futimes getgroups \
 	gethostname getentropy getrandom getspnam gettimeofday getusershell \
-	getutent initgroups lchown lckpwdf lstat lutimes memcpy memset \
+	getutent initgroups lchown lckpwdf lstat lutimes memset \
 	setgroups sigaction strchr updwtmp updwtmpx innetgr getpwnam_r \
 	getpwuid_r getgrnam_r getgrgid_r getspnam_r getaddrinfo ruserok \
 	dlopen)

--- a/configure.ac
+++ b/configure.ac
@@ -53,7 +53,7 @@ AC_CHECK_HEADER([shadow.h],,[AC_MSG_ERROR([You need a libc with shadow.h])])
 
 AC_CHECK_FUNCS(arc4random_buf l64a fchmod fchown fsync futimes getgroups \
 	gethostname getentropy getrandom getspnam gettimeofday getusershell \
-	getutent initgroups lchown lckpwdf lstat lutimes memset \
+	getutent initgroups lchown lckpwdf lstat lutimes \
 	setgroups sigaction strchr updwtmp updwtmpx innetgr getpwnam_r \
 	getpwuid_r getgrnam_r getgrgid_r getspnam_r getaddrinfo ruserok \
 	dlopen)

--- a/lib/defines.h
+++ b/lib/defines.h
@@ -111,11 +111,7 @@ char *strchr (), *strrchr (), *strtok ();
 # endif
 #endif				/* not TIME_WITH_SYS_TIME */
 
-#ifdef HAVE_MEMSET
-# define memzero(ptr, size) memset((void *)(ptr), 0, (size))
-#else
-# define memzero(ptr, size) bzero((char *)(ptr), (size))
-#endif
+#define memzero(ptr, size) memset((void *)(ptr), 0, (size))
 #define strzero(s) memzero(s, strlen(s))	/* warning: evaluates twice */
 
 #ifdef HAVE_DIRENT_H		/* DIR_SYSV */

--- a/lib/defines.h
+++ b/lib/defines.h
@@ -70,10 +70,6 @@ extern char * textdomain (const char * domainname);
 #  define strrchr rindex
 # endif
 char *strchr (), *strrchr (), *strtok ();
-
-# ifndef HAVE_MEMCPY
-#  define memcpy(d, s, n) bcopy((s), (d), (n))
-# endif
 #endif				/* not STDC_HEADERS */
 
 #if HAVE_ERRNO_H

--- a/libmisc/getdate.y
+++ b/libmisc/getdate.y
@@ -61,7 +61,7 @@
 /* Some old versions of bison generate parsers that use bcopy.
    That loses on systems that don't provide the function, so we have
    to redefine it here.  */
-#if !defined (HAVE_BCOPY) && defined (HAVE_MEMCPY) && !defined (bcopy)
+#if !defined (HAVE_BCOPY) && !defined (bcopy)
 # define bcopy(from, to, len) memcpy ((to), (from), (len))
 #endif
 


### PR DESCRIPTION
memcpy(3) has been in standard C since C89.  It is also in
POSIX.1-2001, in SVr4, and in 4.3BSD (see [`memcpy(3)`](https://man7.org/linux/man-pages/man3/memcpy.3.html) and [`memcpy(3p)`](https://man7.org/linux/man-pages/man3/memcpy.3p.html)).
We can assume that this function is always available.

Signed-off-by: Alejandro Colomar <alx.manpages@gmail.com>