### PR TITLE
Correctly handle illegal system file in tz

### DIFF
--- a/lib/port.c
+++ b/lib/port.c
@@ -130,8 +130,8 @@ static struct port *getportent (void)
       again:
 
 	/*
-	 * Get the next line and remove the last character, which
-	 * is a '\n'.  Lines which begin with '#' are all ignored.
+	 * Get the next line and remove optional trailing '\n'.
+	 * Lines which begin with '#' are all ignored.
 	 */
 
 	if (fgets (buf, (int) sizeof buf, ports) == 0) {
@@ -149,7 +149,7 @@ static struct port *getportent (void)
 	 * TTY devices.
 	 */
 
-	buf[strlen (buf) - 1] = 0;
+	buf[strcspn (buf, "\n")] = 0;
 
 	port.pt_names = ttys;
 	for (cp = buf, j = 0; j < PORT_TTY; j++) {

--- a/libmisc/console.c
+++ b/libmisc/console.c
@@ -71,7 +71,8 @@ static bool is_listed (const char *cfgin, const char *tty, bool def)
 	 */
 
 	while (fgets (buf, (int) sizeof (buf), fp) != NULL) {
-		buf[strlen (buf) - 1] = '\0';
+		/* Remove optional trailing '\n'. */
+		buf[strcspn (buf, "\n")] = '\0';
 		if (strcmp (buf, tty) == 0) {
 			(void) fclose (fp);
 			return true;

--- a/libmisc/tz.c
+++ b/libmisc/tz.c
@@ -42,7 +42,8 @@
 
 		strcpy (tzbuf, def_tz);
 	} else {
-		tzbuf[strlen (tzbuf) - 1] = '\0';
+		/* Remove optional trailing '\n'. */
+		tzbuf[strcspn (tzbuf, "\n")] = '\0';
 	}
 
 	if (NULL != fp) {

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -100,7 +100,7 @@ int login_access (const char *user, const char *from)
 			int end;
 			lineno++;
 			end = (int) strlen (line) - 1;
-			if (line[end] != '\n') {
+			if (line[0] == '\0' || line[end] != '\n') {
 				SYSLOG ((LOG_ERR,
 					 "%s: line %d: missing newline or line too long",
 					 TABLE, lineno));
@@ -320,7 +320,7 @@ static bool from_match (const char *tok, const char *string)
 		if (strchr (string, '.') == NULL) {
 			return true;
 		}
-	} else if (   (tok[(tok_len = strlen (tok)) - 1] == '.') /* network */
+	} else if (   (tok[0] != '\0' && tok[(tok_len = strlen (tok)) - 1] == '.') /* network */
 		   && (strncmp (tok, resolve_hostname (string), tok_len) == 0)) {
 		return true;
 	}

--- a/src/suauth.c
+++ b/src/suauth.c
@@ -68,8 +68,9 @@ int check_su_auth (const char *actual_id,
 
 	while (fgets (temp, sizeof (temp), authfile_fd) != NULL) {
 		lines++;
+		endline = strlen(temp) - 1;
 
-		if (temp[endline = strlen (temp) - 1] != '\n') {
+		if (temp[0] == '\0' || temp[endline] != '\n') {
 			SYSLOG ((LOG_ERR,
 				 "%s, line %d: line too long or missing newline",
 				 SUAUTHFILE, lines));


### PR DESCRIPTION
If the file referenced by ENV_TZ has a zero length string, then an out of boundary write occurs. Also the result can be wrong because it is assumed that the file will always end with a newline.

Only override a newline character with '\0' to avoid these cases.

This cannot be considered to be security relevant because login.defs and its contained references to system files should be trusted to begin with.

Proof of Concept:

1. Compile shadow's su with address sanitizer and --without-libpam

2. Setup your /etc/login.defs to contain ENV_TZ=/etc/tzname

3. Prepare /etc/tzname to contain a '\0' byte at the beginning

`python -c "print('\x00')" > /etc/tzname`

4. Use su

`su -l`

You can see the following output:

`tz.c:45:8: runtime error: index 18446744073709551615 out of bounds for type 'char [8192]'`

Signed-off-by: Samanta Navarro <ferivoz@riseup.net>