### PR TITLE
build: include lib/shadowlog_internal.h in dist tarballs

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -38,6 +38,7 @@ libshadow_la_SOURCES = \
 	nscd.h \
 	shadowlog.c \
 	shadowlog.h \
+	shadowlog_internal.h \
 	sssd.c \
 	sssd.h \
 	pam_defs.h \


### PR DESCRIPTION
Will need to regenerate dist tarball after this (would recommend doing a new release to avoid confusion, e.g. 4.11.1.).

Seems to work for me after running `make dist` then trying to `./configure && make` from that new tarball.

Fixes: #485
Signed-off-by: Sam James <sam@gentoo.org>