### PR TITLE
Use safer and simpler string copy functions.

### DIFF
--- a/contrib/pwdauth.c
+++ b/contrib/pwdauth.c
@@ -223,8 +223,7 @@ main(argc, argv)
 		fprintf(stderr, "Who are you?\n");
 		exit(2);
 	}
-	strncpy(myname, pw->pw_name, sizeof myname - 1);
-	myname[sizeof myname - 1] = '\0';
+	STRLCPY (myname, pw->pw_name);
 	name = myname;
 
 	if (argc > 1) {

--- a/contrib/shadow-anonftp.patch
+++ b/contrib/shadow-anonftp.patch
@@ -81,7 +81,7 @@ diff -uNr shadow-980403.orig/src/newusers.c shadow-980403/src/newusers.c
 +	while ((flag = getopt (argc, argv, "p:h")) != EOF) {
 +		switch (flag) {
 +		case 'p':
-+			STRFCPY(anonproto, optarg);
++			STRLCPY(anonproto, optarg);
 +			break;
 +		case 'h':
 +		default:

--- a/lib/defines.h
+++ b/lib/defines.h
@@ -241,6 +241,8 @@ static inline void memzero(void *ptr, size_t size)
 #define SCALE DAY
 #endif
 
+#define NITEMS(arr)  (sizeof((arr)) / sizeof((arr)[0]))
+
 /* Copy string pointed by B to array A with size checking.  It was originally
    in lmain.c but is _very_ useful elsewhere.  Some setuid root programs with
    very sloppy coding used to assume that BUFSIZ will always be enough...  */

--- a/lib/defines.h
+++ b/lib/defines.h
@@ -251,6 +251,11 @@ static inline void memzero(void *ptr, size_t size)
 #define STRFCPY(A,B) \
 	(strncpy((A), (B), sizeof(A) - 1), (A)[sizeof(A) - 1] = '\0')
 #define STRLCPY(dst, src)  (strlcpy((dst), (src), NITEMS(dst)) >= NITEMS(src))
+#define USTR2STR(dst, src)  do \
+{ \
+	static_assert(NITEMS(dst) > NITEMS(src), ""); \
+	ustr2str((dst), (src), NITEMS(src)); \
+} while (0)
 
 #ifndef PASSWD_FILE
 #define PASSWD_FILE "/etc/passwd"

--- a/lib/defines.h
+++ b/lib/defines.h
@@ -250,6 +250,7 @@ static inline void memzero(void *ptr, size_t size)
 					/* danger - side effects */
 #define STRFCPY(A,B) \
 	(strncpy((A), (B), sizeof(A) - 1), (A)[sizeof(A) - 1] = '\0')
+#define STRLCPY(dst, src)  (strlcpy((dst), (src), NITEMS(dst)) >= NITEMS(src))
 
 #ifndef PASSWD_FILE
 #define PASSWD_FILE "/etc/passwd"

--- a/lib/defines.h
+++ b/lib/defines.h
@@ -248,8 +248,6 @@ static inline void memzero(void *ptr, size_t size)
    very sloppy coding used to assume that BUFSIZ will always be enough...  */
 
 					/* danger - side effects */
-#define STRFCPY(A,B) \
-	(strncpy((A), (B), sizeof(A) - 1), (A)[sizeof(A) - 1] = '\0')
 #define STRLCPY(dst, src)  (strlcpy((dst), (src), NITEMS(dst)) >= NITEMS(src))
 #define USTR2STR(dst, src)  do \
 { \

--- a/lib/fields.c
+++ b/lib/fields.c
@@ -100,8 +100,7 @@ void change_field (char *buf, size_t maxsize, const char *prompt)
 			cp++;
 		}
 
-		strncpy (buf, cp, maxsize - 1);
-		buf[maxsize - 1] = '\0';
+		strlcpy (buf, cp, maxsize);
 	}
 }
 

--- a/lib/gshadow.c
+++ b/lib/gshadow.c
@@ -15,6 +15,8 @@
 #ident "$Id$"
 
 #include <stdio.h>
+#include <string.h>
+
 #include "prototypes.h"
 #include "defines.h"
 static /*@null@*/FILE *shadow;
@@ -124,8 +126,7 @@ void endsgent (void)
 		sgrbuflen = len;
 	}
 
-	strncpy (sgrbuf, string, len);
-	sgrbuf[len-1] = '\0';
+	strlcpy (sgrbuf, string, len);
 
 	cp = strrchr (sgrbuf, '\n');
 	if (NULL != cp) {

--- a/lib/prototypes.h
+++ b/lib/prototypes.h
@@ -459,6 +459,9 @@ extern int set_filesize_limit (int blocks);
 /* user_busy.c */
 extern int user_busy (const char *name, uid_t uid);
 
+/* ustr2str.c */
+extern void ustr2str (char *restrict dst, const u_char *restrict src, size_t n);
+
 /* utmp.c */
 #ifndef USE_UTMPX
 extern /*@null@*/struct utmp *get_current_utmp (void);

--- a/libmisc/console.c
+++ b/libmisc/console.c
@@ -44,8 +44,7 @@ static bool is_listed (const char *cfgin, const char *tty, bool def)
 
 	if (*cons != '/') {
 		char *pbuf;
-		strncpy (buf, cons, sizeof (buf));
-		buf[sizeof (buf) - 1] = '\0';
+		STRLCPY (buf, cons);
 		pbuf = &buf[0];
 		while ((s = strtok (pbuf, ":")) != NULL) {
 			if (strcmp (s, tty) == 0) {

--- a/libmisc/date_to_str.c
+++ b/libmisc/date_to_str.c
@@ -39,7 +39,7 @@ void date_to_str (size_t size, char buf[size], long date)
 
 	t = date;
 	if (date < 0)
-		(void) strncpy (buf, "never", size);
+		strlcpy (buf, "never", size);
 	else
 		(void) strftime (buf, size, "%Y-%m-%d", gmtime (&t));
 	buf[size - 1] = '\0';

--- a/libmisc/env.c
+++ b/libmisc/env.c
@@ -194,8 +194,7 @@ void set_env (int argc, char *const *argv)
 			}
 
 			if (NULL != *p) {
-				strncpy (variable, *argv, (size_t)(cp - *argv));
-				variable[cp - *argv] = '\0';
+				ustr2str (variable, *argv, cp - *argv);
 				printf (_("You may not change $%s\n"),
 					variable);
 				continue;

--- a/libmisc/failure.c
+++ b/libmisc/failure.c
@@ -18,6 +18,7 @@
 #include "faillog.h"
 #include "getdef.h"
 #include "failure.h"
+#include "prototypes.h"
 #define	YEAR	(365L*DAY)
 /*
  * failure - make failure entry
@@ -75,7 +76,7 @@ void failure (uid_t uid, const char *tty, struct faillog *fl)
 		fl->fail_cnt++;
 	}
 
-	strncpy (fl->fail_line, tty, sizeof (fl->fail_line) - 1);
+	STRLCPY (fl->fail_line, tty);
 	(void) time (&fl->fail_time);
 
 	/*

--- a/libmisc/log.c
+++ b/libmisc/log.c
@@ -77,9 +77,9 @@ void dolastlog (
 	ll_time = newlog.ll_time;
 	(void) time (&ll_time);
 	newlog.ll_time = ll_time;
-	strncpy (newlog.ll_line, line, sizeof (newlog.ll_line) - 1);
+	STRLCPY (newlog.ll_line, line);
 #if HAVE_LL_HOST
-	strncpy (newlog.ll_host, host, sizeof (newlog.ll_host) - 1);
+	STRLCPY (newlog.ll_host, host);
 #endif
 	if (   (lseek (fd, offset, SEEK_SET) != offset)
 	    || (write (fd, (const void *) &newlog, sizeof newlog) != (ssize_t) sizeof newlog)
@@ -90,4 +90,3 @@ void dolastlog (
 		(void) close (fd);
 	}
 }
-

--- a/libmisc/ustr2str.c
+++ b/libmisc/ustr2str.c
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2022, Alejandro Colomar <alx.manpages@gmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the copyright holders or contributors may not be used to
+ *    endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stddef.h>
+#include <string.h>
+
+#ident "$Id$"
+
+#include "prototypes.h"
+
+
+/*
+ * SYNOPSIS
+ *	void ustr2str(char dst[restrict .n+1], const u_char src[restrict .n],
+ *	              size_t n);
+ *
+ * ARGUMENTS
+ *	dst	Pointer to the first byte of the destination buffer.
+ *
+ *	src	Pointer to the first byte of the source unterminated string.
+ *
+ *	n	Size of 'src'.
+ *
+ * DESCRIPTION
+ *	Copy a string from the source unterminated string, into a
+ *	NUL-terminated string in the destination buffer.
+ *
+ * CAVEATS
+ *	If the destination buffer is not wider than the source buffer
+ *	at least by 1 byte, the behavior is undefined.
+ *
+ *	Use of this function normally indicates a problem in the design
+ *	of the strings, since normally it's better to guarantee that all
+ *	strings are properly terminated.  The main use for this function
+ *	is to interface with some standard buffers, such as those
+ *	defined in utmp(7), which for historical reasons are not
+ *	guaranteed to be terminated.
+ *
+ *	Other valid uses are in projects where, for performance reasons, it's
+ *	useful to have strings that overlap (thus defining a string by a
+ *	pointer and a length).  In such cases, it's necessary to use distinct
+ *	types for strings and unterminated strings, so that the compiler can
+ *	enforce that we don't mix them accidentally.  This function has been
+ *	designed with that use case in mind, and uses u_char* for the
+ *	u_nterminated string.
+ *
+ * EXAMPLES
+ *	u_char  src[10] = "0123456789";  // not NUL-terminated
+ *	char    dst[sizeof(src) + 1];
+ *
+ *	static_assert(nitems(src) < nitems(dst))
+ *	ustr2str(dst, src, lengthof(src));
+ */
+
+void
+ustr2str(char *restrict dst, const u_char *restrict src, size_t n)
+{
+	memcpy(dst, src, n);
+	dst[n] = '\0';
+}

--- a/libmisc/utmp.c
+++ b/libmisc/utmp.c
@@ -209,13 +209,11 @@ static void updwtmpx (const char *filename, const struct utmpx *utx)
 
 	if (   (NULL != host)
 	    && ('\0' != host[0])) {
-		hostname = (char *) xmalloc (strlen (host) + 1);
-		strcpy (hostname, host);
+		hostname = xstrdup (host);
 #ifdef HAVE_STRUCT_UTMP_UT_HOST
 	} else if (   (NULL != ut)
 	           && ('\0' != ut->ut_host[0])) {
-		hostname = (char *) xmalloc (sizeof (ut->ut_host) + 1);
-		USTR2STR (hostname, ut->ut_host);
+		hostname = xstrdup (ut->ut_host);
 #endif				/* HAVE_STRUCT_UTMP_UT_HOST */
 	}
 
@@ -353,14 +351,12 @@ int setutmp (struct utmp *ut)
 
 	if (   (NULL != host)
 	    && ('\0' != host[0])) {
-		hostname = (char *) xmalloc (strlen (host) + 1);
-		strcpy (hostname, host);
+		hostname = xstrdup (host);
 #ifdef HAVE_STRUCT_UTMP_UT_HOST
 	} else if (   (NULL != ut)
 	           && (NULL != ut->ut_host)
 	           && ('\0' != ut->ut_host[0])) {
-		hostname = (char *) xmalloc (sizeof (ut->ut_host) + 1);
-		USTR2STR (hostname, ut->ut_host);
+		hostname = xstrdup (ut->ut_host);
 #endif				/* HAVE_STRUCT_UTMP_UT_TYPE */
 	}
 

--- a/libmisc/utmp.c
+++ b/libmisc/utmp.c
@@ -46,8 +46,7 @@ static bool is_my_tty (const char *tty)
 	if ('\0' == tmptty[0]) {
 		const char *tname = ttyname (STDIN_FILENO);
 		if (NULL != tname) {
-			(void) strncpy (tmptty, tname, sizeof tmptty);
-			tmptty[sizeof (tmptty) - 1] = '\0';
+			STRLCPY (tmptty, tname);
 		}
 	}
 
@@ -216,8 +215,7 @@ static void updwtmpx (const char *filename, const struct utmpx *utx)
 	} else if (   (NULL != ut)
 	           && ('\0' != ut->ut_host[0])) {
 		hostname = (char *) xmalloc (sizeof (ut->ut_host) + 1);
-		strncpy (hostname, ut->ut_host, sizeof (ut->ut_host));
-		hostname[sizeof (ut->ut_host)] = '\0';
+		USTR2STR (hostname, ut->ut_host);
 #endif				/* HAVE_STRUCT_UTMP_UT_HOST */
 	}
 
@@ -235,25 +233,25 @@ static void updwtmpx (const char *filename, const struct utmpx *utx)
 	utent->ut_type = USER_PROCESS;
 #endif				/* HAVE_STRUCT_UTMP_UT_TYPE */
 	utent->ut_pid = getpid ();
-	strncpy (utent->ut_line, line,      sizeof (utent->ut_line) - 1);
+	STRLCPY (utent->ut_line, line);
 #ifdef HAVE_STRUCT_UTMP_UT_ID
 	if (NULL != ut) {
 		strncpy (utent->ut_id, ut->ut_id, sizeof (utent->ut_id));
 	} else {
 		/* XXX - assumes /dev/tty?? */
-		strncpy (utent->ut_id, line + 3, sizeof (utent->ut_id) - 1);
+		STRLCPY (utent->ut_id, line + 3);
 	}
 #endif				/* HAVE_STRUCT_UTMP_UT_ID */
 #ifdef HAVE_STRUCT_UTMP_UT_NAME
-	strncpy (utent->ut_name, name,      sizeof (utent->ut_name));
+	STRLCPY (utent->ut_name, name);
 #endif				/* HAVE_STRUCT_UTMP_UT_NAME */
 #ifdef HAVE_STRUCT_UTMP_UT_USER
-	strncpy (utent->ut_user, name,      sizeof (utent->ut_user) - 1);
+	STRLCPY (utent->ut_user, name);
 #endif				/* HAVE_STRUCT_UTMP_UT_USER */
 	if (NULL != hostname) {
 		struct addrinfo *info = NULL;
 #ifdef HAVE_STRUCT_UTMP_UT_HOST
-		strncpy (utent->ut_host, hostname, sizeof (utent->ut_host) - 1);
+		STRLCPY (utent->ut_host, hostname);
 #endif				/* HAVE_STRUCT_UTMP_UT_HOST */
 #ifdef HAVE_STRUCT_UTMP_UT_SYSLEN
 		utent->ut_syslen = MIN (strlen (hostname),
@@ -362,8 +360,7 @@ int setutmp (struct utmp *ut)
 	           && (NULL != ut->ut_host)
 	           && ('\0' != ut->ut_host[0])) {
 		hostname = (char *) xmalloc (sizeof (ut->ut_host) + 1);
-		strncpy (hostname, ut->ut_host, sizeof (ut->ut_host));
-		hostname[sizeof (ut->ut_host)] = '\0';
+		USTR2STR (hostname, ut->ut_host);
 #endif				/* HAVE_STRUCT_UTMP_UT_TYPE */
 	}
 
@@ -378,22 +375,22 @@ int setutmp (struct utmp *ut)
 
 	utxent->ut_type = USER_PROCESS;
 	utxent->ut_pid = getpid ();
-	strncpy (utxent->ut_line, line,      sizeof (utxent->ut_line));
+	STRLCPY (utxent->ut_line, line);
 	/* existence of ut->ut_id is enforced by configure */
 	if (NULL != ut) {
 		strncpy (utxent->ut_id, ut->ut_id, sizeof (utxent->ut_id));
 	} else {
 		/* XXX - assumes /dev/tty?? */
-		strncpy (utxent->ut_id, line + 3, sizeof (utxent->ut_id));
+		STRLCPY (utxent->ut_id, line + 3);
 	}
 #ifdef HAVE_STRUCT_UTMPX_UT_NAME
-	strncpy (utxent->ut_name, name,      sizeof (utxent->ut_name));
+	STRLCPY (utxent->ut_name, name);
 #endif				/* HAVE_STRUCT_UTMPX_UT_NAME */
-	strncpy (utxent->ut_user, name,      sizeof (utxent->ut_user));
+	STRLCPY (utxent->ut_user, name);
 	if (NULL != hostname) {
 		struct addrinfo *info = NULL;
 #ifdef HAVE_STRUCT_UTMPX_UT_HOST
-		strncpy (utxent->ut_host, hostname, sizeof (utxent->ut_host));
+		STRLCPY (utxent->ut_host, hostname);
 #endif				/* HAVE_STRUCT_UTMPX_UT_HOST */
 #ifdef HAVE_STRUCT_UTMPX_UT_SYSLEN
 		utxent->ut_syslen = MIN (strlen (hostname),

--- a/src/chage.c
+++ b/src/chage.c
@@ -809,7 +809,7 @@ int main (int argc, char **argv)
 		fail_exit (E_NOPERM);
 	}
 
-	STRFCPY (user_name, pw->pw_name);
+	STRLCPY (user_name, pw->pw_name);
 #ifdef WITH_TCB
 	if (shadowtcb_set_user (pw->pw_name) == SHADOWTCB_FAILURE) {
 		fail_exit (E_NOPERM);

--- a/src/chfn.c
+++ b/src/chfn.c
@@ -271,7 +271,7 @@ static void process_flags (int argc, char **argv)
 				exit (E_NOPERM);
 			}
 			fflg = true;
-			STRFCPY (fullnm, optarg);
+			STRLCPY (fullnm, optarg);
 			break;
 		case 'h':
 			if (!may_change_field ('h')) {
@@ -280,7 +280,7 @@ static void process_flags (int argc, char **argv)
 				exit (E_NOPERM);
 			}
 			hflg = true;
-			STRFCPY (homeph, optarg);
+			STRLCPY (homeph, optarg);
 			break;
 		case 'o':
 			if (!amroot) {
@@ -294,7 +294,7 @@ static void process_flags (int argc, char **argv)
 				         _("%s: fields too long\n"), Prog);
 				exit (E_NOPERM);
 			}
-			STRFCPY (slop, optarg);
+			STRLCPY (slop, optarg);
 			break;
 		case 'r':
 			if (!may_change_field ('r')) {
@@ -303,7 +303,7 @@ static void process_flags (int argc, char **argv)
 				exit (E_NOPERM);
 			}
 			rflg = true;
-			STRFCPY (roomno, optarg);
+			STRLCPY (roomno, optarg);
 			break;
 		case 'R': /* no-op, handled in process_root_flag () */
 			break;
@@ -317,7 +317,7 @@ static void process_flags (int argc, char **argv)
 				exit (E_NOPERM);
 			}
 			wflg = true;
-			STRFCPY (workph, optarg);
+			STRLCPY (workph, optarg);
 			break;
 		default:
 			usage (E_USAGE);
@@ -504,7 +504,7 @@ static void get_old_fields (const char *gecos)
 {
 	char *cp;		/* temporary character pointer       */
 	char old_gecos[BUFSIZ];	/* buffer for old GECOS fields       */
-	STRFCPY (old_gecos, gecos);
+	STRLCPY (old_gecos, gecos);
 
 	/*
 	 * Now get the full name. It is the first comma separated field in

--- a/src/chsh.c
+++ b/src/chsh.c
@@ -197,7 +197,7 @@ static void process_flags (int argc, char **argv)
 			break;
 		case 's':
 			sflg = true;
-			STRFCPY (loginsh, optarg);
+			STRLCPY (loginsh, optarg);
 			break;
 		default:
 			usage (E_USAGE);
@@ -492,7 +492,7 @@ int main (int argc, char **argv)
 	 * file, or use the value from the command line.
 	 */
 	if (!sflg) {
-		STRFCPY (loginsh, pw->pw_shell);
+		STRLCPY (loginsh, pw->pw_shell);
 	}
 
 	/*

--- a/src/gpasswd.c
+++ b/src/gpasswd.c
@@ -892,7 +892,7 @@ static void change_passwd (struct group *gr)
 			exit (1);
 		}
 
-		STRFCPY (pass, cp);
+		STRLCPY (pass, cp);
 		strzero (cp);
 		cp = getpass (_("Re-enter new password: "));
 		if (NULL == cp) {

--- a/src/login.c
+++ b/src/login.c
@@ -743,8 +743,7 @@ int main (int argc, char **argv)
 			          sizeof (loginprompt),
 			          _("%s login: "), hostn);
 		} else {
-			strncpy (loginprompt, _("login: "),
-			         sizeof (loginprompt));
+			STRLCPY (loginprompt, _("login: "));
 		}
 
 		retcode = pam_set_item (pamh, PAM_USER_PROMPT, loginprompt);

--- a/src/login.c
+++ b/src/login.c
@@ -585,7 +585,7 @@ int main (int argc, char **argv)
 	if (NULL == tmptty) {
 		tmptty = "UNKNOWN";
 	}
-	STRFCPY (tty, tmptty);
+	STRLCPY (tty, tmptty);
 
 #ifndef USE_PAM
 	is_console = console (tty);

--- a/src/logoutd.c
+++ b/src/logoutd.c
@@ -54,8 +54,7 @@ static int check_login (const struct utmp *ut)
 	/*
 	 * ut_user may not have the terminating NUL.
 	 */
-	strncpy (user, ut->ut_user, sizeof (ut->ut_user));
-	user[sizeof (ut->ut_user)] = '\0';
+	USTR2STR (user, ut->ut_user);
 
 	(void) time (&now);
 
@@ -246,8 +245,7 @@ int main (int argc, char **argv)
 				kill (-ut->ut_pid, SIGKILL);
 			}
 
-			strncpy (user, ut->ut_user, sizeof (user) - 1);
-			user[sizeof (user) - 1] = '\0';
+			USTR2STR (user, ut->ut_user);
 
 			SYSLOG ((LOG_NOTICE,
 				 "logged off user '%s' on '%s'", user,

--- a/src/passwd.c
+++ b/src/passwd.c
@@ -233,7 +233,7 @@ static int new_password (const struct passwd *pw)
 			                pw->pw_name);
 			return -1;
 		}
-		STRFCPY (orig, clear);
+		STRLCPY (orig, clear);
 		strzero (clear);
 		strzero (cipher);
 	} else {
@@ -295,7 +295,7 @@ static int new_password (const struct passwd *pw)
 		if (warned && (strcmp (pass, cp) != 0)) {
 			warned = false;
 		}
-		STRFCPY (pass, cp);
+		STRLCPY (pass, cp);
 		strzero (cp);
 
 		if (!amroot && (!obscure (orig, pass, pw) || reuse (pass, pw))) {
@@ -351,7 +351,7 @@ static int new_password (const struct passwd *pw)
 #ifdef HAVE_LIBCRACK_HIST
 	HistUpdate (pw->pw_name, crypt_passwd);
 #endif				/* HAVE_LIBCRACK_HIST */
-	STRFCPY (crypt_passwd, cp);
+	STRLCPY (crypt_passwd, cp);
 	return 0;
 }
 
@@ -1008,7 +1008,7 @@ int main (int argc, char **argv)
 	 * If there are no other flags, just change the password.
 	 */
 	if (!anyflag) {
-		STRFCPY (crypt_passwd, cp);
+		STRLCPY (crypt_passwd, cp);
 
 		/*
 		 * See if the user is permitted to change the password.

--- a/src/su.c
+++ b/src/su.c
@@ -752,7 +752,7 @@ static void save_caller_context (char **argv)
 		         (unsigned long) caller_uid));
 		su_failure (caller_tty, true); /* unknown target UID*/
 	}
-	STRFCPY (caller_name, pw->pw_name);
+	STRLCPY (caller_name, pw->pw_name);
 
 #ifndef USE_PAM
 #ifdef SU_ACCESS
@@ -827,7 +827,7 @@ static void process_flags (int argc, char **argv)
 	}
 
 	if (optind < argc) {
-		STRFCPY (name, argv[optind++]);	/* use this login id */
+		STRLCPY (name, argv[optind++]);	/* use this login id */
 	}
 	if ('\0' == name[0]) {		/* use default user */
 		struct passwd *root_pw = getpwnam ("root");

--- a/src/su.c
+++ b/src/su.c
@@ -655,8 +655,7 @@ static /*@only@*/struct passwd * check_perms (void)
 		SYSLOG ((LOG_INFO,
 		         "Change user from '%s' to '%s' as requested by PAM",
 		         name, tmp_name));
-		strncpy (name, tmp_name, sizeof(name) - 1);
-		name[sizeof(name) - 1] = '\0';
+		STRLCPY (name, tmp_name);
 		pw = xgetpwnam (name);
 		if (NULL == pw) {
 			(void) fprintf (stderr,

--- a/src/sulogin.c
+++ b/src/sulogin.c
@@ -203,7 +203,7 @@ static void catch_signals (unused int sig)
 #endif
 			exit (0);
 		} else {
-			STRFCPY (pass, cp);
+			STRLCPY (pass, cp);
 			strzero (cp);
 		}
 		if (valid (pass, &pwent)) {	/* check encrypted passwords ... */


### PR DESCRIPTION
Please review that str_l_cpy() and STR_L_CPY() are only used with input strings that are guaranteed to be NUL-terminated, and also review that str_s_cpy() and STR_S_CPY() are only used with input strings that can be not terminated under some circumstances.  I'm almost sure that there are cases where I used the _s_ function where we could use the _l_ one.  Another pair of eyes will help for sure.

Also: not tested.  I didn't remember how to build the project, so I couldn't run the tests.  I hope CI helps me in this.