### PR TITLE
useradd: Fix buffer overflow when using a prefix

### DIFF
--- a/src/useradd.c
+++ b/src/useradd.c
@@ -2372,7 +2372,7 @@ static void create_mail (void)
 		if (NULL == spool) {
 			return;
 		}
-		file = alloca (strlen (prefix) + strlen (spool) + strlen (user_name) + 2);
+		file = alloca (strlen (prefix) + strlen (spool) + strlen (user_name) + 3);
 		if (prefix[0])
 			sprintf (file, "%s/%s/%s", prefix, spool, user_name);
 		else


### PR DESCRIPTION
Running `useradd --prefix ...` aborts on openSUSE due to their hardening flags with a `buffer overflow detected` message.  It looks like this buffer is one byte short.