### PR TITLE
Don't test for NULL before calling free(3)

### DIFF
--- a/lib/commonio.c
+++ b/lib/commonio.c
@@ -85,9 +85,7 @@ int lrename (const char *old, const char *new)
 	res = rename (old, new);
 
 #ifdef __GLIBC__
-	if (NULL != r) {
-		free (r);
-	}
+	free (r);
 #endif				/* __GLIBC__ */
 
 	return res;
@@ -337,9 +335,7 @@ static void free_linked_list (struct commonio_db *db)
 		p = db->head;
 		db->head = p->next;
 
-		if (NULL != p->line) {
-			free (p->line);
-		}
+		free (p->line);
 
 		if (NULL != p->eptr) {
 			db->ops->free (p->eptr);
@@ -395,10 +391,8 @@ int commonio_lock_nowait (struct commonio_db *db, bool log)
 		err = 1;
 	}
 cleanup_ENOMEM:
-	if (file)
-		free(file);
-	if (lock)
-		free(lock);
+	free(file);
+	free(lock);
 	return err;
 }
 
@@ -1200,9 +1194,7 @@ int commonio_remove (struct commonio_db *db, const char *name)
 
 	commonio_del_entry (db, p);
 
-	if (NULL != p->line) {
-		free (p->line);
-	}
+	free (p->line);
 
 	if (NULL != p->eptr) {
 		db->ops->free (p->eptr);

--- a/lib/getdef.c
+++ b/lib/getdef.c
@@ -388,10 +388,7 @@ int putdef_str (const char *name, const char *value)
 		return -1;
 	}
 
-	if (NULL != d->value) {
-		free (d->value);
-	}
-
+	free (d->value);
 	d->value = cp;
 	return 0;
 }

--- a/lib/groupio.c
+++ b/lib/groupio.c
@@ -418,9 +418,7 @@ static int split_groups (unsigned int max_members)
 		/* Shift all the members */
 		/* The number of members in new_gptr will be check later */
 		for (i = 0; NULL != new_gptr->gr_mem[i + max_members]; i++) {
-			if (NULL != new_gptr->gr_mem[i]) {
-				free (new_gptr->gr_mem[i]);
-			}
+			free (new_gptr->gr_mem[i]);
 			new_gptr->gr_mem[i] = new_gptr->gr_mem[i + max_members];
 			new_gptr->gr_mem[i + max_members] = NULL;
 		}

--- a/lib/prototypes.h
+++ b/lib/prototypes.h
@@ -483,7 +483,6 @@ extern bool valid (const char *, const struct passwd *);
 extern /*@maynotreturn@*/ /*@only@*//*@out@*//*@notnull@*/void *xmalloc (size_t size)
   /*@ensures MaxSet(result) == (size - 1); @*/;
 extern /*@maynotreturn@*/ /*@only@*//*@notnull@*/char *xstrdup (const char *);
-extern void xfree(void *ap);
 
 /* xgetpwnam.c */
 extern /*@null@*/ /*@only@*/struct passwd *xgetpwnam (const char *);

--- a/lib/sgetgrent.c
+++ b/lib/sgetgrent.c
@@ -54,8 +54,7 @@ static char **list (char *s)
 				rbuf = malloc (size * sizeof (char *));
 			}
 			if (!rbuf) {
-				if (members)
-					free (members);
+				free (members);
 				members = 0;
 				size = 0;
 				return (char **) 0;
@@ -89,8 +88,7 @@ struct group *sgetgrent (const char *buf)
 	if (strlen (buf) + 1 > size) {
 		/* no need to use realloc() here - just free it and
 		   allocate a larger block */
-		if (grpbuf)
-			free (grpbuf);
+		free (grpbuf);
 		size = strlen (buf) + 1000;	/* at least: strlen(buf) + 1 */
 		grpbuf = malloc (size);
 		if (!grpbuf) {

--- a/lib/tcbfuncs.c
+++ b/lib/tcbfuncs.c
@@ -380,9 +380,7 @@ shadowtcb_status shadowtcb_set_user (const char* name)
 		return SHADOWTCB_SUCCESS;
 	}
 
-	if (NULL != stored_tcb_user) {
-		free (stored_tcb_user);
-	}
+	free (stored_tcb_user);
 
 	stored_tcb_user = strdup (name);
 	if (NULL == stored_tcb_user) {

--- a/libmisc/copydir.c
+++ b/libmisc/copydir.c
@@ -354,12 +354,8 @@ static int copy_tree_impl (const struct path_info *src, const struct path_info *
 				                  old_uid, new_uid,
 				                  old_gid, new_gid);
 			}
-			if (NULL != src_name) {
-				free (src_name);
-			}
-			if (NULL != dst_name) {
-				free (dst_name);
-			}
+			free (src_name);
+			free (dst_name);
 		}
 	}
 	(void) closedir (dir);

--- a/libmisc/xmalloc.c
+++ b/libmisc/xmalloc.c
@@ -44,10 +44,3 @@
 {
 	return strcpy (xmalloc (strlen (str) + 1), str);
 }
-
-void xfree(void *ap)
-{
-	if (ap) {
-		free(ap);
-	}
-}

--- a/src/gpasswd.c
+++ b/src/gpasswd.c
@@ -1186,17 +1186,11 @@ int main (int argc, char **argv)
 
 #ifdef SHADOWGRP
 	if (is_shadowgrp) {
-		if (sgent.sg_adm) {
-			xfree(sgent.sg_adm);
-		}
-		if (sgent.sg_mem) {
-			xfree(sgent.sg_mem);
-		}
+		free(sgent.sg_adm);
+		free(sgent.sg_mem);
 	}
 #endif
-	if (grent.gr_mem) {
-		xfree(grent.gr_mem);
-	}
+	free(grent.gr_mem);
 	exit (E_SUCCESS);
 }
 

--- a/src/login.c
+++ b/src/login.c
@@ -419,9 +419,7 @@ static void get_pam_user (char **ptr_pam_user)
 	retcode = pam_get_item (pamh, PAM_USER, (const void **)&ptr_user);
 	PAM_FAIL_CHECK;
 
-	if (NULL != *ptr_pam_user) {
-		free (*ptr_pam_user);
-	}
+	free (*ptr_pam_user);
 	if (NULL != ptr_user) {
 		*ptr_pam_user = xstrdup ((const char *)ptr_user);
 	} else {
@@ -872,9 +870,7 @@ int main (int argc, char **argv)
 	 * PAM APIs.
 	 */
 	get_pam_user (&pam_user);
-	if (NULL != username) {
-		free (username);
-	}
+	free (username);
 	username = xstrdup (pam_user);
 	failent_user = get_failent_user (username);
 

--- a/src/newusers.c
+++ b/src/newusers.c
@@ -285,8 +285,7 @@ static int add_group (const char *name, const char *gid, gid_t *ngid, uid_t uid)
 		fprintf (stderr,
 		         _("%s: invalid group name '%s'\n"),
 		         Prog, grent.gr_name);
-		if (grent.gr_name)
-			free (grent.gr_name);
+		free (grent.gr_name);
 		return -1;
 	}
 


### PR DESCRIPTION
```
free(3) accepts NULL, since the oldest ISO C.  I guess the paranoid code was taking
care of prehistoric implementations of free(3).  I've never known of an implementation
that doesn't conform to this, so let's simplify this.

Remove xfree(3), which was effectively an equivalent of free(3).

Signed-off-by: Alejandro Colomar <alx@kernel.org>
```

I found this while merging `xmalloc()`+`str*cpy()` into `xstrdup()`.