### PR TITLE
Remove superfluous casts

### DIFF
--- a/contrib/adduser.c
+++ b/contrib/adduser.c
@@ -489,7 +489,7 @@ safeget (char *buf, int maxlen)
   while ((c = getc (stdin)) != EOF && (c != '\n') && (++i < maxlen))
     {
       bad = (!isalnum (c) && (c != '_') && (c != ' '));
-      *(buf++) = (char) c;
+      *(buf++) = c;
     }
   *buf = '\0';
 

--- a/lib/commonio.c
+++ b/lib/commonio.c
@@ -216,8 +216,8 @@ int do_fcntl_lock (const char *file, bool log, short type)
 	fd = open (file, O_WRONLY, 0600);
 	if (-1 == fd) {
 		if (log) {
-				(void) fprintf (shadow_logfd, "%s: %s: %s\n",
-				                shadow_progname, file, strerror (errno));
+			(void) fprintf (shadow_logfd, "%s: %s: %s\n",
+			                shadow_progname, file, strerror (errno));
 		}
 		return 0;
 	}
@@ -518,7 +518,7 @@ int commonio_open (struct commonio_db *db, int mode)
 		goto cleanup_ENOMEM;
 	}
 
-	while (db->ops->fgets (buf, (int) buflen, db->fp) == buf) {
+	while (db->ops->fgets (buf, buflen, db->fp) == buf) {
 		while (   ((cp = strrchr (buf, '\n')) == NULL)
 		       && (feof (db->fp) == 0)) {
 			size_t len;

--- a/lib/fields.c
+++ b/lib/fields.c
@@ -74,7 +74,7 @@ void change_field (char *buf, size_t maxsize, const char *prompt)
 
 	printf ("\t%s [%s]: ", prompt, buf);
 	(void) fflush (stdout);
-	if (fgets (newf, (int) maxsize, stdin) != newf) {
+	if (fgets (newf, maxsize, stdin) != newf) {
 		return;
 	}
 

--- a/lib/get_gid.c
+++ b/lib/get_gid.c
@@ -25,7 +25,7 @@ int get_gid (const char *gidstr, gid_t *gid)
 		return 0;
 	}
 
-	*gid = (gid_t)val;
+	*gid = val;
 	return 1;
 }
 

--- a/lib/get_pid.c
+++ b/lib/get_pid.c
@@ -25,7 +25,7 @@ int get_pid (const char *pidstr, pid_t *pid)
 		return 0;
 	}
 
-	*pid = (pid_t)val;
+	*pid = val;
 	return 1;
 }
 

--- a/lib/get_uid.c
+++ b/lib/get_uid.c
@@ -25,7 +25,7 @@ int get_uid (const char *uidstr, uid_t *uid)
 		return 0;
 	}
 
-	*uid = (uid_t)val;
+	*uid = val;
 	return 1;
 }
 

--- a/lib/getdef.c
+++ b/lib/getdef.c
@@ -13,6 +13,7 @@
 
 #include "prototypes.h"
 #include "defines.h"
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>
@@ -191,7 +192,7 @@ static void def_load (void);
 	}
 
 	d = def_find (item);
-	return ((NULL == d)? (const char *) NULL : d->value);
+	return (NULL == d) ? NULL : d->value;
 }
 
 
@@ -249,7 +250,7 @@ int getdef_num (const char *item, int dflt)
 		return dflt;
 	}
 
-	return (int) val;
+	return val;
 }
 
 
@@ -284,7 +285,7 @@ unsigned int getdef_unum (const char *item, unsigned int dflt)
 		return dflt;
 	}
 
-	return (unsigned int) val;
+	return val;
 }
 
 
@@ -428,7 +429,7 @@ static /*@observer@*/ /*@null@*/struct itemdef *def_find (const char *name)
 	SYSLOG ((LOG_CRIT, "unknown configuration item `%s'", name));
 
 out:
-	return (struct itemdef *) NULL;
+	return NULL;
 }
 
 /*
@@ -540,12 +541,12 @@ static void def_load (void)
 	/*
 	 * Go through all of the lines in the file.
 	 */
-	while (fgets (buf, (int) sizeof (buf), fp) != NULL) {
+	while (fgets (buf, sizeof (buf), fp) != NULL) {
 
 		/*
 		 * Trim trailing whitespace.
 		 */
-		for (i = (int) strlen (buf) - 1; i >= 0; --i) {
+		for (i = (ptrdiff_t) strlen (buf) - 1; i >= 0; --i) {
 			if (!isspace (buf[i])) {
 				break;
 			}

--- a/lib/groupio.c
+++ b/lib/groupio.c
@@ -159,7 +159,7 @@ int gr_open (int mode)
 
 int gr_update (const struct group *gr)
 {
-	return commonio_update (&group_db, (const void *) gr);
+	return commonio_update (&group_db, gr);
 }
 
 int gr_remove (const char *name)
@@ -247,8 +247,8 @@ static int group_open_hook (void)
 
 	for (gr1 = group_db.head; NULL != gr1; gr1 = gr1->next) {
 		for (gr2 = gr1->next; NULL != gr2; gr2 = gr2->next) {
-			struct group *g1 = (struct group *)gr1->eptr;
-			struct group *g2 = (struct group *)gr2->eptr;
+			struct group *g1 = gr1->eptr;
+			struct group *g2 = gr2->eptr;
 			if (NULL != g1 &&
 			    NULL != g2 &&
 			    0 == strcmp (g1->gr_name, g2->gr_name) &&
@@ -302,8 +302,8 @@ static /*@null@*/struct commonio_entry *merge_group_entries (
 		return NULL;
 	}
 
-	gptr1 = (struct group *)gr1->eptr;
-	gptr2 = (struct group *)gr2->eptr;
+	gptr1 = gr1->eptr;
+	gptr2 = gr2->eptr;
 	if (NULL == gptr2 || NULL == gptr1) {
 		errno = EINVAL;
 		return NULL;
@@ -377,7 +377,7 @@ static int split_groups (unsigned int max_members)
 	struct commonio_entry *gr;
 
 	for (gr = group_db.head; NULL != gr; gr = gr->next) {
-		struct group *gptr = (struct group *)gr->eptr;
+		struct group *gptr = gr->eptr;
 		struct commonio_entry *new;
 		struct group *new_gptr;
 		unsigned int members = 0;
@@ -406,7 +406,7 @@ static int split_groups (unsigned int max_members)
 			errno = ENOMEM;
 			return 0;
 		}
-		new_gptr = (struct group *)new->eptr;
+		new_gptr = new->eptr;
 		new->line = NULL;
 		new->changed = true;
 

--- a/lib/gshadow.c
+++ b/lib/gshadow.c
@@ -207,9 +207,9 @@ void endsgent (void)
 	}
 
 #ifdef	USE_NIS
-	while (fgetsx (buf, (int) buflen, fp) == buf)
+	while (fgetsx (buf, buflen, fp) == buf)
 #else
-	if (fgetsx (buf, (int) buflen, fp) == buf)
+	if (fgetsx (buf, buflen, fp) == buf)
 #endif
 	{
 		while (   ((cp = strrchr (buf, '\n')) == NULL)

--- a/lib/port.c
+++ b/lib/port.c
@@ -134,7 +134,7 @@ static struct port *getportent (void)
 	 * Lines which begin with '#' are all ignored.
 	 */
 
-	if (fgets (buf, (int) sizeof buf, ports) == 0) {
+	if (fgets (buf, sizeof buf, ports) == 0) {
 		errno = saveerr;
 		return 0;
 	}

--- a/lib/pwio.c
+++ b/lib/pwio.c
@@ -137,7 +137,7 @@ int pw_open (int mode)
 
 int pw_update (const struct passwd *pw)
 {
-	return commonio_update (&passwd_db, (const void *) pw);
+	return commonio_update (&passwd_db, pw);
 }
 
 int pw_remove (const char *name)

--- a/lib/sgroupio.c
+++ b/lib/sgroupio.c
@@ -253,7 +253,7 @@ int sgr_open (int mode)
 
 int sgr_update (const struct sgrp *sg)
 {
-	return commonio_update (&gshadow_db, (const void *) sg);
+	return commonio_update (&gshadow_db, sg);
 }
 
 int sgr_remove (const char *name)

--- a/lib/shadow.c
+++ b/lib/shadow.c
@@ -336,9 +336,9 @@ struct spwd *fgetspent (FILE * fp)
 	}
 
 #ifdef	USE_NIS
-	while (fgets (buf, (int) sizeof buf, fp) != NULL)
+	while (fgets (buf, sizeof buf, fp) != NULL)
 #else
-	if (fgets (buf, (int) sizeof buf, fp) != NULL)
+	if (fgets (buf, sizeof buf, fp) != NULL)
 #endif
 	{
 		cp = strchr (buf, '\n');

--- a/lib/shadowio.c
+++ b/lib/shadowio.c
@@ -164,7 +164,7 @@ int spw_open (int mode)
 
 int spw_update (const struct spwd *sp)
 {
-	return commonio_update (&shadow_db, (const void *) sp);
+	return commonio_update (&shadow_db, sp);
 }
 
 int spw_remove (const char *name)

--- a/lib/subordinateio.c
+++ b/lib/subordinateio.c
@@ -355,13 +355,14 @@ static int subordinate_range_cmp (const void *p1, const void *p2)
 {
 	struct subordinate_range *range1, *range2;
 
-	if ((*(struct commonio_entry **) p1)->eptr == NULL)
-		return 1;
-	if ((*(struct commonio_entry **) p2)->eptr == NULL)
-		return -1;
 
-	range1 = ((struct subordinate_range *) (*(struct commonio_entry **) p1)->eptr);
-	range2 = ((struct subordinate_range *) (*(struct commonio_entry **) p2)->eptr);
+	range1 = (*(struct commonio_entry **) p1)->eptr;
+	if (range1 == NULL)
+		return 1;
+
+	range2 = (*(struct commonio_entry **) p2)->eptr;
+	if (range2 == NULL)
+		return -1;
 
 	if (range1->start < range2->start)
 		return -1;

--- a/lib/tcbfuncs.c
+++ b/lib/tcbfuncs.c
@@ -141,7 +141,7 @@ static /*@null@*/ char *shadowtcb_path_rel_existing (const char *name)
 		         shadow_progname, link);
 		return NULL;
 	}
-	link[(size_t)ret] = '\0';
+	link[ret] = '\0';
 	rval = strdup (link);
 	if (NULL == rval) {
 		OUT_OF_MEMORY;

--- a/libmisc/addgrps.c
+++ b/libmisc/addgrps.c
@@ -100,7 +100,7 @@ int add_groups (const char *list)
 	}
 
 	if (added) {
-		ret = setgroups ((size_t)ngroups, grouplist);
+		ret = setgroups (ngroups, grouplist);
 		free (grouplist);
 		return ret;
 	}

--- a/libmisc/age.c
+++ b/libmisc/age.c
@@ -139,7 +139,7 @@ int expire (const struct passwd *pw, /*@null@*/const struct spwd *sp)
 
 void agecheck (/*@null@*/const struct spwd *sp)
 {
-	long now = (long) time(NULL) / SCALE;
+	long now = time(NULL) / SCALE;
 	long remain;
 
 	if (NULL == sp) {

--- a/libmisc/audit_help.c
+++ b/libmisc/audit_help.c
@@ -62,7 +62,7 @@ void audit_logger (int type, unused const char *pgname, const char *op,
 		return;
 	} else {
 		audit_log_acct_message (audit_fd, type, NULL, op, name, id,
-		                        NULL, NULL, NULL, (int) result);
+		                        NULL, NULL, NULL, result);
 	}
 }
 
@@ -77,7 +77,7 @@ void audit_logger_message (const char *message, shadow_audit_result result)
 		                        NULL, /* hostname */
 		                        NULL, /* addr */
 		                        NULL, /* tty */
-		                        (int) result);
+		                        result);
 	}
 }
 

--- a/libmisc/chowntty.c
+++ b/libmisc/chowntty.c
@@ -51,7 +51,7 @@ void chown_tty (const struct passwd *info)
 	 */
 
 	if (   (fchown (STDIN_FILENO, info->pw_uid, gid) != 0)
-	    || (fchmod (STDIN_FILENO, (mode_t)getdef_num ("TTYPERM", 0600)) != 0)) {
+	    || (fchmod (STDIN_FILENO, getdef_num ("TTYPERM", 0600)) != 0)) {
 		int err = errno;
 		FILE *shadow_logfd = log_get_logfd();
 

--- a/libmisc/cleanup_group.c
+++ b/libmisc/cleanup_group.c
@@ -22,7 +22,7 @@
  */
 void cleanup_report_add_group (void *group_name)
 {
-	const char *name = (const char *)group_name;
+	const char *name = group_name;
 
 	SYSLOG ((LOG_ERR, "failed to add group %s", name));
 #ifdef WITH_AUDIT
@@ -40,7 +40,7 @@ void cleanup_report_add_group (void *group_name)
  */
 void cleanup_report_del_group (void *group_name)
 {
-	const char *name = (const char *)group_name;
+	const char *name = group_name;
 
 	SYSLOG ((LOG_ERR, "failed to remove group %s", name));
 #ifdef WITH_AUDIT
@@ -95,7 +95,7 @@ void cleanup_report_mod_gshadow (void *cleanup_info)
  */
 void cleanup_report_add_group_group (void *group_name)
 {
-	const char *name = (const char *)group_name;
+	const char *name = group_name;
 
 	SYSLOG ((LOG_ERR, "failed to add group %s to %s", name, gr_dbname ()));
 #ifdef WITH_AUDIT
@@ -115,7 +115,7 @@ void cleanup_report_add_group_group (void *group_name)
  */
 void cleanup_report_add_group_gshadow (void *group_name)
 {
-	const char *name = (const char *)group_name;
+	const char *name = group_name;
 
 	SYSLOG ((LOG_ERR, "failed to add group %s to %s", name, sgr_dbname ()));
 #ifdef WITH_AUDIT
@@ -136,7 +136,7 @@ void cleanup_report_add_group_gshadow (void *group_name)
  */
 void cleanup_report_del_group_group (void *group_name)
 {
-	const char *name = (const char *)group_name;
+	const char *name = group_name;
 
 	SYSLOG ((LOG_ERR,
 	         "failed to remove group %s from %s",
@@ -159,7 +159,7 @@ void cleanup_report_del_group_group (void *group_name)
  */
 void cleanup_report_del_group_gshadow (void *group_name)
 {
-	const char *name = (const char *)group_name;
+	const char *name = group_name;
 
 	SYSLOG ((LOG_ERR,
 	         "failed to remove group %s from %s",

--- a/libmisc/cleanup_user.c
+++ b/libmisc/cleanup_user.c
@@ -22,7 +22,7 @@
  */
 void cleanup_report_add_user (void *user_name)
 {
-	const char *name = (const char *)user_name;
+	const char *name = user_name;
 
 	SYSLOG ((LOG_ERR, "failed to add user %s", name));
 #ifdef WITH_AUDIT
@@ -59,7 +59,7 @@ void cleanup_report_mod_passwd (void *cleanup_info)
  */
 void cleanup_report_add_user_passwd (void *user_name)
 {
-	const char *name = (const char *)user_name;
+	const char *name = user_name;
 
 	SYSLOG ((LOG_ERR, "failed to add user %s to %s", name, pw_dbname ()));
 #ifdef WITH_AUDIT
@@ -79,7 +79,7 @@ void cleanup_report_add_user_passwd (void *user_name)
  */
 void cleanup_report_add_user_shadow (void *user_name)
 {
-	const char *name = (const char *)user_name;
+	const char *name = user_name;
 
 	SYSLOG ((LOG_ERR, "failed to add user %s to %s", name, spw_dbname ()));
 #ifdef WITH_AUDIT

--- a/libmisc/console.c
+++ b/libmisc/console.c
@@ -70,7 +70,7 @@ static bool is_listed (const char *cfgin, const char *tty, bool def)
 	 * See if this tty is listed in the console file.
 	 */
 
-	while (fgets (buf, (int) sizeof (buf), fp) != NULL) {
+	while (fgets (buf, sizeof (buf), fp) != NULL) {
 		/* Remove optional trailing '\n'. */
 		buf[strcspn (buf, "\n")] = '\0';
 		if (strcmp (buf, tty) == 0) {

--- a/libmisc/copydir.c
+++ b/libmisc/copydir.c
@@ -768,7 +768,7 @@ static ssize_t full_write(int fd, const void *buf, size_t count) {
 
 		written += res;
 		buf = (const unsigned char*)buf + res;
-		count -= (size_t)res;
+		count -= res;
 	}
 
 	return written;
@@ -850,7 +850,7 @@ static int copy_file (const struct path_info *src, const struct path_info *dst,
 			break;
 		}
 
-		if (full_write (ofd, buf, (size_t)cnt) < 0) {
+		if (full_write (ofd, buf, cnt) < 0) {
 			(void) close (ofd);
 			(void) close (ifd);
 			return -1;

--- a/libmisc/failure.c
+++ b/libmisc/failure.c
@@ -53,7 +53,7 @@ void failure (uid_t uid, const char *tty, struct faillog *fl)
 	 */
 
 	if (   (lseek (fd, offset_uid, SEEK_SET) != offset_uid)
-	    || (read (fd, (char *) fl, sizeof *fl) != (ssize_t) sizeof *fl)) {
+	    || (read (fd, fl, sizeof *fl) != (ssize_t) sizeof *fl)) {
 		/* This is not necessarily a failure. The file is
 		 * initially zero length.
 		 *
@@ -86,7 +86,7 @@ void failure (uid_t uid, const char *tty, struct faillog *fl)
 	 */
 
 	if (   (lseek (fd, offset_uid, SEEK_SET) != offset_uid)
-	    || (write (fd, (char *) fl, sizeof *fl) != (ssize_t) sizeof *fl)
+	    || (write (fd, fl, sizeof *fl) != (ssize_t) sizeof *fl)
 	    || (close (fd) != 0)) {
 		SYSLOG ((LOG_WARN,
 		         "Can't write faillog entry for UID %lu in %s.",
@@ -163,7 +163,7 @@ int failcheck (uid_t uid, struct faillog *fl, bool failed)
 	 */
 
 	if (   (lseek (fd, offset_uid, SEEK_SET) != offset_uid)
-	    || (read (fd, (char *) fl, sizeof *fl) != (ssize_t) sizeof *fl)) {
+	    || (read (fd, fl, sizeof *fl) != (ssize_t) sizeof *fl)) {
 		(void) close (fd);
 		return 1;
 	}
@@ -185,7 +185,7 @@ int failcheck (uid_t uid, struct faillog *fl, bool failed)
 		fail.fail_cnt = 0;
 
 		if (   (lseek (fd, offset_uid, SEEK_SET) != offset_uid)
-		    || (write (fd, (const void *) &fail, sizeof fail) != (ssize_t) sizeof fail)
+		    || (write (fd, &fail, sizeof fail) != (ssize_t) sizeof fail)
 		    || (close (fd) != 0)) {
 			SYSLOG ((LOG_WARN,
 			         "Can't reset faillog entry for UID %lu in %s.",
@@ -278,7 +278,7 @@ void failtmp (const char *username, const struct utmp *failent)
 	 * Append the new failure record and close the log file.
 	 */
 
-	if (   (write (fd, (const void *) failent, sizeof *failent) != (ssize_t) sizeof *failent)
+	if (   (write (fd, failent, sizeof *failent) != (ssize_t) sizeof *failent)
 	    || (close (fd) != 0)) {
 		SYSLOG ((LOG_WARN,
 		         "Can't append failure of user %s to %s.",

--- a/libmisc/find_new_gid.c
+++ b/libmisc/find_new_gid.c
@@ -40,15 +40,14 @@ static int get_ranges (bool sys_group, gid_t *min_id, gid_t *max_id,
 		*preferred_min = (gid_t) 1;
 
 		/* Get the minimum ID range from login.defs or default to 101 */
-		*min_id = (gid_t) getdef_ulong ("SYS_GID_MIN", 101UL);
+		*min_id = getdef_ulong ("SYS_GID_MIN", 101UL);
 
 		/*
 		 * If SYS_GID_MAX is unspecified, we should assume it to be one
 		 * less than the GID_MIN (which is reserved for non-system accounts)
 		 */
-		gid_def_max = (gid_t) getdef_ulong ("GID_MIN", 1000UL) - 1;
-		*max_id = (gid_t) getdef_ulong ("SYS_GID_MAX",
-				(unsigned long) gid_def_max);
+		gid_def_max = getdef_ulong ("GID_MIN", 1000UL) - 1;
+		*max_id = getdef_ulong ("SYS_GID_MAX", gid_def_max);
 
 		/* Check that the ranges make sense */
 		if (*max_id < *min_id) {
@@ -71,8 +70,8 @@ static int get_ranges (bool sys_group, gid_t *min_id, gid_t *max_id,
 		/* Non-system groups */
 
 		/* Get the values from login.defs or use reasonable defaults */
-		*min_id = (gid_t) getdef_ulong ("GID_MIN", 1000UL);
-		*max_id = (gid_t) getdef_ulong ("GID_MAX", 60000UL);
+		*min_id = getdef_ulong ("GID_MIN", 1000UL);
+		*max_id = getdef_ulong ("GID_MAX", 60000UL);
 
 		/*
 		 * The preferred minimum should match the standard ID minimum

--- a/libmisc/find_new_uid.c
+++ b/libmisc/find_new_uid.c
@@ -40,15 +40,14 @@ static int get_ranges (bool sys_user, uid_t *min_id, uid_t *max_id,
 		*preferred_min = (uid_t) 1;
 
 		/* Get the minimum ID range from login.defs or default to 101 */
-		*min_id = (uid_t) getdef_ulong ("SYS_UID_MIN", 101UL);
+		*min_id = getdef_ulong ("SYS_UID_MIN", 101UL);
 
 		/*
 		 * If SYS_UID_MAX is unspecified, we should assume it to be one
 		 * less than the UID_MIN (which is reserved for non-system accounts)
 		 */
-		uid_def_max = (uid_t) getdef_ulong ("UID_MIN", 1000UL) - 1;
-		*max_id = (uid_t) getdef_ulong ("SYS_UID_MAX",
-				(unsigned long) uid_def_max);
+		uid_def_max = getdef_ulong ("UID_MIN", 1000UL) - 1;
+		*max_id = getdef_ulong ("SYS_UID_MAX", uid_def_max);
 
 		/* Check that the ranges make sense */
 		if (*max_id < *min_id) {
@@ -71,8 +70,8 @@ static int get_ranges (bool sys_user, uid_t *min_id, uid_t *max_id,
 		/* Non-system users */
 
 		/* Get the values from login.defs or use reasonable defaults */
-		*min_id = (uid_t) getdef_ulong ("UID_MIN", 1000UL);
-		*max_id = (uid_t) getdef_ulong ("UID_MAX", 60000UL);
+		*min_id = getdef_ulong ("UID_MIN", 1000UL);
+		*max_id = getdef_ulong ("UID_MAX", 60000UL);
 
 		/*
 		 * The preferred minimum should match the standard ID minimum

--- a/libmisc/getgr_nam_gid.c
+++ b/libmisc/getgr_nam_gid.c
@@ -36,7 +36,7 @@ extern /*@only@*//*@null@*/struct group *getgr_nam_gid (/*@null@*/const char *gr
 	    && ('\0' == *endptr)
 	    && (ERANGE != errno)
 	    && (/*@+longintegral@*/gid == (gid_t)gid)/*@=longintegral@*/) {
-		return xgetgrgid ((gid_t) gid);
+		return xgetgrgid (gid);
 	}
 	return xgetgrnam (grname);
 }

--- a/libmisc/gettime.c
+++ b/libmisc/gettime.c
@@ -61,7 +61,7 @@
 			 fallback, epoch);
 	} else {
 		/* Valid */
-		return (time_t)epoch;
+		return epoch;
 	}
 
 	return fallback;

--- a/libmisc/hushed.c
+++ b/libmisc/hushed.c
@@ -66,7 +66,7 @@ bool hushed (const char *username)
 	if (NULL == fp) {
 		return false;
 	}
-	for (found = false; !found && (fgets (buf, (int) sizeof buf, fp) == buf);) {
+	for (found = false; !found && (fgets (buf, sizeof buf, fp) == buf);) {
 		buf[strcspn (buf, "\n")] = '\0';
 		found = (strcmp (buf, pw->pw_shell) == 0) ||
 		        (strcmp (buf, pw->pw_name) == 0);

--- a/libmisc/isexpired.c
+++ b/libmisc/isexpired.c
@@ -40,7 +40,7 @@ int isexpired (const struct passwd *pw, /*@null@*/const struct spwd *sp)
 {
 	long now;
 
-	now = (long) time(NULL) / SCALE;
+	now = time(NULL) / SCALE;
 
 	if (NULL == sp) {
 		return 0;

--- a/libmisc/limits.c
+++ b/libmisc/limits.c
@@ -68,7 +68,7 @@ static int setrlimit_value (unsigned int resource,
 			return 0;
 		}
 		longlimit *= multiplier;
-		limit = (rlim_t)longlimit;
+		limit = longlimit;
 		if (longlimit != limit)
 		{
 			/* FIXME: Again, silent error handling...
@@ -95,7 +95,7 @@ static int set_prio (const char *value)
 	    || (prio != (int) prio)) {
 		return 0;
 	}
-	if (setpriority (PRIO_PROCESS, 0, (int) prio) != 0) {
+	if (setpriority (PRIO_PROCESS, 0, prio) != 0) {
 		return LOGIN_ERROR_RLIMIT;
 	}
 	return 0;
@@ -111,7 +111,7 @@ static int set_umask (const char *value)
 		return 0;
 	}
 
-	(void) umask ((mode_t) mask);
+	(void) umask (mask);
 	return 0;
 }
 
@@ -508,7 +508,7 @@ void setup_limits (const struct passwd *info)
 				if (   (getlong (cp + 4, &inc) == 1)
 				    && (inc >= -20) && (inc <= 20)) {
 					errno = 0;
-					if (   (nice ((int) inc) != -1)
+					if (   (nice (inc) != -1)
 					    || (0 != errno)) {
 						continue;
 					}
@@ -525,7 +525,7 @@ void setup_limits (const struct passwd *info)
 				long int blocks;
 				if (   (getlong (cp + 7, &blocks) == 0)
 				    || (blocks != (int) blocks)
-				    || (set_filesize_limit ((int) blocks) != 0)) {
+				    || (set_filesize_limit (blocks) != 0)) {
 					SYSLOG ((LOG_WARN,
 					         "Can't set the ulimit for user %s",
 					         info->pw_name));
@@ -540,7 +540,7 @@ void setup_limits (const struct passwd *info)
 					         "Can't set umask value for user %s",
 					         info->pw_name));
 				} else {
-					(void) umask ((mode_t) mask);
+					(void) umask (mask);
 				}
 
 				continue;

--- a/libmisc/log.c
+++ b/libmisc/log.c
@@ -82,7 +82,7 @@ void dolastlog (
 	strncpy (newlog.ll_host, host, sizeof (newlog.ll_host) - 1);
 #endif
 	if (   (lseek (fd, offset, SEEK_SET) != offset)
-	    || (write (fd, (const void *) &newlog, sizeof newlog) != (ssize_t) sizeof newlog)
+	    || (write (fd, &newlog, sizeof newlog) != (ssize_t) sizeof newlog)
 	    || (close (fd) != 0)) {
 		SYSLOG ((LOG_WARN,
 		         "Can't write lastlog entry for UID %lu in %s.",

--- a/libmisc/loginprompt.c
+++ b/libmisc/loginprompt.c
@@ -81,7 +81,7 @@ void login_prompt (const char *prompt, char *name, int namesize)
 	 */
 
 	memzero (buf, sizeof buf);
-	if (fgets (buf, (int) sizeof buf, stdin) != buf) {
+	if (fgets (buf, sizeof buf, stdin) != buf) {
 		exit (EXIT_FAILURE);
 	}
 

--- a/libmisc/obscure.c
+++ b/libmisc/obscure.c
@@ -257,7 +257,7 @@ static /*@observer@*//*@null@*/const char *obscure_msg (
 		}
 
 	}
-	maxlen = (size_t) getdef_num ("PASS_MAX_LEN", 8);
+	maxlen = getdef_num ("PASS_MAX_LEN", 8);
 	if (   (oldlen <= maxlen)
 	    && (newlen <= maxlen)) {
 		return NULL;

--- a/libmisc/pam_pass_non_interactive.c
+++ b/libmisc/pam_pass_non_interactive.c
@@ -43,8 +43,7 @@ static int ni_conv (int num_msg,
 		return PAM_CONV_ERR;
 	}
 
-	responses = (struct pam_response *) calloc ((size_t) num_msg,
-	                                            sizeof (*responses));
+	responses = (struct pam_response *) calloc (num_msg, sizeof (*responses));
 	if (NULL == responses) {
 		return PAM_CONV_ERR;
 	}

--- a/libmisc/prefix_flag.c
+++ b/libmisc/prefix_flag.c
@@ -330,7 +330,7 @@ extern struct group *prefix_getgr_nam_gid(const char *grname)
 	    	&& ('\0' == *endptr)
 	    	&& (ERANGE != errno)
 	    	&& (gid == (gid_t)gid)) {
-			return prefix_getgrgid ((gid_t) gid);
+			return prefix_getgrgid (gid);
 		}
 		g = prefix_getgrnam (grname);
 		return g ? __gr_dup(g) : NULL;

--- a/libmisc/pwd2spwd.c
+++ b/libmisc/pwd2spwd.c
@@ -42,7 +42,7 @@ struct spwd *pwd_to_spwd (const struct passwd *pw)
 		 */
 		sp.sp_min = 0;
 		sp.sp_max = (10000L * DAY) / SCALE;
-		sp.sp_lstchg = (long) gettime () / SCALE;
+		sp.sp_lstchg = gettime () / SCALE;
 		if (0 == sp.sp_lstchg) {
 			/* Better disable aging than requiring a password
 			 * change */

--- a/libmisc/salt.c
+++ b/libmisc/salt.c
@@ -377,26 +377,26 @@ static /*@observer@*/const char *gensalt (size_t salt_size)
 	} else if (0 == strcmp (method, "BCRYPT")) {
 		BCRYPTMAGNUM(result);
 		salt_len = BCRYPT_SALT_SIZE;
-		rounds = BCRYPT_get_salt_rounds ((int *) arg);
+		rounds = BCRYPT_get_salt_rounds (arg);
 		BCRYPT_salt_rounds_to_buf (result, rounds);
 #endif /* USE_BCRYPT */
 #ifdef USE_YESCRYPT
 	} else if (0 == strcmp (method, "YESCRYPT")) {
 		MAGNUM(result, 'y');
 		salt_len = YESCRYPT_SALT_SIZE;
-		rounds = YESCRYPT_get_salt_cost ((int *) arg);
+		rounds = YESCRYPT_get_salt_cost (arg);
 		YESCRYPT_salt_cost_to_buf (result, rounds);
 #endif /* USE_YESCRYPT */
 #ifdef USE_SHA_CRYPT
 	} else if (0 == strcmp (method, "SHA256")) {
 		MAGNUM(result, '5');
 		salt_len = SHA_CRYPT_SALT_SIZE;
-		rounds = SHA_get_salt_rounds ((int *) arg);
+		rounds = SHA_get_salt_rounds (arg);
 		SHA_salt_rounds_to_buf (result, rounds);
 	} else if (0 == strcmp (method, "SHA512")) {
 		MAGNUM(result, '6');
 		salt_len = SHA_CRYPT_SALT_SIZE;
-		rounds = SHA_get_salt_rounds ((int *) arg);
+		rounds = SHA_get_salt_rounds (arg);
 		SHA_salt_rounds_to_buf (result, rounds);
 #endif /* USE_SHA_CRYPT */
 	} else if (0 != strcmp (method, "DES")) {

--- a/libmisc/ttytype.c
+++ b/libmisc/ttytype.c
@@ -43,7 +43,7 @@ void ttytype (const char *line)
 		perror (typefile);
 		return;
 	}
-	while (fgets (buf, (int) sizeof buf, fp) == buf) {
+	while (fgets (buf, sizeof buf, fp) == buf) {
 		if (buf[0] == '#') {
 			continue;
 		}

--- a/libmisc/ttytype.c
+++ b/libmisc/ttytype.c
@@ -34,13 +34,11 @@ void ttytype (const char *line)
 	if (NULL == typefile) {
 		return;
 	}
-	if (access (typefile, F_OK) != 0) {
-		return;
-	}
 
 	fp = fopen (typefile, "r");
 	if (NULL == fp) {
-		perror (typefile);
+		if (errno != ENOENT)
+			perror (typefile);
 		return;
 	}
 	while (fgets (buf, sizeof buf, fp) == buf) {

--- a/libmisc/tz.c
+++ b/libmisc/tz.c
@@ -34,7 +34,7 @@
 
 	fp = fopen (fname, "r");
 	if (   (NULL == fp)
-	    || (fgets (tzbuf, (int) sizeof (tzbuf), fp) == NULL)) {
+	    || (fgets (tzbuf, sizeof (tzbuf), fp) == NULL)) {
 		def_tz = getdef_str ("ENV_TZ");
 		if ((NULL == def_tz) || ('/' == def_tz[0])) {
 			def_tz = "TZ=CST6CDT";

--- a/libmisc/utmp.c
+++ b/libmisc/utmp.c
@@ -115,7 +115,7 @@ static void updwtmp (const char *filename, const struct utmp *ut)
 
 	fd = open (filename, O_APPEND | O_WRONLY, 0);
 	if (fd >= 0) {
-		write (fd, (const char *) ut, sizeof (*ut));
+		write (fd, ut, sizeof (*ut));
 		close (fd);
 	}
 }

--- a/libmisc/yesno.c
+++ b/libmisc/yesno.c
@@ -47,7 +47,7 @@ bool yes_or_no (bool read_only)
 	 * Get a line and see what the first character is.
 	 */
 	/* TODO: use gettext */
-	if (fgets (buf, (int) sizeof buf, stdin) == buf) {
+	if (fgets (buf, sizeof buf, stdin) == buf) {
 		return buf[0] == 'y' || buf[0] == 'Y';
 	}
 

--- a/libsubid/api.c
+++ b/libsubid/api.c
@@ -66,12 +66,12 @@ int get_subid_owner(unsigned long id, enum subid_type id_type, uid_t **owner)
 
 int subid_get_uid_owners(uid_t uid, uid_t **owner)
 {
-	return get_subid_owner((unsigned long)uid, ID_TYPE_UID, owner);
+	return get_subid_owner(uid, ID_TYPE_UID, owner);
 }
 
 int subid_get_gid_owners(gid_t gid, uid_t **owner)
 {
-	return get_subid_owner((unsigned long)gid, ID_TYPE_GID, owner);
+	return get_subid_owner(gid, ID_TYPE_GID, owner);
 }
 
 static

--- a/src/chage.c
+++ b/src/chage.c
@@ -103,8 +103,7 @@ fail_exit (int code)
 #ifdef WITH_AUDIT
 	if (E_SUCCESS != code) {
 		audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
-		              "change age",
-		              user_name, (unsigned int) user_uid, 0);
+		              "change age", user_name, user_uid, 0);
 	}
 #endif
 
@@ -260,7 +259,7 @@ static void list_fields (void)
 		(void) puts (_("password must be changed"));
 	} else {
 		changed = lstchgdate * SCALE;
-		print_date ((time_t) changed);
+		print_date (changed);
 	}
 
 	/*
@@ -277,7 +276,7 @@ static void list_fields (void)
 		(void) puts (_("never"));
 	} else {
 		expires = changed + maxdays * SCALE;
-		print_date ((time_t) expires);
+		print_date (expires);
 	}
 
 	/*
@@ -298,7 +297,7 @@ static void list_fields (void)
 		(void) puts (_("never"));
 	} else {
 		expires = changed + (maxdays + inactdays) * SCALE;
-		print_date ((time_t) expires);
+		print_date (expires);
 	}
 
 	/*
@@ -310,7 +309,7 @@ static void list_fields (void)
 		(void) puts (_("never"));
 	} else {
 		expires = expdate * SCALE;
-		print_date ((time_t) expires);
+		print_date (expires);
 	}
 
 	/*
@@ -835,8 +834,7 @@ int main (int argc, char **argv)
 		}
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
-		              "display aging info",
-		              user_name, (unsigned int) user_uid, 1);
+		              "display aging info", user_name, user_uid, 1);
 #endif
 		list_fields ();
 		fail_exit (E_SUCCESS);
@@ -858,40 +856,38 @@ int main (int argc, char **argv)
 		else {
 			audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
 			              "change all aging information",
-			              user_name, (unsigned int) user_uid, 1);
+			              user_name, user_uid, 1);
 		}
 #endif
 	} else {
 #ifdef WITH_AUDIT
 		if (Mflg) {
 			audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
-			              "change max age",
-			              user_name, (unsigned int) user_uid, 1);
+			              "change max age", user_name, user_uid, 1);
 		}
 		if (mflg) {
 			audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
-			              "change min age",
-			              user_name, (unsigned int) user_uid, 1);
+			              "change min age", user_name, user_uid, 1);
 		}
 		if (dflg) {
 			audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
 			              "change last change date",
-			              user_name, (unsigned int) user_uid, 1);
+			              user_name, user_uid, 1);
 		}
 		if (Wflg) {
 			audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
 			              "change passwd warning",
-			              user_name, (unsigned int) user_uid, 1);
+			              user_name, user_uid, 1);
 		}
 		if (Iflg) {
 			audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
 			              "change inactive days",
-			              user_name, (unsigned int) user_uid, 1);
+			              user_name, user_uid, 1);
 		}
 		if (Eflg) {
 			audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
 			              "change passwd expiration",
-			              user_name, (unsigned int) user_uid, 1);
+			              user_name, user_uid, 1);
 		}
 #endif
 	}

--- a/src/chpasswd.c
+++ b/src/chpasswd.c
@@ -484,7 +484,7 @@ int main (int argc, char **argv)
 	 * last change date is set in the age only if aging information is
 	 * present.
 	 */
-	while (fgets (buf, (int) sizeof buf, stdin) != NULL) {
+	while (fgets (buf, sizeof buf, stdin) != NULL) {
 		line++;
 		cp = strrchr (buf, '\n');
 		if (NULL != cp) {
@@ -493,7 +493,7 @@ int main (int argc, char **argv)
 			if (feof (stdin) == 0) {
 
 				// Drop all remaining characters on this line.
-				while (fgets (buf, (int) sizeof buf, stdin) != NULL) {
+				while (fgets (buf, sizeof buf, stdin) != NULL) {
 					cp = strchr (buf, '\n');
 					if (cp != NULL) {
 						break;
@@ -608,7 +608,7 @@ int main (int argc, char **argv)
 		if (NULL != sp) {
 			newsp = *sp;
 			newsp.sp_pwdp = cp;
-			newsp.sp_lstchg = (long) gettime () / SCALE;
+			newsp.sp_lstchg = gettime () / SCALE;
 			if (0 == newsp.sp_lstchg) {
 				/* Better disable aging than requiring a
 				 * password change */

--- a/src/faillog.c
+++ b/src/faillog.c
@@ -106,7 +106,7 @@ static void print_one (/*@null@*/const struct passwd *pw, bool force)
 		 * entered for this user, which should be able to get the
 		 * empty entry in this case.
 		 */
-		if (fread ((char *) &fl, sizeof (fl), 1, fail) != 1) {
+		if (fread (&fl, sizeof (fl), 1, fail) != 1) {
 			fprintf (stderr,
 			         _("%s: Failed to get the entry for UID %lu\n"),
 			         Prog, (unsigned long int)pw->pw_uid);
@@ -166,7 +166,7 @@ static void print_one (/*@null@*/const struct passwd *pw, bool force)
 static void print (void)
 {
 	if (uflg && has_umin && has_umax && (umin==umax)) {
-		print_one (getpwuid ((uid_t)umin), true);
+		print_one (getpwuid (umin), true);
 	} else {
 		/* We only print records for existing users.
 		 * Loop based on the user database instead of reading the
@@ -208,7 +208,7 @@ static bool reset_one (uid_t uid)
 		 * entered for this user, which should be able to get the
 		 * empty entry in this case.
 		 */
-		if (fread ((char *) &fl, sizeof (fl), 1, fail) != 1) {
+		if (fread (&fl, sizeof (fl), 1, fail) != 1) {
 			fprintf (stderr,
 			         _("%s: Failed to get the entry for UID %lu\n"),
 			         Prog, (unsigned long int)uid);
@@ -234,7 +234,7 @@ static bool reset_one (uid_t uid)
 	fl.fail_cnt = 0;
 
 	if (   (fseeko (fail, offset, SEEK_SET) == 0)
-	    && (fwrite ((char *) &fl, sizeof (fl), 1, fail) == 1)) {
+	    && (fwrite (&fl, sizeof (fl), 1, fail) == 1)) {
 		(void) fflush (fail);
 		return false;
 	}
@@ -248,7 +248,7 @@ static bool reset_one (uid_t uid)
 static void reset (void)
 {
 	if (uflg && has_umin && has_umax && (umin==umax)) {
-		if (reset_one ((uid_t)umin)) {
+		if (reset_one (umin)) {
 			errors = true;
 		}
 	} else {
@@ -260,7 +260,7 @@ static void reset (void)
 			uidmax--;
 		}
 		if (has_umax && (uid_t)umax < uidmax) {
-			uidmax = (uid_t)umax;
+			uidmax = umax;
 		}
 
 		/* Reset all entries in the specified range.
@@ -273,7 +273,7 @@ static void reset (void)
 
 			/* Make sure we stay in the umin-umax range if specified */
 			if (has_umin) {
-				uid = (uid_t)umin;
+				uid = umin;
 			}
 
 			while (uid <= uidmax) {
@@ -322,7 +322,7 @@ static bool setmax_one (uid_t uid, short max)
 		 * entered for this user, which should be able to get the
 		 * empty entry in this case.
 		 */
-		if (fread ((char *) &fl, sizeof (fl), 1, fail) != 1) {
+		if (fread (&fl, sizeof (fl), 1, fail) != 1) {
 			fprintf (stderr,
 			         _("%s: Failed to get the entry for UID %lu\n"),
 			         Prog, (unsigned long int)uid);
@@ -349,7 +349,7 @@ static bool setmax_one (uid_t uid, short max)
 	fl.fail_max = max;
 
 	if (   (fseeko (fail, offset, SEEK_SET) == 0)
-	    && (fwrite ((char *) &fl, sizeof (fl), 1, fail) == 1)) {
+	    && (fwrite (&fl, sizeof (fl), 1, fail) == 1)) {
 		(void) fflush (fail);
 		return false;
 	}
@@ -363,7 +363,7 @@ static bool setmax_one (uid_t uid, short max)
 static void setmax (short max)
 {
 	if (uflg && has_umin && has_umax && (umin==umax)) {
-		if (setmax_one ((uid_t)umin, max)) {
+		if (setmax_one (umin, max)) {
 			errors = true;
 		}
 	} else {
@@ -387,10 +387,10 @@ static void setmax (short max)
 
 			/* Make sure we stay in the umin-umax range if specified */
 			if (has_umin) {
-				uid = (uid_t)umin;
+				uid = umin;
 			}
 			if (has_umax) {
-				uidmax = (uid_t)umax;
+				uidmax = umax;
 			}
 
 			while (uid <= uidmax) {
@@ -439,7 +439,7 @@ static bool set_locktime_one (uid_t uid, long locktime)
 		 * entered for this user, which should be able to get the
 		 * empty entry in this case.
 		 */
-		if (fread ((char *) &fl, sizeof (fl), 1, fail) != 1) {
+		if (fread (&fl, sizeof (fl), 1, fail) != 1) {
 			fprintf (stderr,
 			         _("%s: Failed to get the entry for UID %lu\n"),
 			         Prog, (unsigned long int)uid);
@@ -466,7 +466,7 @@ static bool set_locktime_one (uid_t uid, long locktime)
 	fl.fail_locktime = locktime;
 
 	if (   (fseeko (fail, offset, SEEK_SET) == 0)
-	    && (fwrite ((char *) &fl, sizeof (fl), 1, fail) == 1)) {
+	    && (fwrite (&fl, sizeof (fl), 1, fail) == 1)) {
 		(void) fflush (fail);
 		return false;
 	}
@@ -480,7 +480,7 @@ static bool set_locktime_one (uid_t uid, long locktime)
 static void set_locktime (long locktime)
 {
 	if (uflg && has_umin && has_umax && (umin==umax)) {
-		if (set_locktime_one ((uid_t)umin, locktime)) {
+		if (set_locktime_one (umin, locktime)) {
 			errors = true;
 		}
 	} else {
@@ -504,10 +504,10 @@ static void set_locktime (long locktime)
 
 			/* Make sure we stay in the umin-umax range if specified */
 			if (has_umin) {
-				uid = (uid_t)umin;
+				uid = umin;
 			}
 			if (has_umax) {
-				uidmax = (uid_t)umax;
+				uidmax = umax;
 			}
 
 			while (uid <= uidmax) {
@@ -598,7 +598,7 @@ int main (int argc, char **argv)
 					         Prog, optarg);
 					exit (E_BAD_ARG);
 				}
-				fail_max = (short) lmax;
+				fail_max = lmax;
 				mflg = true;
 				break;
 			}
@@ -632,7 +632,7 @@ int main (int argc, char **argv)
 				/* local, no need for xgetpwnam */
 				pwent = getpwnam (optarg);
 				if (NULL != pwent) {
-					umin = (unsigned long) pwent->pw_uid;
+					umin = pwent->pw_uid;
 					has_umin = true;
 					umax = umin;
 					has_umax = true;

--- a/src/groupadd.c
+++ b/src/groupadd.c
@@ -264,8 +264,7 @@ static void close_files (void)
 #ifdef WITH_AUDIT
 	audit_logger (AUDIT_ADD_GROUP, Prog,
 	              "adding group to /etc/group",
-	              group_name, (unsigned int) group_id,
-	              SHADOW_AUDIT_SUCCESS);
+	              group_name, group_id, SHADOW_AUDIT_SUCCESS);
 #endif
 	SYSLOG ((LOG_INFO, "group added to %s: name=%s, GID=%u",
 	         gr_dbname (), group_name, (unsigned int) group_id));
@@ -286,8 +285,7 @@ static void close_files (void)
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_ADD_GROUP, Prog,
 		              "adding group to /etc/gshadow",
-		              group_name, (unsigned int) group_id,
-		              SHADOW_AUDIT_SUCCESS);
+		              group_name, group_id, SHADOW_AUDIT_SUCCESS);
 #endif
 		SYSLOG ((LOG_INFO, "group added to %s: name=%s",
 		         sgr_dbname (), group_name));
@@ -301,9 +299,7 @@ static void close_files (void)
 	/* Report success at the system level */
 #ifdef WITH_AUDIT
 	audit_logger (AUDIT_ADD_GROUP, Prog,
-	              "",
-	              group_name, (unsigned int) group_id,
-	              SHADOW_AUDIT_SUCCESS);
+	              "", group_name, group_id, SHADOW_AUDIT_SUCCESS);
 #endif
 	SYSLOG ((LOG_INFO, "new group: name=%s, GID=%u",
 	         group_name, (unsigned int) group_id));

--- a/src/groupdel.c
+++ b/src/groupdel.c
@@ -149,8 +149,7 @@ static void close_files (void)
 #ifdef WITH_AUDIT
 	audit_logger (AUDIT_DEL_GROUP, Prog,
 	              "removing group from /etc/group",
-	              group_name, (unsigned int) group_id,
-	              SHADOW_AUDIT_SUCCESS);
+	              group_name, group_id, SHADOW_AUDIT_SUCCESS);
 #endif
 	SYSLOG ((LOG_INFO,
 	         "group '%s' removed from %s",
@@ -174,8 +173,7 @@ static void close_files (void)
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_DEL_GROUP, Prog,
 		              "removing group from /etc/gshadow",
-		              group_name, (unsigned int) group_id,
-		              SHADOW_AUDIT_SUCCESS);
+		              group_name, group_id, SHADOW_AUDIT_SUCCESS);
 #endif
 		SYSLOG ((LOG_INFO,
 		         "group '%s' removed from %s",
@@ -190,9 +188,7 @@ static void close_files (void)
 	/* Report success at the system level */
 #ifdef WITH_AUDIT
 	audit_logger (AUDIT_DEL_GROUP, Prog,
-	              "",
-	              group_name, (unsigned int) group_id,
-	              SHADOW_AUDIT_SUCCESS);
+	              "", group_name, group_id, SHADOW_AUDIT_SUCCESS);
 #endif
 	SYSLOG ((LOG_INFO, "group '%s' removed\n", group_name));
 	del_cleanup (cleanup_report_del_group);

--- a/src/lastlog.c
+++ b/src/lastlog.c
@@ -116,7 +116,7 @@ static void print_one (/*@null@*/const struct passwd *pw)
 		 * entered for this user, which should be able to get the
 		 * empty entry in this case.
 		 */
-		if (fread ((char *) &ll, sizeof (ll), 1, lastlogfile) != 1) {
+		if (fread (&ll, sizeof (ll), 1, lastlogfile) != 1) {
 			fprintf (stderr,
 			         _("%s: Failed to get the entry for UID %lu\n"),
 			         Prog, (unsigned long int)pw->pw_uid);
@@ -184,7 +184,7 @@ static void print (void)
 	}
 
 	if (uflg && has_umin && has_umax && (umin == umax)) {
-		print_one (getpwuid ((uid_t)umin));
+		print_one (getpwuid (umin));
 	} else {
 		setpwent ();
 		while ( (pwent = getpwent ()) != NULL ) {
@@ -227,14 +227,14 @@ static void update_one (/*@null@*/const struct passwd *pw)
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_ACCT_UNLOCK, Prog,
 			"clearing-lastlog",
-			pw->pw_name, (unsigned int) pw->pw_uid, SHADOW_AUDIT_SUCCESS);
+			pw->pw_name, pw->pw_uid, SHADOW_AUDIT_SUCCESS);
 #endif
 	}
 #ifdef WITH_AUDIT
 	else {
 		audit_logger (AUDIT_ACCT_UNLOCK, Prog,
 			"refreshing-lastlog",
-			pw->pw_name, (unsigned int) pw->pw_uid, SHADOW_AUDIT_SUCCESS);
+			pw->pw_name, pw->pw_uid, SHADOW_AUDIT_SUCCESS);
 	}
 #endif
 
@@ -263,7 +263,7 @@ static void update (void)
 	}
 
 	if (has_umin && has_umax && (umin == umax)) {
-		update_one (getpwuid ((uid_t)umin));
+		update_one (getpwuid (umin));
 	} else {
 		setpwent ();
 		while ( (pwent = getpwent ()) != NULL ) {
@@ -375,7 +375,7 @@ int main (int argc, char **argv)
 				/* local, no need for xgetpwnam */
 				pwent = getpwnam (optarg);
 				if (NULL != pwent) {
-					umin = (unsigned long) pwent->pw_uid;
+					umin = pwent->pw_uid;
 					has_umin = true;
 					umax = umin;
 					has_umax = true;

--- a/src/login.c
+++ b/src/login.c
@@ -167,10 +167,10 @@ static void setup_tty (void)
 #endif
 
 		/* leave these values unchanged if not specified in login.defs */
-		erasechar = getdef_num ("ERASECHAR", (int) termio.c_cc[VERASE]);
-		killchar = getdef_num ("KILLCHAR", (int) termio.c_cc[VKILL]);
-		termio.c_cc[VERASE] = (cc_t) erasechar;
-		termio.c_cc[VKILL] = (cc_t) killchar;
+		erasechar = getdef_num ("ERASECHAR", termio.c_cc[VERASE]);
+		killchar = getdef_num ("KILLCHAR", termio.c_cc[VKILL]);
+		termio.c_cc[VERASE] = erasechar;
+		termio.c_cc[VKILL] = killchar;
 		/* Make sure the values were valid.
 		 * getdef_num cannot validate this.
 		 */
@@ -411,17 +411,17 @@ static void alarm_handler (unused int sig)
  */
 static void get_pam_user (char **ptr_pam_user)
 {
-	int retcode;
-	void *ptr_user;
+	int         retcode;
+	const void  *ptr_user;
 
 	assert (NULL != ptr_pam_user);
 
-	retcode = pam_get_item (pamh, PAM_USER, (const void **)&ptr_user);
+	retcode = pam_get_item (pamh, PAM_USER, &ptr_user);
 	PAM_FAIL_CHECK;
 
 	free (*ptr_pam_user);
 	if (NULL != ptr_user) {
-		*ptr_pam_user = xstrdup ((const char *)ptr_user);
+		*ptr_pam_user = xstrdup (ptr_user);
 	} else {
 		*ptr_pam_user = NULL;
 	}
@@ -938,7 +938,8 @@ int main (int argc, char **argv)
 			}
 
 			if (strcmp (user_passwd, "") == 0) {
-				char *prevent_no_auth = getdef_str("PREVENT_NO_AUTH");
+				const char *prevent_no_auth = getdef_str("PREVENT_NO_AUTH");
+
 				if (prevent_no_auth == NULL) {
 					prevent_no_auth = "superuser";
 				}

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -39,6 +39,7 @@
      * Author: Wietse Venema, Eindhoven University of Technology, The Netherlands.
      */
 #include <sys/types.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <syslog.h>
 #include <ctype.h>
@@ -96,10 +97,10 @@ int login_access (const char *user, const char *from)
 	if (NULL != fp) {
 		int lineno = 0;	/* for diagnostics */
 		while (   !match
-		       && (fgets (line, (int) sizeof (line), fp) == line)) {
-			int end;
+		       && (fgets (line, sizeof (line), fp) == line)) {
+			ptrdiff_t  end;
 			lineno++;
-			end = (int) strlen (line) - 1;
+			end = strlen (line) - 1;
 			if (line[0] == '\0' || line[end] != '\n') {
 				SYSLOG ((LOG_ERR,
 					 "%s: line %d: missing newline or line too long",

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -187,8 +187,7 @@ static void check_perms (const struct group *grp,
 			          "authentication new-gid=%lu",
 			          (unsigned long) grp->gr_gid);
 			audit_logger (AUDIT_GRP_AUTH, Prog,
-			              audit_buf, NULL,
-			              (unsigned int) getuid (), 0);
+			              audit_buf, NULL, getuid (), 0);
 #endif
 			SYSLOG ((LOG_INFO,
 				 "Invalid password for group '%s' from '%s'",
@@ -202,8 +201,7 @@ static void check_perms (const struct group *grp,
 		          "authentication new-gid=%lu",
 		          (unsigned long) grp->gr_gid);
 		audit_logger (AUDIT_GRP_AUTH, Prog,
-		              audit_buf, NULL,
-		              (unsigned int) getuid (), 1);
+		              audit_buf, NULL, getuid (), 1);
 #endif
 	}
 
@@ -219,12 +217,10 @@ failure:
 		snprintf (audit_buf, sizeof(audit_buf),
 		          "changing new-group=%s", groupname);
 		audit_logger (AUDIT_CHGRP_ID, Prog,
-		              audit_buf, NULL,
-		              (unsigned int) getuid (), 0);
+		              audit_buf, NULL, getuid (), 0);
 	} else {
 		audit_logger (AUDIT_CHGRP_ID, Prog,
-		              "changing", NULL,
-		              (unsigned int) getuid (), 0);
+		              "changing", NULL, getuid (), 0);
 	}
 #endif
 	exit (EXIT_FAILURE);
@@ -300,12 +296,10 @@ static void syslog_sg (const char *name, const char *group)
 				snprintf (audit_buf, sizeof(audit_buf),
 				          "changing new-group=%s", group);
 				audit_logger (AUDIT_CHGRP_ID, Prog,
-				              audit_buf, NULL,
-				              (unsigned int) getuid (), 0);
+				              audit_buf, NULL, getuid (), 0);
 			} else {
 				audit_logger (AUDIT_CHGRP_ID, Prog,
-				              "changing", NULL,
-				              (unsigned int) getuid (), 0);
+				              "changing", NULL, getuid (), 0);
 			}
 #endif
 			exit (EXIT_FAILURE);
@@ -434,8 +428,7 @@ int main (int argc, char **argv)
 		         Prog);
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_CHGRP_ID, Prog,
-		              "changing", NULL,
-		              (unsigned int) getuid (), 0);
+		              "changing", NULL, getuid (), 0);
 #endif
 		SYSLOG ((LOG_WARN, "Cannot determine the user name of the caller (UID %lu)",
 		         (unsigned long) getuid ()));
@@ -554,12 +547,10 @@ int main (int argc, char **argv)
 			snprintf (audit_buf, sizeof(audit_buf),
 			          "changing new-group=%s", group);
 			audit_logger (AUDIT_CHGRP_ID, Prog,
-			              audit_buf, NULL,
-			              (unsigned int) getuid (), 0);
+			              audit_buf, NULL, getuid (), 0);
 		} else {
 			audit_logger (AUDIT_CHGRP_ID, Prog,
-			              "changing", NULL,
-			              (unsigned int) getuid (), 0);
+			              "changing", NULL, getuid (), 0);
 		}
 #endif
 		exit (EXIT_FAILURE);
@@ -716,8 +707,7 @@ int main (int argc, char **argv)
 		snprintf (audit_buf, sizeof(audit_buf),
 		          "changing new-gid=%lu", (unsigned long) gid);
 		audit_logger (AUDIT_CHGRP_ID, Prog,
-		              audit_buf, NULL,
-		              (unsigned int) getuid (), 0);
+		              audit_buf, NULL, getuid (), 0);
 #endif
 		exit (EXIT_FAILURE);
 	}
@@ -728,8 +718,7 @@ int main (int argc, char **argv)
 		snprintf (audit_buf, sizeof(audit_buf),
 		          "changing new-gid=%lu", (unsigned long) gid);
 		audit_logger (AUDIT_CHGRP_ID, Prog,
-		              audit_buf, NULL,
-		              (unsigned int) getuid (), 0);
+		              audit_buf, NULL, getuid (), 0);
 #endif
 		exit (EXIT_FAILURE);
 	}
@@ -745,8 +734,7 @@ int main (int argc, char **argv)
 		snprintf (audit_buf, sizeof(audit_buf),
 		          "changing new-gid=%lu", (unsigned long) gid);
 		audit_logger (AUDIT_CHGRP_ID, Prog,
-		              audit_buf, NULL,
-		              (unsigned int) getuid (), 0);
+		              audit_buf, NULL, getuid (), 0);
 #endif
 		perror (SHELL);
 		exit ((errno == ENOENT) ? E_CMD_NOTFOUND : E_CMD_NOEXEC);
@@ -813,8 +801,7 @@ int main (int argc, char **argv)
 	snprintf (audit_buf, sizeof(audit_buf), "changing new-gid=%lu",
 	          (unsigned long) gid);
 	audit_logger (AUDIT_CHGRP_ID, Prog,
-	              audit_buf, NULL,
-	              (unsigned int) getuid (), 1);
+	              audit_buf, NULL, getuid (), 1);
 #endif
 	/*
 	 * Exec the login shell and go away. We are trying to get back to
@@ -841,12 +828,10 @@ int main (int argc, char **argv)
 		snprintf (audit_buf, sizeof(audit_buf),
 		          "changing new-group=%s", group);
 		audit_logger (AUDIT_CHGRP_ID, Prog,
-		              audit_buf, NULL,
-		              (unsigned int) getuid (), 0);
+		              audit_buf, NULL, getuid (), 0);
 	} else {
 		audit_logger (AUDIT_CHGRP_ID, Prog,
-		              "changing", NULL,
-		              (unsigned int) getuid (), 0);
+		              "changing", NULL, getuid (), 0);
 	}
 #endif
 	exit (EXIT_FAILURE);

--- a/src/newusers.c
+++ b/src/newusers.c
@@ -245,11 +245,11 @@ static int add_group (const char *name, const char *gid, gid_t *ngid, uid_t uid)
 		/* Look in both the system database (getgrgid) and in the
 		 * internal database (gr_locate_gid), which may contain
 		 * uncommitted changes */
-		if (   (getgrgid ((gid_t) grent.gr_gid) != NULL)
-		    || (gr_locate_gid ((gid_t) grent.gr_gid) != NULL)) {
+		if (   (getgrgid (grent.gr_gid) != NULL)
+		    || (gr_locate_gid (grent.gr_gid) != NULL)) {
 			/* The user will use this ID for her
 			 * primary group */
-			*ngid = (gid_t) grent.gr_gid;
+			*ngid = grent.gr_gid;
 			return 0;
 		}
 
@@ -527,7 +527,7 @@ static int add_passwd (struct passwd *pwd, const char *password)
 			}
 			spent.sp_pwdp = cp;
 		}
-		spent.sp_lstchg = (long) gettime () / SCALE;
+		spent.sp_lstchg = gettime () / SCALE;
 		if (0 == spent.sp_lstchg) {
 			/* Better disable aging than requiring a password
 			 * change */
@@ -584,7 +584,7 @@ static int add_passwd (struct passwd *pwd, const char *password)
 	 */
 	spent.sp_pwdp = "!";
 #endif
-	spent.sp_lstchg = (long) gettime () / SCALE;
+	spent.sp_lstchg = gettime () / SCALE;
 	if (0 == spent.sp_lstchg) {
 		/* Better disable aging than requiring a password change */
 		spent.sp_lstchg = -1;
@@ -1088,7 +1088,7 @@ int main (int argc, char **argv)
 	 * over 100 is allocated. The pw_gid field will be updated with that
 	 * value.
 	 */
-	while (fgets (buf, (int) sizeof buf, stdin) != NULL) {
+	while (fgets (buf, sizeof buf, stdin) != NULL) {
 		line++;
 		cp = strrchr (buf, '\n');
 		if (NULL != cp) {

--- a/src/passwd.c
+++ b/src/passwd.c
@@ -646,7 +646,7 @@ static void update_shadow (void)
 	}
 #ifndef USE_PAM
 	if (do_update_age) {
-		nsp->sp_lstchg = (long) gettime () / SCALE;
+		nsp->sp_lstchg = gettime () / SCALE;
 		if (0 == nsp->sp_lstchg) {
 			/* Better disable aging than requiring a password
 			 * change */

--- a/src/pwck.c
+++ b/src/pwck.c
@@ -369,8 +369,8 @@ static void check_pw_file (int *errors, bool *changed)
 	struct commonio_entry *pfe, *tpfe;
 	struct passwd *pwd;
 	const struct spwd *spw;
-	uid_t min_sys_id = (uid_t) getdef_ulong ("SYS_UID_MIN", 101UL);
-	uid_t max_sys_id = (uid_t) getdef_ulong ("SYS_UID_MAX", 999UL);
+	uid_t min_sys_id = getdef_ulong ("SYS_UID_MIN", 101UL);
+	uid_t max_sys_id = getdef_ulong ("SYS_UID_MAX", 999UL);
 
 	/*
 	 * Loop through the entire password file.
@@ -609,7 +609,7 @@ static void check_pw_file (int *errors, bool *changed)
 					sp.sp_inact  = -1;
 					sp.sp_expire = -1;
 					sp.sp_flag   = SHADOW_SP_FLAG_UNSET;
-					sp.sp_lstchg = (long) gettime () / SCALE;
+					sp.sp_lstchg = gettime () / SCALE;
 					if (0 == sp.sp_lstchg) {
 						/* Better disable aging than
 						 * requiring a password change

--- a/src/pwconv.c
+++ b/src/pwconv.c
@@ -247,7 +247,7 @@ int main (int argc, char **argv)
 			spent.sp_flag   = SHADOW_SP_FLAG_UNSET;
 		}
 		spent.sp_pwdp = pw->pw_passwd;
-		spent.sp_lstchg = (long) gettime () / SCALE;
+		spent.sp_lstchg = gettime () / SCALE;
 		if (0 == spent.sp_lstchg) {
 			/* Better disable aging than requiring a password
 			 * change */

--- a/src/su.c
+++ b/src/su.c
@@ -225,7 +225,7 @@ static void execve_shell (const char *shellname,
                           char *const envp[])
 {
 	int err;
-	(void) execve (shellname, (char **) args, envp);
+	(void) execve (shellname, args, envp);
 	err = errno;
 
 	if (access (shellname, R_OK|X_OK) == 0) {
@@ -501,7 +501,8 @@ static void check_perms_nopam (const struct passwd *pw)
 	}
 
 	if (strcmp (pw->pw_passwd, "") == 0) {
-		char *prevent_no_auth = getdef_str("PREVENT_NO_AUTH");
+		const char  *prevent_no_auth = getdef_str("PREVENT_NO_AUTH");
+
 		if (prevent_no_auth == NULL) {
 			prevent_no_auth = "superuser";
 		}
@@ -621,7 +622,7 @@ static void check_perms_nopam (const struct passwd *pw)
 static /*@only@*/struct passwd * check_perms (void)
 {
 #ifdef USE_PAM
-	const char *tmp_name;
+	const void *tmp_name;
 	int ret;
 #endif				/* !USE_PAM */
 	/*
@@ -642,7 +643,7 @@ static /*@only@*/struct passwd * check_perms (void)
 #ifdef USE_PAM
 	check_perms_pam (pw);
 	/* PAM authentication can request a change of account */
-	ret = pam_get_item(pamh, PAM_USER, (const void **) &tmp_name);
+	ret = pam_get_item(pamh, PAM_USER, &tmp_name);
 	if (ret != PAM_SUCCESS) {
 		SYSLOG((LOG_ERR, "pam_get_item: internal PAM error\n"));
 		(void) fprintf (stderr,
@@ -1001,9 +1002,9 @@ int main (int argc, char **argv)
 		exit (1);
 	}
 
-	ret = pam_set_item (pamh, PAM_TTY, (const void *) caller_tty);
+	ret = pam_set_item (pamh, PAM_TTY, caller_tty);
 	if (PAM_SUCCESS == ret) {
-		ret = pam_set_item (pamh, PAM_RUSER, (const void *) caller_name);
+		ret = pam_set_item (pamh, PAM_RUSER, caller_name);
 	}
 	if (PAM_SUCCESS != ret) {
 		SYSLOG ((LOG_ERR, "pam_set_item: %s",

--- a/src/suauth.c
+++ b/src/suauth.c
@@ -92,9 +92,9 @@ int check_su_auth (const char *actual_id,
 			continue;
 		}
 		if (!(to_users = strtok (temp + posn, field))
-		    || !(from_users = strtok ((char *) NULL, field))
-		    || !(action = strtok ((char *) NULL, field))
-		    || strtok ((char *) NULL, field)) {
+		    || !(from_users = strtok (NULL, field))
+		    || !(action = strtok (NULL, field))
+		    || strtok (NULL, field)) {
 			SYSLOG ((LOG_ERR,
 				 "%s, line %d. Bad number of fields.\n",
 				 SUAUTHFILE, lines));

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -375,7 +375,7 @@ static void get_defaults (void)
 	 * Read the file a line at a time. Only the lines that have relevant
 	 * values are used, everything else can be ignored.
 	 */
-	while (fgets (buf, (int) sizeof buf, fp) == buf) {
+	while (fgets (buf, sizeof buf, fp) == buf) {
 		cp = strrchr (buf, '\n');
 		if (NULL != cp) {
 			*cp = '\0';
@@ -653,7 +653,7 @@ static int set_defaults (void)
 		goto skip;
 	}
 
-	while (fgets (buf, (int) sizeof buf, ifp) == buf) {
+	while (fgets (buf, sizeof buf, ifp) == buf) {
 		cp = strrchr (buf, '\n');
 		if (NULL != cp) {
 			*cp = '\0';
@@ -925,7 +925,7 @@ static struct group * get_local_group(char * grp_name)
 		&& ('\0' == *endptr)
 		&& (ERANGE != errno)
 		&& (gid == (gid_t)gid)) {
-		grp = gr_locate_gid ((gid_t) gid);
+		grp = gr_locate_gid (gid);
 	}
 	else {
 		grp = gr_locate(grp_name);
@@ -1043,7 +1043,7 @@ static void new_spent (struct spwd *spent)
 	memzero (spent, sizeof *spent);
 	spent->sp_namp = (char *) user_name;
 	spent->sp_pwdp = (char *) user_pass;
-	spent->sp_lstchg = (long) gettime () / SCALE;
+	spent->sp_lstchg = gettime () / SCALE;
 	if (0 == spent->sp_lstchg) {
 		/* Better disable aging than requiring a password change */
 		spent->sp_lstchg = -1;
@@ -2095,7 +2095,7 @@ static void lastlog_reset (uid_t uid)
 		return;
 	}
 
-	max_uid = (uid_t) getdef_ulong ("LASTLOG_UID_MAX", 0xFFFFFFFFUL);
+	max_uid = getdef_ulong ("LASTLOG_UID_MAX", 0xFFFFFFFFUL);
 	if (uid > max_uid) {
 		/* do not touch lastlog for large uids */
 		return;
@@ -2237,8 +2237,7 @@ static void usr_update (unsigned long subuid_count, unsigned long subgid_count)
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_ADD_USER, Prog,
 		              "adding shadow password",
-		              user_name, (unsigned int) user_id,
-		              SHADOW_AUDIT_FAILURE);
+		              user_name, user_id, SHADOW_AUDIT_FAILURE);
 #endif
 		fail_exit (E_PW_UPDATE);
 	}
@@ -2359,9 +2358,8 @@ static void create_home (void)
 							Prog, path);
 #ifdef WITH_AUDIT
 			audit_logger (AUDIT_ADD_USER, Prog,
-										"adding home directory",
-										user_name, (unsigned int) user_id,
-										SHADOW_AUDIT_FAILURE);
+				"adding home directory",
+				user_name, user_id, SHADOW_AUDIT_FAILURE);
 #endif
 			fail_exit (E_HOMEDIR);
 		}
@@ -2391,8 +2389,7 @@ static void create_home (void)
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_ADD_USER, Prog,
 		              "adding home directory",
-		              user_name, (unsigned int) user_id,
-		              SHADOW_AUDIT_SUCCESS);
+		              user_name, user_id, SHADOW_AUDIT_SUCCESS);
 #endif
 #ifdef WITH_SELINUX
 		/* Reset SELinux to create files with default contexts */
@@ -2488,13 +2485,13 @@ static void check_uid_range(int rflg, uid_t user_id)
 	uid_t uid_min ;
 	uid_t uid_max ;
 	if (rflg) {
-		uid_max = (uid_t)getdef_ulong("SYS_UID_MAX",getdef_ulong("UID_MIN",1000UL)-1);
+		uid_max = getdef_ulong("SYS_UID_MAX",getdef_ulong("UID_MIN",1000UL)-1);
 		if (user_id > uid_max) {
 			fprintf(stderr, _("%s warning: %s's uid %d is greater than SYS_UID_MAX %d\n"), Prog, user_name, user_id, uid_max);
 		}
 	}else{
-		uid_min = (uid_t)getdef_ulong("UID_MIN", 1000UL);
-		uid_max = (uid_t)getdef_ulong("UID_MAX", 6000UL);
+		uid_min = getdef_ulong("UID_MIN", 1000UL);
+		uid_max = getdef_ulong("UID_MAX", 6000UL);
 		if (uid_min <= uid_max) {
 			if (user_id < uid_min || user_id >uid_max)
 				fprintf(stderr, _("%s warning: %s's uid %d outside of the UID_MIN %d and UID_MAX %d range.\n"), Prog, user_name, user_id, uid_min, uid_max);
@@ -2559,8 +2556,8 @@ int main (int argc, char **argv)
 	process_flags (argc, argv);
 
 #ifdef ENABLE_SUBIDS
-	uid_min = (uid_t) getdef_ulong ("UID_MIN", 1000UL);
-	uid_max = (uid_t) getdef_ulong ("UID_MAX", 60000UL);
+	uid_min = getdef_ulong ("UID_MIN", 1000UL);
+	uid_max = getdef_ulong ("UID_MAX", 60000UL);
 	subuid_count = getdef_ulong ("SUB_UID_COUNT", 65536);
 	subgid_count = getdef_ulong ("SUB_GID_COUNT", 65536);
 	is_sub_uid = subuid_count > 0 && sub_uid_file_present () &&
@@ -2689,7 +2686,7 @@ int main (int argc, char **argv)
 #ifdef WITH_AUDIT
 				audit_logger (AUDIT_ADD_USER, Prog,
 				              "adding user",
-				              user_name, (unsigned int) user_id,
+				              user_name, user_id,
 				              SHADOW_AUDIT_FAILURE);
 #endif
 				fail_exit (E_UID_IN_USE);
@@ -2768,7 +2765,7 @@ int main (int argc, char **argv)
 #ifdef WITH_AUDIT
 			audit_logger (AUDIT_ADD_USER, Prog,
 			              "adding SELinux user mapping",
-			              user_name, (unsigned int) user_id, 0);
+			              user_name, user_id, 0);
 #endif				/* WITH_AUDIT */
 			fail_exit (E_SE_UPDATE);
 		}

--- a/src/userdel.c
+++ b/src/userdel.c
@@ -204,8 +204,7 @@ static void update_groups (void)
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_DEL_USER, Prog,
 		              "deleting user from group",
-		              user_name, (unsigned int) user_id,
-		              SHADOW_AUDIT_SUCCESS);
+		              user_name, user_id, SHADOW_AUDIT_SUCCESS);
 #endif				/* WITH_AUDIT */
 		SYSLOG ((LOG_INFO, "delete '%s' from group '%s'\n",
 			 user_name, ngrp->gr_name));
@@ -266,8 +265,7 @@ static void update_groups (void)
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_DEL_USER, Prog,
 		              "deleting user from shadow group",
-		              user_name, (unsigned int) user_id,
-		              SHADOW_AUDIT_SUCCESS);
+		              user_name, user_id, SHADOW_AUDIT_SUCCESS);
 #endif				/* WITH_AUDIT */
 		SYSLOG ((LOG_INFO, "delete '%s' from shadow group '%s'\n",
 		         user_name, nsgrp->sg_name));
@@ -526,8 +524,7 @@ static void fail_exit (int code)
 #ifdef WITH_AUDIT
 	audit_logger (AUDIT_DEL_USER, Prog,
 	              "deleting user",
-	              user_name, (unsigned int) user_id,
-	              SHADOW_AUDIT_FAILURE);
+	              user_name, user_id, SHADOW_AUDIT_FAILURE);
 #endif				/* WITH_AUDIT */
 
 	exit (code);
@@ -548,8 +545,7 @@ static void open_files (void)
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_DEL_USER, Prog,
 		              "locking password file",
-		              user_name, (unsigned int) user_id,
-		              SHADOW_AUDIT_FAILURE);
+		              user_name, user_id, SHADOW_AUDIT_FAILURE);
 #endif				/* WITH_AUDIT */
 		fail_exit (E_PW_UPDATE);
 	}
@@ -560,8 +556,7 @@ static void open_files (void)
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_DEL_USER, Prog,
 		              "opening password file",
-		              user_name, (unsigned int) user_id,
-		              SHADOW_AUDIT_FAILURE);
+		              user_name, user_id, SHADOW_AUDIT_FAILURE);
 #endif				/* WITH_AUDIT */
 		fail_exit (E_PW_UPDATE);
 	}
@@ -573,8 +568,7 @@ static void open_files (void)
 #ifdef WITH_AUDIT
 			audit_logger (AUDIT_DEL_USER, Prog,
 			              "locking shadow password file",
-			              user_name, (unsigned int) user_id,
-			              SHADOW_AUDIT_FAILURE);
+			              user_name, user_id, SHADOW_AUDIT_FAILURE);
 #endif				/* WITH_AUDIT */
 			fail_exit (E_PW_UPDATE);
 		}
@@ -586,8 +580,7 @@ static void open_files (void)
 #ifdef WITH_AUDIT
 			audit_logger (AUDIT_DEL_USER, Prog,
 			              "opening shadow password file",
-			              user_name, (unsigned int) user_id,
-			              SHADOW_AUDIT_FAILURE);
+			              user_name, user_id, SHADOW_AUDIT_FAILURE);
 #endif				/* WITH_AUDIT */
 			fail_exit (E_PW_UPDATE);
 		}
@@ -599,8 +592,7 @@ static void open_files (void)
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_DEL_USER, Prog,
 		              "locking group file",
-		              user_name, (unsigned int) user_id,
-		              SHADOW_AUDIT_FAILURE);
+		              user_name, user_id, SHADOW_AUDIT_FAILURE);
 #endif				/* WITH_AUDIT */
 		fail_exit (E_GRP_UPDATE);
 	}
@@ -610,8 +602,7 @@ static void open_files (void)
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_DEL_USER, Prog,
 		              "opening group file",
-		              user_name, (unsigned int) user_id,
-		              SHADOW_AUDIT_FAILURE);
+		              user_name, user_id, SHADOW_AUDIT_FAILURE);
 #endif				/* WITH_AUDIT */
 		fail_exit (E_GRP_UPDATE);
 	}
@@ -624,8 +615,7 @@ static void open_files (void)
 #ifdef WITH_AUDIT
 			audit_logger (AUDIT_DEL_USER, Prog,
 			              "locking shadow group file",
-			              user_name, (unsigned int) user_id,
-			              SHADOW_AUDIT_FAILURE);
+			              user_name, user_id, SHADOW_AUDIT_FAILURE);
 #endif				/* WITH_AUDIT */
 			fail_exit (E_GRP_UPDATE);
 		}
@@ -636,8 +626,7 @@ static void open_files (void)
 #ifdef WITH_AUDIT
 			audit_logger (AUDIT_DEL_USER, Prog,
 			              "opening shadow group file",
-			              user_name, (unsigned int) user_id,
-			              SHADOW_AUDIT_FAILURE);
+			              user_name, user_id, SHADOW_AUDIT_FAILURE);
 #endif				/* WITH_AUDIT */
 			fail_exit (E_GRP_UPDATE);
 		}
@@ -652,8 +641,7 @@ static void open_files (void)
 #ifdef WITH_AUDIT
 			audit_logger (AUDIT_DEL_USER, Prog,
 				"locking subordinate user file",
-				user_name, (unsigned int) user_id,
-				SHADOW_AUDIT_FAILURE);
+				user_name, user_id, SHADOW_AUDIT_FAILURE);
 #endif				/* WITH_AUDIT */
 			fail_exit (E_SUB_UID_UPDATE);
 		}
@@ -664,8 +652,7 @@ static void open_files (void)
 #ifdef WITH_AUDIT
 			audit_logger (AUDIT_DEL_USER, Prog,
 				"opening subordinate user file",
-				user_name, (unsigned int) user_id,
-				SHADOW_AUDIT_FAILURE);
+				user_name, user_id, SHADOW_AUDIT_FAILURE);
 #endif				/* WITH_AUDIT */
 			fail_exit (E_SUB_UID_UPDATE);
 		}
@@ -678,8 +665,7 @@ static void open_files (void)
 #ifdef WITH_AUDIT
 			audit_logger (AUDIT_DEL_USER, Prog,
 				"locking subordinate group file",
-				user_name, (unsigned int) user_id,
-				SHADOW_AUDIT_FAILURE);
+				user_name, user_id, SHADOW_AUDIT_FAILURE);
 #endif				/* WITH_AUDIT */
 			fail_exit (E_SUB_GID_UPDATE);
 		}
@@ -690,8 +676,7 @@ static void open_files (void)
 #ifdef WITH_AUDIT
 			audit_logger (AUDIT_DEL_USER, Prog,
 				"opening subordinate group file",
-				user_name, (unsigned int) user_id,
-				SHADOW_AUDIT_FAILURE);
+				user_name, user_id, SHADOW_AUDIT_FAILURE);
 #endif				/* WITH_AUDIT */
 			fail_exit (E_SUB_GID_UPDATE);
 		}
@@ -738,8 +723,7 @@ static void update_user (void)
 #ifdef WITH_AUDIT
 	audit_logger (AUDIT_DEL_USER, Prog,
 	              "deleting user entries",
-	              user_name, (unsigned int) user_id,
-	              SHADOW_AUDIT_SUCCESS);
+	              user_name, user_id, SHADOW_AUDIT_SUCCESS);
 #endif				/* WITH_AUDIT */
 	SYSLOG ((LOG_INFO, "delete user '%s'\n", user_name));
 }
@@ -846,8 +830,7 @@ static int remove_mailbox (void)
 #ifdef WITH_AUDIT
 			audit_logger (AUDIT_DEL_USER, Prog,
 			              "deleting mail file",
-			              user_name, (unsigned int) user_id,
-			              SHADOW_AUDIT_FAILURE);
+			              user_name, user_id, SHADOW_AUDIT_FAILURE);
 #endif				/* WITH_AUDIT */
 			free(mailfile);
 			return -1;
@@ -863,8 +846,7 @@ static int remove_mailbox (void)
 #ifdef WITH_AUDIT
 			audit_logger (AUDIT_DEL_USER, Prog,
 			              "deleting mail file",
-			              user_name, (unsigned int) user_id,
-			              SHADOW_AUDIT_FAILURE);
+			              user_name, user_id, SHADOW_AUDIT_FAILURE);
 #endif				/* WITH_AUDIT */
 			errors = 1;
 			/* continue */
@@ -874,8 +856,7 @@ static int remove_mailbox (void)
 		{
 			audit_logger (AUDIT_DEL_USER, Prog,
 			              "deleting mail file",
-			              user_name, (unsigned int) user_id,
-			              SHADOW_AUDIT_SUCCESS);
+			              user_name, user_id, SHADOW_AUDIT_SUCCESS);
 		}
 #endif				/* WITH_AUDIT */
 		free(mailfile);
@@ -892,8 +873,7 @@ static int remove_mailbox (void)
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_DEL_USER, Prog,
 		              "deleting mail file",
-		              user_name, (unsigned int) user_id,
-		              SHADOW_AUDIT_FAILURE);
+		              user_name, user_id, SHADOW_AUDIT_FAILURE);
 #endif				/* WITH_AUDIT */
 		free(mailfile);
 		return 1;
@@ -909,8 +889,7 @@ static int remove_mailbox (void)
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_DEL_USER, Prog,
 		              "deleting mail file",
-		              user_name, (unsigned int) user_id,
-		              SHADOW_AUDIT_FAILURE);
+		              user_name, user_id, SHADOW_AUDIT_FAILURE);
 #endif				/* WITH_AUDIT */
 		errors = 1;
 		/* continue */
@@ -920,8 +899,7 @@ static int remove_mailbox (void)
 	{
 		audit_logger (AUDIT_DEL_USER, Prog,
 		              "deleting mail file",
-		              user_name, (unsigned int) user_id,
-		              SHADOW_AUDIT_SUCCESS);
+		              user_name, user_id, SHADOW_AUDIT_SUCCESS);
 	}
 #endif				/* WITH_AUDIT */
 	free(mailfile);
@@ -1290,8 +1268,7 @@ int main (int argc, char **argv)
 		{
 			audit_logger (AUDIT_DEL_USER, Prog,
 			              "deleting home directory",
-			              user_name, (unsigned int) user_id,
-			              SHADOW_AUDIT_SUCCESS);
+			              user_name, user_id, SHADOW_AUDIT_SUCCESS);
 		}
 #endif				/* WITH_AUDIT */
 	}
@@ -1313,8 +1290,7 @@ int main (int argc, char **argv)
 #ifdef WITH_AUDIT
 			audit_logger (AUDIT_ADD_USER, Prog,
 			              "removing SELinux user mapping",
-			              user_name, (unsigned int) user_id,
-			              SHADOW_AUDIT_FAILURE);
+			              user_name, user_id, SHADOW_AUDIT_FAILURE);
 #endif				/* WITH_AUDIT */
 			fail_exit (E_SE_UPDATE);
 		}

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -198,7 +198,7 @@ extern int allow_bad_names;
 static int get_groups (char *list)
 {
 	char *cp;
-	const struct group *grp;
+	struct group *grp;
 	int errors = 0;
 	int ngroups = 0;
 
@@ -260,7 +260,7 @@ static int get_groups (char *list)
 			fprintf (stderr,
 			         _("%s: group '%s' is a NIS group.\n"),
 			         Prog, grp->gr_name);
-			gr_free ((struct group *)grp);
+			gr_free (grp);
 			continue;
 		}
 #endif
@@ -269,7 +269,7 @@ static int get_groups (char *list)
 			fprintf (stderr,
 			         _("%s: too many groups specified (max %d).\n"),
 			         Prog, ngroups);
-			gr_free ((struct group *)grp);
+			gr_free (grp);
 			break;
 		}
 
@@ -277,7 +277,7 @@ static int get_groups (char *list)
 		 * Add the group name to the user's list of groups.
 		 */
 		user_groups[ngroups++] = xstrdup (grp->gr_name);
-		gr_free ((struct group *)grp);
+		gr_free (grp);
 	} while (NULL != list);
 
 	user_groups[ngroups] = NULL;
@@ -419,8 +419,7 @@ static char *new_pw_passwd (char *pw_pass)
 
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
-		              "updating passwd",
-		              user_newname, (unsigned int) user_newid, 0);
+		              "updating passwd", user_newname, user_newid, 0);
 #endif
 		SYSLOG ((LOG_INFO, "lock user '%s' password", user_newname));
 		strcpy (buf, "!");
@@ -439,8 +438,7 @@ static char *new_pw_passwd (char *pw_pass)
 
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
-		              "updating password",
-		              user_newname, (unsigned int) user_newid, 0);
+		              "updating password", user_newname, user_newid, 0);
 #endif
 		SYSLOG ((LOG_INFO, "unlock user '%s' password", user_newname));
 		s = pw_pass;
@@ -451,8 +449,7 @@ static char *new_pw_passwd (char *pw_pass)
 	} else if (pflg) {
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
-		              "changing password",
-		              user_newname, (unsigned int) user_newid, 1);
+		              "changing password", user_newname, user_newid, 1);
 #endif
 		SYSLOG ((LOG_INFO, "change user '%s' password", user_newname));
 		pw_pass = xstrdup (user_pass);
@@ -481,8 +478,7 @@ static void new_pwent (struct passwd *pwent)
 		}
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
-		              "changing name",
-		              user_newname, (unsigned int) user_newid, 1);
+		              "changing name", user_newname, user_newid, 1);
 #endif
 		SYSLOG ((LOG_INFO,
 		         "change user name '%s' to '%s'",
@@ -502,8 +498,7 @@ static void new_pwent (struct passwd *pwent)
 	if (uflg) {
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
-		              "changing uid",
-		              user_newname, (unsigned int) user_newid, 1);
+		              "changing uid", user_newname, user_newid, 1);
 #endif
 		SYSLOG ((LOG_INFO,
 		         "change user '%s' UID from '%d' to '%d'",
@@ -514,7 +509,7 @@ static void new_pwent (struct passwd *pwent)
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
 		              "changing primary group",
-		              user_newname, (unsigned int) user_newid, 1);
+		              user_newname, user_newid, 1);
 #endif
 		SYSLOG ((LOG_INFO,
 		         "change user '%s' GID from '%d' to '%d'",
@@ -524,8 +519,7 @@ static void new_pwent (struct passwd *pwent)
 	if (cflg) {
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
-		              "changing comment",
-		              user_newname, (unsigned int) user_newid, 1);
+		              "changing comment", user_newname, user_newid, 1);
 #endif
 		pwent->pw_gecos = user_newcomment;
 	}
@@ -534,7 +528,7 @@ static void new_pwent (struct passwd *pwent)
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
 		              "changing home directory",
-		              user_newname, (unsigned int) user_newid, 1);
+		              user_newname, user_newid, 1);
 #endif
 		SYSLOG ((LOG_INFO,
 		         "change user '%s' home from '%s' to '%s'",
@@ -551,7 +545,7 @@ static void new_pwent (struct passwd *pwent)
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
 		              "changing user shell",
-		              user_newname, (unsigned int) user_newid, 1);
+		              user_newname, user_newid, 1);
 #endif
 		SYSLOG ((LOG_INFO,
 		         "change user '%s' shell from '%s' to '%s'",
@@ -582,7 +576,7 @@ static void new_spent (struct spwd *spent)
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
 		              "changing inactive days",
-		              user_newname, (unsigned int) user_newid, 1);
+		              user_newname, user_newid, 1);
 #endif
 		SYSLOG ((LOG_INFO,
 		         "change user '%s' inactive from '%ld' to '%ld'",
@@ -597,7 +591,7 @@ static void new_spent (struct spwd *spent)
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
 		              "changing expiration date",
-		              user_newname, (unsigned int) user_newid, 1);
+		              user_newname, user_newid, 1);
 #endif
 		SYSLOG ((LOG_INFO,
 		         "change user '%s' expiration from '%s' to '%s'",
@@ -617,7 +611,7 @@ static void new_spent (struct spwd *spent)
 	spent->sp_pwdp = new_pw_passwd (spent->sp_pwdp);
 
 	if (pflg) {
-		spent->sp_lstchg = (long) gettime () / SCALE;
+		spent->sp_lstchg = gettime () / SCALE;
 		if (0 == spent->sp_lstchg) {
 			/* Better disable aging than requiring a password
 			 * change. */
@@ -1736,7 +1730,7 @@ static void usr_update (void)
 			spent.sp_pwdp   = xstrdup (pwent.pw_passwd);
 			pwent.pw_passwd = xstrdup (SHADOW_PASSWD_STRING);
 
-			spent.sp_lstchg = (long) gettime () / SCALE;
+			spent.sp_lstchg = gettime () / SCALE;
 			if (0 == spent.sp_lstchg) {
 				/* Better disable aging than
 				 * requiring a password change */
@@ -1823,7 +1817,7 @@ static void move_home (void)
 		if (uflg || gflg) {
 			audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
 				      "changing home directory owner",
-				      user_newname, (unsigned int) user_newid, 1);
+				      user_newname, user_newid, 1);
 		}
 #endif
 
@@ -1842,8 +1836,7 @@ static void move_home (void)
 #ifdef WITH_AUDIT
 			audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
 			              "moving home directory",
-			              user_newname, (unsigned int) user_newid,
-			              1);
+			              user_newname, user_newid, 1);
 #endif
 			return;
 		} else {
@@ -1873,7 +1866,7 @@ static void move_home (void)
 					              Prog,
 					              "moving home directory",
 					              user_newname,
-					              (unsigned int) user_newid,
+					              user_newid,
 					              1);
 #endif
 					return;
@@ -1913,7 +1906,7 @@ static void update_lastlog (void)
 		return;
 	}
 
-	max_uid = (uid_t) getdef_ulong ("LASTLOG_UID_MAX", 0xFFFFFFFFUL);
+	max_uid = getdef_ulong ("LASTLOG_UID_MAX", 0xFFFFFFFFUL);
 	if (user_newid > max_uid) {
 		/* do not touch lastlog for large uids */
 		return;
@@ -1988,7 +1981,7 @@ static void update_faillog (void)
 	}
 
 	if (   (lseek (fd, off_uid, SEEK_SET) == off_uid)
-	    && (read (fd, (char *) &fl, sizeof fl) == (ssize_t) sizeof fl)) {
+	    && (read (fd, &fl, sizeof fl) == (ssize_t) sizeof fl)) {
 		/* Copy the old entry to its new location */
 		if (   (lseek (fd, off_newuid, SEEK_SET) != off_newuid)
 		    || (write (fd, &fl, sizeof fl) != (ssize_t) sizeof fl)
@@ -2091,7 +2084,7 @@ static void move_mailbox (void)
 		else {
 			audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
 			              "changing mail file owner",
-			              user_newname, (unsigned int) user_newid, 1);
+			              user_newname, user_newid, 1);
 		}
 #endif
 	}
@@ -2118,7 +2111,7 @@ static void move_mailbox (void)
 		else {
 			audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
 			              "changing mail file name",
-			              user_newname, (unsigned int) user_newid, 1);
+			              user_newname, user_newid, 1);
 		}
 #endif
 	}
@@ -2316,7 +2309,7 @@ int main (int argc, char **argv)
 #ifdef WITH_AUDIT
 				audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
 				              "modifying User mapping ",
-				              user_name, (unsigned int) user_id,
+				              user_name, user_id,
 				              SHADOW_AUDIT_FAILURE);
 #endif				/* WITH_AUDIT */
 				fail_exit (E_SE_UPDATE);
@@ -2329,7 +2322,7 @@ int main (int argc, char **argv)
 #ifdef WITH_AUDIT
 				audit_logger (AUDIT_ADD_USER, Prog,
 				              "removing SELinux user mapping",
-				              user_name, (unsigned int) user_id,
+				              user_name, user_id,
 				              SHADOW_AUDIT_FAILURE);
 #endif				/* WITH_AUDIT */
 				fail_exit (E_SE_UPDATE);
@@ -2371,7 +2364,7 @@ int main (int argc, char **argv)
 			if (uflg || gflg) {
 				audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
 					      "changing home directory owner",
-					      user_newname, (unsigned int) user_newid, 1);
+					      user_newname, user_newid, 1);
 			}
 #endif
 			if (chown_tree (dflg ? prefix_user_newhome : prefix_user_home,


### PR DESCRIPTION
-  Every non-const pointer converts automatically to void *.
-  Every pointer converts automatically to void *.
-  void * converts to any other pointer.
-  const void * converts to any other const pointer.
-  Integer variables convert to each other.

I changed the declaration of a few variables in order to allow removing a cast.

However, I didn't attempt to edit casts inside comparisons, since they are very delicate.  I also kept casts in variadic functions, since they are necessary, and in allocation functions, because I have other plans for them.

Signed-off-by: Alejandro Colomar <alx@kernel.org>