### PR TITLE
Add stpeprintf()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -47,7 +47,7 @@ AC_CHECK_HEADER([shadow.h],,[AC_MSG_ERROR([You need a libc with shadow.h])])
 
 AC_CHECK_FUNCS(arc4random_buf futimes \
 	getentropy getrandom getspnam getusershell \
-	initgroups lckpwdf lutimes \
+	initgroups lckpwdf lutimes mempcpy \
 	setgroups updwtmp updwtmpx innetgr \
 	getspnam_r \
 	memset_explicit explicit_bzero stpeprintf)

--- a/configure.ac
+++ b/configure.ac
@@ -50,7 +50,7 @@ AC_CHECK_FUNCS(arc4random_buf futimes \
 	initgroups lckpwdf lutimes \
 	setgroups updwtmp updwtmpx innetgr \
 	getspnam_r \
-	memset_explicit explicit_bzero)
+	memset_explicit explicit_bzero stpeprintf)
 AC_SYS_LARGEFILE
 
 dnl Checks for typedefs, structures, and compiler characteristics.

--- a/configure.ac
+++ b/configure.ac
@@ -50,7 +50,7 @@ AC_CHECK_FUNCS(arc4random_buf futimes \
 	initgroups lckpwdf lutimes mempcpy \
 	setgroups updwtmp updwtmpx innetgr \
 	getspnam_r \
-	memset_explicit explicit_bzero stpeprintf)
+	memset_explicit explicit_bzero stpecpy stpeprintf)
 AC_SYS_LARGEFILE
 
 dnl Checks for typedefs, structures, and compiler characteristics.

--- a/lib/mempcpy.h
+++ b/lib/mempcpy.h
@@ -1,0 +1,31 @@
+/*
+ * SPDX-FileCopyrightText:  2023, Alejandro Colomar <alx@kernel.org>
+ *
+ * SPDX-License-Identifier:  BSD-3-Clause
+ */
+
+
+#ifndef SHADOW_INCLUDE_LIB_MEMPCPY_H_
+#define SHADOW_INCLUDE_LIB_MEMPCPY_H_
+
+
+#include <config.h>
+
+#if !defined(HAVE_MEMPCPY)
+
+#include <stddef.h>
+#include <string.h>
+
+
+inline void *mempcpy(void *restrict dst, const void *restrict src, size_t n);
+
+
+inline void *
+mempcpy(void *restrict dst, const void *restrict src, size_t n)
+{
+	return memcpy(dst, src, n) + n;
+}
+
+
+#endif  // !HAVE_MEMPCPY
+#endif  // include guard

--- a/lib/stpecpy.h
+++ b/lib/stpecpy.h
@@ -1,0 +1,92 @@
+/*
+ * SPDX-FileCopyrightText:  2022 - 2023, Alejandro Colomar <alx@kernel.org>
+ *
+ * SPDX-License-Identifier:  BSD-3-Clause
+ */
+
+
+#ifndef SHADOW_INCLUDE_LIB_STPECPY_H_
+#define SHADOW_INCLUDE_LIB_STPECPY_H_
+
+
+#include <config.h>
+
+#if !defined(HAVE_STPECPY)
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+
+#include "defines.h"
+
+
+inline char *stpecpy(char *dst, char *end, const char *restrict src);
+
+
+/*
+ * SYNOPSIS
+ *	char *_Nullable stpecpy(char *_Nullable dst, char end[0],
+ *	                        const char *restrict src);
+ *
+ * ARGUMENTS
+ *	dst	Destination buffer where to copy a string.
+ *
+ *	end	Pointer to one after the last element of the buffer
+ *		pointed to by `dst`.  Usually, it should be calculated
+ *		as `dst + NITEMS(dst)`.
+ *
+ *	src	Source string to be copied into dst.
+ *
+ * DESCRIPTION
+ *	This function copies the string pointed to by src, into a string
+ *	at the buffer pointed to by dst.  If the destination buffer,
+ *	limited by a pointer to its end --one after its last element--,
+ *	isn't large enough to hold the copy, the resulting string is
+ *	truncated.
+ *
+ *	This function can be chained with calls to [v]stpeprintf().
+ *
+ * RETURN VALUE
+ *	dst + strlen(dst)
+ *		•  On success, this function returns a pointer to the
+ *		   terminating NUL byte.
+ *
+ *	end
+ *		•  If this call truncated the resulting string.
+ *		•  If `dst == end` (a previous chained call to these
+ *		   functions truncated).
+ *	NULL
+ *		•  If `dst == NULL` (a previous chained call to
+ *		   [v]stpeprintf() failed).
+ *
+ * ERRORS
+ *	This function doesn't set errno.
+ */
+
+
+inline char *
+stpecpy(char *dst, char *end, const char *restrict src)
+{
+	bool    trunc;
+	char    *p;
+	size_t  dsize, dlen, slen;
+
+	if (dst == end)
+		return end;
+	if (dst == NULL)
+		return NULL;
+
+	dsize = end - dst;
+	slen = strnlen(src, dsize);
+	trunc = (slen == dsize);
+	dlen = slen - trunc;
+
+	p = mempcpy(dst, src, dlen);
+	*p = '\0';
+
+	return p + trunc;
+}
+
+
+#endif  // !HAVE_STPECPY
+#endif  // include guard

--- a/lib/stpeprintf.h
+++ b/lib/stpeprintf.h
@@ -1,0 +1,119 @@
+/*
+ * SPDX-FileCopyrightText:  2022 - 2023, Alejandro Colomar <alx@kernel.org>
+ *
+ * SPDX-License-Identifier:  BSD-3-Clause
+ */
+
+
+#ifndef SHADOW_INCLUDE_LIB_STPEPRINTF_H_
+#define SHADOW_INCLUDE_LIB_STPEPRINTF_H_
+
+
+#include <config.h>
+
+#if !defined(HAVE_STPEPRINTF)
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdio.h>
+
+#include "defines.h"
+
+
+format_attr(printf, 3, 4)
+inline char *stpeprintf(char *dst, char *end, const char *restrict fmt, ...);
+
+format_attr(printf, 3, 0)
+inline char *vstpeprintf(char *dst, char *end, const char *restrict fmt,
+    va_list ap);
+
+
+/*
+ * SYNOPSIS
+ *	[[gnu::format(printf, 3, 4)]]
+ *	char *_Nullable stpeprintf(char *_Nullable dst, char end[0],
+ *	                           const char *restrict fmt, ...);
+ *
+ *	[[gnu::format(printf, 3, 0)]]
+ *	char *_Nullable vstpeprintf(char *_Nullable dst, char end[0],
+ *	                           const char *restrict fmt, va_list ap);
+ *
+ *
+ * ARGUMENTS
+ *	dst	Destination buffer where to write a string.
+ *
+ *	end	Pointer to one after the last element of the buffer
+ *		pointed to by `dst`.  Usually, it should be calculated
+ *		as `dst + NITEMS(dst)`.
+ *
+ *	fmt	Format string
+ *
+ *	...
+ *	ap	Variadic argument list
+ *
+ * DESCRIPTION
+ *	These functions are very similar to [v]snprintf(3).
+ *
+ *	The destination buffer is limited by a pointer to its end --one
+ *	after its last element-- instead of a size.  This allows
+ *	chaining calls to it safely, unlike [v]snprintf(3), which is
+ *	difficult to chain without invoking Undefined Behavior.
+ *
+ * RETURN VALUE
+ *	dst + strlen(dst)
+ *		•  On success, these functions return a pointer to the
+ *		   terminating NUL byte.
+ *
+ *	end
+ *		•  If this call truncated the resulting string.
+ *		•  If `dst == end` (a previous chained call to these
+ *		   functions truncated).
+ *	NULL
+ *		•  If this function failed (see ERRORS).
+ *		•  If `dst == NULL` (a previous chained call to these
+ *		   functions failed).
+ *
+ * ERRORS
+ *	These functions may fail for the same reasons as vsnprintf(3).
+ */
+
+
+inline char *
+stpeprintf(char *dst, char *end, const char *restrict fmt, ...)
+{
+	char     *p;
+	va_list  ap;
+
+	va_start(ap, fmt);
+	p = vstpeprintf(dst, end, fmt, ap);
+	va_end(ap);
+
+	return p;
+}
+
+
+inline char *
+vstpeprintf(char *dst, char *end, const char *restrict fmt, va_list ap)
+{
+	int        len;
+	ptrdiff_t  size;
+
+	if (dst == end)
+		return end;
+	if (dst == NULL)
+		return NULL;
+
+	size = end - dst;
+	len = vsnprintf(dst, size, fmt, ap);
+
+	if (len == -1)
+		return NULL;
+	if (len >= size)
+		return end;
+
+	return dst + len;
+}
+
+
+#endif  // !HAVE_STPEPRINTF
+#endif  // include guard

--- a/libmisc/Makefile.am
+++ b/libmisc/Makefile.am
@@ -61,6 +61,7 @@ libmisc_la_SOURCES = \
 	setugid.c \
 	setupenv.c \
 	shell.c \
+	stpeprintf.c \
 	strtoday.c \
 	sub.c \
 	sulog.c \

--- a/libmisc/Makefile.am
+++ b/libmisc/Makefile.am
@@ -44,6 +44,7 @@ libmisc_la_SOURCES = \
 	list.c log.c \
 	loginprompt.c \
 	mail.c \
+	mempcpy.c \
 	motd.c \
 	myname.c \
 	obscure.c \

--- a/libmisc/Makefile.am
+++ b/libmisc/Makefile.am
@@ -62,6 +62,7 @@ libmisc_la_SOURCES = \
 	setugid.c \
 	setupenv.c \
 	shell.c \
+	stpecpy.c \
 	stpeprintf.c \
 	strtoday.c \
 	sub.c \

--- a/libmisc/agetpass.c
+++ b/libmisc/agetpass.c
@@ -1,30 +1,9 @@
 /*
- * Copyright (c) 2022, Alejandro Colomar <alx@kernel.org>
+ * SPDX-FileCopyrightText:  2022, Alejandro Colomar <alx@kernel.org>
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
- * 3. The name of the copyright holders or contributors may not be used to
- *    endorse or promote products derived from this software without
- *    specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
- * PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT
- * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
- * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * SPDX-License-Identifier:  BSD-3-Clause
  */
+
 
 #include <config.h>
 

--- a/libmisc/mempcpy.c
+++ b/libmisc/mempcpy.c
@@ -1,0 +1,23 @@
+/*
+ * SPDX-FileCopyrightText:  2023, Alejandro Colomar <alx@kernel.org>
+ *
+ * SPDX-License-Identifier:  BSD-3-Clause
+ */
+
+
+#include <config.h>
+
+#if !defined(HAVE_MEMPCPY)
+
+#ident "$Id$"
+
+#include "mempcpy.h"
+
+#include <stddef.h>
+
+
+extern inline void *mempcpy(void *restrict dst, const void *restrict src,
+    size_t n);
+
+
+#endif

--- a/libmisc/stpecpy.c
+++ b/libmisc/stpecpy.c
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText:  2022 - 2023, Alejandro Colomar <alx@kernel.org>
+ *
+ * SPDX-License-Identifier:  BSD-3-Clause
+ */
+
+
+#include <config.h>
+
+#if !defined(HAVE_STPECPY)
+
+#ident "$Id$"
+
+#include "stpecpy.h"
+
+
+extern inline char *stpecpy(char *dst, char *end, const char *restrict src);
+
+
+#endif  // !HAVE_STPECPY

--- a/libmisc/stpeprintf.c
+++ b/libmisc/stpeprintf.c
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText:  2022 - 2023, Alejandro Colomar <alx@kernel.org>
+ *
+ * SPDX-License-Identifier:  BSD-3-Clause
+ */
+
+
+#include <config.h>
+
+#if !defined(HAVE_STPEPRINTF)
+
+#ident "$Id$"
+
+#include "stpeprintf.h"
+
+#include <stdarg.h>
+
+
+extern inline char *stpeprintf(char *dst, char *end, const char *restrict fmt,
+    ...);
+extern inline char *vstpeprintf(char *dst, char *end, const char *restrict fmt,
+    va_list ap);
+
+
+#endif  // !HAVE_STPEPRINTF

--- a/src/groupmod.c
+++ b/src/groupmod.c
@@ -627,11 +627,6 @@ static void prepare_failure_reports (void)
 		stpeprintf(info_passwd.action+strlen (info_passwd.action),
 		                 pw_end, "%ju", (uintmax_t) group_newid);
 	}
-	info_group.audit_msg[511]   = '\0';
-#ifdef	SHADOWGRP
-	info_gshadow.audit_msg[511] = '\0';
-#endif
-	info_passwd.audit_msg[511]  = '\0';
 
 // FIXME: add a system cleanup
 	add_cleanup (cleanup_report_mod_group, &info_group);

--- a/src/groupmod.c
+++ b/src/groupmod.c
@@ -35,6 +35,7 @@
 #include "sgroupio.h"
 #endif
 #include "shadowlog.h"
+#include "stpecpy.h"
 #include "stpeprintf.h"
 /*
  * exit status values
@@ -590,42 +591,27 @@ static void prepare_failure_reports (void)
 	                 "group %s/%ju", group_name, (uintmax_t) group_id);
 
 	if (nflg) {
-		strncat (info_group.action, ", new name: ",
-		         511 - strlen (info_group.audit_msg));
-		strncat (info_group.action, group_newname,
-		         511 - strlen (info_group.audit_msg));
-
+		gr = stpecpy(gr, gr_end, ", new name: ");
+		gr = stpecpy(gr, gr_end, group_newname);
 #ifdef	SHADOWGRP
-		strncat (info_gshadow.action, ", new name: ",
-		         511 - strlen (info_gshadow.audit_msg));
-		strncat (info_gshadow.action, group_newname,
-		         511 - strlen (info_gshadow.audit_msg));
+		sgr = stpecpy(sgr, sgr_end, ", new name: ");
+		sgr = stpecpy(sgr, sgr_end, group_newname);
 #endif
-
-		strncat (info_passwd.action, ", new name: ",
-		         511 - strlen (info_passwd.audit_msg));
-		strncat (info_passwd.action, group_newname,
-		         511 - strlen (info_passwd.audit_msg));
+		pw = stpecpy(pw, pw_end, ", new name: ");
+		pw = stpecpy(pw, pw_end, group_newname);
 	}
 	if (pflg) {
-		strncat (info_group.action, ", new password",
-		         511 - strlen (info_group.audit_msg));
-
+		gr = stpecpy(gr, gr_end, ", new password");
 #ifdef	SHADOWGRP
-		strncat (info_gshadow.action, ", new password",
-		         511 - strlen (info_gshadow.audit_msg));
+		sgr = stpecpy(sgr, sgr_end, ", new password");
 #endif
 	}
 	if (gflg) {
-		strncat (info_group.action, ", new gid: ",
-		         511 - strlen (info_group.audit_msg));
-		stpeprintf(info_group.action+strlen (info_group.action),
-		                 gr_end, "%ju", (uintmax_t) group_newid);
+		gr = stpecpy(gr, gr_end, ", new gid: ");
+		stpeprintf(gr, gr_end, "%ju", (uintmax_t) group_newid);
 
-		strncat (info_passwd.action, ", new gid: ",
-		         511 - strlen (info_passwd.audit_msg));
-		stpeprintf(info_passwd.action+strlen (info_passwd.action),
-		                 pw_end, "%ju", (uintmax_t) group_newid);
+		pw = stpecpy(pw, pw_end, ", new gid: ");
+		stpeprintf(pw, pw_end, "%ju", (uintmax_t) group_newid);
 	}
 
 // FIXME: add a system cleanup


### PR DESCRIPTION
I've seen far too many cases of Undefined Behavior in calls to snprintf(3) that catenate a string just in the last few months.  It's not designed for catenating strings, and should _never_ be used for that.  Let's replace it by a safer API.

The simplification of code at call site talks by itself.

You'll notice that some calls to strncat(3) didn't allow me to write the most beautiful code in  the last calls to stpeprintf(); don't worry; I also plan to replace those strncat(3) calls by some other API.  But not in this patch set, which is restricted to stpeprintf() for simplicity.

---

Edit:

strncat has also been replaced by stpecpy(), which has the same improvements compared to other string copying functions that stpeprintf() has over snprintf(3).