### PR TITLE
libmisc: minimum id check for system accounts

### DIFF
--- a/libmisc/find_new_gid.c
+++ b/libmisc/find_new_gid.c
@@ -60,6 +60,13 @@ static int get_ranges (bool sys_group, gid_t *min_id, gid_t *max_id,
                             (unsigned long) *max_id);
 			return EINVAL;
 		}
+		/*
+		 * Zero is reserved for root and the allocation algorithm does not
+		 * work right with it.
+		 */
+		if (*min_id == 0) {
+			*min_id = (gid_t) 1;
+		}
 	} else {
 		/* Non-system groups */
 

--- a/libmisc/find_new_uid.c
+++ b/libmisc/find_new_uid.c
@@ -60,6 +60,13 @@ static int get_ranges (bool sys_user, uid_t *min_id, uid_t *max_id,
                             (unsigned long) *max_id);
 			return EINVAL;
 		}
+		/*
+		 * Zero is reserved for root and the allocation algorithm does not
+		 * work right with it.
+		 */
+		if (*min_id == 0) {
+			*min_id = (uid_t) 1;
+		}
 	} else {
 		/* Non-system users */
 


### PR DESCRIPTION
The minimum id allocation for system accounts shouldn't be 0 as this is reserved for root.