### PR TITLE
agetpass() to replace getpass(3)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -405,6 +405,21 @@ AC_SUBST(LIYESCRYPT)
 AC_CHECK_LIB(crypt, crypt, [LIYESCRYPT=-lcrypt],
 	[AC_MSG_ERROR([crypt() not found])])
 
+AC_SEARCH_LIBS([readpassphrase], [bsd], [], [
+	AC_MSG_ERROR([readpassphrase() is missing, either from libc or libbsd])
+])
+AS_IF([test "$ac_cv_search_readpassphrase" = "-lbsd"], [
+	PKG_CHECK_MODULES([LIBBSD], [libbsd-overlay])
+])
+dnl Make sure either the libc or libbsd provide the header.
+save_CFLAGS="$CFLAGS"
+CFLAGS="$CFLAGS $LIBBSD_CFLAGS"
+AC_CHECK_HEADERS([readpassphrase.h])
+AS_IF([test "$ac_cv_header_readpassphrase_h" != "yes"], [
+	AC_MSG_ERROR([readpassphrase.h is missing])
+])
+CFLAGS="$save_CFLAGS"
+
 AC_SUBST(LIBACL)
 if test "$with_acl" != "no"; then
 	AC_CHECK_HEADERS(acl/libacl.h attr/error_context.h, [acl_header="yes"], [acl_header="no"])

--- a/lib/defines.h
+++ b/lib/defines.h
@@ -330,6 +330,12 @@ extern char *strerror ();
 /* Maximum length of passwd entry */
 #define PASSWD_ENTRY_MAX_LENGTH 32768
 
+#if (__GNUC__ >= 11) && !defined(__clang__)
+# define ATTR_MALLOC(deallocator)  [[gnu::malloc(deallocator)]]
+#else
+# define ATTR_MALLOC(deallocator)
+#endif
+
 #ifdef HAVE_SECURE_GETENV
 #  define shadow_getenv(name) secure_getenv(name)
 # else

--- a/lib/prototypes.h
+++ b/lib/prototypes.h
@@ -47,7 +47,7 @@ extern int expire (const struct passwd *, /*@null@*/const struct spwd *);
 
 /* agetpass.c */
 extern void erase_pass(char *pass);
-[[gnu::malloc(erase_pass)]]
+ATTR_MALLOC(erase_pass)
 extern char *agetpass(const char *prompt);
 
 /* isexpired.c */

--- a/lib/prototypes.h
+++ b/lib/prototypes.h
@@ -44,6 +44,12 @@ extern int add_groups (const char *);
 /* age.c */
 extern void agecheck (/*@null@*/const struct spwd *);
 extern int expire (const struct passwd *, /*@null@*/const struct spwd *);
+
+/* agetpass.c */
+extern void erase_pass(char *pass);
+[[gnu::malloc(erase_pass)]]
+extern char *agetpass(const char *prompt);
+
 /* isexpired.c */
 extern int isexpired (const struct passwd *, /*@null@*/const struct spwd *);
 

--- a/libmisc/Makefile.am
+++ b/libmisc/Makefile.am
@@ -5,6 +5,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/lib -I$(top_srcdir) $(ECONF_CPPFLAGS)
 
 noinst_LTLIBRARIES = libmisc.la
 
+libmisc_la_CFLAGS = $(LIBBSD_CFLAGS)
 libmisc_la_SOURCES = \
 	addgrps.c \
 	age.c \

--- a/libmisc/Makefile.am
+++ b/libmisc/Makefile.am
@@ -8,6 +8,7 @@ noinst_LTLIBRARIES = libmisc.la
 libmisc_la_SOURCES = \
 	addgrps.c \
 	age.c \
+	agetpass.c \
 	audit_help.c \
 	basename.c \
 	chkname.c \

--- a/libmisc/agetpass.c
+++ b/libmisc/agetpass.c
@@ -26,6 +26,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <config.h>
+
 #include <limits.h>
 #include <readpassphrase.h>
 #include <stdio.h>

--- a/libmisc/agetpass.c
+++ b/libmisc/agetpass.c
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2022, Alejandro Colomar <alx@kernel.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the copyright holders or contributors may not be used to
+ *    endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <limits.h>
+#include <readpassphrase.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ident "$Id$"
+
+#include "prototypes.h"
+
+
+#if !defined(PASS_MAX)
+#define PASS_MAX  BUFSIZ
+#endif
+
+
+/*
+ * SYNOPSIS
+ *	[[gnu::malloc(erase_pass)]]
+ *	char *agetpass(const char *prompt);
+ *
+ *	void erase_pass(char *pass);
+ *
+ * ARGUMENTS
+ *   agetpass()
+ *	prompt	String to be printed before reading a password.
+ *
+ *   erase_pass()
+ *	pass	password previously returned by agetpass().
+ *
+ * DESCRIPTION
+ *   agetpass()
+ *	This function is very similar to getpass(3).  It has several
+ *	advantages compared to getpass(3):
+ *
+ *	- Instead of using a static buffer, agetpass() allocates memory
+ *	  through malloc(3).  This makes the function thread-safe, and
+ *	  also reduces the visibility of the buffer.
+ *
+ *	- agetpass() doesn't call realloc(3) internally.  Some
+ *	  implementations of getpass(3), such as glibc, do that, as a
+ *	  consequence of calling getline(3).  That's a bug in glibc,
+ *	  which allows leaking prefixes of passwords in freed memory.
+ *
+ *	- agetpass() doesn't overrun the output buffer.  If the input
+ *	  password is too long, it simply fails.  Some implementations
+ *	  of getpass(3), share the same bug that gets(3) has.
+ *
+ *	As soon as possible, the password obtained from agetpass() be
+ *	erased by calling erase_pass(), to avoid possibly leaking the
+ *	password.
+ *
+ *   erase_pass()
+ *	This function first clears the password, by calling
+ *	explicit_bzero(3) (or an equivalent call), and then frees the
+ *	allocated memory by calling free(3).
+ *
+ *	NULL is a valid input pointer, and in such a case, this call is
+ *	a no-op.
+ *
+ * RETURN VALUE
+ *	agetpass() returns a newly allocated buffer containing the
+ *	password on success.  On error, errno is set to indicate the
+ *	error, and NULL is returned.
+ *
+ * ERRORS
+ *   agetpass()
+ *	This function may fail for any errors that malloc(3) or
+ *	readpassphrase(3) may fail, and in addition it may fail for the
+ *	following errors:
+ *
+ *	ENOBUFS
+ *		The input password was longer than PASS_MAX.
+ *
+ * CAVEATS
+ *	If a password is passed twice to erase_pass(), the behavior is
+ *	undefined.
+ */
+
+
+char *
+agetpass(const char *prompt)
+{
+	char    *pass;
+	size_t  len;
+
+	pass = malloc(PASS_MAX);
+	if (pass == NULL)
+		return NULL;
+
+	if (readpassphrase(prompt, pass, PASS_MAX, RPP_REQUIRE_TTY) == NULL)
+		goto fail;
+
+	len = strlen(pass);
+
+	if (len == 0)
+		return pass;
+
+	if (pass[len - 1] != '\n') {
+		errno = ENOBUFS;
+		goto fail;
+	}
+
+	pass[len - 1] = '\0';
+
+	return pass;
+
+fail:
+	memzero(pass, PASS_MAX);
+	free(pass);
+	return NULL;
+}
+
+
+void
+erase_pass(char *pass)
+{
+	if (pass == NULL)
+		return;
+	memzero(pass, PASS_MAX);
+	free(pass);
+}

--- a/src/gpasswd.c
+++ b/src/gpasswd.c
@@ -887,24 +887,24 @@ static void change_passwd (struct group *gr)
 	printf (_("Changing the password for group %s\n"), group);
 
 	for (retries = 0; retries < RETRIES; retries++) {
-		cp = getpass (_("New Password: "));
+		cp = agetpass (_("New Password: "));
 		if (NULL == cp) {
 			exit (1);
 		}
 
 		STRFCPY (pass, cp);
-		strzero (cp);
-		cp = getpass (_("Re-enter new password: "));
+		erase_pass (cp);
+		cp = agetpass (_("Re-enter new password: "));
 		if (NULL == cp) {
 			exit (1);
 		}
 
 		if (strcmp (pass, cp) == 0) {
-			strzero (cp);
+			erase_pass (cp);
 			break;
 		}
 
-		strzero (cp);
+		erase_pass (cp);
 		memzero (pass, sizeof pass);
 
 		if (retries + 1 < RETRIES) {

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -158,7 +158,7 @@ static void check_perms (const struct group *grp,
 		 * get the password from her, and set the salt for
 		 * the decryption from the group file.
 		 */
-		cp = getpass (_("Password: "));
+		cp = agetpass (_("Password: "));
 		if (NULL == cp) {
 			goto failure;
 		}
@@ -169,7 +169,7 @@ static void check_perms (const struct group *grp,
 		 * must match the previously encrypted value in the file.
 		 */
 		cpasswd = pw_encrypt (cp, grp->gr_passwd);
-		strzero (cp);
+		erase_pass (cp);
 
 		if (NULL == cpasswd) {
 			fprintf (stderr,

--- a/src/sulogin.c
+++ b/src/sulogin.c
@@ -202,10 +202,9 @@ static void catch_signals (unused int sig)
 			execl (PATH_TELINIT, "telinit", RUNLEVEL, (char *) 0);
 #endif
 			exit (0);
-		} else {
-			STRFCPY (pass, cp);
-			strzero (cp);
 		}
+		STRFCPY (pass, cp);
+		strzero (cp);
 		if (valid (pass, &pwent)) {	/* check encrypted passwords ... */
 			break;	/* ... encrypted passwords matched */
 		}

--- a/src/sulogin.c
+++ b/src/sulogin.c
@@ -182,7 +182,7 @@ static void catch_signals (unused int sig)
 		 */
 
 		/* get a password for root */
-		cp = getpass (_(
+		cp = agetpass (_(
 "\n"
 "Type control-d to proceed with normal startup,\n"
 "(or give root password for system maintenance):"));
@@ -193,6 +193,7 @@ static void catch_signals (unused int sig)
 		 * --marekm
 		 */
 		if ((NULL == cp) || ('\0' == *cp)) {
+			erase_pass (cp);
 #ifdef	USE_SYSLOG
 			SYSLOG (LOG_INFO, "Normal startup\n");
 			closelog ();
@@ -204,7 +205,8 @@ static void catch_signals (unused int sig)
 			exit (0);
 		}
 		STRFCPY (pass, cp);
-		strzero (cp);
+		erase_pass (cp);
+
 		if (valid (pass, &pwent)) {	/* check encrypted passwords ... */
 			break;	/* ... encrypted passwords matched */
 		}


### PR DESCRIPTION
```
There are several issues with getpass(3).

Many implementations of it share the same issues that the infamous
gets(3).  In glibc it's not so terrible, since it's a wrapper
around getline(3).  But it still has an important bug:

If the password is long enough, getline(3) will realloc(3) memory,
and prefixes of the password will be laying around in some
deallocated memory.

See the getpass(3) manual page for more details, and especially
the commit that marked it as deprecated, which links to a long
discussion in the linux-man@ mailing list.

So, readpassphrase(3bsd) is preferrable, which is provided by
libbsd on GNU systems.  However, using readpassphrase(3) directly
is a bit verbose, so we can write our own wrapper with a simpler
interface similar to that of getpass(3).

One of the benefits of writing our own interface around
readpassphrase(3) is that we can hide there any checks that should
be done always and which would be error-prone to repeat every
time.  For example, check that there was no truncation in the
password.

Also, use malloc(3) to get the buffer, instead of using a global
buffer.  We're not using a multithreaded program (and it wouldn't
make sense to do so), but it's nice to know that the visibility of
our passwords is as limited as possible.

erase_pass() is a clean-up function that handles all clean-up
correctly, including zeroing the entire buffer, and then
free(3)ing the memory.  By using [[gnu::malloc(erase_pass)]], we
make sure that we don't leak the buffers in any case, since the
compiler will be able to enforce clean up.

Link: <https://git.kernel.org/pub/scm/docs/man-pages/man-pages.git/commit?id=7ca189099d73bde954eed2d7fc21732bcc8ddc6b>
Reported-by: Christian Göttsche <cgzones@googlemail.com>
Signed-off-by: Alejandro Colomar <alx@kernel.org>
```

I still haven't added autoconf code to add the libbsd dependency, since I don't have much experience in using autoconf.  If someone wants to help with that, please do :)  Otherwise, gimme some time to do that.

I also reopened an old thread in the libc-alpha@ mailing list to discuss the possible addition of readpassphrase(3) to glibc (and also discuss the agetpass(3) interface, in case they want to add it too).