### PR TITLE
AUTHORS: improve markdown output

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -3,87 +3,87 @@ reports and various comments. This list may be incomplete, I received
 a lot of mail...
 
 # Maintainers
-Tomasz Kłoczko <kloczek@pld.org.pl> (2000-2007)
-Nicolas François <nicolas.francois@centraliens.net> (2007-2014)
-Serge E. Hallyn <serge@hallyn.com> (2014-now)
-Christian Brauner <christian@brauner.io> (2019-now)
+* Tomasz Kłoczko <kloczek@pld.org.pl> (2000-2007)
+* Nicolas François <nicolas.francois@centraliens.net> (2007-2014)
+* Serge E. Hallyn <serge@hallyn.com> (2014-now)
+* Christian Brauner <christian@brauner.io> (2019-now)
+* Iker Pedrosa <ipedrosa@redhat.com> (2022-now)
 
 # Authors and contributors
-Adam Rudnicki <adam@v-lo.krakow.pl>
-Alan Curry <pacman@tardis.mars.net>
-Aleksa Sarai <cyphar@cyphar.com>
-Alexander O. Yuriev <alex@bach.cis.temple.edu>
-Algis Rudys <arudys@rice.edu>
-Andreas Jaeger <aj@arthur.rhein-neckar.de>
-Andy Zaugg <andy.zaugg@gmail.com>
-Aniello Del Sorbo <anidel@edu-gw.dia.unisa.it>
-Anton Gluck <gluc@midway.uchicago.edu>
-Arkadiusz Miskiewicz <misiek@pld.org.pl>
-Ben Collins <bcollins@debian.org>
-Brian R. Gaeke <brg@dgate.org>
-Calle Karlsson <ckn@kash.se>
-Chip Rosenthal <chip@unicom.com>
-Chris Evans <lady0110@sable.ox.ac.uk>
-Chris Lamb <chris@chris-lamb.co.uk>
-Cristian Gafton <gafton@sorosis.ro>
-Dan Walsh <dwalsh@redhat.com>
-Darcy Boese <possum@chardonnay.niagara.com>
-Dave Hagewood <admin@arrowweb.com>
-David A. Holland <dholland@hcs.harvard.edu>
-David Frey <David.Frey@lugs.ch>
-Ed Carp <ecarp@netcom.com>
-Ed Neville <ed@s5h.net>
-Eric W. Biederman" <ebiederm@xmission.com>
-Floody <flood@evcom.net>
-Frank Denis <j@4u.net>
-George Kraft IV <gk4@us.ibm.com>
-Greg Mortensen <loki@world.std.com>
-Guido van Rooij
-Guy Maor <maor@debian.org>
-Hrvoje Dogan <hdogan@bjesomar.srce.hr>
-Iker Pedrosa <ipedrosa@redhat.com>
-Jakub Hrozek <jhrozek@redhat.com>
-Janos Farkas <chexum@bankinf.banki.hu>
-Jason Franklin <jason.franklin@quoininc.com>
-Jay Soffian <jay@lw.net>
-Jesse Thilo <Jesse.Thilo@pobox.com>
-Joey Hess <joey@kite.ml.org>
-John Adelsberger <jja@umr.edu>
-Jonathan Hankins <jhankins@mailserv.homewood.k12.al.us>
-Jon Lewis <jlewis@lewis.org>
-Joshua Cowan <jcowan@hermit.reslife.okstate.edu>
-Judd Bourgeois <shagboy@bluesky.net>
-Juergen Heinzl <unicorn@noris.net>
-Juha Virtanen <jiivee@iki.fi>
-Julian Pidancet <julian.pidancet@gmail.com>
-Julianne Frances Haugh <julie78787@gmail.com>
-Leonard N. Zubkoff <lnz@dandelion.com>
-Luca Berra <bluca@www.polimi.it>
-Lukáš Kuklínek <lkukline@redhat.com>
-Lutz Schwalowsky <schwalow@mineralogie.uni-hamburg.de>
-Marc Ewing <marc@redhat.com>
-Martin Bene <mb@sime.com>
-Martin Mares <mj@gts.cz>
-Michael Meskes <meskes@topsystem.de>
-Michael Talbot-Wilson <mike@calypso.bns.com.au>
-Michael Vetter <jubalh@iodoru.org>
-Mike Frysinger <vapier@gentoo.org>
-Mike Pakovic <mpakovic@users.southeast.net>
-Nicolas François <nicolas.francois@centraliens.net>
-Nikos Mavroyanopoulos <nmav@i-net.paiko.gr>
-Pavel Machek <pavel@bug.ucw.cz>
-Peter Vrabec <pvrabec@redhat.com>
-Phillip Street
-Rafał Maszkowski <rzm@icm.edu.pl>
-Rani Chouha <ranibey@smartec.com>
-Sami Kerola <kerolasa@rocketmail.com>
-Scott Garman <scott.a.garman@intel.com>
-Sebastian Rick Rijkers <srrijkers@gmail.com>
-Seraphim Mellos <mellos@ceid.upatras.gr>
-Shane Watts <shane@nexus.mlckew.edu.au>
-Steve M. Robbins <steve@nyongwa.montreal.qc.ca>
-Thorsten Kukuk <kukuk@suse.de>
-Tim Hockin <thockin@eagle.ais.net>
-Timo Karjalainen <timok@iki.fi>
-Ulisses Alonso Camaro <ulisses@pusa.eleinf.uv.es>
-Werner Fink <werner@suse.de>
+* Adam Rudnicki <adam@v-lo.krakow.pl>
+* Alan Curry <pacman@tardis.mars.net>
+* Aleksa Sarai <cyphar@cyphar.com>
+* Alexander O. Yuriev <alex@bach.cis.temple.edu>
+* Algis Rudys <arudys@rice.edu>
+* Andreas Jaeger <aj@arthur.rhein-neckar.de>
+* Andy Zaugg <andy.zaugg@gmail.com>
+* Aniello Del Sorbo <anidel@edu-gw.dia.unisa.it>
+* Anton Gluck <gluc@midway.uchicago.edu>
+* Arkadiusz Miskiewicz <misiek@pld.org.pl>
+* Ben Collins <bcollins@debian.org>
+* Brian R. Gaeke <brg@dgate.org>
+* Calle Karlsson <ckn@kash.se>
+* Chip Rosenthal <chip@unicom.com>
+* Chris Evans <lady0110@sable.ox.ac.uk>
+* Chris Lamb <chris@chris-lamb.co.uk>
+* Cristian Gafton <gafton@sorosis.ro>
+* Dan Walsh <dwalsh@redhat.com>
+* Darcy Boese <possum@chardonnay.niagara.com>
+* Dave Hagewood <admin@arrowweb.com>
+* David A. Holland <dholland@hcs.harvard.edu>
+* David Frey <David.Frey@lugs.ch>
+* Ed Carp <ecarp@netcom.com>
+* Ed Neville <ed@s5h.net>
+* Eric W. Biederman" <ebiederm@xmission.com>
+* Floody <flood@evcom.net>
+* Frank Denis <j@4u.net>
+* George Kraft IV <gk4@us.ibm.com>
+* Greg Mortensen <loki@world.std.com>
+* Guido van Rooij
+* Guy Maor <maor@debian.org>
+* Hrvoje Dogan <hdogan@bjesomar.srce.hr>
+* Jakub Hrozek <jhrozek@redhat.com>
+* Janos Farkas <chexum@bankinf.banki.hu>
+* Jason Franklin <jason.franklin@quoininc.com>
+* Jay Soffian <jay@lw.net>
+* Jesse Thilo <Jesse.Thilo@pobox.com>
+* Joey Hess <joey@kite.ml.org>
+* John Adelsberger <jja@umr.edu>
+* Jonathan Hankins <jhankins@mailserv.homewood.k12.al.us>
+* Jon Lewis <jlewis@lewis.org>
+* Joshua Cowan <jcowan@hermit.reslife.okstate.edu>
+* Judd Bourgeois <shagboy@bluesky.net>
+* Juergen Heinzl <unicorn@noris.net>
+* Juha Virtanen <jiivee@iki.fi>
+* Julian Pidancet <julian.pidancet@gmail.com>
+* Julianne Frances Haugh <julie78787@gmail.com>
+* Leonard N. Zubkoff <lnz@dandelion.com>
+* Luca Berra <bluca@www.polimi.it>
+* Lukáš Kuklínek <lkukline@redhat.com>
+* Lutz Schwalowsky <schwalow@mineralogie.uni-hamburg.de>
+* Marc Ewing <marc@redhat.com>
+* Martin Bene <mb@sime.com>
+* Martin Mares <mj@gts.cz>
+* Michael Meskes <meskes@topsystem.de>
+* Michael Talbot-Wilson <mike@calypso.bns.com.au>
+* Michael Vetter <jubalh@iodoru.org>
+* Mike Frysinger <vapier@gentoo.org>
+* Mike Pakovic <mpakovic@users.southeast.net>
+* Nicolas François <nicolas.francois@centraliens.net>
+* Nikos Mavroyanopoulos <nmav@i-net.paiko.gr>
+* Pavel Machek <pavel@bug.ucw.cz>
+* Peter Vrabec <pvrabec@redhat.com>
+* Phillip Street
+* Rafał Maszkowski <rzm@icm.edu.pl>
+* Rani Chouha <ranibey@smartec.com>
+* Sami Kerola <kerolasa@rocketmail.com>
+* Scott Garman <scott.a.garman@intel.com>
+* Sebastian Rick Rijkers <srrijkers@gmail.com>
+* Seraphim Mellos <mellos@ceid.upatras.gr>
+* Shane Watts <shane@nexus.mlckew.edu.au>
+* Steve M. Robbins <steve@nyongwa.montreal.qc.ca>
+* Thorsten Kukuk <kukuk@suse.de>
+* Tim Hockin <thockin@eagle.ais.net>
+* Timo Karjalainen <timok@iki.fi>
+* Ulisses Alonso Camaro <ulisses@pusa.eleinf.uv.es>
+* Werner Fink <werner@suse.de>


### PR DESCRIPTION
The markdown output for the maintainers, authors and contributors list
was wrapped in a single line and it was difficult to read. I've created
an unordered list to get a better output. On top of that I've also added
myself as a maintainer.