### PR TITLE
Fix syntax error in usermod man source

### DIFF
--- a/man/usermod.8.xml
+++ b/man/usermod.8.xml
@@ -132,7 +132,7 @@
 	  <para>
             The date on which the user account will be disabled. The
             date is specified in the format 
-            <emphasis remap=\"I\">YYYY-MM-DD</emphasis>. Integers as input are
+            <emphasis remap="I">YYYY-MM-DD</emphasis>. Integers as input are
             interpreted as days after 1970-01-01.
 	  </para>
 	  <para>


### PR DESCRIPTION
This was introduced in 2f30d235c2b6ba565c50d492d7be33380f73164a; it breaks the build if manpages are enabled.