### PR TITLE
Fix CI by testing Ubuntu 22.04 instead of 21.10.

### DIFF
--- a/.builds/ubuntu-jammy.yml
+++ b/.builds/ubuntu-jammy.yml
@@ -1,4 +1,4 @@
-image: ubuntu/21.10
+image: ubuntu/22.04
 packages:
   - automake
   - autopoint


### PR DESCRIPTION
Since Ubuntu 21.10 has gone out of support it no longer works for
testing with CI. Instead use 22.04 which is still supported.