### PR TITLE
shadow: use relaxed usernames

### DIFF
--- a/man/groupadd.8.xml
+++ b/man/groupadd.8.xml
@@ -64,10 +64,12 @@
       files as needed.
     </para>
      <para>
-       Groupnames must start with a lower case letter or an underscore,
-       followed by lower case letters, digits, underscores, or dashes.
-       They can end with a dollar sign.
-       In regular expression terms: [a-z_][a-z0-9_-]*[$]?
+       Groupnames may contain only lower and upper case letters, digits,
+       underscores, or dashes. They can end with a dollar sign.
+
+       Dashes are not allowed at the beginning of the groupname.
+       Fully numeric groupnames and groupnames . or .. are
+       also disallowed.
      </para>
      <para>
        Groupnames may only be up to &GROUP_NAME_MAX_LENGTH; characters long.

--- a/man/useradd.8.xml
+++ b/man/useradd.8.xml
@@ -692,10 +692,14 @@
     </para>
 
     <para>
-      Usernames must start with a lower case letter or an underscore,
-      followed by lower case letters, digits, underscores, or dashes.
-      They can end with a dollar sign.
-      In regular expression terms: [a-z_][a-z0-9_-]*[$]?
+      Usernames may contain only lower and upper case letters, digits,
+      underscores, or dashes. They can end with a dollar sign.
+
+      Dashes are not allowed at the beginning of the username.
+      Fully numeric usernames and usernames . or .. are
+      also disallowed. It is not recommended to use usernames beginning
+      with . character as their home directories will be hidden in
+      the <command>ls</command> output.
     </para>
     <para>
       Usernames may only be up to 32 characters long.


### PR DESCRIPTION
The groupadd from shadow does not allow upper case group names, the
same is true for the upstream shadow. But distributions like
Debian/Ubuntu/CentOS has their own way to cope with this problem,
this patch is picked up from CentOS release 7.0 to relax the usernames
restrictions to allow the upper case group names, and the relaxation is
POSIX compliant because POSIX indicate that usernames are composed of
characters from the portable filename character set [A-Za-z0-9._-].

Note from Alexander: Yocto project has been carrying this patch for several years, we're not aware of any reasons why it shouldn't be acceptable, but if such reasons exist, we would like to document or link to them.