### PR TITLE
Fix HAVE_SHADOWGRP configure check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -116,6 +116,10 @@ if test "$ac_cv_header_shadow_h" = "yes"; then
 		ac_cv_libc_shadowgrp,
 		AC_RUN_IFELSE([AC_LANG_SOURCE([
 				#include <shadow.h>
+				#ifdef HAVE_GSHADOW_H
+				#include <gshadow.h>
+				#endif
+				int
 				main()
 				{
 					struct sgrp *sg = sgetsgent("test:x::");


### PR DESCRIPTION
The missing #include <gshadow.h> causes the configure check to fail spuriously, resulting in HAVE_SHADOWGRP not being defined even on systems that actually have sgetsgent (such as current glibc).