### PR TITLE
Raise limit for passwd and shadow entry length

### DIFF
--- a/lib/defines.h
+++ b/lib/defines.h
@@ -327,6 +327,9 @@ extern char *strerror ();
 # endif
 #endif
 
+/* Maximum length of passwd entry */
+#define PASSWD_ENTRY_MAX_LENGTH 32768
+
 #ifdef HAVE_SECURE_GETENV
 #  define shadow_getenv(name) secure_getenv(name)
 # else

--- a/lib/pwio.c
+++ b/lib/pwio.c
@@ -56,7 +56,10 @@ static int passwd_put (const void *ent, FILE * file)
 	    || (pw->pw_gid == (gid_t)-1)
 	    || (valid_field (pw->pw_gecos, ":\n") == -1)
 	    || (valid_field (pw->pw_dir, ":\n") == -1)
-	    || (valid_field (pw->pw_shell, ":\n") == -1)) {
+	    || (valid_field (pw->pw_shell, ":\n") == -1)
+	    || (strlen (pw->pw_name) + strlen (pw->pw_passwd) +
+	        strlen (pw->pw_gecos) + strlen (pw->pw_dir) +
+	        strlen (pw->pw_shell) + 100 > PASSWD_ENTRY_MAX_LENGTH)) {
 		return -1;
 	}
 

--- a/lib/sgetpwent.c
+++ b/lib/sgetpwent.c
@@ -16,6 +16,7 @@
 #include <stdio.h>
 #include <pwd.h>
 #include "prototypes.h"
+#include "shadowlog_internal.h"
 
 #define	NFIELDS	7
 
@@ -34,7 +35,7 @@
 struct passwd *sgetpwent (const char *buf)
 {
 	static struct passwd pwent;
-	static char pwdbuf[1024];
+	static char pwdbuf[PASSWD_ENTRY_MAX_LENGTH];
 	int i;
 	char *cp;
 	char *fields[NFIELDS];
@@ -44,8 +45,12 @@ struct passwd *sgetpwent (const char *buf)
 	 * the password structure remain valid.
 	 */
 
-	if (strlen (buf) >= sizeof pwdbuf)
+	if (strlen (buf) >= sizeof pwdbuf) {
+		fprintf (shadow_logfd,
+		         "%s: Too long passwd entry encountered, file corruption?\n",
+		         shadow_progname);
 		return 0;	/* fail if too long */
+	}
 	strcpy (pwdbuf, buf);
 
 	/*

--- a/lib/sgetspent.c
+++ b/lib/sgetspent.c
@@ -16,6 +16,7 @@
 
 #include <sys/types.h>
 #include "prototypes.h"
+#include "shadowlog_internal.h"
 #include "defines.h"
 #include <stdio.h>
 #define	FIELDS	9
@@ -25,7 +26,7 @@
  */
 struct spwd *sgetspent (const char *string)
 {
-	static char spwbuf[1024];
+	static char spwbuf[PASSWD_ENTRY_MAX_LENGTH];
 	static struct spwd spwd;
 	char *fields[FIELDS];
 	char *cp;
@@ -37,6 +38,9 @@ struct spwd *sgetspent (const char *string)
 	 */
 
 	if (strlen (string) >= sizeof spwbuf) {
+		fprintf (shadow_logfd,
+		         "%s: Too long passwd entry encountered, file corruption?\n",
+		         shadow_progname);
 		return 0;	/* fail if too long */
 	}
 	strcpy (spwbuf, string);

--- a/lib/shadowio.c
+++ b/lib/shadowio.c
@@ -56,7 +56,9 @@ static int shadow_put (const void *ent, FILE * file)
 
 	if (   (NULL == sp)
 	    || (valid_field (sp->sp_namp, ":\n") == -1)
-	    || (valid_field (sp->sp_pwdp, ":\n") == -1)) {
+	    || (valid_field (sp->sp_pwdp, ":\n") == -1)
+	    || (strlen (sp->sp_namp) + strlen (sp->sp_pwdp) +
+	        1000 > PASSWD_ENTRY_MAX_LENGTH)) {
 		return -1;
 	}
 


### PR DESCRIPTION
Moreover, include checks to prevent writing entries longer than the length limit.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1422497