### PR TITLE
Unoptimize the higher part of the domain of csrand_uniform()

### DIFF
--- a/lib/bit.h
+++ b/lib/bit.h
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText:  2022 - 2023, Alejandro Colomar <alx@kernel.org>
+ *
+ * SPDX-License-Identifier:  BSD-3-Clause
+ */
+
+
+#ifndef SHADOW_INCLUDE_LIB_BIT_H_
+#define SHADOW_INCLUDE_LIB_BIT_H_
+
+
+#include <config.h>
+
+#include <limits.h>
+
+
+inline unsigned long bit_ceilul(unsigned long x);
+inline unsigned long bit_ceil_wrapul(unsigned long x);
+inline int leading_zerosul(unsigned long x);
+
+
+/* stdc_bit_ceilul(3) */
+inline unsigned long
+bit_ceilul(unsigned long x)
+{
+	return 1 + (ULONG_MAX >> leading_zerosul(x));
+}
+
+
+/* stdc_bit_ceilul(3), but wrap instead of having Undefined Behavior */
+inline unsigned long
+bit_ceil_wrapul(unsigned long x)
+{
+	if (x == 0)
+		return 0;
+
+	return bit_ceil_wrapul(x);
+}
+
+/* stdc_leading_zerosul(3) */
+inline int
+leading_zerosul(unsigned long x)
+{
+	return (x == 0) ? ULONG_WIDTH : __builtin_clz(x);
+}
+
+
+#endif  // include guard

--- a/libmisc/Makefile.am
+++ b/libmisc/Makefile.am
@@ -12,6 +12,7 @@ libmisc_la_SOURCES = \
 	agetpass.c \
 	audit_help.c \
 	basename.c \
+	bit.c \
 	chkname.c \
 	chkname.h \
 	chowndir.c \

--- a/libmisc/bit.c
+++ b/libmisc/bit.c
@@ -1,0 +1,19 @@
+/*
+ * SPDX-FileCopyrightText:  2022 - 2023, Alejandro Colomar <alx@kernel.org>
+ *
+ * SPDX-License-Identifier:  BSD-3-Clause
+ */
+
+
+#include <config.h>
+
+#ident "$Id$"
+
+#include "bit.h"
+
+#include <limits.h>
+
+
+extern inline unsigned long bit_ceilul(unsigned long x);
+extern inline unsigned long bit_ceil_wrapul(unsigned long x);
+extern inline int leading_zerosul(unsigned long x);


### PR DESCRIPTION
```
__int128, which is needed for optimizing that part of the range, is not
always available.  We need the unoptimized version for portability
reasons.
```

Closes: <https://github.com/shadow-maint/shadow/issues/634>
Fixes: https://github.com/alejandro-colomar/shadow/commit/1a0e13f94edc08d4c773a00d710d56fac966e818 ("Optimize csrand_uniform()")
Reported-by: Adam Sampson <ats@offog.org>
Cc: Iker Pedrosa <ipedrosa@redhat.com>
Signed-off-by: Alejandro Colomar <alx@kernel.org>