### PR TITLE
Warn if failed to read existing /etc/nsswitch.conf

### DIFF
--- a/lib/nss.c
+++ b/lib/nss.c
@@ -59,6 +59,9 @@ void nss_init(const char *nsswitch_path) {
 	//   subid:	files
 	nssfp = fopen(nsswitch_path, "r");
 	if (!nssfp) {
+		if (errno != ENOENT)
+			fprintf(shadow_logfd, "Failed opening %s: %m\n", nsswitch_path);
+
 		atomic_store(&nss_init_completed, true);
 		return;
 	}


### PR DESCRIPTION
Commit 90424e7c ("Don't warn when failed to open /etc/nsswitch.conf") removed the logging for failing to read /etc/nsswitch.conf to reduce the noise in the case the file does not exists (e.g. musl based systems).

Reintroduce a warning if /etc/nsswitch.conf exists but we failed to read it (e.g. permission denied).

Improves: 90424e7c ("Don't warn when failed to open /etc/nsswitch.conf")

/cc @agherzan