### PR TITLE
chfn: fix the change_field results printed

### DIFF
--- a/src/chfn.c
+++ b/src/chfn.c
@@ -175,19 +175,19 @@ static void new_fields (void)
 	if (may_change_field ('r')) {
 		change_field (roomno, sizeof roomno, _("Room Number"));
 	} else {
-		printf (_("\t%s: %s\n"), _("Room Number"), fullnm);
+		printf (_("\t%s: %s\n"), _("Room Number"), roomno);
 	}
 
 	if (may_change_field ('w')) {
 		change_field (workph, sizeof workph, _("Work Phone"));
 	} else {
-		printf (_("\t%s: %s\n"), _("Work Phone"), fullnm);
+		printf (_("\t%s: %s\n"), _("Work Phone"), workph);
 	}
 
 	if (may_change_field ('h')) {
 		change_field (homeph, sizeof homeph, _("Home Phone"));
 	} else {
-		printf (_("\t%s: %s\n"), _("Home Phone"), fullnm);
+		printf (_("\t%s: %s\n"), _("Home Phone"), homeph);
 	}
 
 	if (amroot) {


### PR DESCRIPTION
When chfn calls change_field on some fields, if it is not allowed to print some fields, it instead prints them out - except it always prints the fullname.  Fix the field being printed in that case.

Signed-off-by: Serge Hallyn <serge@hallyn.com>