### PR TITLE
Use freezero(3) where suitable

### DIFF
--- a/libmisc/agetpass.c
+++ b/libmisc/agetpass.c
@@ -136,8 +136,7 @@ agetpass(const char *prompt)
 	return pass;
 
 fail:
-	memzero(pass, PASS_MAX);
-	free(pass);
+	freezero(pass, PASS_MAX);
 	return NULL;
 }
 
@@ -145,8 +144,5 @@ fail:
 void
 erase_pass(char *pass)
 {
-	if (pass == NULL)
-		return;
-	memzero(pass, PASS_MAX);
-	free(pass);
+	freezero(pass, PASS_MAX);
 }

--- a/libmisc/obscure.c
+++ b/libmisc/obscure.c
@@ -274,10 +274,8 @@ static /*@observer@*//*@null@*/const char *obscure_msg (
 
 	msg = password_check (old1, new1, pwdp);
 
-	memzero (new1, newlen);
-	memzero (old1, oldlen);
-	free (new1);
-	free (old1);
+	freezero (new1, newlen);
+	freezero (old1, oldlen);
 
 	return msg;
 }


### PR DESCRIPTION
It originated in OpenBSD, and is available in libbsd.

Signed-off-by: Alejandro Colomar <alx@kernel.org>