### PR TITLE
copy_tree: Fix regressions

### DIFF
--- a/libmisc/copydir.c
+++ b/libmisc/copydir.c
@@ -126,12 +126,12 @@ static int perm_copy_path(const struct path_info *src,
 {
 	int src_fd, dst_fd, ret;
 
-	src_fd = openat(src->dirfd, src->name, O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
+	src_fd = openat(src->dirfd, src->name, O_RDONLY | O_NOFOLLOW | O_NONBLOCK | O_CLOEXEC);
 	if (src_fd < 0) {
 		return -1;
 	}
 
-	dst_fd = openat(dst->dirfd, dst->name, O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
+	dst_fd = openat(dst->dirfd, dst->name, O_RDONLY | O_NOFOLLOW | O_NONBLOCK | O_CLOEXEC);
 	if (dst_fd < 0) {
 		(void) close (src_fd);
 		return -1;
@@ -152,12 +152,12 @@ static int attr_copy_path(const struct path_info *src,
 {
 	int src_fd, dst_fd, ret;
 
-	src_fd = openat(src->dirfd, src->name, O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
+	src_fd = openat(src->dirfd, src->name, O_RDONLY | O_NOFOLLOW | O_NONBLOCK | O_CLOEXEC);
 	if (src_fd < 0) {
 		return -1;
 	}
 
-	dst_fd = openat(dst->dirfd, dst->name, O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
+	dst_fd = openat(dst->dirfd, dst->name, O_RDONLY | O_NOFOLLOW | O_NONBLOCK | O_CLOEXEC);
 	if (dst_fd < 0) {
 		(void) close (src_fd);
 		return -1;

--- a/libmisc/copydir.c
+++ b/libmisc/copydir.c
@@ -529,7 +529,7 @@ static int copy_dir (const struct path_info *src, const struct path_info *dst,
 	    || (   (perm_copy_path (src, dst, &ctx) != 0)
 	        && (errno != 0))
 #else				/* !WITH_ACL */
-	    || (chmod (dst, statp->st_mode) != 0)
+	    || (fchmodat (dst->dirfd, dst->name, statp->st_mode & 07777, AT_SYMLINK_NOFOLLOW) != 0)
 #endif				/* !WITH_ACL */
 #ifdef WITH_ATTR
 	/*


### PR DESCRIPTION
This pull request fixes regressions in copy_tree:
- `./configure --without-acl` leads to a usermod which does not work due to invalid chmod call.
- FIFOs in user home directories prevent `usermod -md /new_home user` from working.

Please see commit messages for more details.