### PR TITLE
Remove superfluous casts to 'void*'

### DIFF
--- a/lib/groupio.c
+++ b/lib/groupio.c
@@ -50,7 +50,7 @@ static const char *group_getname (const void *ent)
 
 static void *group_parse (const char *line)
 {
-	return (void *) sgetgrent (line);
+	return sgetgrent (line);
 }
 
 static int group_put (const void *ent, FILE * file)

--- a/lib/pwio.c
+++ b/lib/pwio.c
@@ -42,7 +42,7 @@ static const char *passwd_getname (const void *ent)
 
 static void *passwd_parse (const char *line)
 {
-	return (void *) sgetpwent (line);
+	return sgetpwent (line);
 }
 
 static int passwd_put (const void *ent, FILE * file)

--- a/lib/sgroupio.c
+++ b/lib/sgroupio.c
@@ -151,7 +151,7 @@ static const char *gshadow_getname (const void *ent)
 
 static void *gshadow_parse (const char *line)
 {
-	return (void *) sgetsgent (line);
+	return sgetsgent (line);
 }
 
 static int gshadow_put (const void *ent, FILE * file)

--- a/lib/shadowio.c
+++ b/lib/shadowio.c
@@ -47,7 +47,7 @@ static const char *shadow_getname (const void *ent)
 
 static void *shadow_parse (const char *line)
 {
-	return (void *) sgetspent (line);
+	return sgetspent (line);
 }
 
 static int shadow_put (const void *ent, FILE * file)

--- a/libmisc/log.c
+++ b/libmisc/log.c
@@ -67,7 +67,7 @@ void dolastlog (
 	 * the way we read the old one in.
 	 */
 
-	if (read (fd, (void *) &newlog, sizeof newlog) != (ssize_t) sizeof newlog) {
+	if (read (fd, &newlog, sizeof newlog) != (ssize_t) sizeof newlog) {
 		memzero (&newlog, sizeof newlog);
 	}
 	if (NULL != ll) {


### PR DESCRIPTION
Every non-const pointer converts automatically to it.

Signed-off-by: Alejandro Colomar <alx@kernel.org>