### PR TITLE
Raise the bar to POSIX.1-2008

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -54,7 +54,6 @@ AC_CHECK_FUNCS(arc4random_buf futimes \
 AC_SYS_LARGEFILE
 
 dnl Checks for typedefs, structures, and compiler characteristics.
-AC_STRUCT_TM
 
 AC_CHECK_MEMBERS([struct utmp.ut_type,
                   struct utmp.ut_id,

--- a/configure.ac
+++ b/configure.ac
@@ -54,10 +54,6 @@ AC_CHECK_FUNCS(arc4random_buf futimes \
 AC_SYS_LARGEFILE
 
 dnl Checks for typedefs, structures, and compiler characteristics.
-AC_CHECK_MEMBERS([struct stat.st_atim])
-AC_CHECK_MEMBERS([struct stat.st_atimensec])
-AC_CHECK_MEMBERS([struct stat.st_mtim])
-AC_CHECK_MEMBERS([struct stat.st_mtimensec])
 AC_STRUCT_TM
 
 AC_CHECK_MEMBERS([struct utmp.ut_type,

--- a/libmisc/copydir.c
+++ b/libmisc/copydir.c
@@ -419,29 +419,11 @@ static int copy_entry (const struct path_info *src, const struct path_info *dst,
 	if (fstatat(src->dirfd, src->name, &sb, AT_SYMLINK_NOFOLLOW) == -1) {
 		/* If we cannot stat the file, do not care. */
 	} else {
-#ifdef HAVE_STRUCT_STAT_ST_ATIM
 		mt[0].tv_sec  = sb.st_atim.tv_sec;
 		mt[0].tv_nsec = sb.st_atim.tv_nsec;
-#else				/* !HAVE_STRUCT_STAT_ST_ATIM */
-		mt[0].tv_sec  = sb.st_atime;
-# ifdef HAVE_STRUCT_STAT_ST_ATIMENSEC
-		mt[0].tv_nsec = sb.st_atimensec;
-# else				/* !HAVE_STRUCT_STAT_ST_ATIMENSEC */
-		mt[0].tv_nsec = 0;
-# endif				/* !HAVE_STRUCT_STAT_ST_ATIMENSEC */
-#endif				/* !HAVE_STRUCT_STAT_ST_ATIM */
 
-#ifdef HAVE_STRUCT_STAT_ST_MTIM
 		mt[1].tv_sec  = sb.st_mtim.tv_sec;
 		mt[1].tv_nsec = sb.st_mtim.tv_nsec;
-#else				/* !HAVE_STRUCT_STAT_ST_MTIM */
-		mt[1].tv_sec  = sb.st_mtime;
-# ifdef HAVE_STRUCT_STAT_ST_MTIMENSEC
-		mt[1].tv_nsec = sb.st_mtimensec;
-# else				/* !HAVE_STRUCT_STAT_ST_MTIMENSEC */
-		mt[1].tv_nsec = 0;
-# endif				/* !HAVE_STRUCT_STAT_ST_MTIMENSEC */
-#endif				/* !HAVE_STRUCT_STAT_ST_MTIM */
 
 		if (S_ISDIR (sb.st_mode)) {
 			err = copy_dir (src, dst, reset_selinux, &sb, mt,


### PR DESCRIPTION
However, don't stop using functions that were once required by POSIX.1-2001 that were good functions, and which have been removed by POSIX.1-2008 without good reasons.  For example, continue using `bzero(3)`.  However, there may be functions that were removed with a good reason.  We should stop using those.