### PR TITLE
Address CVE-2013-4235

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -49,7 +49,7 @@ AC_CHECK_HEADER([shadow.h],,[AC_MSG_ERROR([You need a libc with shadow.h])])
 
 AC_CHECK_FUNCS(arc4random_buf l64a fchmod fchown fsync futimes \
 	getentropy getrandom getspnam getusershell \
-	getutent initgroups lchown lckpwdf lstat lutimes \
+	getutent initgroups lckpwdf lutimes \
 	setgroups updwtmp updwtmpx innetgr getpwnam_r \
 	getpwuid_r getgrnam_r getgrgid_r getspnam_r \
 	memset_s explicit_bzero)

--- a/lib/commonio.c
+++ b/lib/commonio.c
@@ -65,7 +65,6 @@ int lrename (const char *old, const char *new)
 	int res;
 	char *r = NULL;
 
-#if defined(S_ISLNK)
 #ifndef __GLIBC__
 	char resolved_path[PATH_MAX];
 #endif				/* !__GLIBC__ */
@@ -82,7 +81,6 @@ int lrename (const char *old, const char *new)
 			new = r;
 		}
 	}
-#endif				/* S_ISLNK */
 
 	res = rename (old, new);
 

--- a/lib/defines.h
+++ b/lib/defines.h
@@ -205,22 +205,6 @@ static inline void memzero(void *ptr, size_t size)
 # define SEEK_END 2
 #endif
 
-#ifndef S_ISLNK
-#define S_ISLNK(x) (0)
-#endif
-
-#if HAVE_LCHOWN
-#define LCHOWN lchown
-#else
-#define LCHOWN chown
-#endif
-
-#if HAVE_LSTAT
-#define LSTAT lstat
-#else
-#define LSTAT stat
-#endif
-
 #if HAVE_TERMIOS_H
 # include <termios.h>
 # define STTY(fd, termio) tcsetattr(fd, TCSANOW, termio)

--- a/libmisc/chowndir.c
+++ b/libmisc/chowndir.c
@@ -17,6 +17,112 @@
 #include "defines.h"
 #include <fcntl.h>
 #include <stdio.h>
+#include <unistd.h>
+
+static int chown_tree_at (int at_fd,
+                const char *path,
+                uid_t old_uid,
+                uid_t new_uid,
+                gid_t old_gid,
+                gid_t new_gid)
+{
+	DIR *dir;
+	const struct dirent *ent;
+	struct stat dir_sb;
+	int dir_fd, rc = 0;
+
+	dir_fd = openat (at_fd, path, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+	if (dir_fd < 0) {
+		return -1;
+	}
+
+	dir = fdopendir (dir_fd);
+	if (!dir) {
+		(void) close (dir_fd);
+		return -1;
+	}
+
+	/*
+	 * Open the directory and read each entry.  Every entry is tested
+	 * to see if it is a directory, and if so this routine is called
+	 * recursively.  If not, it is checked to see if an ownership
+	 * shall be changed.
+	 */
+	while ((ent = readdir (dir))) {
+		uid_t tmpuid = (uid_t) -1;
+		gid_t tmpgid = (gid_t) -1;
+		struct stat ent_sb;
+
+		/*
+		 * Skip the "." and ".." entries
+		 */
+		if (   (strcmp (ent->d_name, ".") == 0)
+		    || (strcmp (ent->d_name, "..") == 0)) {
+			continue;
+		}
+
+		rc = fstatat (dirfd(dir), ent->d_name, &ent_sb, AT_SYMLINK_NOFOLLOW);
+		if (rc < 0) {
+			break;
+		}
+
+		if (S_ISDIR (ent_sb.st_mode)) {
+			/*
+			 * Do the entire subdirectory.
+			 */
+			rc = chown_tree_at (dirfd(dir), ent->d_name, old_uid, new_uid, old_gid, new_gid);
+			if (0 != rc) {
+				break;
+			}
+		}
+
+		/*
+		 * By default, the IDs are not changed (-1).
+		 *
+		 * If the file is not owned by the user, the owner is not
+		 * changed.
+		 *
+		 * If the file is not group-owned by the group, the
+		 * group-owner is not changed.
+		 */
+		if (((uid_t) -1 == old_uid) || (ent_sb.st_uid == old_uid)) {
+			tmpuid = new_uid;
+		}
+		if (((gid_t) -1 == old_gid) || (ent_sb.st_gid == old_gid)) {
+			tmpgid = new_gid;
+		}
+		if (((uid_t) -1 != tmpuid) || ((gid_t) -1 != tmpgid)) {
+			rc = fchownat (dirfd(dir), ent->d_name, tmpuid, tmpgid, AT_SYMLINK_NOFOLLOW);
+			if (0 != rc) {
+				break;
+			}
+		}
+	}
+
+	/*
+	 * Now do the root of the tree
+	 */
+	if ((0 == rc) && (fstat (dirfd(dir), &dir_sb) == 0)) {
+		uid_t tmpuid = (uid_t) -1;
+		gid_t tmpgid = (gid_t) -1;
+		if (((uid_t) -1 == old_uid) || (dir_sb.st_uid == old_uid)) {
+			tmpuid = new_uid;
+		}
+		if (((gid_t) -1 == old_gid) || (dir_sb.st_gid == old_gid)) {
+			tmpgid = new_gid;
+		}
+		if (((uid_t) -1 != tmpuid) || ((gid_t) -1 != tmpgid)) {
+			rc = fchown (dirfd(dir), tmpuid, tmpgid);
+		}
+	} else {
+		rc = -1;
+	}
+
+	(void) closedir (dir);
+
+	return rc;
+}
+
 /*
  * chown_tree - change ownership of files in a directory tree
  *
@@ -36,143 +142,5 @@ int chown_tree (const char *root,
                 gid_t old_gid,
                 gid_t new_gid)
 {
-	char *new_name;
-	size_t new_name_len;
-	int rc = 0;
-	struct dirent *ent;
-	struct stat sb;
-	DIR *dir;
-
-	new_name = malloc (1024);
-	if (NULL == new_name) {
-		return -1;
-	}
-	new_name_len = 1024;
-
-	/*
-	 * Make certain the directory exists.  This routine is called
-	 * directly by the invoker, or recursively.
-	 */
-
-	if (access (root, F_OK) != 0) {
-		free (new_name);
-		return -1;
-	}
-
-	/*
-	 * Open the directory and read each entry.  Every entry is tested
-	 * to see if it is a directory, and if so this routine is called
-	 * recursively.  If not, it is checked to see if an ownership
-	 * shall be changed.
-	 */
-
-	dir = opendir (root);
-	if (NULL == dir) {
-		free (new_name);
-		return -1;
-	}
-
-	while ((ent = readdir (dir))) {
-		size_t ent_name_len;
-		uid_t tmpuid = (uid_t) -1;
-		gid_t tmpgid = (gid_t) -1;
-
-		/*
-		 * Skip the "." and ".." entries
-		 */
-
-		if (   (strcmp (ent->d_name, ".") == 0)
-		    || (strcmp (ent->d_name, "..") == 0)) {
-			continue;
-		}
-
-		/*
-		 * Make the filename for both the source and the
-		 * destination files.
-		 */
-
-		ent_name_len = strlen (root) + strlen (ent->d_name) + 2;
-		if (ent_name_len > new_name_len) {
-			/*@only@*/char *tmp = realloc (new_name, ent_name_len);
-			if (NULL == tmp) {
-				rc = -1;
-				break;
-			}
-			new_name = tmp;
-			new_name_len = ent_name_len;
-		}
-
-		(void) snprintf (new_name, new_name_len, "%s/%s", root, ent->d_name);
-
-		/* Don't follow symbolic links! */
-		if (LSTAT (new_name, &sb) == -1) {
-			continue;
-		}
-
-		if (S_ISDIR (sb.st_mode) && !S_ISLNK (sb.st_mode)) {
-
-			/*
-			 * Do the entire subdirectory.
-			 */
-
-			rc = chown_tree (new_name, old_uid, new_uid,
-			                 old_gid, new_gid);
-			if (0 != rc) {
-				break;
-			}
-		}
-#ifndef HAVE_LCHOWN
-		/* don't use chown (follows symbolic links!) */
-		if (S_ISLNK (sb.st_mode)) {
-			continue;
-		}
-#endif
-		/*
-		 * By default, the IDs are not changed (-1).
-		 *
-		 * If the file is not owned by the user, the owner is not
-		 * changed.
-		 *
-		 * If the file is not group-owned by the group, the
-		 * group-owner is not changed.
-		 */
-		if (((uid_t) -1 == old_uid) || (sb.st_uid == old_uid)) {
-			tmpuid = new_uid;
-		}
-		if (((gid_t) -1 == old_gid) || (sb.st_gid == old_gid)) {
-			tmpgid = new_gid;
-		}
-		if (((uid_t) -1 != tmpuid) || ((gid_t) -1 != tmpgid)) {
-			rc = LCHOWN (new_name, tmpuid, tmpgid);
-			if (0 != rc) {
-				break;
-			}
-		}
-	}
-
-	free (new_name);
-	(void) closedir (dir);
-
-	/*
-	 * Now do the root of the tree
-	 */
-
-	if ((0 == rc) && (stat (root, &sb) == 0)) {
-		uid_t tmpuid = (uid_t) -1;
-		gid_t tmpgid = (gid_t) -1;
-		if (((uid_t) -1 == old_uid) || (sb.st_uid == old_uid)) {
-			tmpuid = new_uid;
-		}
-		if (((gid_t) -1 == old_gid) || (sb.st_gid == old_gid)) {
-			tmpgid = new_gid;
-		}
-		if (((uid_t) -1 != tmpuid) || ((gid_t) -1 != tmpgid)) {
-			rc = LCHOWN (root, tmpuid, tmpgid);
-		}
-	} else {
-		rc = -1;
-	}
-
-	return rc;
+	return chown_tree_at (AT_FDCWD, root, old_uid, new_uid, old_gid, new_gid);
 }
-

--- a/libmisc/copydir.c
+++ b/libmisc/copydir.c
@@ -692,6 +692,42 @@ static int copy_special (const char *src, const char *dst,
 }
 
 /*
+ * full_write - write entire buffer
+ *
+ * Write up to count bytes from the buffer starting at buf to the
+ * file referred to by the file descriptor fd.
+ * Retry in case of a short write.
+ *
+ * Returns the number of bytes written on success, -1 on error.
+ */
+static ssize_t full_write(int fd, const void *buf, size_t count) {
+	ssize_t written = 0;
+
+	while (count > 0) {
+		ssize_t res;
+
+		res = write(fd, buf, count);
+		if (res < 0) {
+			if (errno == EINTR) {
+				continue;
+			}
+
+			return res;
+		}
+
+		if (res == 0) {
+			break;
+		}
+
+		written += res;
+		buf = (const unsigned char*)buf + res;
+		count -= (size_t)res;
+	}
+
+	return written;
+}
+
+/*
  * copy_file - copy a file
  *
  *	Copy a file from src to dst.
@@ -710,8 +746,6 @@ static int copy_file (const char *src, const char *dst,
 	int err = 0;
 	int ifd;
 	int ofd;
-	char buf[1024];
-	ssize_t cnt;
 
 	ifd = open (src, O_RDONLY|O_NOFOLLOW);
 	if (ifd < 0) {
@@ -753,8 +787,24 @@ static int copy_file (const char *src, const char *dst,
 		return -1;
 	}
 
-	while ((cnt = read (ifd, buf, sizeof buf)) > 0) {
-		if (write (ofd, buf, (size_t)cnt) != cnt) {
+	while (true) {
+		char buf[8192];
+		ssize_t cnt;
+
+		cnt = read (ifd, buf, sizeof buf);
+		if (cnt < 0) {
+			if (errno == EINTR) {
+				continue;
+			}
+			(void) close (ofd);
+			(void) close (ifd);
+			return -1;
+		}
+		if (cnt == 0) {
+			break;
+		}
+
+		if (full_write (ofd, buf, (size_t)cnt) < 0) {
 			(void) close (ofd);
 			(void) close (ifd);
 			return -1;

--- a/libmisc/copydir.c
+++ b/libmisc/copydir.c
@@ -112,7 +112,7 @@ static void error_acl (unused struct error_context *ctx, const char *fmt, ...)
 }
 
 static struct error_context ctx = {
-	error_acl
+	error_acl, NULL, NULL
 };
 #endif				/* WITH_ACL || WITH_ATTR */
 
@@ -663,7 +663,7 @@ static int copy_special (const char *src, const char *dst,
 	}
 #endif				/* WITH_SELINUX */
 
-	if (   (mknod (dst, statp->st_mode & ~07777, statp->st_rdev) != 0)
+	if (   (mknod (dst, statp->st_mode & ~07777U, statp->st_rdev) != 0)
 	    || (chown_if_needed (dst, statp,
 	                         old_uid, new_uid, old_gid, new_gid) != 0)
 #ifdef WITH_ACL

--- a/libmisc/copydir.c
+++ b/libmisc/copydir.c
@@ -56,14 +56,12 @@ static int copy_dir (const char *src, const char *dst,
                      const struct stat *statp, const struct timeval mt[],
                      uid_t old_uid, uid_t new_uid,
                      gid_t old_gid, gid_t new_gid);
-#ifdef	S_IFLNK
 static /*@null@*/char *readlink_malloc (const char *filename);
 static int copy_symlink (const char *src, const char *dst,
                          unused bool reset_selinux,
                          const struct stat *statp, const struct timeval mt[],
                          uid_t old_uid, uid_t new_uid,
                          gid_t old_gid, gid_t new_gid);
-#endif				/* S_IFLNK */
 static int copy_hardlink (const char *dst,
                           unused bool reset_selinux,
                           struct link_name *lp);
@@ -223,7 +221,7 @@ int copy_tree (const char *src_root, const char *dst_root,
 			return -1;
 		}
 
-		if (LSTAT (src_root, &sb) == -1) {
+		if (lstat (src_root, &sb) == -1) {
 			return -1;
 		}
 
@@ -364,7 +362,7 @@ static int copy_entry (const char *src, const char *dst,
 	struct link_name *lp;
 	struct timeval mt[2];
 
-	if (LSTAT (src, &sb) == -1) {
+	if (lstat (src, &sb) == -1) {
 		/* If we cannot stat the file, do not care. */
 	} else {
 #ifdef HAVE_STRUCT_STAT_ST_ATIM
@@ -396,7 +394,6 @@ static int copy_entry (const char *src, const char *dst,
 			                old_uid, new_uid, old_gid, new_gid);
 		}
 
-#ifdef	S_IFLNK
 		/*
 		 * Copy any symbolic links
 		 */
@@ -405,7 +402,6 @@ static int copy_entry (const char *src, const char *dst,
 			err = copy_symlink (src, dst, reset_selinux, &sb, mt,
 			                    old_uid, new_uid, old_gid, new_gid);
 		}
-#endif				/* S_IFLNK */
 
 		/*
 		 * See if this is a previously copied link
@@ -498,7 +494,6 @@ static int copy_dir (const char *src, const char *dst,
 	return err;
 }
 
-#ifdef	S_IFLNK
 /*
  * readlink_malloc - wrapper for readlink
  *
@@ -616,7 +611,6 @@ static int copy_symlink (const char *src, const char *dst,
 
 	return 0;
 }
-#endif				/* S_IFLNK */
 
 /*
  * copy_hardlink - copy a hardlink

--- a/libmisc/copydir.c
+++ b/libmisc/copydir.c
@@ -723,7 +723,7 @@ static int copy_file (const char *src, const char *dst,
 		return -1;
 	}
 #endif				/* WITH_SELINUX */
-	ofd = open (dst, O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW, statp->st_mode & 07777);
+	ofd = open (dst, O_WRONLY | O_CREAT | O_EXCL | O_TRUNC | O_NOFOLLOW | O_CLOEXEC, statp->st_mode & 07777);
 	if (   (ofd < 0)
 	    || (fchown_if_needed (ofd, statp,
 	                          old_uid, new_uid, old_gid, new_gid) != 0)


### PR DESCRIPTION
Address CVE-2013-4235 (#317) by pinning the directories operating in and using the *at() version of file related functions.

Requires openat(2), fstatat(2), mkdirat(2), symlinkat(2), linkat(2), mknodat(2), unlinkat(2), fchmodat(2), fchownat(2) and utimensat(2) specified in POSIX.1-2008.

*Should* be supported by glibc 2.6 and Linux 2.6.22.