### PR TITLE
CI: enable CodeQL analyzer

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -1,0 +1,12 @@
+name: 'Install dependencies'
+description: 'Install dependencies to build shadow-utils'
+runs:
+  using: "composite"
+  steps:
+  - shell: bash
+    run: |
+      sudo apt-get update -y
+      sudo apt-get install -y ubuntu-dev-tools
+      sudo sed -Ei 's/^# deb-src /deb-src /' /etc/apt/sources.list
+      sudo apt-get update -y
+      sudo apt-get -y build-dep shadow

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -1,0 +1,38 @@
+name: "Static code analysis"
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    # Everyday at midnight
+    - cron: '0 0 * * *'
+jobs:
+  codeql:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Install dependencies
+      id: dependencies
+      uses: ./.github/actions/install-dependencies
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: cpp
+        queries: +security-and-quality
+
+    - name: Configure shadow-utils
+      run: ./autogen.sh --without-selinux --disable-man
+
+    - name: Build shadow-utils
+      run: |
+        PROCESSORS=$(/usr/bin/getconf _NPROCESSORS_ONLN)
+        make -j$PROCESSORS
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
Create a Github workflow to install the dependencies to build shadow-utils. Enable the CodeQL analyzer, which first needs to build the project in order to analyze it.