### PR TITLE
useradd.8.xml: fix default group id from 100 to 1000

### DIFF
--- a/man/useradd.8.xml
+++ b/man/useradd.8.xml
@@ -248,7 +248,7 @@
 	    command line), useradd will set the primary group of the new
 	    user to the value specified by the <option>GROUP</option>
 	    variable in <filename>/etc/default/useradd</filename>, or
-	    100 by default.
+	    1000 by default.
 	  </para>
 	</listitem>
       </varlistentry>


### PR DESCRIPTION
As discussed on irc and according to bbf4b79