### PR TITLE
Fix typos

### DIFF
--- a/contrib/adduser.c
+++ b/contrib/adduser.c
@@ -60,7 +60,7 @@
 ** Added in the password date field, which should always reflect the last
 **     date the password was changed, for expiry purposes.  "passwd" always
 **     updates this field, so the adduser program should set it up right
-**     initially (or a user could keep thier initial password forever ;)
+**     initially (or a user could keep their initial password forever ;)
 **     The number is in days since Jan 1st, 1970.
 **
 **                       Have fun with it, and someone please make

--- a/lib/shadowlog_internal.h
+++ b/lib/shadowlog_internal.h
@@ -2,6 +2,6 @@
 #define _SHADOWLOG_INTERNAL_H
 
 extern const char *shadow_progname; /* Program name showed in error messages */
-extern FILE *shadow_logfd;  /* file descripter to which error messages are printed */
+extern FILE *shadow_logfd;  /* file descriptor to which error messages are printed */
 
 #endif /* _SHADOWLOG_INTERNAL_H */

--- a/lib/subordinateio.c
+++ b/lib/subordinateio.c
@@ -985,7 +985,7 @@ bool new_subid_range(struct subordinate_range *range, enum subid_type id_type, b
 	switch (id_type) {
 	case ID_TYPE_UID:
 		if (!sub_uid_lock()) {
-			printf("Failed loging subuids (errno %d)\n", errno);
+			printf("Failed locking subuids (errno %d)\n", errno);
 			return false;
 		}
 		if (!sub_uid_open(O_CREAT | O_RDWR)) {
@@ -997,7 +997,7 @@ bool new_subid_range(struct subordinate_range *range, enum subid_type id_type, b
 		break;
 	case ID_TYPE_GID:
 		if (!sub_gid_lock()) {
-			printf("Failed loging subgids (errno %d)\n", errno);
+			printf("Failed locking subgids (errno %d)\n", errno);
 			return false;
 		}
 		if (!sub_gid_open(O_CREAT | O_RDWR)) {
@@ -1057,7 +1057,7 @@ bool release_subid_range(struct subordinate_range *range, enum subid_type id_typ
 	switch (id_type) {
 	case ID_TYPE_UID:
 		if (!sub_uid_lock()) {
-			printf("Failed loging subuids (errno %d)\n", errno);
+			printf("Failed locking subuids (errno %d)\n", errno);
 			return false;
 		}
 		if (!sub_uid_open(O_CREAT | O_RDWR)) {
@@ -1069,7 +1069,7 @@ bool release_subid_range(struct subordinate_range *range, enum subid_type id_typ
 		break;
 	case ID_TYPE_GID:
 		if (!sub_gid_lock()) {
-			printf("Failed loging subgids (errno %d)\n", errno);
+			printf("Failed locking subgids (errno %d)\n", errno);
 			return false;
 		}
 		if (!sub_gid_open(O_CREAT | O_RDWR)) {

--- a/libmisc/xgetXXbyYY.c
+++ b/libmisc/xgetXXbyYY.c
@@ -23,7 +23,7 @@
  *  Two important function classes that fall into this category are
  *  getpwnam(3) and syslog(3).
  *
- * This file provide wrapper to the getpwnam or getpwnam_r functions.
+ * This file provides wrapper to the getpwnam or getpwnam_r functions.
  */
 
 #include <unistd.h>

--- a/libmisc/xgetgrnam.c
+++ b/libmisc/xgetgrnam.c
@@ -23,7 +23,7 @@
  *  Two important function classes that fall into this category are
  *  getpwnam(3) and syslog(3).
  *
- * This file provide wrapper to the getpwnam or getpwnam_r functions.
+ * This file provides wrapper to the getpwnam or getpwnam_r functions.
  */
 
 #include <config.h>

--- a/libmisc/xgetpwnam.c
+++ b/libmisc/xgetpwnam.c
@@ -23,7 +23,7 @@
  *  Two important function classes that fall into this category are
  *  getpwnam(3) and syslog(3).
  *
- * This file provide wrapper to the getpwnam or getpwnam_r functions.
+ * This file provides wrapper to the getpwnam or getpwnam_r functions.
  */
 
 #include <config.h>

--- a/libmisc/xgetspnam.c
+++ b/libmisc/xgetspnam.c
@@ -23,7 +23,7 @@
  *  Two important function classes that fall into this category are
  *  getpwnam(3) and syslog(3).
  *
- * This file provide wrapper to the getpwnam or getpwnam_r functions.
+ * This file provides wrapper to the getpwnam or getpwnam_r functions.
  */
 
 #include <config.h>

--- a/man/usermod.8.xml
+++ b/man/usermod.8.xml
@@ -562,7 +562,7 @@
       <varlistentry condition="gshadow">
 	<term><filename>/etc/gshadow</filename></term>
 	<listitem>
-	  <para>Secure group account informatio.</para>
+	  <para>Secure group account information</para>
 	</listitem>
       </varlistentry>
       <varlistentry>

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -397,7 +397,7 @@ int main (int argc, char **argv)
 	(void) textdomain (PACKAGE);
 
 	/*
-	 * Save my name for error messages and save my real gid incase of
+	 * Save my name for error messages and save my real gid in case of
 	 * errors. If there is an error i have to exec a new login shell for
 	 * the user since her old shell won't have fork'd to create the
 	 * process. Skip over the program name to the next command line
@@ -626,7 +626,7 @@ int main (int argc, char **argv)
 	}
 #endif                          /* HAVE_SETGROUPS */
 	/*
-	 * For splitted groups (due to limitations of NIS), check all
+	 * For split groups (due to limitations of NIS), check all
 	 * groups of the same GID like the requested group for
 	 * membership of the current user.
 	 */

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -409,7 +409,7 @@ static void get_defaults (void)
 		if (MATCH (buf, DGROUPS)) {
 			if (get_groups (cp) != 0) {
 				fprintf (stderr,
-				         _("%s: the '%s' configuraton in %s has an invalid group, ignoring the bad group\n"),
+				         _("%s: the '%s' configuration in %s has an invalid group, ignoring the bad group\n"),
 				         Prog, DGROUPS, default_file);
 			}
 			if (user_groups[0] != NULL) {
@@ -2323,7 +2323,7 @@ static void create_home (void)
 			strcat (path, cp);
 			if (access (path, F_OK) != 0) {
 				/* Check if parent directory is BTRFS, fail if requesting
-				   subvolume but no BTRFS. The paths cound be different by the
+				   subvolume but no BTRFS. The paths could be different by the
 				   trailing slash
 				 */
 #if WITH_BTRFS


### PR DESCRIPTION
Fix a few typos found within the source tree. Mostly found with codespell.