### PR TITLE
Fix E_NAME_IN_USE documentation.

### DIFF
--- a/man/useradd.8.xml
+++ b/man/useradd.8.xml
@@ -841,7 +841,7 @@
 	<varlistentry>
 	  <term><replaceable>9</replaceable></term>
 	  <listitem>
-	    <para>username already in use</para>
+	    <para>username or group name already in use</para>
 	  </listitem>
 	</varlistentry>
 	<varlistentry>

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -172,7 +172,7 @@ static bool home_added = false;
 #define E_BAD_ARG	3	/* invalid argument to option */
 #define E_UID_IN_USE	4	/* UID already in use (and no -o) */
 #define E_NOTFOUND	6	/* specified group doesn't exist */
-#define E_NAME_IN_USE	9	/* username already in use */
+#define E_NAME_IN_USE	9	/* username or group name already in use */
 #define E_GRP_UPDATE	10	/* can't update group file */
 #define E_HOMEDIR	12	/* can't create home directory */
 #define E_MAILBOXFILE	13	/* can't create mailbox file */

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -67,7 +67,7 @@
 /* #define E_BAD_PWFILE	5	   passwd file contains errors */
 #define E_NOTFOUND	6	/* specified user/group doesn't exist */
 #define E_USER_BUSY	8	/* user to modify is logged in */
-#define E_NAME_IN_USE	9	/* username already in use */
+#define E_NAME_IN_USE	9	/* username or group name already in use */
 #define E_GRP_UPDATE	10	/* can't update group file */
 /* #define E_NOSPACE	11	   insufficient space to move home dir */
 #define E_HOMEDIR	12	/* unable to complete home dir move */


### PR DESCRIPTION
Since code gives this error if username or group name is already
used the documentation should reflect that.

Found by accident when testing useradd when the username's corresponding group already existed and got 9 return code.