### PR TITLE
Make libsubid more easily usable from C++

### DIFF
--- a/libsubid/subid.h.in
+++ b/libsubid/subid.h.in
@@ -35,6 +35,10 @@ enum subid_status {
 	SUBID_STATUS_ERROR = 3,
 };
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * subid_init: initialize libsubid
  *
@@ -150,6 +154,10 @@ bool subid_ungrant_uid_range(struct subordinate_range *range);
  * delegation did not exist.
  */
 bool subid_ungrant_gid_range(struct subordinate_range *range);
+
+#ifdef __cplusplus
+}
+#endif
 
 #define SUBID_NFIELDS 3
 #endif


### PR DESCRIPTION
C++ requires extern "C" linkage specification to call functions from a C
library. Enclose the function definitions in subid.h in an extern "C"
block if compiling in C++ mode to achieve this.

Signed-off-by: Alois Wohlschlager <alois1@gmx-topmail.de>