### PR TITLE
man (useradd): add a note about -r option and /etc/subuid and subgid

### DIFF
--- a/man/useradd.8.xml
+++ b/man/useradd.8.xml
@@ -464,6 +464,10 @@
 	    <option>-m</option> options if you want a home directory for a
 	    system account to be created.
 	  </para>
+	  <para>
+	    Note that this option will not update <filename>/etc/subuid
+	    </filename> and <filename>/etc/subgid</filename>.
+	  </para>
 	</listitem>
       </varlistentry>
       <varlistentry>


### PR DESCRIPTION
With -r option, `useradd` doesn't update /etc/sub{u,g}id can be a pitfall.


I'm looking into https://gitlab.com/gitlab-org/gitlab-runner/-/blob/main/packaging/root/usr/share/gitlab-runner/post-install#L25 to use podman as a runner of gitlab.
The podman runs a container with a non-admin account called `gitlab-runner`.
However, the running failed because the way to add `gitlab-runner` user done in the `post-install` script was wrong; it was created with `useradd --system`; entries for `gitlab-runner` were not added to /etc/subuid and /etc/subgid.

Adding a note to useradd(8) I proposed here may make the pitfall small a bit.