### PR TITLE
tests: replace egrep -> grep -E

### DIFF
--- a/tests/chsh/01/run
+++ b/tests/chsh/01/run
@@ -105,7 +105,7 @@ echo $(pwd)/tmp/sh:ell >> /etc/shells
 chsh -s $(pwd)/tmp/sh:ell myuser 2> tmp/out && exit 1
 ent=$(getent passwd myuser)
 [ "$ent" = "myuser:x:424242:424242::/home:/bin/bash" ] || exit 1
-egrep "chsh: Invalid entry: .*/tmp/sh:ell" tmp/out > /dev/null
+grep -E "chsh: Invalid entry: .*/tmp/sh:ell" tmp/out > /dev/null
 [ $(wc -l tmp/out| cut -d" " -f1) = "1" ] || exit 1
 echo "OK"
 
@@ -136,7 +136,7 @@ echo "OK"
 echo "testing the interactive mode (4)..."
 rm -f tmp/out
 ./run.exp $(pwd)/tmp/sh:ell myuser && exit 1
-egrep "chsh: Invalid entry: .*/tmp/sh:ell" tmp/out > /dev/null
+grep -E "chsh: Invalid entry: .*/tmp/sh:ell" tmp/out > /dev/null
 ent=$(getent passwd myuser)
 [ "$ent" = "myuser:x:424242:424242::/home:/bin/sh" ] || exit 1
 echo "OK"

--- a/tests/convtools/01/run
+++ b/tests/convtools/01/run
@@ -21,7 +21,7 @@ save()
 	done
 	DATE=$(date '+%s')
 	DATE=$(( DATE/3600/24 ))
-	WARN=$( egrep "^PASS_WARN_AGE" /etc/login.defs | { read var val ; echo $val; } )
+	WARN=$( grep -E "^PASS_WARN_AGE" /etc/login.defs | { read var val ; echo $val; } )
 	saveifs=$IFS
 	IFS=":"
 	cat data/2/shadow |

--- a/tests/su/10_su_sulog_success/su.test
+++ b/tests/su/10_su_sulog_success/su.test
@@ -27,8 +27,8 @@ echo -n "Check /var/log/sulog..."
 wc -l /var/log/sulog > tmp/sulog
 d=$(date +"SU %m/%d %H:%M")
 cat /var/log/sulog | \
-    egrep -v "$d \+ /dev/pts/[0-9]* root-testsuite" | \
-    egrep -v "$d \+ /dev/pts/[0-9]* testsuite-myuser" \
+    grep -E -v "$d \+ /dev/pts/[0-9]* root-testsuite" | \
+    grep -E -v "$d \+ /dev/pts/[0-9]* testsuite-myuser" \
         >> tmp/sulog || true
 diff -auN tmp/sulog data/sulog
 echo "OK"

--- a/tests/su/11_su_sulog_failure/su.test
+++ b/tests/su/11_su_sulog_failure/su.test
@@ -28,10 +28,10 @@ wc -l /var/log/sulog > tmp/sulog
 d1=$(date +"SU %m/%d %H:%M")
 d2=$(date -d"1 minute ago" +"SU %m/%d %H:%M")
 cat /var/log/sulog | \
-    egrep -v "$d1 \+ /dev/pts/[0-9]* root-testsuite"  | \
-    egrep -v "$d2 \+ /dev/pts/[0-9]* root-testsuite"  | \
-    egrep -v "$d1 - /dev/pts/[0-9]* testsuite-myuser" | \
-    egrep -v "$d2 - /dev/pts/[0-9]* testsuite-myuser" \
+    grep -E -v "$d1 \+ /dev/pts/[0-9]* root-testsuite"  | \
+    grep -E -v "$d2 \+ /dev/pts/[0-9]* root-testsuite"  | \
+    grep -E -v "$d1 - /dev/pts/[0-9]* testsuite-myuser" | \
+    grep -E -v "$d2 - /dev/pts/[0-9]* testsuite-myuser" \
         >> tmp/sulog || true
 diff -au data/sulog tmp/sulog
 echo "OK"


### PR DESCRIPTION
"egrep" is an obsolete alias for grep -E and newer greps will warn on usage
of egrep, so let's just swap it out.

Signed-off-by: Sam James <sam@gentoo.org>