### PR TITLE
Don't redefine errno(3)

### DIFF
--- a/lib/gshadow.c
+++ b/lib/gshadow.c
@@ -502,5 +502,5 @@ int putsgent (const struct sgrp *sgrp, FILE * fp)
 	return 0;
 }
 #else
-extern int errno;		/* warning: ANSI C forbids an empty source file */
+extern int ISO_C_forbids_an_empty_translation_unit;
 #endif				/*} SHADOWGRP */

--- a/lib/lockpw.c
+++ b/lib/lockpw.c
@@ -81,5 +81,5 @@ int ulckpwdf (void)
 	return (pw_unlock () && spw_unlock ())? 0 : -1;
 }
 #else
-extern int errno;		/* warning: ANSI C forbids an empty source file */
+extern int ISO_C_forbids_an_empty_translation_unit;
 #endif

--- a/lib/nscd.c
+++ b/lib/nscd.c
@@ -53,6 +53,6 @@ int nscd_flush_cache (const char *service)
 	return 0;
 }
 #else				/* USE_NSCD */
-extern int errno;		/* warning: ANSI C forbids an empty source file */
+extern int ISO_C_forbids_an_empty_translation_unit;
 #endif				/* USE_NSCD */
 

--- a/lib/pwauth.c
+++ b/lib/pwauth.c
@@ -207,5 +207,5 @@ int pw_auth (const char *cipher,
 	return retval;
 }
 #else				/* !USE_PAM */
-extern int errno;		/* warning: ANSI C forbids an empty source file */
+extern int ISO_C_forbids_an_empty_translation_unit;
 #endif				/* !USE_PAM */

--- a/lib/selinux.c
+++ b/lib/selinux.c
@@ -206,5 +206,5 @@ int check_selinux_permit (const char *perm_name)
 }
 
 #else				/* !WITH_SELINUX */
-extern int errno;		/* warning: ANSI C forbids an empty source file */
+extern int ISO_C_forbids_an_empty_translation_unit;
 #endif				/* !WITH_SELINUX */

--- a/lib/semanage.c
+++ b/lib/semanage.c
@@ -357,5 +357,5 @@ done:
 	return ret;
 }
 #else				/* !WITH_SELINUX */
-extern int errno;		/* warning: ANSI C forbids an empty source file */
+extern int ISO_C_forbids_an_empty_translation_unit;
 #endif				/* !WITH_SELINUX */

--- a/lib/sgetspent.c
+++ b/lib/sgetspent.c
@@ -182,6 +182,6 @@ struct spwd *sgetspent (const char *string)
 	return (&spwd);
 }
 #else
-extern int errno;		/* warning: ANSI C forbids an empty source file */
+extern int ISO_C_forbids_an_empty_translation_unit;
 #endif
 

--- a/lib/sgroupio.c
+++ b/lib/sgroupio.c
@@ -302,5 +302,5 @@ int sgr_sort ()
 	return commonio_sort_wrt (&gshadow_db, __gr_get_db ());
 }
 #else
-extern int errno;		/* warning: ANSI C forbids an empty source file */
+extern int ISO_C_forbids_an_empty_translation_unit;
 #endif

--- a/lib/shadow.c
+++ b/lib/shadow.c
@@ -525,6 +525,6 @@ struct spwd *getspnam (const char *name)
 	return (sp);
 }
 #else
-extern int errno;		/* warning: ANSI C forbids an empty source file */
+extern int ISO_C_forbids_an_empty_translation_unit;
 #endif
 

--- a/lib/sssd.c
+++ b/lib/sssd.c
@@ -70,6 +70,6 @@ int sssd_flush_cache (int dbflags)
 	return 0;
 }
 #else				/* USE_SSSD */
-extern int errno;		/* warning: ANSI C forbids an empty source file */
+extern int ISO_C_forbids_an_empty_translation_unit;
 #endif				/* USE_SSSD */
 

--- a/lib/subordinateio.c
+++ b/lib/subordinateio.c
@@ -1097,6 +1097,6 @@ bool release_subid_range(struct subordinate_range *range, enum subid_type id_typ
 }
 
 #else				/* !ENABLE_SUBIDS */
-extern int errno;		/* warning: ANSI C forbids an empty source file */
+extern int ISO_C_forbids_an_empty_translation_unit;
 #endif				/* !ENABLE_SUBIDS */
 

--- a/lib/utent.c
+++ b/lib/utent.c
@@ -66,5 +66,5 @@ struct utmp *getutent (void)
 	return &utmp_buf;
 }
 #else
-extern int errno;		/* warning: ANSI C forbids an empty source file */
+extern int ISO_C_forbids_an_empty_translation_unit;
 #endif

--- a/libmisc/addgrps.c
+++ b/libmisc/addgrps.c
@@ -109,6 +109,6 @@ int add_groups (const char *list)
 	return 0;
 }
 #else				/* HAVE_SETGROUPS && !USE_PAM */
-extern int errno;		/* warning: ANSI C forbids an empty source file */
+extern int ISO_C_forbids_an_empty_translation_unit;
 #endif				/* HAVE_SETGROUPS && !USE_PAM */
 

--- a/libmisc/audit_help.c
+++ b/libmisc/audit_help.c
@@ -82,6 +82,6 @@ void audit_logger_message (const char *message, shadow_audit_result result)
 }
 
 #else				/* WITH_AUDIT */
-extern int errno;	/* warning: ANSI C forbids an empty source file */
+extern int ISO_C_forbids_an_empty_translation_unit;
 #endif				/* WITH_AUDIT */
 

--- a/libmisc/find_new_sub_gids.c
+++ b/libmisc/find_new_sub_gids.c
@@ -59,6 +59,6 @@ int find_new_sub_gids (gid_t *range_start, unsigned long *range_count)
 	return 0;
 }
 #else				/* !ENABLE_SUBIDS */
-extern int errno;		/* warning: ANSI C forbids an empty source file */
+extern int ISO_C_forbids_an_empty_translation_unit;
 #endif				/* !ENABLE_SUBIDS */
 

--- a/libmisc/find_new_sub_uids.c
+++ b/libmisc/find_new_sub_uids.c
@@ -59,6 +59,6 @@ int find_new_sub_uids (uid_t *range_start, unsigned long *range_count)
 	return 0;
 }
 #else				/* !ENABLE_SUBIDS */
-extern int errno;		/* warning: ANSI C forbids an empty source file */
+extern int ISO_C_forbids_an_empty_translation_unit;
 #endif				/* !ENABLE_SUBIDS */
 

--- a/libmisc/limits.c
+++ b/libmisc/limits.c
@@ -563,6 +563,6 @@ void setup_limits (const struct passwd *info)
 }
 
 #else				/* !USE_PAM */
-extern int errno;		/* warning: ANSI C forbids an empty source file */
+extern int ISO_C_forbids_an_empty_translation_unit;
 #endif				/* !USE_PAM */
 

--- a/libmisc/obscure.c
+++ b/libmisc/obscure.c
@@ -302,5 +302,5 @@ bool obscure (const char *old, const char *new, const struct passwd *pwdp)
 }
 
 #else				/* !USE_PAM */
-extern int errno;		/* warning: ANSI C forbids an empty source file */
+extern int ISO_C_forbids_an_empty_translation_unit;
 #endif				/* !USE_PAM */

--- a/libmisc/pam_pass.c
+++ b/libmisc/pam_pass.c
@@ -55,5 +55,5 @@ void do_pam_passwd (const char *user, bool silent, bool change_expired)
 	(void) pam_end (pamh, PAM_SUCCESS);
 }
 #else				/* !USE_PAM */
-extern int errno;		/* warning: ANSI C forbids an empty source file */
+extern int ISO_C_forbids_an_empty_translation_unit;
 #endif				/* !USE_PAM */

--- a/libmisc/pam_pass_non_interactive.c
+++ b/libmisc/pam_pass_non_interactive.c
@@ -141,5 +141,5 @@ int do_pam_passwd_non_interactive (const char *pam_service,
 	return ((PAM_SUCCESS == ret) ? 0 : 1);
 }
 #else				/* !USE_PAM */
-extern int errno;		/* warning: ANSI C forbids an empty source file */
+extern int ISO_C_forbids_an_empty_translation_unit;
 #endif				/* !USE_PAM */

--- a/libmisc/pwd2spwd.c
+++ b/libmisc/pwd2spwd.c
@@ -62,6 +62,6 @@ struct spwd *pwd_to_spwd (const struct passwd *pw)
 	return &sp;
 }
 #else				/* USE_PAM */
-extern int errno;	/* warning: ANSI C forbids an empty source file */
+extern int ISO_C_forbids_an_empty_translation_unit;
 #endif				/* !USE_PAM */
 

--- a/libmisc/pwdcheck.c
+++ b/libmisc/pwdcheck.c
@@ -34,5 +34,5 @@ void passwd_check (const char *user, const char *passwd, unused const char *prog
 	}
 }
 #else			/* USE_PAM */
-extern int errno;	/* warning: ANSI C forbids an empty source file */
+extern int ISO_C_forbids_an_empty_translation_unit;
 #endif			/* USE_PAM */

--- a/libmisc/tz.c
+++ b/libmisc/tz.c
@@ -52,6 +52,6 @@
 	return tzbuf;
 }
 #else				/* !USE_PAM */
-extern int errno;		/* warning: ANSI C forbids an empty source file */
+extern int ISO_C_forbids_an_empty_translation_unit;
 #endif				/* !USE_PAM */
 

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -335,5 +335,5 @@ static bool string_match (const char *tok, const char *string)
 }
 
 #else				/* !USE_PAM */
-extern int errno;		/* warning: ANSI C forbids an empty source file */
+extern int ISO_C_forbids_an_empty_translation_unit;
 #endif				/* !USE_PAM */


### PR DESCRIPTION
It is Undefined Behavior to declare errno (see NOTES in its manual page). Instead of using the errno dummy declaration, use one that doesn't need a comment.

Signed-off-by: Alejandro Colomar <alx@kernel.org>