### PR TITLE
changing lock mechanism

### DIFF
--- a/lib/commonio.h
+++ b/lib/commonio.h
@@ -123,6 +123,7 @@ extern int commonio_setname (struct commonio_db *, const char *);
 extern bool commonio_present (const struct commonio_db *db);
 extern int commonio_lock (struct commonio_db *);
 extern int commonio_lock_nowait (struct commonio_db *, bool log);
+extern int do_fcntl_lock (const char *file, bool log, short type);
 extern int commonio_open (struct commonio_db *, int);
 extern /*@observer@*/ /*@null@*/const void *commonio_locate (struct commonio_db *, const char *);
 extern int commonio_update (struct commonio_db *, const void *);

--- a/man/groupmems.8.xml
+++ b/man/groupmems.8.xml
@@ -167,7 +167,7 @@
     <programlisting>
 	$ groupadd -r groups
 	$ chmod 2710 groupmems
-	$ chown root.groups groupmems
+	$ chown root:groups groupmems
 	$ groupmems -g groups -a gk4
     </programlisting>
   </refsect1>


### PR DESCRIPTION
Systems can suffer power interruptions whilst .lock files are in /etc, preventing scripts and other automation tools from updating shadow's files which persist across boots.

This commit replaces that mechanism with file locking to avoid problems of power interruption/crashing.

Signed-off-by: ed neville <ed@s5h.net>