### PR TITLE
useradd: check MLS enablement before setting serange

### DIFF
--- a/lib/semanage.c
+++ b/lib/semanage.c
@@ -122,12 +122,14 @@ static int semanage_user_mod (semanage_handle_t *handle,
 		goto done;
 	}
 
-	ret = semanage_seuser_set_mlsrange (handle, seuser, DEFAULT_SERANGE);
-	if (ret != 0) {
-		fprintf (shadow_logfd,
-		         _("Could not set serange for %s\n"), login_name);
-		ret = 1;
-		goto done;
+	if (semanage_mls_enabled(handle)) {
+		ret = semanage_seuser_set_mlsrange (handle, seuser, DEFAULT_SERANGE);
+		if (ret != 0) {
+			fprintf (shadow_logfd,
+			         _("Could not set serange for %s\n"), login_name);
+			ret = 1;
+			goto done;
+		}
 	}
 
 	ret = semanage_seuser_set_sename (handle, seuser, seuser_name);
@@ -179,13 +181,14 @@ static int semanage_user_add (semanage_handle_t *handle,
 		goto done;
 	}
 
-	ret = semanage_seuser_set_mlsrange (handle, seuser, DEFAULT_SERANGE);
-	if (ret != 0) {
-		fprintf (shadow_logfd,
-		         _("Could not set serange for %s\n"),
-		         login_name);
-		ret = 1;
-		goto done;
+	if (semanage_mls_enabled(handle)) {
+		ret = semanage_seuser_set_mlsrange (handle, seuser, DEFAULT_SERANGE);
+		if (ret != 0) {
+			fprintf (shadow_logfd,
+			         _("Could not set serange for %s\n"), login_name);
+			ret = 1;
+			goto done;
+		}
 	}
 
 	ret = semanage_seuser_set_sename (handle, seuser, seuser_name);


### PR DESCRIPTION
useradd: check MLS enablement before setting serange

Resolves: https://github.com/shadow-maint/shadow/issues/552

This fix wraps the calls to set the s0 MLS range in an `if (semanage_mls_enabled(handle)) { }` block to ask the real libsemanage to verify MLS is actually in use.
- now MLS detection is dynamic and optional, not every SELinux user uses MLS