### PR TITLE
Fix memory leaks by replacing realloc(3) with reallocf(3)

### DIFF
--- a/lib/groupmem.c
+++ b/lib/groupmem.c
@@ -86,33 +86,3 @@ void gr_free (/*@out@*/ /*@only@*/struct group *grent)
 	gr_free_members(grent);
 	free (grent);
 }
-
-bool gr_append_member(struct group *grp, char *member)
-{
-	int i;
-
-	if (NULL == grp->gr_mem || grp->gr_mem[0] == NULL) {
-		grp->gr_mem = (char **)malloc(2 * sizeof(char *));
-		if (!grp->gr_mem) {
-			return false;
-		}
-		grp->gr_mem[0] = strdup(member);
-		if (!grp->gr_mem[0]) {
-			return false;
-		}
-		grp->gr_mem[1] = NULL;
-		return true;
-	}
-
-	for (i = 0; grp->gr_mem[i]; i++) ;
-	grp->gr_mem = realloc(grp->gr_mem, (i + 2) * sizeof(char *));
-	if (NULL == grp->gr_mem) {
-		return false;
-	}
-	grp->gr_mem[i] = strdup(member);
-	if (NULL == grp->gr_mem[i]) {
-		return false;
-	}
-	grp->gr_mem[i + 1] = NULL;
-	return true;
-}

--- a/lib/prototypes.h
+++ b/lib/prototypes.h
@@ -189,7 +189,6 @@ extern void __gr_set_changed (void);
 extern /*@null@*/ /*@only@*/struct group *__gr_dup (const struct group *grent);
 extern void gr_free_members (struct group *grent);
 extern void gr_free (/*@out@*/ /*@only@*/struct group *grent);
-extern bool gr_append_member (struct group *grp, char *member);
 
 /* hushed.c */
 extern bool hushed (const char *username);

--- a/src/newusers.c
+++ b/src/newusers.c
@@ -1200,9 +1200,9 @@ int main (int argc, char **argv)
 #ifdef USE_PAM
 		/* keep the list of user/password for later update by PAM */
 		nusers++;
-		lines     = realloc (lines,     sizeof (lines[0])     * nusers);
-		usernames = realloc (usernames, sizeof (usernames[0]) * nusers);
-		passwords = realloc (passwords, sizeof (passwords[0]) * nusers);
+		lines     = reallocf (lines,     sizeof (lines[0])     * nusers);
+		usernames = reallocf (usernames, sizeof (usernames[0]) * nusers);
+		passwords = reallocf (passwords, sizeof (passwords[0]) * nusers);
 		lines[nusers-1]     = line;
 		usernames[nusers-1] = strdup (fields[0]);
 		passwords[nusers-1] = strdup (fields[1]);

--- a/src/newusers.c
+++ b/src/newusers.c
@@ -1203,6 +1203,13 @@ int main (int argc, char **argv)
 		lines     = reallocf (lines,     sizeof (lines[0])     * nusers);
 		usernames = reallocf (usernames, sizeof (usernames[0]) * nusers);
 		passwords = reallocf (passwords, sizeof (passwords[0]) * nusers);
+		if (lines == NULL || usernames == NULL || passwords == NULL) {
+			fprintf (stderr,
+			         _("%s: line %d: %s\n"),
+			         Prog, line, strerror(errno));
+			errors++;
+			continue;
+		}
 		lines[nusers-1]     = line;
 		usernames[nusers-1] = strdup (fields[0]);
 		passwords[nusers-1] = strdup (fields[1]);


### PR DESCRIPTION
Signed-off-by: Alejandro Colomar <alx@kernel.org>