### PR TITLE
Raise the bar to POSIX.1-2001

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,7 @@ dnl Checks for libraries.
 
 dnl Checks for header files.
 AC_CHECK_HEADERS(crypt.h utmp.h \
-	utmpx.h termios.h termio.h sgtty.h sys/ioctl.h syslog.h paths.h \
+	termios.h termio.h sgtty.h sys/ioctl.h syslog.h paths.h \
 	utime.h ulimit.h sys/capability.h sys/random.h sys/resource.h \
 	gshadow.h lastlog.h rpc/key_prot.h netdb.h acl/libacl.h \
 	attr/libattr.h attr/error_context.h)

--- a/configure.ac
+++ b/configure.ac
@@ -39,7 +39,7 @@ dnl Checks for header files.
 AC_CHECK_HEADERS(crypt.h utmp.h \
 	termio.h sgtty.h sys/ioctl.h paths.h \
 	sys/capability.h sys/random.h \
-	gshadow.h lastlog.h rpc/key_prot.h netdb.h acl/libacl.h \
+	gshadow.h lastlog.h rpc/key_prot.h acl/libacl.h \
 	attr/libattr.h attr/error_context.h)
 
 dnl shadow now uses the libc's shadow implementation

--- a/configure.ac
+++ b/configure.ac
@@ -100,7 +100,7 @@ fi
 dnl Checks for library functions.
 AC_TYPE_GETGROUPS
 AC_FUNC_UTIME_NULL
-AC_REPLACE_FUNCS(putgrent putpwent putspent rmdir)
+AC_REPLACE_FUNCS(putgrent putpwent putspent)
 AC_REPLACE_FUNCS(sgetgrent sgetpwent sgetspent)
 AC_REPLACE_FUNCS(strcasecmp strdup)
 

--- a/configure.ac
+++ b/configure.ac
@@ -45,7 +45,7 @@ AC_CHECK_HEADERS(crypt.h utmp.h \
 dnl shadow now uses the libc's shadow implementation
 AC_CHECK_HEADER([shadow.h],,[AC_MSG_ERROR([You need a libc with shadow.h])])
 
-AC_CHECK_FUNCS(arc4random_buf fchown fsync futimes \
+AC_CHECK_FUNCS(arc4random_buf fsync futimes \
 	getentropy getrandom getspnam getusershell \
 	getutent initgroups lckpwdf lutimes \
 	setgroups updwtmp updwtmpx innetgr getpwnam_r \

--- a/configure.ac
+++ b/configure.ac
@@ -49,7 +49,7 @@ AC_CHECK_FUNCS(arc4random_buf futimes \
 	getentropy getrandom getspnam getusershell \
 	getutent initgroups lckpwdf lutimes \
 	setgroups updwtmp updwtmpx innetgr \
-	getpwuid_r getgrnam_r getgrgid_r getspnam_r \
+	getgrnam_r getgrgid_r getspnam_r \
 	memset_s explicit_bzero)
 AC_SYS_LARGEFILE
 

--- a/configure.ac
+++ b/configure.ac
@@ -100,7 +100,7 @@ fi
 dnl Checks for library functions.
 AC_TYPE_GETGROUPS
 AC_FUNC_UTIME_NULL
-AC_REPLACE_FUNCS(mkdir putgrent putpwent putspent rmdir)
+AC_REPLACE_FUNCS(putgrent putpwent putspent rmdir)
 AC_REPLACE_FUNCS(sgetgrent sgetpwent sgetspent)
 AC_REPLACE_FUNCS(strcasecmp strdup)
 

--- a/configure.ac
+++ b/configure.ac
@@ -45,7 +45,7 @@ AC_CHECK_HEADERS(crypt.h utmp.h \
 dnl shadow now uses the libc's shadow implementation
 AC_CHECK_HEADER([shadow.h],,[AC_MSG_ERROR([You need a libc with shadow.h])])
 
-AC_CHECK_FUNCS(arc4random_buf fsync futimes \
+AC_CHECK_FUNCS(arc4random_buf futimes \
 	getentropy getrandom getspnam getusershell \
 	getutent initgroups lckpwdf lutimes \
 	setgroups updwtmp updwtmpx innetgr getpwnam_r \

--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,7 @@ dnl Checks for libraries.
 
 dnl Checks for header files.
 AC_CHECK_HEADERS(crypt.h utmp.h \
-	termios.h termio.h sgtty.h sys/ioctl.h syslog.h paths.h \
+	termio.h sgtty.h sys/ioctl.h syslog.h paths.h \
 	utime.h ulimit.h sys/capability.h sys/random.h sys/resource.h \
 	gshadow.h lastlog.h rpc/key_prot.h netdb.h acl/libacl.h \
 	attr/libattr.h attr/error_context.h)

--- a/configure.ac
+++ b/configure.ac
@@ -102,7 +102,6 @@ AC_TYPE_GETGROUPS
 AC_FUNC_UTIME_NULL
 AC_REPLACE_FUNCS(putgrent putpwent putspent)
 AC_REPLACE_FUNCS(sgetgrent sgetpwent sgetspent)
-AC_REPLACE_FUNCS(strdup)
 
 AC_CHECK_FUNC(setpgrp)
 AC_CHECK_FUNC(secure_getenv, [AC_DEFINE(HAS_SECURE_GETENV,

--- a/configure.ac
+++ b/configure.ac
@@ -36,7 +36,7 @@ LT_INIT
 dnl Checks for libraries.
 
 dnl Checks for header files.
-AC_CHECK_HEADERS(crypt.h sys/time.h utmp.h \
+AC_CHECK_HEADERS(crypt.h utmp.h \
 	utmpx.h termios.h termio.h sgtty.h sys/ioctl.h syslog.h paths.h \
 	utime.h ulimit.h sys/capability.h sys/random.h sys/resource.h \
 	gshadow.h lastlog.h rpc/key_prot.h netdb.h acl/libacl.h \

--- a/configure.ac
+++ b/configure.ac
@@ -48,7 +48,7 @@ AC_CHECK_HEADER([shadow.h],,[AC_MSG_ERROR([You need a libc with shadow.h])])
 AC_CHECK_FUNCS(arc4random_buf futimes \
 	getentropy getrandom getspnam getusershell \
 	getutent initgroups lckpwdf lutimes \
-	setgroups updwtmp updwtmpx innetgr getpwnam_r \
+	setgroups updwtmp updwtmpx innetgr \
 	getpwuid_r getgrnam_r getgrgid_r getspnam_r \
 	memset_s explicit_bzero)
 AC_SYS_LARGEFILE

--- a/configure.ac
+++ b/configure.ac
@@ -38,7 +38,7 @@ dnl Checks for libraries.
 dnl Checks for header files.
 AC_CHECK_HEADERS(crypt.h utmp.h \
 	termio.h sgtty.h sys/ioctl.h paths.h \
-	ulimit.h sys/capability.h sys/random.h sys/resource.h \
+	sys/capability.h sys/random.h sys/resource.h \
 	gshadow.h lastlog.h rpc/key_prot.h netdb.h acl/libacl.h \
 	attr/libattr.h attr/error_context.h)
 

--- a/configure.ac
+++ b/configure.ac
@@ -49,7 +49,7 @@ AC_CHECK_FUNCS(arc4random_buf futimes \
 	getentropy getrandom getspnam getusershell \
 	getutent initgroups lckpwdf lutimes \
 	setgroups updwtmp updwtmpx innetgr \
-	getgrnam_r getgrgid_r getspnam_r \
+	getgrgid_r getspnam_r \
 	memset_s explicit_bzero)
 AC_SYS_LARGEFILE
 

--- a/configure.ac
+++ b/configure.ac
@@ -36,7 +36,7 @@ LT_INIT
 dnl Checks for libraries.
 
 dnl Checks for header files.
-AC_CHECK_HEADERS(crypt.h fcntl.h unistd.h sys/time.h utmp.h \
+AC_CHECK_HEADERS(crypt.h unistd.h sys/time.h utmp.h \
 	utmpx.h termios.h termio.h sgtty.h sys/ioctl.h syslog.h paths.h \
 	utime.h ulimit.h sys/capability.h sys/random.h sys/resource.h \
 	gshadow.h lastlog.h rpc/key_prot.h netdb.h acl/libacl.h \

--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,7 @@ dnl Checks for libraries.
 
 dnl Checks for header files.
 AC_CHECK_HEADERS(crypt.h utmp.h \
-	termio.h sgtty.h sys/ioctl.h syslog.h paths.h \
+	termio.h sgtty.h sys/ioctl.h paths.h \
 	utime.h ulimit.h sys/capability.h sys/random.h sys/resource.h \
 	gshadow.h lastlog.h rpc/key_prot.h netdb.h acl/libacl.h \
 	attr/libattr.h attr/error_context.h)

--- a/configure.ac
+++ b/configure.ac
@@ -337,7 +337,6 @@ dnl Check for some functions in libc first, only if not found check for
 dnl other libraries.  This should prevent linking libnsl if not really
 dnl needed (Linux glibc, Irix), but still link it if needed (Solaris).
 
-AC_SEARCH_LIBS(inet_ntoa, inet)
 AC_SEARCH_LIBS(socket, socket)
 AC_SEARCH_LIBS(gethostbyname, nsl)
 

--- a/configure.ac
+++ b/configure.ac
@@ -192,6 +192,7 @@ AC_DEFINE_UNQUOTED(PASSWD_PROGRAM, "$shadow_cv_passwd_dir/passwd",
 	[Path to passwd program.])
 
 dnl XXX - quick hack, should disappear before anyone notices :).
+dnl XXX - I just read the above message :).
 AC_DEFINE(USE_SYSLOG, 1, [Define to use syslog().])
 if test "$ac_cv_func_ruserok" = "yes"; then
 	AC_DEFINE(RLOGIN, 1, [Define if login should support the -r flag for rlogind.])

--- a/configure.ac
+++ b/configure.ac
@@ -38,7 +38,7 @@ dnl Checks for libraries.
 dnl Checks for header files.
 AC_CHECK_HEADERS(crypt.h utmp.h \
 	termio.h sgtty.h sys/ioctl.h paths.h \
-	utime.h ulimit.h sys/capability.h sys/random.h sys/resource.h \
+	ulimit.h sys/capability.h sys/random.h sys/resource.h \
 	gshadow.h lastlog.h rpc/key_prot.h netdb.h acl/libacl.h \
 	attr/libattr.h attr/error_context.h)
 

--- a/configure.ac
+++ b/configure.ac
@@ -337,7 +337,6 @@ dnl Check for some functions in libc first, only if not found check for
 dnl other libraries.  This should prevent linking libnsl if not really
 dnl needed (Linux glibc, Irix), but still link it if needed (Solaris).
 
-AC_SEARCH_LIBS(socket, socket)
 AC_SEARCH_LIBS(gethostbyname, nsl)
 
 AC_CHECK_LIB([econf],[econf_readDirs],[LIBECONF="-leconf"],[LIBECONF=""])

--- a/configure.ac
+++ b/configure.ac
@@ -49,7 +49,7 @@ AC_CHECK_FUNCS(arc4random_buf futimes \
 	getentropy getrandom getspnam getusershell \
 	getutent initgroups lckpwdf lutimes \
 	setgroups updwtmp updwtmpx innetgr \
-	getgrgid_r getspnam_r \
+	getspnam_r \
 	memset_s explicit_bzero)
 AC_SYS_LARGEFILE
 

--- a/configure.ac
+++ b/configure.ac
@@ -36,7 +36,7 @@ LT_INIT
 dnl Checks for libraries.
 
 dnl Checks for header files.
-AC_CHECK_HEADERS(crypt.h unistd.h sys/time.h utmp.h \
+AC_CHECK_HEADERS(crypt.h sys/time.h utmp.h \
 	utmpx.h termios.h termio.h sgtty.h sys/ioctl.h syslog.h paths.h \
 	utime.h ulimit.h sys/capability.h sys/random.h sys/resource.h \
 	gshadow.h lastlog.h rpc/key_prot.h netdb.h acl/libacl.h \

--- a/configure.ac
+++ b/configure.ac
@@ -102,7 +102,7 @@ AC_TYPE_GETGROUPS
 AC_FUNC_UTIME_NULL
 AC_REPLACE_FUNCS(putgrent putpwent putspent)
 AC_REPLACE_FUNCS(sgetgrent sgetpwent sgetspent)
-AC_REPLACE_FUNCS(strcasecmp strdup)
+AC_REPLACE_FUNCS(strdup)
 
 AC_CHECK_FUNC(setpgrp)
 AC_CHECK_FUNC(secure_getenv, [AC_DEFINE(HAS_SECURE_GETENV,

--- a/configure.ac
+++ b/configure.ac
@@ -45,7 +45,7 @@ AC_CHECK_HEADERS(crypt.h utmp.h \
 dnl shadow now uses the libc's shadow implementation
 AC_CHECK_HEADER([shadow.h],,[AC_MSG_ERROR([You need a libc with shadow.h])])
 
-AC_CHECK_FUNCS(arc4random_buf l64a fchmod fchown fsync futimes \
+AC_CHECK_FUNCS(arc4random_buf fchmod fchown fsync futimes \
 	getentropy getrandom getspnam getusershell \
 	getutent initgroups lckpwdf lutimes \
 	setgroups updwtmp updwtmpx innetgr getpwnam_r \

--- a/configure.ac
+++ b/configure.ac
@@ -45,7 +45,7 @@ AC_CHECK_HEADERS(crypt.h utmp.h \
 dnl shadow now uses the libc's shadow implementation
 AC_CHECK_HEADER([shadow.h],,[AC_MSG_ERROR([You need a libc with shadow.h])])
 
-AC_CHECK_FUNCS(arc4random_buf fchmod fchown fsync futimes \
+AC_CHECK_FUNCS(arc4random_buf fchown fsync futimes \
 	getentropy getrandom getspnam getusershell \
 	getutent initgroups lckpwdf lutimes \
 	setgroups updwtmp updwtmpx innetgr getpwnam_r \

--- a/configure.ac
+++ b/configure.ac
@@ -38,7 +38,7 @@ dnl Checks for libraries.
 dnl Checks for header files.
 AC_CHECK_HEADERS(crypt.h utmp.h \
 	termio.h sgtty.h sys/ioctl.h paths.h \
-	sys/capability.h sys/random.h sys/resource.h \
+	sys/capability.h sys/random.h \
 	gshadow.h lastlog.h rpc/key_prot.h netdb.h acl/libacl.h \
 	attr/libattr.h attr/error_context.h)
 

--- a/lib/commonio.c
+++ b/lib/commonio.c
@@ -261,15 +261,10 @@ static /*@null@*/ /*@dependent@*/FILE *fopen_set_perms (
 	}
 #endif				/* !HAVE_FCHOWN */
 
-#ifdef HAVE_FCHMOD
 	if (fchmod (fileno (fp), sb->st_mode & 0664) != 0) {
 		goto fail;
 	}
-#else				/* !HAVE_FCHMOD */
-	if (chmod (name, sb->st_mode & 0664) != 0) {
-		goto fail;
-	}
-#endif				/* !HAVE_FCHMOD */
+
 	return fp;
 
       fail:

--- a/lib/commonio.c
+++ b/lib/commonio.c
@@ -251,16 +251,9 @@ static /*@null@*/ /*@dependent@*/FILE *fopen_set_perms (
 		return NULL;
 	}
 
-#ifdef HAVE_FCHOWN
 	if (fchown (fileno (fp), sb->st_uid, sb->st_gid) != 0) {
 		goto fail;
 	}
-#else				/* !HAVE_FCHOWN */
-	if (chown (name, sb->st_mode) != 0) {
-		goto fail;
-	}
-#endif				/* !HAVE_FCHOWN */
-
 	if (fchmod (fileno (fp), sb->st_mode & 0664) != 0) {
 		goto fail;
 	}

--- a/lib/commonio.c
+++ b/lib/commonio.c
@@ -986,13 +986,11 @@ int commonio_close (struct commonio_db *db)
 	if (fflush (db->fp) != 0) {
 		errors++;
 	}
-#ifdef HAVE_FSYNC
+
 	if (fsync (fileno (db->fp)) != 0) {
 		errors++;
 	}
-#else				/* !HAVE_FSYNC */
-	sync ();
-#endif				/* !HAVE_FSYNC */
+
 	if (fclose (db->fp) != 0) {
 		errors++;
 	}

--- a/lib/defines.h
+++ b/lib/defines.h
@@ -154,19 +154,6 @@ static inline void memzero(void *ptr, size_t size)
 
 #define OPENLOG(progname) openlog(progname, SYSLOG_OPTIONS, SYSLOG_FACILITY)
 
-#ifndef F_OK
-# define F_OK 0
-# define X_OK 1
-# define W_OK 2
-# define R_OK 4
-#endif
-
-#ifndef SEEK_SET
-# define SEEK_SET 0
-# define SEEK_CUR 1
-# define SEEK_END 2
-#endif
-
 #include <termios.h>
 #define STTY(fd, termio) tcsetattr(fd, TCSANOW, termio)
 #define GTTY(fd, termio) tcgetattr(fd, termio)

--- a/lib/defines.h
+++ b/lib/defines.h
@@ -7,17 +7,6 @@
 #include "config.h"
 
 #include <stdbool.h>
-
-/* Take care of NLS matters.  */
-#ifdef S_SPLINT_S
-extern char *setlocale(int categories, const char *locale);
-# define LC_ALL		(6)
-extern char * bindtextdomain (const char * domainname, const char * dirname);
-extern char * textdomain (const char * domainname);
-# define _(Text) Text
-# define ngettext(Msgid1, Msgid2, N) \
-    ((N) == 1 ? (const char *) (Msgid1) : (const char *) (Msgid2))
-#else
 #include <locale.h>
 
 #define gettext_noop(String) (String)
@@ -34,7 +23,6 @@ extern char * textdomain (const char * domainname);
 # define _(Text) Text
 # define ngettext(Msgid1, Msgid2, N) \
     ((N) == 1 ? (const char *) (Msgid1) : (const char *) (Msgid2))
-#endif
 #endif
 
 #include <stdlib.h>

--- a/lib/defines.h
+++ b/lib/defines.h
@@ -158,7 +158,6 @@ static inline void memzero(void *ptr, size_t size)
 #define STTY(fd, termio) tcsetattr(fd, TCSANOW, termio)
 #define GTTY(fd, termio) tcgetattr(fd, termio)
 #define TERMIO struct termios
-#define USE_TERMIOS
 
 /*
  * Password aging constants

--- a/lib/defines.h
+++ b/lib/defines.h
@@ -46,9 +46,7 @@ extern char * textdomain (const char * domainname);
 #include <sys/types.h>
 #include <sys/wait.h>
 
-#if HAVE_UNISTD_H
-# include <unistd.h>
-#endif
+#include <unistd.h>
 
 /*
  * crypt(3), crypt_gensalt(3), and their

--- a/lib/defines.h
+++ b/lib/defines.h
@@ -279,21 +279,8 @@ extern char *strdup ();
 #endif
 
 /* Maximum length of usernames */
-#ifdef HAVE_UTMPX_H
-# include <utmpx.h>
-# define USER_NAME_MAX_LENGTH (sizeof (((struct utmpx *)NULL)->ut_user))
-#else
-# include <utmp.h>
-# ifdef HAVE_STRUCT_UTMP_UT_USER
-#  define USER_NAME_MAX_LENGTH (sizeof (((struct utmp *)NULL)->ut_user))
-# else
-#  ifdef HAVE_STRUCT_UTMP_UT_NAME
-#   define USER_NAME_MAX_LENGTH (sizeof (((struct utmp *)NULL)->ut_name))
-#  else
-#   define USER_NAME_MAX_LENGTH 32
-#  endif
-# endif
-#endif
+#include <utmpx.h>
+#define USER_NAME_MAX_LENGTH (sizeof (((struct utmpx *)NULL)->ut_user))
 
 /* Maximum length of passwd entry */
 #define PASSWD_ENTRY_MAX_LENGTH 32768

--- a/lib/defines.h
+++ b/lib/defines.h
@@ -232,12 +232,6 @@ static inline void memzero(void *ptr, size_t size)
 #endif
 #endif
 
-#ifdef sun			/* hacks for compiling on SunOS */
-# ifndef SOLARIS
-extern char *strdup ();
-# endif
-#endif
-
 /*
  * string to use for the pw_passwd field in /etc/passwd when using
  * shadow passwords - most systems use "x" but there are a few

--- a/lib/defines.h
+++ b/lib/defines.h
@@ -179,20 +179,11 @@ static inline void memzero(void *ptr, size_t size)
 # define SEEK_END 2
 #endif
 
-#if HAVE_TERMIOS_H
-# include <termios.h>
-# define STTY(fd, termio) tcsetattr(fd, TCSANOW, termio)
-# define GTTY(fd, termio) tcgetattr(fd, termio)
-# define TERMIO struct termios
-# define USE_TERMIOS
-#else				/* assumed HAVE_TERMIO_H */
-# include <sys/ioctl.h>
-# include <termio.h>
-# define STTY(fd, termio) ioctl(fd, TCSETA, termio)
-# define GTTY(fd, termio) ioctl(fd, TCGETA, termio)
-# define TEMRIO struct termio
-# define USE_TERMIO
-#endif
+#include <termios.h>
+#define STTY(fd, termio) tcsetattr(fd, TCSANOW, termio)
+#define GTTY(fd, termio) tcgetattr(fd, termio)
+#define TERMIO struct termios
+#define USE_TERMIOS
 
 /*
  * Password aging constants

--- a/libmisc/limits.c
+++ b/libmisc/limits.c
@@ -239,13 +239,11 @@ static int do_user_limits (const char *buf, const char *name)
 
 	while ('\0' != *pp) {
 		switch (*pp++) {
-#ifdef RLIMIT_AS
 		case 'a':
 		case 'A':
 			/* RLIMIT_AS - max address space (KB) */
 			retval |= setrlimit_value (RLIMIT_AS, pp, 1024);
 			break;
-#endif
 		case 'c':
 		case 'C':
 			/* RLIMIT_CORE - max core file size (KB) */

--- a/libmisc/limits.c
+++ b/libmisc/limits.c
@@ -28,10 +28,8 @@
 #include <pwd.h>
 #include "getdef.h"
 #include "shadowlog.h"
-#ifdef HAVE_SYS_RESOURCE_H
 #include <sys/resource.h>
 #define LIMITS
-#endif
 #ifdef LIMITS
 #ifndef LIMITS_FILE
 #define LIMITS_FILE "/etc/limits"

--- a/libmisc/limits.c
+++ b/libmisc/limits.c
@@ -29,8 +29,6 @@
 #include "getdef.h"
 #include "shadowlog.h"
 #include <sys/resource.h>
-#define LIMITS
-#ifdef LIMITS
 #ifndef LIMITS_FILE
 #define LIMITS_FILE "/etc/limits"
 #endif
@@ -477,7 +475,6 @@ static int setup_user_limits (const char *uname)
 	}
 	return do_user_limits (limits, uname);
 }
-#endif				/* LIMITS */
 
 
 static void setup_usergroups (const struct passwd *info)
@@ -521,7 +518,6 @@ void setup_limits (const struct passwd *info)
 	 */
 
 	if (getdef_bool ("QUOTAS_ENAB")) {
-#ifdef LIMITS
 		if (info->pw_uid != 0) {
 			if ((setup_user_limits (info->pw_name) & LOGIN_ERROR_LOGIN) != 0) {
 				(void) fputs (_("Too many logins.\n"), log_get_logfd());
@@ -529,7 +525,6 @@ void setup_limits (const struct passwd *info)
 				exit (EXIT_FAILURE);
 			}
 		}
-#endif
 		for (cp = info->pw_gecos; cp != NULL; cp = strchr (cp, ',')) {
 			if (',' == *cp) {
 				cp++;

--- a/libmisc/limits.c
+++ b/libmisc/limits.c
@@ -305,13 +305,11 @@ static int do_user_limits (const char *buf, const char *name)
 			retval |= setrlimit_value (RLIMIT_RSS, pp, 1024);
 			break;
 #endif
-#ifdef RLIMIT_STACK
 		case 's':
 		case 'S':
 			/* RLIMIT_STACK - max stack size (KB) */
 			retval |= setrlimit_value (RLIMIT_STACK, pp, 1024);
 			break;
-#endif
 		case 't':
 		case 'T':
 			/* RLIMIT_CPU - max CPU time (MIN) */

--- a/libmisc/limits.c
+++ b/libmisc/limits.c
@@ -318,13 +318,11 @@ static int do_user_limits (const char *buf, const char *name)
 			retval |= setrlimit_value (RLIMIT_STACK, pp, 1024);
 			break;
 #endif
-#ifdef RLIMIT_CPU
 		case 't':
 		case 'T':
 			/* RLIMIT_CPU - max CPU time (MIN) */
 			retval |= setrlimit_value (RLIMIT_CPU, pp, 60);
 			break;
-#endif
 #ifdef RLIMIT_NPROC
 		case 'u':
 		case 'U':

--- a/libmisc/limits.c
+++ b/libmisc/limits.c
@@ -249,13 +249,11 @@ static int do_user_limits (const char *buf, const char *name)
 			/* RLIMIT_CORE - max core file size (KB) */
 			retval |= setrlimit_value (RLIMIT_CORE, pp, 1024);
 			break;
-#ifdef RLIMIT_DATA
 		case 'd':
 		case 'D':
 			/* RLIMIT_DATA - max data size (KB) */
 			retval |= setrlimit_value (RLIMIT_DATA, pp, 1024);
 			break;
-#endif
 #ifdef RLIMIT_FSIZE
 		case 'f':
 		case 'F':

--- a/libmisc/limits.c
+++ b/libmisc/limits.c
@@ -282,13 +282,11 @@ static int do_user_limits (const char *buf, const char *name)
 			retval |= setrlimit_value (RLIMIT_MEMLOCK, pp, 1024);
 			break;
 #endif
-#ifdef RLIMIT_NOFILE
 		case 'n':
 		case 'N':
 			/* RLIMIT_NOFILE - max number of open files */
 			retval |= setrlimit_value (RLIMIT_NOFILE, pp, 1);
 			break;
-#endif
 #ifdef RLIMIT_RTPRIO
 		case 'o':
 		case 'O':

--- a/libmisc/limits.c
+++ b/libmisc/limits.c
@@ -246,13 +246,11 @@ static int do_user_limits (const char *buf, const char *name)
 			retval |= setrlimit_value (RLIMIT_AS, pp, 1024);
 			break;
 #endif
-#ifdef RLIMIT_CORE
 		case 'c':
 		case 'C':
 			/* RLIMIT_CORE - max core file size (KB) */
 			retval |= setrlimit_value (RLIMIT_CORE, pp, 1024);
 			break;
-#endif
 #ifdef RLIMIT_DATA
 		case 'd':
 		case 'D':

--- a/libmisc/limits.c
+++ b/libmisc/limits.c
@@ -254,13 +254,11 @@ static int do_user_limits (const char *buf, const char *name)
 			/* RLIMIT_DATA - max data size (KB) */
 			retval |= setrlimit_value (RLIMIT_DATA, pp, 1024);
 			break;
-#ifdef RLIMIT_FSIZE
 		case 'f':
 		case 'F':
 			/* RLIMIT_FSIZE - Maximum filesize (KB) */
 			retval |= setrlimit_value (RLIMIT_FSIZE, pp, 1024);
 			break;
-#endif
 #ifdef RLIMIT_NICE
 		case 'i':
 		case 'I':

--- a/libmisc/loginprompt.c
+++ b/libmisc/loginprompt.c
@@ -42,21 +42,16 @@ void login_prompt (const char *prompt, char *name, int namesize)
 	FILE *fp;
 
 	sighandler_t sigquit;
-#ifdef	SIGTSTP
 	sighandler_t sigtstp;
-#endif
 
 	/*
 	 * There is a small chance that a QUIT character will be part of
 	 * some random noise during a prompt.  Deal with this by exiting
-	 * instead of core dumping.  If SIGTSTP is defined, do the same
-	 * thing for that signal.
+	 * instead of core dumping.  Do the same thing for SIGTSTP.
 	 */
 
 	sigquit = signal (SIGQUIT, login_exit);
-#ifdef	SIGTSTP
 	sigtstp = signal (SIGTSTP, login_exit);
-#endif
 
 	/*
 	 * See if the user has configured the issue file to
@@ -148,8 +143,6 @@ void login_prompt (const char *prompt, char *name, int namesize)
 	 */
 
 	(void) signal (SIGQUIT, sigquit);
-#ifdef	SIGTSTP
 	(void) signal (SIGTSTP, sigtstp);
-#endif
 }
 

--- a/libmisc/pwd_init.c
+++ b/libmisc/pwd_init.c
@@ -37,9 +37,7 @@ void pwd_init (void)
 	setrlimit (RLIMIT_CPU, &rlim);
 	setrlimit (RLIMIT_DATA, &rlim);
 	setrlimit (RLIMIT_FSIZE, &rlim);
-#ifdef RLIMIT_NOFILE
 	setrlimit (RLIMIT_NOFILE, &rlim);
-#endif
 #ifdef RLIMIT_RSS
 	setrlimit (RLIMIT_RSS, &rlim);
 #endif

--- a/libmisc/pwd_init.c
+++ b/libmisc/pwd_init.c
@@ -50,9 +50,7 @@ void pwd_init (void)
 	signal (SIGQUIT, SIG_IGN);
 	signal (SIGTERM, SIG_IGN);
 	signal (SIGTSTP, SIG_IGN);
-#ifdef SIGTTOU
 	signal (SIGTTOU, SIG_IGN);
-#endif
 
 	umask (077);
 }

--- a/libmisc/pwd_init.c
+++ b/libmisc/pwd_init.c
@@ -31,32 +31,32 @@ void pwd_init (void)
 #ifdef HAVE_SYS_RESOURCE_H
 	struct rlimit rlim;
 
-#ifdef RLIMIT_CORE
+# ifdef RLIMIT_CORE
 	rlim.rlim_cur = rlim.rlim_max = 0;
 	setrlimit (RLIMIT_CORE, &rlim);
-#endif
+# endif
 	rlim.rlim_cur = rlim.rlim_max = RLIM_INFINITY;
-#ifdef RLIMIT_AS
+# ifdef RLIMIT_AS
 	setrlimit (RLIMIT_AS, &rlim);
-#endif
-#ifdef RLIMIT_CPU
+# endif
+# ifdef RLIMIT_CPU
 	setrlimit (RLIMIT_CPU, &rlim);
-#endif
-#ifdef RLIMIT_DATA
+# endif
+# ifdef RLIMIT_DATA
 	setrlimit (RLIMIT_DATA, &rlim);
-#endif
-#ifdef RLIMIT_FSIZE
+# endif
+# ifdef RLIMIT_FSIZE
 	setrlimit (RLIMIT_FSIZE, &rlim);
-#endif
-#ifdef RLIMIT_NOFILE
+# endif
+# ifdef RLIMIT_NOFILE
 	setrlimit (RLIMIT_NOFILE, &rlim);
-#endif
-#ifdef RLIMIT_RSS
+# endif
+# ifdef RLIMIT_RSS
 	setrlimit (RLIMIT_RSS, &rlim);
-#endif
-#ifdef RLIMIT_STACK
+# endif
+# ifdef RLIMIT_STACK
 	setrlimit (RLIMIT_STACK, &rlim);
-#endif
+# endif
 #else				/* !HAVE_SYS_RESOURCE_H */
 	set_filesize_limit (30000);
 	/* don't know how to set the other limits... */

--- a/libmisc/pwd_init.c
+++ b/libmisc/pwd_init.c
@@ -15,9 +15,7 @@
 #include <signal.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#ifdef HAVE_SYS_RESOURCE_H
 #include <sys/resource.h>
-#endif
 
 #include "prototypes.h"
 
@@ -28,39 +26,34 @@
  */
 void pwd_init (void)
 {
-#ifdef HAVE_SYS_RESOURCE_H
 	struct rlimit rlim;
 
-# ifdef RLIMIT_CORE
+#ifdef RLIMIT_CORE
 	rlim.rlim_cur = rlim.rlim_max = 0;
 	setrlimit (RLIMIT_CORE, &rlim);
-# endif
+#endif
 	rlim.rlim_cur = rlim.rlim_max = RLIM_INFINITY;
-# ifdef RLIMIT_AS
+#ifdef RLIMIT_AS
 	setrlimit (RLIMIT_AS, &rlim);
-# endif
-# ifdef RLIMIT_CPU
+#endif
+#ifdef RLIMIT_CPU
 	setrlimit (RLIMIT_CPU, &rlim);
-# endif
-# ifdef RLIMIT_DATA
+#endif
+#ifdef RLIMIT_DATA
 	setrlimit (RLIMIT_DATA, &rlim);
-# endif
-# ifdef RLIMIT_FSIZE
+#endif
+#ifdef RLIMIT_FSIZE
 	setrlimit (RLIMIT_FSIZE, &rlim);
-# endif
-# ifdef RLIMIT_NOFILE
+#endif
+#ifdef RLIMIT_NOFILE
 	setrlimit (RLIMIT_NOFILE, &rlim);
-# endif
-# ifdef RLIMIT_RSS
+#endif
+#ifdef RLIMIT_RSS
 	setrlimit (RLIMIT_RSS, &rlim);
-# endif
-# ifdef RLIMIT_STACK
+#endif
+#ifdef RLIMIT_STACK
 	setrlimit (RLIMIT_STACK, &rlim);
-# endif
-#else				/* !HAVE_SYS_RESOURCE_H */
-	set_filesize_limit (30000);
-	/* don't know how to set the other limits... */
-#endif				/* !HAVE_SYS_RESOURCE_H */
+#endif
 
 	signal (SIGALRM, SIG_IGN);
 	signal (SIGHUP, SIG_IGN);

--- a/libmisc/pwd_init.c
+++ b/libmisc/pwd_init.c
@@ -36,9 +36,7 @@ void pwd_init (void)
 
 	setrlimit (RLIMIT_CPU, &rlim);
 	setrlimit (RLIMIT_DATA, &rlim);
-#ifdef RLIMIT_FSIZE
 	setrlimit (RLIMIT_FSIZE, &rlim);
-#endif
 #ifdef RLIMIT_NOFILE
 	setrlimit (RLIMIT_NOFILE, &rlim);
 #endif

--- a/libmisc/pwd_init.c
+++ b/libmisc/pwd_init.c
@@ -49,9 +49,7 @@ void pwd_init (void)
 	signal (SIGPIPE, SIG_IGN);
 	signal (SIGQUIT, SIG_IGN);
 	signal (SIGTERM, SIG_IGN);
-#ifdef SIGTSTP
 	signal (SIGTSTP, SIG_IGN);
-#endif
 #ifdef SIGTTOU
 	signal (SIGTTOU, SIG_IGN);
 #endif

--- a/libmisc/pwd_init.c
+++ b/libmisc/pwd_init.c
@@ -32,9 +32,8 @@ void pwd_init (void)
 	setrlimit (RLIMIT_CORE, &rlim);
 
 	rlim.rlim_cur = rlim.rlim_max = RLIM_INFINITY;
-#ifdef RLIMIT_AS
 	setrlimit (RLIMIT_AS, &rlim);
-#endif
+
 #ifdef RLIMIT_CPU
 	setrlimit (RLIMIT_CPU, &rlim);
 #endif

--- a/libmisc/pwd_init.c
+++ b/libmisc/pwd_init.c
@@ -35,9 +35,7 @@ void pwd_init (void)
 	setrlimit (RLIMIT_AS, &rlim);
 
 	setrlimit (RLIMIT_CPU, &rlim);
-#ifdef RLIMIT_DATA
 	setrlimit (RLIMIT_DATA, &rlim);
-#endif
 #ifdef RLIMIT_FSIZE
 	setrlimit (RLIMIT_FSIZE, &rlim);
 #endif

--- a/libmisc/pwd_init.c
+++ b/libmisc/pwd_init.c
@@ -34,9 +34,7 @@ void pwd_init (void)
 	rlim.rlim_cur = rlim.rlim_max = RLIM_INFINITY;
 	setrlimit (RLIMIT_AS, &rlim);
 
-#ifdef RLIMIT_CPU
 	setrlimit (RLIMIT_CPU, &rlim);
-#endif
 #ifdef RLIMIT_DATA
 	setrlimit (RLIMIT_DATA, &rlim);
 #endif

--- a/libmisc/pwd_init.c
+++ b/libmisc/pwd_init.c
@@ -41,9 +41,7 @@ void pwd_init (void)
 #ifdef RLIMIT_RSS
 	setrlimit (RLIMIT_RSS, &rlim);
 #endif
-#ifdef RLIMIT_STACK
 	setrlimit (RLIMIT_STACK, &rlim);
-#endif
 
 	signal (SIGALRM, SIG_IGN);
 	signal (SIGHUP, SIG_IGN);

--- a/libmisc/pwd_init.c
+++ b/libmisc/pwd_init.c
@@ -28,10 +28,9 @@ void pwd_init (void)
 {
 	struct rlimit rlim;
 
-#ifdef RLIMIT_CORE
 	rlim.rlim_cur = rlim.rlim_max = 0;
 	setrlimit (RLIMIT_CORE, &rlim);
-#endif
+
 	rlim.rlim_cur = rlim.rlim_max = RLIM_INFINITY;
 #ifdef RLIMIT_AS
 	setrlimit (RLIMIT_AS, &rlim);

--- a/libmisc/rlogin.c
+++ b/libmisc/rlogin.c
@@ -23,68 +23,22 @@ static struct {
 	int spd_baud;
 } speed_table[] =
 {
-#ifdef B50
-	{
-	B50, 50},
-#endif
-#ifdef B75
-	{
-	B75, 75},
-#endif
-#ifdef B110
-	{
-	B110, 110},
-#endif
-#ifdef B134
-	{
-	B134, 134},
-#endif
-#ifdef B150
-	{
-	B150, 150},
-#endif
-#ifdef B200
-	{
-	B200, 200},
-#endif
-#ifdef B300
-	{
-	B300, 300},
-#endif
-#ifdef B600
-	{
-	B600, 600},
-#endif
-#ifdef B1200
-	{
-	B1200, 1200},
-#endif
-#ifdef B1800
-	{
-	B1800, 1800},
-#endif
-#ifdef B2400
-	{
-	B2400, 2400},
-#endif
-#ifdef B4800
-	{
-	B4800, 4800},
-#endif
-#ifdef B9600
-	{
-	B9600, 9600},
-#endif
-#ifdef B19200
-	{
-	B19200, 19200},
-#endif
-#ifdef B38400
-	{
-	B38400, 38400},
-#endif
-	{
-	-1, -1}
+	{ B50, 50},
+	{ B75, 75},
+	{ B110, 110},
+	{ B134, 134},
+	{ B150, 150},
+	{ B200, 200},
+	{ B300, 300},
+	{ B600, 600},
+	{ B1200, 1200},
+	{ B1800, 1800},
+	{ B2400, 2400},
+	{ B4800, 4800},
+	{ B9600, 9600},
+	{ B19200, 19200},
+	{ B38400, 38400},
+	{ -1, -1}
 };
 
 static void get_remote_string (char *buf, size_t size)

--- a/libmisc/salt.c
+++ b/libmisc/salt.c
@@ -10,8 +10,6 @@
  *
  * Written by Marek Michalkiewicz <marekm@i17linuxb.ists.pwr.wroc.pl>,
  * it is in the public domain.
- *
- * l64a was Written by J.T. Conklin <jtc@netbsd.org>. Public domain.
  */
 
 #include <config.h>
@@ -110,42 +108,6 @@ static /*@observer@*/void BCRYPT_salt_rounds_to_buf (char *buf, unsigned long ro
 static /*@observer@*/unsigned long YESCRYPT_get_salt_cost (/*@null@*/const int *prefered_cost);
 static /*@observer@*/void YESCRYPT_salt_cost_to_buf (char *buf, unsigned long cost);
 #endif /* USE_YESCRYPT */
-
-#if !USE_XCRYPT_GENSALT && !defined(HAVE_L64A)
-static /*@observer@*/char *l64a (long value)
-{
-	static char buf[8];
-	char *s = buf;
-	int digit;
-	int i;
-
-	if (value < 0) {
-		errno = EINVAL;
-		return(NULL);
-	}
-
-	for (i = 0; value != 0 && i < 6; i++) {
-		digit = value & 0x3f;
-
-		if (digit < 2) {
-			*s = digit + '.';
-		} else if (digit < 12) {
-			*s = digit + '0' - 2;
-		} else if (digit < 38) {
-			*s = digit + 'A' - 12;
-		} else {
-			*s = digit + 'a' - 38;
-		}
-
-		value >>= 6;
-		s++;
-	}
-
-	*s = '\0';
-
-	return buf;
-}
-#endif /* !USE_XCRYPT_GENSALT && !defined(HAVE_L64A) */
 
 /* Read sizeof (long) random bytes from /dev/urandom. */
 static long read_random_bytes (void)

--- a/libmisc/ulimit.c
+++ b/libmisc/ulimit.c
@@ -11,8 +11,7 @@
 
 #ident "$Id$"
 
-#include <sys/time.h>		/* for struct timeval on sunos4 */
-/* XXX - is the above ok or should it be <time.h> on ultrix? */
+#include <sys/time.h>
 #include <sys/resource.h>
 #include "prototypes.h"
 

--- a/libmisc/ulimit.c
+++ b/libmisc/ulimit.c
@@ -12,18 +12,18 @@
 #ident "$Id$"
 
 #if HAVE_ULIMIT_H
-#include <ulimit.h>
-#ifndef UL_SETFSIZE
-#ifdef UL_SFILLIM
-#define UL_SETFSIZE UL_SFILLIM
-#else
-#define UL_SETFSIZE 2
-#endif
-#endif
+# include <ulimit.h>
+# ifndef UL_SETFSIZE
+#  ifdef UL_SFILLIM
+#   define UL_SETFSIZE UL_SFILLIM
+#  else
+#   define UL_SETFSIZE 2
+#  endif
+# endif
 #elif HAVE_SYS_RESOURCE_H
-#include <sys/time.h>		/* for struct timeval on sunos4 */
+# include <sys/time.h>		/* for struct timeval on sunos4 */
 /* XXX - is the above ok or should it be <time.h> on ultrix? */
-#include <sys/resource.h>
+# include <sys/resource.h>
 #endif
 #include "prototypes.h"
 

--- a/libmisc/ulimit.c
+++ b/libmisc/ulimit.c
@@ -19,13 +19,11 @@
 int set_filesize_limit (int blocks)
 {
 	int ret = -1;
-#if defined(RLIMIT_FSIZE)
 	struct rlimit rlimit_fsize;
 
 	rlimit_fsize.rlim_cur = 512L * blocks;
 	rlimit_fsize.rlim_max = rlimit_fsize.rlim_cur;
 	ret = setrlimit (RLIMIT_FSIZE, &rlimit_fsize);
-#endif
 
 	return ret;
 }

--- a/libmisc/ulimit.c
+++ b/libmisc/ulimit.c
@@ -11,11 +11,9 @@
 
 #ident "$Id$"
 
-#if HAVE_SYS_RESOURCE_H
-# include <sys/time.h>		/* for struct timeval on sunos4 */
+#include <sys/time.h>		/* for struct timeval on sunos4 */
 /* XXX - is the above ok or should it be <time.h> on ultrix? */
-# include <sys/resource.h>
-#endif
+#include <sys/resource.h>
 #include "prototypes.h"
 
 int set_filesize_limit (int blocks)

--- a/libmisc/ulimit.c
+++ b/libmisc/ulimit.c
@@ -11,16 +11,7 @@
 
 #ident "$Id$"
 
-#if HAVE_ULIMIT_H
-# include <ulimit.h>
-# ifndef UL_SETFSIZE
-#  ifdef UL_SFILLIM
-#   define UL_SETFSIZE UL_SFILLIM
-#  else
-#   define UL_SETFSIZE 2
-#  endif
-# endif
-#elif HAVE_SYS_RESOURCE_H
+#if HAVE_SYS_RESOURCE_H
 # include <sys/time.h>		/* for struct timeval on sunos4 */
 /* XXX - is the above ok or should it be <time.h> on ultrix? */
 # include <sys/resource.h>
@@ -30,11 +21,7 @@
 int set_filesize_limit (int blocks)
 {
 	int ret = -1;
-#if HAVE_ULIMIT_H
-	if (ulimit (UL_SETFSIZE, blocks) != -1) {
-		ret = 0;
-	}
-#elif defined(RLIMIT_FSIZE)
+#if defined(RLIMIT_FSIZE)
 	struct rlimit rlimit_fsize;
 
 	rlimit_fsize.rlim_cur = 512L * blocks;

--- a/libmisc/xgetgrgid.c
+++ b/libmisc/xgetgrgid.c
@@ -35,7 +35,7 @@
 #define ARG_TYPE	gid_t
 #define ARG_NAME	gid
 #define DUP_FUNCTION	__gr_dup
-#define HAVE_FUNCTION_R (defined HAVE_GETGRGID_R)
+#define HAVE_FUNCTION_R 1
 
 #include "xgetXXbyYY.c"
 

--- a/libmisc/xgetgrnam.c
+++ b/libmisc/xgetgrnam.c
@@ -35,7 +35,7 @@
 #define ARG_TYPE	const char *
 #define ARG_NAME	name
 #define DUP_FUNCTION	__gr_dup
-#define HAVE_FUNCTION_R (defined HAVE_GETGRNAM_R)
+#define HAVE_FUNCTION_R 1
 
 #include "xgetXXbyYY.c"
 

--- a/libmisc/xgetpwnam.c
+++ b/libmisc/xgetpwnam.c
@@ -35,7 +35,7 @@
 #define ARG_TYPE	const char *
 #define ARG_NAME	name
 #define DUP_FUNCTION	__pw_dup
-#define HAVE_FUNCTION_R (defined HAVE_GETPWNAM_R)
+#define HAVE_FUNCTION_R 1
 
 #include "xgetXXbyYY.c"
 

--- a/libmisc/xgetpwuid.c
+++ b/libmisc/xgetpwuid.c
@@ -35,7 +35,7 @@
 #define ARG_TYPE	uid_t
 #define ARG_NAME	uid
 #define DUP_FUNCTION	__pw_dup
-#define HAVE_FUNCTION_R (defined HAVE_GETPWUID_R)
+#define HAVE_FUNCTION_R 1
 
 #include "xgetXXbyYY.c"
 

--- a/src/expiry.c
+++ b/src/expiry.c
@@ -133,9 +133,7 @@ int main (int argc, char **argv)
 	(void) signal (SIGHUP, catch_signals);
 	(void) signal (SIGINT, catch_signals);
 	(void) signal (SIGQUIT, catch_signals);
-#ifdef	SIGTSTP
 	(void) signal (SIGTSTP, catch_signals);
-#endif
 
 	/*
 	 * expiry takes one of two arguments. The default action is to give

--- a/src/gpasswd.c
+++ b/src/gpasswd.c
@@ -1145,9 +1145,7 @@ int main (int argc, char **argv)
 	(void) signal (SIGINT, catch_signals);
 	(void) signal (SIGQUIT, catch_signals);
 	(void) signal (SIGTERM, catch_signals);
-#ifdef SIGTSTP
 	(void) signal (SIGTSTP, catch_signals);
-#endif
 
 	/* Prompt for the new password */
 #ifdef SHADOWGRP

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -42,9 +42,7 @@
 #include <stdio.h>
 #include <syslog.h>
 #include <ctype.h>
-#ifdef HAVE_NETDB_H
 #include <netdb.h>
-#endif
 #include <grp.h>
 #ifdef PRIMARY_GROUP_MATCH
 #include <pwd.h>

--- a/src/sulogin.c
+++ b/src/sulogin.c
@@ -67,14 +67,6 @@ static void catch_signals (unused int sig)
 	TERMIO termio;
 	int err = 0;
 
-#ifdef	USE_TERMIO
-	ioctl (0, TCGETA, &termio);
-	termio.c_iflag |= (ICRNL | IXON);
-	termio.c_oflag |= (OPOST | ONLCR);
-	termio.c_cflag |= (CREAD);
-	termio.c_lflag |= (ISIG | ICANON | ECHO | ECHOE | ECHOK);
-	ioctl (0, TCSETAF, &termio);
-#endif
 #ifdef	USE_TERMIOS
 	tcgetattr (0, &termio);
 	termio.c_iflag |= (ICRNL | IXON);

--- a/src/sulogin.c
+++ b/src/sulogin.c
@@ -67,13 +67,11 @@ static void catch_signals (unused int sig)
 	TERMIO termio;
 	int err = 0;
 
-#ifdef	USE_TERMIOS
 	tcgetattr (0, &termio);
 	termio.c_iflag |= (ICRNL | IXON);
 	termio.c_oflag |= (CREAD);
 	termio.c_lflag |= (ECHO | ECHOE | ECHOK | ICANON | ISIG);
 	tcsetattr (0, TCSANOW, &termio);
-#endif
 
 	Prog = Basename (argv[0]);
 	log_set_progname(Prog);


### PR DESCRIPTION
Previously, we required ISO C99.  Let's go a bit further, and require POSIX.1-2001, which allows removing a lot of preprocessor and build system code, and even some alternative definitions.