### PR TITLE
copydir: fix impl usage

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -11,6 +11,7 @@ libshadow_la_CPPFLAGS += -DVENDORDIR=\"$(VENDORDIR)\"
 endif
 
 libshadow_la_CPPFLAGS += -I$(top_srcdir)
+libshadow_la_CFLAGS = $(LIBBSD_CFLAGS)
 
 libshadow_la_SOURCES = \
 	commonio.c \

--- a/lib/pam_defs.h
+++ b/lib/pam_defs.h
@@ -15,7 +15,7 @@
 #endif
 
 
-static struct pam_conv conv = {
+static const struct pam_conv conv = {
 	SHADOW_PAM_CONVERSATION,
 	NULL
 };

--- a/libmisc/copydir.c
+++ b/libmisc/copydir.c
@@ -514,7 +514,7 @@ static int copy_dir (const struct path_info *src, const struct path_info *dst,
          * but copy into it (recursively).
         */
         if (fstatat(dst->dirfd, dst->name, &dst_sb, AT_SYMLINK_NOFOLLOW) == 0 && S_ISDIR(dst_sb.st_mode)) {
-            return (copy_tree (src, dst, false, reset_selinux,
+            return (copy_tree_impl (src, dst, false, reset_selinux,
                            old_uid, new_uid, old_gid, new_gid) != 0);
         }
 

--- a/libmisc/env.c
+++ b/libmisc/env.c
@@ -26,7 +26,6 @@
 #define NEWENVP_STEP 16
 size_t newenvc = 0;
 /*@null@*/char **newenvp = NULL;
-extern char **environ;
 
 static const char *const forbid[] = {
 	"_RLD_=",

--- a/libmisc/gettime.c
+++ b/libmisc/gettime.c
@@ -55,7 +55,7 @@
 		fprintf (shadow_logfd,
 			 _("Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal to %lu but was found to be: %llu\n"),
 			 ULONG_MAX, epoch);
-	} else if (epoch > fallback) {
+	} else if ((time_t)epoch > fallback) {
 		fprintf (shadow_logfd,
 			 _("Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal to the current time (%lu) but was found to be: %llu\n"),
 			 fallback, epoch);

--- a/libmisc/idmapping.c
+++ b/libmisc/idmapping.c
@@ -199,7 +199,7 @@ void write_mapping(int proc_dir_fd, int ranges, const struct map_range *mappings
 			mapping->upper,
 			mapping->lower,
 			mapping->count);
-		if ((written <= 0) || (written >= (bufsize - (pos - buf)))) {
+		if ((written <= 0) || ((size_t)written >= (bufsize - (pos - buf)))) {
 			fprintf(log_get_logfd(), _("%s: snprintf failed!\n"), log_get_progname());
 			exit(EXIT_FAILURE);
 		}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -13,6 +13,8 @@ AM_CPPFLAGS = \
 	-I$(top_srcdir) \
 	-DLOCALEDIR=\"$(datadir)/locale\"
 
+AM_CFLAGS = $(LIBBSD_CFLAGS)
+
 # XXX why are login and su in /bin anyway (other than for
 # historical reasons)?
 #

--- a/src/login.c
+++ b/src/login.c
@@ -89,7 +89,6 @@ static char tmsg[256];
 
 extern char **newenvp;
 extern size_t newenvc;
-extern char **environ;
 
 #ifndef	ALARM
 #define	ALARM	60

--- a/src/newgidmap.c
+++ b/src/newgidmap.c
@@ -175,7 +175,7 @@ int main(int argc, char **argv)
 	/* max string length is 6 + 10 + 1 + 1 = 18, allocate 32 bytes */
 	written = snprintf(proc_dir_name, sizeof(proc_dir_name), "/proc/%u/",
 		target);
-	if ((written <= 0) || (written >= sizeof(proc_dir_name))) {
+	if ((written <= 0) || ((size_t)written >= sizeof(proc_dir_name))) {
 		fprintf(stderr, "%s: snprintf of proc path failed: %s\n",
 			Prog, strerror(errno));
 	}

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -29,7 +29,6 @@
 const char *Prog;
 
 extern char **newenvp;
-extern char **environ;
 
 #ifdef HAVE_SETGROUPS
 static int ngroups;

--- a/src/newuidmap.c
+++ b/src/newuidmap.c
@@ -104,7 +104,7 @@ int main(int argc, char **argv)
 	/* max string length is 6 + 10 + 1 + 1 = 18, allocate 32 bytes */
 	written = snprintf(proc_dir_name, sizeof(proc_dir_name), "/proc/%u/",
 		target);
-	if ((written <= 0) || (written >= sizeof(proc_dir_name))) {
+	if ((written <= 0) || ((size_t)written >= sizeof(proc_dir_name))) {
 		fprintf(stderr, "%s: snprintf of proc path failed: %s\n",
 			Prog, strerror(errno));
 	}

--- a/src/sulogin.c
+++ b/src/sulogin.c
@@ -37,8 +37,6 @@ static struct passwd pwent;
 extern char **newenvp;
 extern size_t newenvc;
 
-extern char **environ;
-
 #ifndef	ALARM
 #define	ALARM	60
 #endif


### PR DESCRIPTION
    copydir.c: In function 'copy_dir':
    copydir.c:517:32: warning: passing argument 1 of 'copy_tree' from incompatible pointer type [-Wincompatible-pointer-types]
      517 |             return (copy_tree (src, dst, false, reset_selinux,
          |                                ^~~
          |                                |
          |                                const struct path_info *
    In file included from copydir.c:20:
    ../lib/prototypes.h:108:35: note: expected 'const char *' but argument is of type 'const struct path_info *'
      108 | extern int copy_tree (const char *src_root, const char *dst_root,
          |                       ~~~~~~~~~~~~^~~~~~~~
    copydir.c:517:37: warning: passing argument 2 of 'copy_tree' from incompatible pointer type [-Wincompatible-pointer-types]
      517 |             return (copy_tree (src, dst, false, reset_selinux,
          |                                     ^~~
          |                                     |
          |                                     const struct path_info *
    ../lib/prototypes.h:108:57: note: expected 'const char *' but argument is of type 'const struct path_info *'
      108 | extern int copy_tree (const char *src_root, const char *dst_root,
          |                                             ~~~~~~~~~~~~^~~~~~~~

Fixes: 74c17c71 ("Add support for skeleton files from /usr/etc/skel")