### PR TITLE
Use getaddrinfo(3) instead of gethostbyname(3)

### DIFF
--- a/lib/prototypes.h
+++ b/lib/prototypes.h
@@ -21,6 +21,7 @@
 
 #include <config.h>
 
+#include <sys/socket.h>
 #include <sys/stat.h>
 #include <utmp.h>
 #include <sys/types.h>
@@ -192,6 +193,9 @@ extern bool gr_append_member (struct group *grp, char *member);
 
 /* hushed.c */
 extern bool hushed (const char *username);
+
+/* inet_sockaddr2str.c */
+extern const char *inet_sockaddr2str(const struct sockaddr *sa);
 
 /* audit_help.c */
 #ifdef WITH_AUDIT

--- a/libmisc/Makefile.am
+++ b/libmisc/Makefile.am
@@ -38,6 +38,7 @@ libmisc_la_SOURCES = \
 	hushed.c \
 	idmapping.h \
 	idmapping.c \
+	inet_sockaddr2str.c \
 	isexpired.c \
 	limits.c \
 	list.c log.c \

--- a/libmisc/inet_sockaddr2str.c
+++ b/libmisc/inet_sockaddr2str.c
@@ -1,0 +1,78 @@
+/*
+ * SPDX-FileCopyrightText: 2022, Alejandro Colomar <alx@kernel.org>
+ *
+ * SPDX-License-Identifier:  BSD-3-Clause
+ */
+
+#include <config.h>
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <netinet/in.h>
+#include <sys/param.h>
+#include <sys/socket.h>
+
+#ident "$Id$"
+
+#include "defines.h"
+#include "prototypes.h"
+
+
+#if !defined(INET_ADDRSTRLENMAX)
+#define INET_ADDRSTRLENMAX  MAX(INET_ADDRSTRLEN, INET6_ADDRSTRLEN)
+#endif
+
+
+/*
+ * SYNOPSIS
+ *	const char *inet_sockaddr2str(const struct sockaddr *sa);
+ *
+ * DESCRIPTION
+ *	This function is similar to inet_ntop(3).  It transforms an address
+ *	in 'struct in_addr' or 'struct in6_addr' form into a human-readable
+ *	string.
+ *
+ *	It receives a sockaddr structure, which is simpler to pass after
+ *	receiving it from getaddrinfo(3).  However, this function is not
+ *	reentrant, and like inet_ntoa(3), it uses an internal buffer, for
+ *	simplicity; anyway we're not in a multithreaded program, and it
+ *	doesn't contain any sensitive data, so it's fine to use static
+ *	storage here.
+ *
+ * RETURN VALUE
+ *	This function returns a pointer to a statically allocated buffer,
+ *	which subsequent calls will overwrite.
+ *
+ *	On error, it returns NULL.
+ *
+ * ERRORS
+ *	EAFNOSUPPORT
+ *		The address family in sa->sa_family is not AF_INET or AF_INET6.
+ *
+ * CAVEATS
+ *	This function is not reentrant.
+ */
+
+
+const char *
+inet_sockaddr2str(const struct sockaddr *sa)
+{
+	struct sockaddr_in   *sin;
+	struct sockaddr_in6  *sin6;
+
+	static char          buf[INET_ADDRSTRLENMAX];
+
+	switch (sa->sa_family) {
+	case AF_INET:
+		sin = (struct sockaddr_in *) sa;
+		inet_ntop(AF_INET, &sin->sin_addr, buf, NITEMS(buf));
+		return buf;
+	case AF_INET6:
+		sin6 = (struct sockaddr_in6 *) sa;
+		inet_ntop(AF_INET6, &sin6->sin6_addr, buf, NITEMS(buf));
+		return buf;
+	default:
+		errno = EAFNOSUPPORT;
+		return NULL;
+	}
+}

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -52,6 +52,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <sys/socket.h>
+#include <sys/param.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>		/* for inet_ntoa() */
 
@@ -68,6 +69,7 @@
 /* Delimiters for fields and for lists of users, ttys or hosts. */
 static char fs[] = ":";		/* field separator */
 static char sep[] = ", \t";	/* list-element separator */
+static char inet_ntop_buffer[MAX(INET_ADDRSTRLEN, INET6_ADDRSTRLEN)];
 
 static bool list_match (char *list, const char *item, bool (*match_fn) (const char *, const char *));
 static bool user_match (const char *tok, const char *string);
@@ -263,18 +265,41 @@ static bool user_match (const char *tok, const char *string)
 
 static const char *resolve_hostname (const char *string)
 {
-	/*
-	 * Resolve hostname to numeric IP address, as suggested
-	 * by Dave Hagewood <admin@arrowweb.com>.  --marekm
-	 */
-	struct hostent *hp;
+	int                  gai;
+	char                 *p;
+	struct addrinfo      *addrs;
+	struct sockaddr      *sa;
+	struct sockaddr_in   *sin;
+	struct sockaddr_in6  *sin6;
 
-	hp = gethostbyname (string);
-	if (NULL != hp) {
-		return inet_ntoa (*((struct in_addr *) *(hp->h_addr_list)));
+	gai = getaddrinfo(string, NULL, NULL, &addrs);
+	if (gai != 0)
+		goto notfound;
+
+	sa = addrs[0].ai_addr;
+	switch (sa->sa_family) {
+	case AF_INET:
+		sin = (struct sockaddr_in *) sa;
+		inet_ntop(AF_INET, &sin->sin_addr,
+		          inet_ntop_buffer, NITEMS(inet_ntop_buffer));
+		p = inet_ntop_buffer;
+		break;
+	case AF_INET6:
+		sin6 = (struct sockaddr_in6 *) sa;
+		inet_ntop(AF_INET6, &sin6->sin6_addr,
+		          inet_ntop_buffer, NITEMS(inet_ntop_buffer));
+		p = inet_ntop_buffer;
+		break;
+	default:
+		SYSLOG ((LOG_ERR, "Hypothetical future IPv7?"));
+		abort();
 	}
 
-	SYSLOG ((LOG_ERR, "%s - unknown host", string));
+	freeaddrinfo(addrs);
+	return p;
+
+notfound:
+	SYSLOG ((LOG_ERR, "getaddrinfo(%s): %s", string, gai_strerror(gai)));
 	return string;
 }
 


### PR DESCRIPTION
gethostbyname(3) was removed in POSIX.1-2008.  It has been obsoleted,
and replaced by getaddrinfo(3), which is superior in several ways:

-  gethostbyname(3) is not reentrant.  There's a GNU extension,
   gethostbyname_r(3) which is reentrant, but it's not likely to be
   standardized for the following reason.  And we don't care too much
   about this point either.

-  gethostbyname(3) only supports IPv4, but getaddrinfo(3) supports both
   IPv4 and IPv6 (and may support other address families in the future).

We don't care about reentrancy, so for keeping the code simple (i.e.,
not touch call site to add code to free(3) an allocated buffer), I added
a static buffer for inet_ntop(3).  We could address that in the future,
but I don't think it's worth it.

BTW, we also replace inet_ntoa(3) by inet_ntop(3), as a consequence of
using getaddrinfo(3).  inet_ntoa(3) is also marked as deprecated, but
that deprecation seems to have been documented only in the manual page,
and POSIX doesn't mark it as deprecated.  The deprecation notice goes
back to when the inet_ntop(3) manual page was added by Sam Varshavchik
to the Linux man-pages in version 1.30 (year 2000).

So, this, apart from updating the code to POSIX.1-2008, is also adding
support for IPv6 :)  Although, probably many other parts of the code are
written for IPv4 only, so I wouldn't yet claim support for it.

A few notes:

-  I didn't check the return value of inet_ntop(3), since it can't fail
   for the given input:

   -  EAFNOSUPPORT:  We only call it with AF_INET and AF_INET6.
   -  ENOSPC:  We calculate the size of the buffer to be wide enough:
               MAX(INET_ADDRSTRLEN, INET6_ADDRSTRLEN) so it always fits.

Link: <https://github.com/shadow-maint/shadow/issues/600>
Cc: Dave Hagewood <admin@arrowweb.com>
Cc: Sam Varshavchik
Cc: Jakub Jelinek <jakub@redhat.com> @jakubjelinek
Cc: Iker Pedrosa <ipedrosa@redhat.com>
Signed-off-by: Alejandro Colomar <alx@kernel.org>