### PR TITLE
Call NULL by its name

### DIFF
--- a/lib/gshadow.c
+++ b/lib/gshadow.c
@@ -103,7 +103,7 @@ void endsgent (void)
 		(void) fclose (shadow);
 	}
 
-	shadow = (FILE *) 0;
+	shadow = NULL;
 }
 
 /*@observer@*//*@null@*/struct sgrp *sgetsgent (const char *string)
@@ -399,7 +399,7 @@ void endsgent (void)
 		nis_disabled = true;
 	}
 #endif
-	while ((sgrp = getsgent ()) != (struct sgrp *) 0) {
+	while ((sgrp = getsgent ()) != NULL) {
 		if (strcmp (name, sgrp->sg_name) == 0) {
 			break;
 		}

--- a/lib/port.c
+++ b/lib/port.c
@@ -79,7 +79,7 @@ static void endportent (void)
 		(void) fclose (ports);
 	}
 
-	ports = (FILE *) 0;
+	ports = NULL;
 }
 
 /*
@@ -172,13 +172,13 @@ static struct port *getportent (void)
 	}
 	*cp = '\0';
 	cp++;
-	port.pt_names[j + 1] = (char *) 0;
+	port.pt_names[j + 1] = NULL;
 
 	/*
 	 * Get the list of user names.  It is the second colon
 	 * separated field, and is a comma separated list of user
 	 * names.  The entry '*' is used to specify all usernames.
-	 * The last entry in the list is a (char *) 0 pointer.
+	 * The last entry in the list is a NULL pointer.
 	 */
 
 	if (':' != *cp) {

--- a/lib/sgetgrent.c
+++ b/lib/sgetgrent.c
@@ -34,7 +34,7 @@
  */
 static char **list (char *s)
 {
-	static char **members = 0;
+	static char **members = NULL;
 	static int size = 0;	/* max members + 1 */
 	int i;
 	char **rbuf;
@@ -55,9 +55,9 @@ static char **list (char *s)
 			}
 			if (!rbuf) {
 				free (members);
-				members = 0;
+				members = NULL;
 				size = 0;
-				return (char **) 0;
+				return NULL;
 			}
 			members = rbuf;
 		}
@@ -71,14 +71,14 @@ static char **list (char *s)
 			*s++ = '\0';
 		}
 	}
-	members[i] = (char *) 0;
+	members[i] = NULL;
 	return members;
 }
 
 
 struct group *sgetgrent (const char *buf)
 {
-	static char *grpbuf = 0;
+	static char *grpbuf = NULL;
 	static size_t size = 0;
 	static char *grpfields[NFIELDS];
 	static struct group grent;
@@ -91,9 +91,9 @@ struct group *sgetgrent (const char *buf)
 		free (grpbuf);
 		size = strlen (buf) + 1000;	/* at least: strlen(buf) + 1 */
 		grpbuf = malloc (size);
-		if (!grpbuf) {
+		if (grpbuf == NULL) {
 			size = 0;
-			return 0;
+			return NULL;
 		}
 	}
 	strcpy (grpbuf, buf);
@@ -112,16 +112,16 @@ struct group *sgetgrent (const char *buf)
 		}
 	}
 	if (i < (NFIELDS - 1) || *grpfields[2] == '\0' || cp != NULL) {
-		return (struct group *) 0;
+		return NULL;
 	}
 	grent.gr_name = grpfields[0];
 	grent.gr_passwd = grpfields[1];
 	if (get_gid (grpfields[2], &grent.gr_gid) == 0) {
-		return (struct group *) 0;
+		return NULL;
 	}
 	grent.gr_mem = list (grpfields[3]);
 	if (NULL == grent.gr_mem) {
-		return (struct group *) 0;	/* out of memory */
+		return NULL;	/* out of memory */
 	}
 
 	return &grent;

--- a/lib/shadow.c
+++ b/lib/shadow.c
@@ -94,7 +94,7 @@ void endspent (void)
 		(void) fclose (shadow);
 	}
 
-	shadow = (FILE *) 0;
+	shadow = NULL;
 }
 
 /*
@@ -336,9 +336,9 @@ struct spwd *fgetspent (FILE * fp)
 	}
 
 #ifdef	USE_NIS
-	while (fgets (buf, (int) sizeof buf, fp) != (char *) 0)
+	while (fgets (buf, (int) sizeof buf, fp) != NULL)
 #else
-	if (fgets (buf, (int) sizeof buf, fp) != (char *) 0)
+	if (fgets (buf, (int) sizeof buf, fp) != NULL)
 #endif
 	{
 		cp = strchr (buf, '\n');
@@ -511,7 +511,7 @@ struct spwd *getspnam (const char *name)
 		nis_disabled = true;
 	}
 #endif
-	while ((sp = getspent ()) != (struct spwd *) 0) {
+	while ((sp = getspent ()) != NULL) {
 		if (strcmp (name, sp->sp_namp) == 0) {
 			break;
 		}

--- a/libmisc/age.c
+++ b/libmisc/age.c
@@ -112,7 +112,7 @@ int expire (const struct passwd *pw, /*@null@*/const struct spwd *sp)
 			_exit (126);
 		}
 
-		(void) execl (PASSWD_PROGRAM, PASSWD_PROGRAM, pw->pw_name, (char *) 0);
+		(void) execl (PASSWD_PROGRAM, PASSWD_PROGRAM, pw->pw_name, (char *) NULL);
 		err = errno;
 		perror ("Can't execute " PASSWD_PROGRAM);
 		_exit ((ENOENT == err) ? E_CMD_NOTFOUND : E_CMD_NOEXEC);
@@ -139,7 +139,7 @@ int expire (const struct passwd *pw, /*@null@*/const struct spwd *sp)
 
 void agecheck (/*@null@*/const struct spwd *sp)
 {
-	long now = (long) time ((time_t *) 0) / SCALE;
+	long now = (long) time(NULL) / SCALE;
 	long remain;
 
 	if (NULL == sp) {

--- a/libmisc/entry.c
+++ b/libmisc/entry.c
@@ -24,7 +24,7 @@ void pw_entry (const char *name, struct passwd *pwent)
 	struct spwd *spwd;
 
 	if (!(passwd = getpwnam (name))) { /* local, no need for xgetpwnam */
-		pwent->pw_name = (char *) 0;
+		pwent->pw_name = NULL;
 		return;
 	} else {
 		pwent->pw_name = xstrdup (passwd->pw_name);

--- a/libmisc/env.c
+++ b/libmisc/env.c
@@ -41,7 +41,7 @@ static const char *const forbid[] = {
 	"PATH=",
 	"SHELL=",
 	"SHLIB_PATH=",
-	(char *) 0
+	NULL
 };
 
 /* these are allowed, but with no slashes inside
@@ -50,7 +50,7 @@ static const char *const noslash[] = {
 	"LANG=",
 	"LANGUAGE=",
 	"LC_",			/* anything with the LC_ prefix */
-	(char *) 0
+	NULL
 };
 
 /*

--- a/libmisc/isexpired.c
+++ b/libmisc/isexpired.c
@@ -40,7 +40,7 @@ int isexpired (const struct passwd *pw, /*@null@*/const struct spwd *sp)
 {
 	long now;
 
-	now = (long) time ((time_t *) 0) / SCALE;
+	now = (long) time(NULL) / SCALE;
 
 	if (NULL == sp) {
 		return 0;

--- a/libmisc/list.c
+++ b/libmisc/list.c
@@ -33,7 +33,7 @@
 	 * pointer if it is present.
 	 */
 
-	for (i = 0; list[i] != (char *) 0; i++) {
+	for (i = 0; list[i] != NULL; i++) {
 		if (strcmp (list[i], member) == 0) {
 			return list;
 		}
@@ -52,12 +52,12 @@
 	 * is returned to the invoker.
 	 */
 
-	for (i = 0; list[i] != (char *) 0; i++) {
+	for (i = 0; list[i] != NULL; i++) {
 		tmp[i] = list[i];
 	}
 
 	tmp[i] = xstrdup (member);
-	tmp[i+1] = (char *) 0;
+	tmp[i+1] = NULL;
 
 	return tmp;
 }
@@ -83,7 +83,7 @@
 	 * pointer if it is not present.
 	 */
 
-	for (i = j = 0; list[i] != (char *) 0; i++) {
+	for (i = j = 0; list[i] != NULL; i++) {
 		if (strcmp (list[i], member) != 0) {
 			j++;
 		}
@@ -106,14 +106,14 @@
 	 * is returned to the invoker.
 	 */
 
-	for (i = j = 0; list[i] != (char *) 0; i++) {
+	for (i = j = 0; list[i] != NULL; i++) {
 		if (strcmp (list[i], member) != 0) {
 			tmp[j] = list[i];
 			j++;
 		}
 	}
 
-	tmp[j] = (char *) 0;
+	tmp[j] = NULL;
 
 	return tmp;
 }
@@ -142,7 +142,7 @@
 		list++;
 	}
 
-	tmp[i] = (char *) 0;
+	tmp[i] = NULL;
 	return tmp;
 }
 
@@ -217,7 +217,7 @@ bool is_on_list (char *const *list, const char *member)
 	 */
 
 	if ('\0' == *members) {
-		*array = (char *) 0;
+		*array = NULL;
 		free (members);
 		return array;
 	}
@@ -235,7 +235,7 @@ bool is_on_list (char *const *list, const char *member)
 			cp2++;
 			cp = cp2;
 		} else {
-			array[i + 1] = (char *) 0;
+			array[i + 1] = NULL;
 			break;
 		}
 	}

--- a/libmisc/loginprompt.c
+++ b/libmisc/loginprompt.c
@@ -122,7 +122,7 @@ void login_prompt (const char *prompt, char *name, int namesize)
 		int envc;
 
 		for (envc = 0; envc < MAX_ENV; envc++) {
-			nvar = strtok ((0 != envc) ? (char *) 0 : cp, " \t,");
+			nvar = strtok ((0 != envc) ? NULL : cp, " \t,");
 			if (NULL == nvar) {
 				break;
 			}

--- a/libmisc/pwdcheck.c
+++ b/libmisc/pwdcheck.c
@@ -26,7 +26,7 @@ void passwd_check (const char *user, const char *passwd, unused const char *prog
 	if (NULL != sp) {
 		passwd = sp->sp_pwdp;
 	}
-	if (pw_auth (passwd, user, PW_LOGIN, (char *) 0) != 0) {
+	if (pw_auth (passwd, user, PW_LOGIN, NULL) != 0) {
 		SYSLOG ((LOG_WARN, "incorrect password for `%s'", user));
 		(void) sleep (1);
 		fprintf (log_get_logfd(), _("Incorrect password for %s.\n"), user);

--- a/libmisc/shell.c
+++ b/libmisc/shell.c
@@ -33,7 +33,7 @@ int shell (const char *file, /*@null@*/const char *arg, char *const envp[])
 	char arg0[1024];
 	int err;
 
-	if (file == (char *) 0) {
+	if (file == NULL) {
 		errno = EINVAL;
 		return errno;
 	}
@@ -44,7 +44,7 @@ int shell (const char *file, /*@null@*/const char *arg, char *const envp[])
 	 * that.  So, we determine the 0'th entry only if they
 	 * don't want to tell us what it is themselves.
 	 */
-	if (arg == (char *) 0) {
+	if (arg == NULL) {
 		(void) snprintf (arg0, sizeof arg0, "-%s", Basename (file));
 		arg0[sizeof arg0 - 1] = '\0';
 		arg = arg0;
@@ -55,7 +55,7 @@ int shell (const char *file, /*@null@*/const char *arg, char *const envp[])
 	 * able to figure out what we are up to without too much
 	 * grief.
 	 */
-	(void) execle (file, arg, (char *) 0, envp);
+	(void) execle (file, arg, (char *) NULL, envp);
 	err = errno;
 
 	if (access (file, R_OK|X_OK) == 0) {
@@ -63,7 +63,7 @@ int shell (const char *file, /*@null@*/const char *arg, char *const envp[])
 		 * Assume this is a shell script (with no shebang).
 		 * Interpret it with /bin/sh
 		 */
-		(void) execle (SHELL, "sh", "-", file, (char *)0, envp);
+		(void) execle (SHELL, "sh", "-", file, (char *) NULL, envp);
 		err = errno;
 	}
 

--- a/libmisc/sulog.c
+++ b/libmisc/sulog.c
@@ -64,7 +64,7 @@ void sulog (const char *tty, bool success, const char *oldname, const char *name
 		/* Do not return if the group permission were raised. */
 		exit (EXIT_FAILURE);
 	}
-	if (fp == (FILE *) 0) {
+	if (fp == NULL) {
 		return;		/* can't open or create logfile */
 	}
 

--- a/src/chfn.c
+++ b/src/chfn.c
@@ -510,28 +510,28 @@ static void get_old_fields (const char *gecos)
 	 * Now get the full name. It is the first comma separated field in
 	 * the GECOS field.
 	 */
-	cp = copy_field (old_gecos, fflg ? (char *) 0 : fullnm, slop);
+	cp = copy_field (old_gecos, fflg ? NULL : fullnm, slop);
 
 	/*
 	 * Now get the room number. It is the next comma separated field,
 	 * if there is indeed one.
 	 */
 	if (NULL != cp) {
-		cp = copy_field (cp, rflg ? (char *) 0 : roomno, slop);
+		cp = copy_field (cp, rflg ? NULL : roomno, slop);
 	}
 
 	/*
 	 * Now get the work phone number. It is the third field.
 	 */
 	if (NULL != cp) {
-		cp = copy_field (cp, wflg ? (char *) 0 : workph, slop);
+		cp = copy_field (cp, wflg ? NULL : workph, slop);
 	}
 
 	/*
 	 * Now get the home phone number. It is the fourth field.
 	 */
 	if (NULL != cp) {
-		cp = copy_field (cp, hflg ? (char *) 0 : homeph, slop);
+		cp = copy_field (cp, hflg ? NULL : homeph, slop);
 	}
 
 	/*

--- a/src/chgpasswd.c
+++ b/src/chgpasswd.c
@@ -441,7 +441,7 @@ int main (int argc, char **argv)
 	 * group entry for each group will be looked up in the appropriate
 	 * file (gshadow or group) and the password changed.
 	 */
-	while (fgets (buf, (int) sizeof buf, stdin) != (char *) 0) {
+	while (fgets (buf, (int) sizeof buf, stdin) != NULL) {
 		line++;
 		cp = strrchr (buf, '\n');
 		if (NULL != cp) {

--- a/src/chpasswd.c
+++ b/src/chpasswd.c
@@ -482,7 +482,7 @@ int main (int argc, char **argv)
 	 * last change date is set in the age only if aging information is
 	 * present.
 	 */
-	while (fgets (buf, (int) sizeof buf, stdin) != (char *) 0) {
+	while (fgets (buf, (int) sizeof buf, stdin) != NULL) {
 		line++;
 		cp = strrchr (buf, '\n');
 		if (NULL != cp) {
@@ -491,7 +491,7 @@ int main (int argc, char **argv)
 			if (feof (stdin) == 0) {
 
 				// Drop all remaining characters on this line.
-				while (fgets (buf, (int) sizeof buf, stdin) != (char *) 0) {
+				while (fgets (buf, (int) sizeof buf, stdin) != NULL) {
 					cp = strchr (buf, '\n');
 					if (cp != NULL) {
 						break;

--- a/src/faillog.c
+++ b/src/faillog.c
@@ -57,7 +57,7 @@ static bool rflg = false;	/* reset the counters of login failures */
 
 static struct stat statbuf;	/* fstat buffer for file size */
 
-#define	NOW	(time((time_t *) 0))
+#define	NOW	time(NULL)
 
 static /*@noreturn@*/void usage (int status)
 {

--- a/src/gpasswd.c
+++ b/src/gpasswd.c
@@ -721,7 +721,7 @@ static void check_perms (const struct group *gr)
 		 * --marekm
 		 */
 		if (!amroot) {
-			if (gr->gr_mem[0] == (char *) 0) {
+			if (gr->gr_mem[0] == NULL) {
 				failure ();
 			}
 

--- a/src/groupdel.c
+++ b/src/groupdel.c
@@ -275,7 +275,7 @@ static void group_busy (gid_t gid)
 	 * If pwd isn't NULL, it stopped because the gid's matched.
 	 */
 
-	if (pwd == (struct passwd *) 0) {
+	if (pwd == NULL) {
 		return;
 	}
 

--- a/src/groupmod.c
+++ b/src/groupmod.c
@@ -248,7 +248,7 @@ static void grp_update (void)
 			if (NULL != grp.gr_mem[0])
 				gr_free_members(&grp);
 			grp.gr_mem = (char **)xmalloc(sizeof(char *));
-			grp.gr_mem[0] = (char *)0;
+			grp.gr_mem[0] = NULL;
 		} else {
 			// append to existing groups
 			if (NULL != grp.gr_mem[0])

--- a/src/lastlog.c
+++ b/src/lastlog.c
@@ -56,7 +56,7 @@ static bool bflg = false;	/* print excludes most recent days */
 static bool Cflg = false;	/* clear record for user */
 static bool Sflg = false;	/* set record for user */
 
-#define	NOW	(time ((time_t *) 0))
+#define	NOW	time(NULL)
 
 static /*@noreturn@*/void usage (int status)
 {

--- a/src/login.c
+++ b/src/login.c
@@ -974,7 +974,7 @@ int main (int argc, char **argv)
 			goto auth_ok;
 		}
 
-		if (pw_auth (user_passwd, username, reason, (char *) 0) == 0) {
+		if (pw_auth (user_passwd, username, reason, NULL) == 0) {
 			goto auth_ok;
 		}
 
@@ -1041,7 +1041,7 @@ int main (int argc, char **argv)
 		 * all).  --marekm
 		 */
 		if (user_passwd[0] == '\0') {
-			pw_auth ("!", username, reason, (char *) 0);
+			pw_auth ("!", username, reason, NULL);
 		}
 
 		/*
@@ -1081,7 +1081,7 @@ int main (int argc, char **argv)
 	 * by Ivan Nejgebauer <ian@unsux.ns.ac.yu>.  --marekm
 	 */
 	if (   getdef_bool ("PORTTIME_CHECKS_ENAB")
-	    && !isttytime (username, tty, time ((time_t *) 0))) {
+	    && !isttytime (username, tty, time (NULL))) {
 		SYSLOG ((LOG_WARN, "invalid login time for '%s'%s",
 		         username, fromhost));
 		closelog ();
@@ -1308,7 +1308,7 @@ int main (int argc, char **argv)
 		err = shell (tmp, pwd->pw_shell, newenvp); /* fake shell */
 	} else {
 		/* exec the shell finally */
-		err = shell (pwd->pw_shell, (char *) 0, newenvp);
+		err = shell (pwd->pw_shell, NULL, newenvp);
 	}
 
 	return ((err == ENOENT) ? E_CMD_NOTFOUND : E_CMD_NOEXEC);

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -117,9 +117,9 @@ int login_access (const char *user, const char *from)
 				continue;
 			}
 			if (   ((perm = strtok (line, fs)) == NULL)
-			    || ((users = strtok ((char *) 0, fs)) == NULL)
-			    || ((froms = strtok ((char *) 0, fs)) == NULL)
-			    || (strtok ((char *) 0, fs) != NULL)) {
+			    || ((users = strtok (NULL, fs)) == NULL)
+			    || ((froms = strtok (NULL, fs)) == NULL)
+			    || (strtok (NULL, fs) != NULL)) {
 				SYSLOG ((LOG_ERR,
 					 "%s: line %d: bad field count",
 					 TABLE, lineno));
@@ -154,7 +154,7 @@ static bool list_match (char *list, const char *item, bool (*match_fn) (const ch
 	 * a match, look for an "EXCEPT" list and recurse to determine whether
 	 * the match is affected by any exceptions.
 	 */
-	for (tok = strtok (list, sep); tok != NULL; tok = strtok ((char *) 0, sep)) {
+	for (tok = strtok (list, sep); tok != NULL; tok = strtok (NULL, sep)) {
 		if (strcasecmp (tok, "EXCEPT") == 0) {	/* EXCEPT: give up */
 			break;
 		}
@@ -166,10 +166,10 @@ static bool list_match (char *list, const char *item, bool (*match_fn) (const ch
 
 	/* Process exceptions to matches. */
 	if (match) {
-		while (   ((tok = strtok ((char *) 0, sep)) != NULL)
+		while (   ((tok = strtok (NULL, sep)) != NULL)
 		       && (strcasecmp (tok, "EXCEPT") != 0))
 			/* VOID */ ;
-		if (tok == 0 || !list_match ((char *) 0, item, match_fn)) {
+		if (tok == 0 || !list_match (NULL, item, match_fn)) {
 			return (match);
 		}
 	}
@@ -193,9 +193,9 @@ static char *myhostname (void)
 static bool
 netgroup_match (const char *group, const char *machine, const char *user)
 {
-	static char *mydomain = (char *)0;
+	static char *mydomain = NULL;
 
-	if (mydomain == (char *)0) {
+	if (mydomain == NULL) {
 		static char domain[MAXHOSTNAMELEN + 1];
 
 		getdomainname (domain, MAXHOSTNAMELEN);
@@ -228,7 +228,7 @@ static bool user_match (const char *tok, const char *string)
 		        && from_match (at + 1, myhostname ()));
 #if HAVE_INNETGR
 	} else if (tok[0] == '@') {	/* netgroup */
-		return (netgroup_match (tok + 1, (char *) 0, string));
+		return (netgroup_match (tok + 1, NULL, string));
 #endif
 	} else if (string_match (tok, string)) {	/* ALL or exact match */
 		return true;
@@ -303,7 +303,7 @@ static bool from_match (const char *tok, const char *string)
 	 */
 #if HAVE_INNETGR
 	if (tok[0] == '@') {	/* netgroup */
-		return (netgroup_match (tok + 1, string, (char *) 0));
+		return (netgroup_match (tok + 1, string, NULL));
 	} else
 #endif
 	if (string_match (tok, string)) {	/* ALL or exact match */

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -504,7 +504,7 @@ int main (int argc, char **argv)
 		if ((argc > 0) && (argv[0][0] == '-')) {
 			usage ();
 			goto failure;
-		} else if (argv[0] != (char *) 0) {
+		} else if (argv[0] != NULL) {
 			group = argv[0];
 		} else {
 			/*
@@ -740,7 +740,7 @@ int main (int argc, char **argv)
 	 */
 	if (cflag) {
 		closelog ();
-		execl (SHELL, "sh", "-c", command, (char *) 0);
+		execl (SHELL, "sh", "-c", command, (char *) NULL);
 #ifdef WITH_AUDIT
 		snprintf (audit_buf, sizeof(audit_buf),
 		          "changing new-gid=%lu", (unsigned long) gid);
@@ -820,7 +820,7 @@ int main (int argc, char **argv)
 	 * Exec the login shell and go away. We are trying to get back to
 	 * the previous environment which should be the user's login shell.
 	 */
-	err = shell (prog, initflag ? (char *) 0 : progbase, newenvp);
+	err = shell (prog, initflag ? NULL : progbase, newenvp);
 	exit ((err == ENOENT) ? E_CMD_NOTFOUND : E_CMD_NOEXEC);
 	/*@notreached@*/
       failure:

--- a/src/newusers.c
+++ b/src/newusers.c
@@ -1088,7 +1088,7 @@ int main (int argc, char **argv)
 	 * over 100 is allocated. The pw_gid field will be updated with that
 	 * value.
 	 */
-	while (fgets (buf, (int) sizeof buf, stdin) != (char *) 0) {
+	while (fgets (buf, (int) sizeof buf, stdin) != NULL) {
 		line++;
 		cp = strrchr (buf, '\n');
 		if (NULL != cp) {

--- a/src/pwck.c
+++ b/src/pwck.c
@@ -812,7 +812,7 @@ static void check_spw_file (int *errors, bool *changed)
 		 * Warn if last password change in the future.  --marekm
 		 */
 		if (!quiet) {
-			time_t t = time ((time_t *) 0);
+			time_t t = time (NULL);
 			if (   (t != 0)
 			    && (spw->sp_lstchg > (long) t / SCALE)) {
 				printf (_("user %s: last password change in the future\n"),

--- a/src/su.c
+++ b/src/su.c
@@ -575,7 +575,7 @@ static void check_perms_nopam (const struct passwd *pw)
 	 * The first character of an administrator defined method is an '@'
 	 * character.
 	 */
-	if (pw_auth (password, name, PW_SU, (char *) 0) != 0) {
+	if (pw_auth (password, name, PW_SU, NULL) != 0) {
 		SYSLOG (((pw->pw_uid != 0)? LOG_NOTICE : LOG_WARN,
 		         "Authentication failed for %s", name));
 		fprintf(stderr, _("%s: Authentication failure\n"), Prog);
@@ -598,7 +598,7 @@ static void check_perms_nopam (const struct passwd *pw)
 	 * there is a "SU" entry in the /etc/porttime file denying access to
 	 * the account.
 	 */
-	if (!isttytime (name, "SU", time ((time_t *) 0))) {
+	if (!isttytime (name, "SU", time (NULL))) {
 		SYSLOG (((0 != pw->pw_uid) ? LOG_WARN : LOG_CRIT,
 		         "SU by %s to restricted account %s",
 		         caller_name, name));
@@ -1130,7 +1130,7 @@ int main (int argc, char **argv)
 		int fd = open ("/dev/tty", O_RDWR);
 
 		if (fd >= 0) {
-			err = ioctl (fd, TIOCNOTTY, (char *) 0);
+			err = ioctl (fd, TIOCNOTTY, (char *) NULL);
 			(void) close (fd);
 		} else if (ENXIO == errno) {
 			/* There are no controlling terminal already */

--- a/src/sulogin.c
+++ b/src/sulogin.c
@@ -127,7 +127,7 @@ static void catch_signals (unused int sig)
 	while (true) {		/* repeatedly get login/password pairs */
 		char *cp;
 		pw_entry (name, &pwent);	/* get entry from password file */
-		if (pwent.pw_name == (char *) 0) {
+		if (pwent.pw_name == NULL) {
 			/*
 			 * Fail secure
 			 */
@@ -155,7 +155,7 @@ static void catch_signals (unused int sig)
 			erase_pass (cp);
 			(void) puts ("");
 #ifdef	TELINIT
-			execl (PATH_TELINIT, "telinit", RUNLEVEL, (char *) 0);
+			execl (PATH_TELINIT, "telinit", RUNLEVEL, (char *) NULL);
 #endif
 			exit (0);
 		}
@@ -177,7 +177,7 @@ static void catch_signals (unused int sig)
 	(void) puts (_("Entering System Maintenance Mode"));
 
 	/* exec the shell finally. */
-	err = shell (pwent.pw_shell, (char *) 0, environ);
+	err = shell (pwent.pw_shell, NULL, environ);
 
 	return ((err == ENOENT) ? E_CMD_NOTFOUND : E_CMD_NOEXEC);
 }

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -894,7 +894,7 @@ static int get_groups (char *list)
 	close_group_files ();
 	unlock_group_files ();
 
-	user_groups[ngroups] = (char *) 0;
+	user_groups[ngroups] = NULL;
 
 	/*
 	 * Any errors in finding group names are fatal
@@ -2546,7 +2546,7 @@ int main (int argc, char **argv)
 	/*
 	 * Initialize the list to be empty
 	 */
-	user_groups[0] = (char *) 0;
+	user_groups[0] = NULL;
 
 
 	is_shadow_pwd = spw_file_present ();

--- a/src/userdel.c
+++ b/src/userdel.c
@@ -763,7 +763,7 @@ static void user_cancel (const char *user)
 	}
 	argv[0] = cmd;
 	argv[1] = user;
-	argv[2] = (char *)0;
+	argv[2] = NULL;
 	(void) run_command (cmd, argv, NULL, &status);
 }
 

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -205,7 +205,7 @@ static int get_groups (char *list)
 	/*
 	 * Initialize the list to be empty
 	 */
-	user_groups[0] = (char *) 0;
+	user_groups[0] = NULL;
 
 	if ('\0' == *list) {
 		return 0;
@@ -280,7 +280,7 @@ static int get_groups (char *list)
 		gr_free ((struct group *)grp);
 	} while (NULL != list);
 
-	user_groups[ngroups] = (char *) 0;
+	user_groups[ngroups] = NULL;
 
 	/*
 	 * Any errors in finding group names are fatal
@@ -2154,7 +2154,7 @@ int main (int argc, char **argv)
 
 	sys_ngroups = sysconf (_SC_NGROUPS_MAX);
 	user_groups = (char **) malloc (sizeof (char *) * (1 + sys_ngroups));
-	user_groups[0] = (char *) 0;
+	user_groups[0] = NULL;
 
 	is_shadow_pwd = spw_file_present ();
 #ifdef SHADOWGRP


### PR DESCRIPTION
In variadic functions we still do the cast.  In POSIX, it's not necessary, since NULL is required to be of type 'void *', and 'void *' is guaranteed to have the same alignment and representation as 'char *'. However, since ISO C still doesn't mandate that, and moreover they're doing dubious stuff by adding nullptr, let's be on the cautious side. Also, C++ requires that NULL is _not_ 'void *', but either plain 0 or some magic stuff.

Signed-off-by: Alejandro Colomar <alx@kernel.org>