### PR TITLE
Assume C89 is available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -38,7 +38,6 @@ dnl Checks for libraries.
 
 dnl Checks for header files.
 AC_HEADER_DIRENT
-AC_HEADER_STDC
 AC_HEADER_SYS_WAIT
 AC_HEADER_STDBOOL
 

--- a/lib/defines.h
+++ b/lib/defines.h
@@ -22,8 +22,6 @@ typedef unsigned char _Bool;
 # define __bool_true_false_are_defined 1
 #endif
 
-#define ISDIGIT_LOCALE(c) isdigit (c)
-
 /* Take care of NLS matters.  */
 #ifdef S_SPLINT_S
 extern char *setlocale(int categories, const char *locale);

--- a/lib/defines.h
+++ b/lib/defines.h
@@ -61,16 +61,8 @@ extern char * textdomain (const char * domainname);
 #endif
 #endif
 
-#if STDC_HEADERS
-# include <stdlib.h>
-# include <string.h>
-#else				/* not STDC_HEADERS */
-# ifndef HAVE_STRCHR
-#  define strchr index
-#  define strrchr rindex
-# endif
-char *strchr (), *strrchr (), *strtok ();
-#endif				/* not STDC_HEADERS */
+#include <stdlib.h>
+#include <string.h>
 
 #if HAVE_ERRNO_H
 # include <errno.h>

--- a/lib/defines.h
+++ b/lib/defines.h
@@ -22,7 +22,7 @@ typedef unsigned char _Bool;
 # define __bool_true_false_are_defined 1
 #endif
 
-#define ISDIGIT_LOCALE(c) (IN_CTYPE_DOMAIN (c) && isdigit (c))
+#define ISDIGIT_LOCALE(c) isdigit (c)
 
 /* Take care of NLS matters.  */
 #ifdef S_SPLINT_S

--- a/libmisc/getdate.y
+++ b/libmisc/getdate.y
@@ -31,15 +31,6 @@
 #include <ctype.h>
 #include <time.h>
 
-/* ISDIGIT differs from isdigit(3), as follows:
-   - Its arg may be any int or unsigned int; it need not be an unsigned char.
-   - It's typically faster.
-   Posix 1003.2-1992 section 2.5.2.1 page 50 lines 1556-1558 says that
-   only '0' through '9' are digits.  Prefer ISDIGIT to isdigit(3) unless
-   it's important to use the locale's definition of `digit' even when the
-   host does not conform to Posix.  */
-#define ISDIGIT(c) ((unsigned) (c) - '0' <= 9)
-
 #include "getdate.h"
 
 #include <string.h>
@@ -760,18 +751,18 @@ yylex (void)
       while (isspace (*yyInput))
 	yyInput++;
 
-      if (ISDIGIT (c = *yyInput) || c == '-' || c == '+')
+      if (isdigit (c = *yyInput) || c == '-' || c == '+')
 	{
 	  if (c == '-' || c == '+')
 	    {
 	      sign = c == '-' ? -1 : 1;
-	      if (!ISDIGIT (*++yyInput))
+	      if (!isdigit (*++yyInput))
 		/* skip the '-' sign */
 		continue;
 	    }
 	  else
 	    sign = 0;
-	  for (yylval.Number = 0; ISDIGIT (c = *yyInput++);)
+	  for (yylval.Number = 0; isdigit (c = *yyInput++);)
 	    yylval.Number = 10 * yylval.Number + c - '0';
 	  yyInput--;
 	  if (sign < 0)

--- a/libmisc/getdate.y
+++ b/libmisc/getdate.y
@@ -31,11 +31,7 @@
 #include <ctype.h>
 #include <time.h>
 
-#if defined (STDC_HEADERS) || (!defined (isascii) && !defined (HAVE_ISASCII))
-# define IN_CTYPE_DOMAIN(c) 1
-#else
-# define IN_CTYPE_DOMAIN(c) isascii(c)
-#endif
+#define IN_CTYPE_DOMAIN(c) 1
 
 #define ISSPACE(c) (IN_CTYPE_DOMAIN (c) && isspace (c))
 #define ISALPHA(c) (IN_CTYPE_DOMAIN (c) && isalpha (c))
@@ -54,9 +50,7 @@
 
 #include "getdate.h"
 
-#if defined (STDC_HEADERS)
-# include <string.h>
-#endif
+#include <string.h>
 
 /* Some old versions of bison generate parsers that use bcopy.
    That loses on systems that don't provide the function, so we have

--- a/libmisc/getdate.y
+++ b/libmisc/getdate.y
@@ -31,14 +31,11 @@
 #include <ctype.h>
 #include <time.h>
 
-#define ISDIGIT_LOCALE(c) isdigit (c)
-
-/* ISDIGIT differs from ISDIGIT_LOCALE, as follows:
+/* ISDIGIT differs from isdigit(3), as follows:
    - Its arg may be any int or unsigned int; it need not be an unsigned char.
-   - It's guaranteed to evaluate its argument exactly once.
    - It's typically faster.
    Posix 1003.2-1992 section 2.5.2.1 page 50 lines 1556-1558 says that
-   only '0' through '9' are digits.  Prefer ISDIGIT to ISDIGIT_LOCALE unless
+   only '0' through '9' are digits.  Prefer ISDIGIT to isdigit(3) unless
    it's important to use the locale's definition of `digit' even when the
    host does not conform to Posix.  */
 #define ISDIGIT(c) ((unsigned) (c) - '0' <= 9)

--- a/libmisc/getdate.y
+++ b/libmisc/getdate.y
@@ -31,12 +31,10 @@
 #include <ctype.h>
 #include <time.h>
 
-#define IN_CTYPE_DOMAIN(c) 1
-
-#define ISSPACE(c) (IN_CTYPE_DOMAIN (c) && isspace (c))
-#define ISALPHA(c) (IN_CTYPE_DOMAIN (c) && isalpha (c))
-#define ISUPPER(c) (IN_CTYPE_DOMAIN (c) && isupper (c))
-#define ISDIGIT_LOCALE(c) (IN_CTYPE_DOMAIN (c) && isdigit (c))
+#define ISSPACE(c) isspace (c)
+#define ISALPHA(c) isalpha (c)
+#define ISUPPER(c) isupper (c)
+#define ISDIGIT_LOCALE(c) isdigit (c)
 
 /* ISDIGIT differs from ISDIGIT_LOCALE, as follows:
    - Its arg may be any int or unsigned int; it need not be an unsigned char.

--- a/libmisc/getdate.y
+++ b/libmisc/getdate.y
@@ -31,9 +31,6 @@
 #include <ctype.h>
 #include <time.h>
 
-#define ISSPACE(c) isspace (c)
-#define ISALPHA(c) isalpha (c)
-#define ISUPPER(c) isupper (c)
 #define ISDIGIT_LOCALE(c) isdigit (c)
 
 /* ISDIGIT differs from ISDIGIT_LOCALE, as follows:
@@ -643,7 +640,7 @@ static int LookupWord (char *buff)
 
   /* Make it lowercase. */
   for (p = buff; '\0' != *p; p++)
-    if (ISUPPER (*p))
+    if (isupper (*p))
       *p = tolower (*p);
 
   if (strcmp (buff, "am") == 0 || strcmp (buff, "a.m.") == 0)
@@ -724,7 +721,7 @@ static int LookupWord (char *buff)
       }
 
   /* Military timezones. */
-  if (buff[1] == '\0' && ISALPHA (*buff))
+  if (buff[1] == '\0' && isalpha (*buff))
     {
       for (tp = MilitaryTable; tp->name; tp++)
 	if (strcmp (buff, tp->name) == 0)
@@ -763,7 +760,7 @@ yylex (void)
 
   for (;;)
     {
-      while (ISSPACE (*yyInput))
+      while (isspace (*yyInput))
 	yyInput++;
 
       if (ISDIGIT (c = *yyInput) || c == '-' || c == '+')
@@ -784,9 +781,9 @@ yylex (void)
 	    yylval.Number = -yylval.Number;
 	  return (0 != sign) ? tSNUMBER : tUNUMBER;
 	}
-      if (ISALPHA (c))
+      if (isalpha (c))
 	{
-	  for (p = buff; (c = *yyInput++, ISALPHA (c)) || c == '.';)
+	  for (p = buff; (c = *yyInput++, isalpha (c)) || c == '.';)
 	    if (p < &buff[sizeof buff - 1])
 	      *p++ = c;
 	  *p = '\0';


### PR DESCRIPTION
Remove STDC_HEADERS, since C89 is nowadays available everywhere (or at least everywhere we can possibly care).

STDC_HEADERS removal allows to simplify other things.  Propagate those changes.