### PR TITLE
memzero updates

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -50,7 +50,7 @@ AC_CHECK_FUNCS(arc4random_buf futimes \
 	getutent initgroups lckpwdf lutimes \
 	setgroups updwtmp updwtmpx innetgr \
 	getspnam_r \
-	memset_s explicit_bzero)
+	memset_explicit explicit_bzero)
 AC_SYS_LARGEFILE
 
 dnl Checks for typedefs, structures, and compiler characteristics.

--- a/lib/defines.h
+++ b/lib/defines.h
@@ -54,10 +54,8 @@
 #else					/* !HAVE_MEMSET_S && HAVE_EXPLICIT_BZERO */
 static inline void memzero(void *ptr, size_t size)
 {
-	volatile unsigned char * volatile p = ptr;
-	while (size--) {
-		*p++ = '\0';
-	}
+	ptr = memset(ptr, '\0', size);
+	__asm__ __volatile__ ("" : : "r"(ptr) : "memory");
 }
 #endif					/* !HAVE_MEMSET_S && !HAVE_EXPLICIT_BZERO */
 

--- a/lib/defines.h
+++ b/lib/defines.h
@@ -47,8 +47,8 @@
 #include <sys/time.h>
 #include <time.h>
 
-#ifdef HAVE_MEMSET_S
-# define memzero(ptr, size) memset_s((ptr), 0, (size))
+#ifdef HAVE_MEMSET_EXPLICIT
+# define memzero(ptr, size) memset_explicit((ptr), 0, (size))
 #elif defined HAVE_EXPLICIT_BZERO	/* !HAVE_MEMSET_S */
 # define memzero(ptr, size) explicit_bzero((ptr), (size))
 #else					/* !HAVE_MEMSET_S && HAVE_EXPLICIT_BZERO */


### PR DESCRIPTION
* Replace flawed memset_s usage

  memset_s() has a different signature than memset(3) or explicit_bzero(), thus the current code would not compile.
  Also memset_s() implementations are quite rare.
  Use the C23 standardized version memset_explicit(3).

  Fixes: https://github.com/shadow-maint/shadow/commit/7a799ebb2c304010c1aad16490e7354c7e7659a2 ("Ensure memory cleaning")

* Modernize manual memzero implementation

  Instead of using volatile pointers to prevent the compiler from optimizing the call away, use a memory barrier.
  This requires support for embedded assembly, which should be fine after the recent requirement bumps.