### PR TITLE
Read whole line in yes_or_no

### DIFF
--- a/libmisc/yesno.c
+++ b/libmisc/yesno.c
@@ -28,7 +28,8 @@
  */
 bool yes_or_no (bool read_only)
 {
-	char buf[80];
+	int c;
+	bool result;
 
 	/*
 	 * In read-only mode all questions are answered "no".
@@ -46,11 +47,13 @@ bool yes_or_no (bool read_only)
 	/*
 	 * Get a line and see what the first character is.
 	 */
+	c = fgetc(stdin);
 	/* TODO: use gettext */
-	if (fgets (buf, sizeof buf, stdin) == buf) {
-		return buf[0] == 'y' || buf[0] == 'Y';
-	}
+	result = (c == 'y' || c == 'Y');
 
-	return false;
+	while (c != '\n' && c != EOF)
+		c = fgetc(stdin);
+
+	return result;
 }
 


### PR DESCRIPTION
Do not stop after 79 characters. Read the complete line to avoid arbitrary limitations.

Proof of Concept:

```
cat > passwd-poc << EOF
root:x:0:0:root:/root:/bin/bash
root:x:0:0:root:/root:/bin/bash
root:x:0:0:root:/root:/bin/bash
EOF
python -c "print(80*'y')" | pwck passwd-poc
```

Two lines should still be within the file because we agreed only once to remove a duplicated line.

Signed-off-by: Samanta Navarro <ferivoz@riseup.net>