### PR TITLE
fix `usermod -rG x y` while user `y` is not in group `x` will cause user `y` add into group `x`

### DIFF
--- a/src/usermod.c
+++ b/src/usermod.c
@@ -716,7 +716,7 @@ static void update_group (void)
 		* If rflg+Gflg  is passed in AKA -rG invert is_member flag, which removes
 		* mentioned groups while leaving the others.
 		*/
-		if (Gflg && rflg && was_member) {
+		if (Gflg && rflg) {
 			is_member = !is_member;
 		}
 
@@ -765,7 +765,7 @@ static void update_group (void)
 				         "delete '%s' from group '%s'",
 				         user_name, ngrp->gr_name));
 			}
-		} else {
+		} else if (is_member) {
 			/* User was not a member but is now a member this
 			 * group.
 			 */
@@ -839,7 +839,7 @@ static void update_gshadow (void)
 		* If rflg+Gflg  is passed in AKA -rG invert is_member, to remove targeted
 		* groups while leaving the user apart of groups not mentioned
 		*/
-		if (Gflg && rflg && was_member) {
+		if (Gflg && rflg) {
 			is_member = !is_member;
 		}
 


### PR DESCRIPTION
fix `usermod -rG x y` while user `y` is not in group `x` will cause user `y` add into group `x`

I'll explain more in details later in an issue thread. I'm not familiar with the code. I'm not sure if my changes consider all edge cases. But it do fix the issue.