### PR TITLE
useradd: Do not reset non-existent data in {last,fail}log

### DIFF
--- a/src/useradd.c
+++ b/src/useradd.c
@@ -1996,8 +1996,9 @@ static void faillog_reset (uid_t uid)
 	struct faillog fl;
 	int fd;
 	off_t offset_uid = (off_t) (sizeof fl) * uid;
+	struct stat st;
 
-	if (access (FAILLOG_FILE, F_OK) != 0) {
+	if (stat (FAILLOG_FILE, &st) != 0 || st.st_size <= offset_uid) {
 		return;
 	}
 
@@ -2033,8 +2034,9 @@ static void lastlog_reset (uid_t uid)
 	int fd;
 	off_t offset_uid = (off_t) (sizeof ll) * uid;
 	uid_t max_uid;
+	struct stat st;
 
-	if (access (LASTLOG_FILE, F_OK) != 0) {
+	if (stat (LASTLOG_FILE, &st) != 0 || st.st_size <= offset_uid) {
 		return;
 	}
 


### PR DESCRIPTION
useradd does not create the files if they don't exist, but if they exist
it will try to reset data even if the data did not exist before
resulting in a lot of zeros ending up in tarballs.

An example is basically every chroot containing a Debian (or derivative) system which is packed into a tarball later on e.g. for build servers. The chroot will have an `_apt` system user created in the bootstrap which fills the {last,fail}log files with zeros as they tend to be already created with the right permissions.

Of course, the files aren't large and zeros compress rather well (if you compress your tarballs), but what doesn't exist takes up even less space.

Rational for "ignoring" `LOG_INIT`: The documentation for `--no-log-init` says that it "do[es] not add the user to the lastlog and faillog databases", but it also says that its propose is a "reset to avoid reusing the entry from a previously deleted user". If the focus were on "add the user" the files should be created if they don't exist, but from the code as well as the later sentence in the docs I get the impression that the focus is on not (re)using incorrect entries and that is achieved just fine by the implicit zeros without making them explicit. So the init is still happening, it just doesn't write to disk for it if it doesn't need to.