### PR TITLE
useradd: check if subid range exists for user

### DIFF
--- a/src/useradd.c
+++ b/src/useradd.c
@@ -2188,14 +2188,14 @@ static void usr_update (unsigned long subuid_count, unsigned long subgid_count)
 		fail_exit (E_PW_UPDATE);
 	}
 #ifdef ENABLE_SUBIDS
-	if (is_sub_uid &&
+	if (is_sub_uid && !local_sub_uid_assigned(user_name) &&
 	    (sub_uid_add(user_name, sub_uid_start, subuid_count) == 0)) {
 		fprintf (stderr,
 		         _("%s: failed to prepare the new %s entry\n"),
 		         Prog, sub_uid_dbname ());
 		fail_exit (E_SUB_UID_UPDATE);
 	}
-	if (is_sub_gid &&
+	if (is_sub_gid && !local_sub_gid_assigned(user_name) &&
 	    (sub_gid_add(user_name, sub_gid_start, subgid_count) == 0)) {
 		fprintf (stderr,
 		         _("%s: failed to prepare the new %s entry\n"),


### PR DESCRIPTION
According to useradd man page: If /etc/subuid exists, the commands useradd and newusers (**unless the user already have subordinate user IDs**) allocate SUB_UID_COUNT unused user IDs from the range SUB_UID_MIN to SUB_UID_MAX for each new user.

Thus, I've added a condition to check if a user already has a subid/subgid range before assigning one.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2012929