### PR TITLE
Change to strncat

### DIFF
--- a/src/logoutd.c
+++ b/src/logoutd.c
@@ -228,7 +228,7 @@ int main (int argc, char **argv)
 				tty_name[0] = '\0';
 			}
 
-			strcat (tty_name, ut->ut_line);
+			strncat (tty_name, ut->ut_line, UT_LINESIZE);
 #ifndef O_NOCTTY
 #define O_NOCTTY 0
 #endif


### PR DESCRIPTION
ut_line is declared as a nonstring in bits/utmp.h. It might not be NUL
terminated. Limit how much it copies to the size of the array.