### PR TITLE
CI: update actions version

### DIFF
--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -21,7 +21,7 @@ jobs:
       uses: ./.github/actions/install-dependencies
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: cpp
         queries: +security-and-quality
@@ -35,4 +35,4 @@ jobs:
         make -j$PROCESSORS
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
CodeQL Action v1 is being deprecated and v2 needs to be used instead.

Reference: https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/