### PR TITLE
libmisc/xgetXXbyYY.c: Handle ERANGE error correctly

### DIFF
--- a/libmisc/xgetXXbyYY.c
+++ b/libmisc/xgetXXbyYY.c
@@ -66,7 +66,6 @@
 			         "x" STRINGIZE(FUNCTION_NAME));
 			exit (13);
 		}
-		errno = 0;
 		status = REENTRANT_NAME(ARG_NAME, result, buffer,
 		                        length, &resbuf);
 		if ((0 == status) && (resbuf == result)) {
@@ -78,7 +77,7 @@
 			return ret_result;
 		}
 
-		if (ERANGE != errno) {
+		if (ERANGE != status) {
 			free (buffer);
 			free (result);
 			return NULL;


### PR DESCRIPTION
The reentrant functions getgrgid_r, getgrnam_r, getpwnam_r, etc. all return an error code instead of setting errno. Adapt the error check accordingly.

See the man page of e.g. getpwnam_r for reference:
> On success, getpwnam_r() and getpwuid_r() return zero, and set *result to pwd.
> If no matching password record was found, these functions return 0 and store NULL in *result.
> **In case of error, an error number is returned**, and NULL is stored in *result.