### PR TITLE
Don't warn when failed to open /etc/nsswitch.conf

### DIFF
--- a/lib/nss.c
+++ b/lib/nss.c
@@ -59,7 +59,6 @@ void nss_init(const char *nsswitch_path) {
 	//   subid:	files
 	nssfp = fopen(nsswitch_path, "r");
 	if (!nssfp) {
-		fprintf(shadow_logfd, "Failed opening %s: %m\n", nsswitch_path);
 		atomic_store(&nss_init_completed, true);
 		return;
 	}


### PR DESCRIPTION
Maybe we should have a debug mode where it's still printed, but we don't, so let's be quieter.

Closes #557