### PR TITLE
Clean strtoday

### DIFF
--- a/libmisc/strtoday.c
+++ b/libmisc/strtoday.c
@@ -13,7 +13,6 @@
 
 #ident "$Id$"
 
-#include "defines.h"
 #include "prototypes.h"
 #include "getdate.h"
 


### PR DESCRIPTION
I was envious because @alejandro-colomar was removing lots of unused lines of code, so I've decided to join his effort.

Jokes aside, while reviewing https://github.com/shadow-maint/shadow/pull/616 I realised that `strtoday.c` contained the preprocessor conditional `USE_GETDATE` and that it was always used. So I've decided to clean up this file and ended up deleting more lines than I initially thought.