### PR TITLE
fix noselinux su config bug

### DIFF
--- a/etc/pam.d/login
+++ b/etc/pam.d/login
@@ -4,8 +4,8 @@ auth		include		system-auth
 account		required	pam_nologin.so
 account		include		system-auth
 password	include		system-auth
-session		required	pam_selinux.so close
+session [success=ok ignore=ignore module_unknown=ignore default=bad] pam_selinux.so close
 session		include		system-auth
 session		required	pam_loginuid.so
 session		optional	pam_console.so
-session		required	pam_selinux.so open
+session [success=ok ignore=ignore module_unknown=ignore default=bad] pam_selinux.so open

--- a/etc/pam.d/su
+++ b/etc/pam.d/su
@@ -7,7 +7,7 @@ auth		required	pam_wheel.so use_uid
 auth		include		system-auth
 account		include		system-auth
 password	include		system-auth
-session		required	pam_selinux.so close
+session [success=ok ignore=ignore module_unknown=ignore default=bad] pam_selinux.so close
 session		include		system-auth
-session		required	pam_selinux.so open multiple
+session [success=ok ignore=ignore module_unknown=ignore default=bad] pam_selinux.so open
 session		optional	pam_xauth.so


### PR DESCRIPTION
If we use **--without-selinux** su say Unknown module. pam_selinux must be optional.