### PR TITLE
useradd: modify check ID range for system users

### DIFF
--- a/src/useradd.c
+++ b/src/useradd.c
@@ -2409,11 +2409,9 @@ static void check_uid_range(int rflg, uid_t user_id)
 	uid_t uid_min ;
 	uid_t uid_max ;
 	if (rflg) {
-		uid_min = (uid_t)getdef_ulong("SYS_UID_MIN",101UL);
 		uid_max = (uid_t)getdef_ulong("SYS_UID_MAX",getdef_ulong("UID_MIN",1000UL)-1);
-		if (uid_min <= uid_max) {
-			if (user_id < uid_min || user_id >uid_max)
-				fprintf(stderr, _("%s warning: %s's uid %d outside of the SYS_UID_MIN %d and SYS_UID_MAX %d range.\n"), Prog, user_name, user_id, uid_min, uid_max);
+		if (user_id > uid_max) {
+			fprintf(stderr, _("%s warning: %s's uid %d is greater than SYS_UID_MAX %d\n"), Prog, user_name, user_id, uid_max);
 		}
 	}else{
 		uid_min = (uid_t)getdef_ulong("UID_MIN", 1000UL);


### PR DESCRIPTION
useradd warns that a system user ID less than SYS_UID_MIN is outside the
expected range, even though that ID has been specifically selected with
the "-u" option.

In my opinion all the user ID's below SYS_UID_MAX are for the system,
thus I change the condition to take that into account. Moreover, I also
modify the check for SYS_UID_MAX, so that it's always less than UID_MIN.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2004911