### PR TITLE
Use libc MAX() and MIN()

### DIFF
--- a/lib/defines.h
+++ b/lib/defines.h
@@ -310,14 +310,6 @@ extern char *strerror ();
 # define format_attr(type, index, check)
 #endif
 
-/* ! Arguments evaluated twice ! */
-#ifndef MIN
-#define MIN(a,b) (((a) < (b)) ? (a) : (b))
-#endif
-#ifndef MAX
-#define MAX(x,y) (((x) > (y)) ? (x) : (y))
-#endif
-
 /* Maximum length of usernames */
 #ifdef HAVE_UTMPX_H
 # include <utmpx.h>

--- a/libmisc/utmp.c
+++ b/libmisc/utmp.c
@@ -19,6 +19,7 @@
 #endif
 
 #include <assert.h>
+#include <sys/param.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netdb.h>


### PR DESCRIPTION
```
glibc, musl, FreeBSD, and OpenBSD define the MAX() and MIN() macros in
<sys/param.h> with the same definition that we use.  Let's not
redefine it here and use the system one, as it's effectively the
same as we define (modulo whitespace).

See:

shadow (previously):

alx@asus5775:~/src/shadow/shadow$ grepc -ktm MAX
./lib/defines.h:318:#define MAX(x,y) (((x) > (y)) ? (x) : (y))

glibc:

alx@asus5775:~/src/gnu/glibc$ grepc -ktm -x 'sys/param.h$' MAX
./misc/sys/param.h:103:#define MAX(a,b) (((a)>(b))?(a):(b))

musl:
    
alx@asus5775:~/src/musl/musl$ grepc -ktm -x 'sys/param.h$' MAX
./include/sys/param.h:19:#define MAX(a,b) (((a)>(b))?(a):(b))

OpenBSD:

alx@asus5775:~/src/bsd/openbsd/src$ grepc -ktm -x 'sys/param.h$' MAX
./sys/sys/param.h:193:#define	MAX(a,b) (((a)>(b))?(a):(b))

FreeBSD:

alx@asus5775:~/src/bsd/freebsd/freebsd-src$ grepc -ktm -x 'sys/param.h$' MAX
./sys/sys/param.h:333:#define	MAX(a,b) (((a)>(b))?(a):(b))

Signed-off-by: Alejandro Colomar <alx@kernel.org>
```

See also `MAX(3)`: <https://man7.org/linux/man-pages/man3/MAX.3.html>