### PR TITLE
Improve TTYGROUP description in login.defs manpage

### DIFF
--- a/man/login.defs.d/TTYGROUP.xml
+++ b/man/login.defs.d/TTYGROUP.xml
@@ -14,13 +14,14 @@
       <option>TTYPERM</option>.
     </para>
     <para>
-      By default, the ownership of the terminal is set to the user's
-      primary group and the permissions are set to
-      <replaceable>0600</replaceable>.
-    </para>
-    <para>
       <option>TTYGROUP</option> can be either the name of a group or a
       numeric group identifier.
+    </para>
+    <para>
+      If TTYGROUP is not defined, then the group ownership of the terminal is
+      set to the user's primary group.  If TTYPERM is not defined, then the
+      permissions are set to
+      <replaceable>0600</replaceable>.
     </para>
     <para>
       If you have a <command>write</command> program which is "setgid" to


### PR DESCRIPTION
Closes #457

The existing prose was confusing, or simply wrong.  Make it clear that only the group ownership of the tty is affected, and how. Also move the paragraph about defaults after the discussion of acceptable TTYGROUPs, as this seems more natural.

Signed-off-by: Serge Hallyn <serge@hallyn.com>