### PR TITLE
Revert "Drop unused function subid_init()"

### DIFF
--- a/libsubid/api.c
+++ b/libsubid/api.c
@@ -17,6 +17,31 @@
 #include "subid.h"
 #include "shadowlog.h"
 
+bool subid_init(const char *progname, FILE * logfd)
+{
+	FILE *shadow_logfd;
+	if (progname) {
+		progname = strdup(progname);
+		if (!progname)
+			return false;
+		log_set_progname(progname);
+	} else {
+		log_set_progname("(libsubid)");
+	}
+
+	if (logfd) {
+		log_set_logfd(logfd);
+		return true;
+	}
+	shadow_logfd = fopen("/dev/null", "w");
+	if (!shadow_logfd) {
+		log_set_logfd(stderr);
+		return false;
+	}
+	log_set_logfd(shadow_logfd);
+	return true;
+}
+
 static
 int get_subid_ranges(const char *owner, enum subid_type id_type, struct subid_range **ranges)
 {

--- a/libsubid/subid.h.in
+++ b/libsubid/subid.h.in
@@ -40,6 +40,22 @@ extern "C" {
 #endif
 
 /*
+ * subid_init: initialize libsubid
+ *
+ * @progname: Name to display as program.  If NULL, then "(libsubid)" will be
+ *            shown in error messages.
+ * @logfd:    Open file pointer to pass error messages to.  If NULL, then
+ *            /dev/null will be opened and messages will be sent there.  The
+ *            default if libsubid_init() is not called is stderr (2).
+ *
+ * This function does not need to be called.  If not called, then the defaults
+ * will be used.
+ *
+ * Returns false if an error occurred.
+ */
+bool subid_init(const char *progname, FILE *logfd);
+
+/*
  * subid_get_uid_ranges: return a list of UID ranges for a user
  *
  * @owner: username being queried


### PR DESCRIPTION
As rbalint points out, this was an exported fn.  It also is
the only way for a libsubid user to do what it does, so let's
not drop it.

This reverts commit 477c8e6f42df1e17e45584e74988eb46a11e6caa.