### PR TITLE
Prefer getrandom(3)/getentropy(3) over arc4random(3bsd)

### DIFF
--- a/libmisc/salt.c
+++ b/libmisc/salt.c
@@ -114,12 +114,6 @@ static long read_random_bytes (void)
 {
 	long randval = 0;
 
-#ifdef HAVE_ARC4RANDOM_BUF
-	/* arc4random_buf, if it exists, can never fail.  */
-	arc4random_buf (&randval, sizeof (randval));
-	goto end;
-#endif
-
 #ifdef HAVE_GETENTROPY
 	/* getentropy may exist but lack kernel support.  */
 	if (getentropy (&randval, sizeof (randval)) == 0) {
@@ -132,6 +126,12 @@ static long read_random_bytes (void)
 	if ((size_t) getrandom (&randval, sizeof (randval), 0) == sizeof (randval)) {
 		goto end;
 	}
+#endif
+
+#ifdef HAVE_ARC4RANDOM_BUF
+	/* arc4random_buf, if it exists, can never fail.  */
+	arc4random_buf (&randval, sizeof (randval));
+	goto end;
 #endif
 
 	/* Use /dev/urandom as a last resort.  */


### PR DESCRIPTION
```
arc4random(3) without kernel support is unsafe, as it can't know when to
drop the buffer.  Since we depend on libbsd since recently, we have
arc4random(3) functions always available, and thus, this code would have
always called arc4random_buf(3bsd), which is unsafe.  Put it after some
better alternatives, at least until in a decade or so all systems have a
recent enough glibc.

glibc implements arc4random(3) safely, since it's just a wrapper around
getrandom(2).

Link: <https://inbox.sourceware.org/libc-alpha/20220722122137.3270666-1-adhemerval.zanella@linaro.org/>
Link: <https://inbox.sourceware.org/libc-alpha/Ytwg8YEJn+76h5g9@zx2c4.com/>
Cc: "Jason A. Donenfeld" <Jason@zx2c4.com>
Cc: Cristian Rodríguez <crrodriguez@opensuse.org>
Cc: Adhemerval Zanella <adhemerval.zanella@linaro.org>
Cc: Guillem Jover <guillem@hadrons.org>
Signed-off-by: Alejandro Colomar <alx@kernel.org>
```

Cc: @zx2c4
Cc: @crrodriguez
Cc: @zatrazz
Cc: @guillemj 