### PR TITLE
find_new_[ug]id: Skip over IDs that could overflow to -1

### DIFF
--- a/libmisc/find_new_uid.c
+++ b/libmisc/find_new_uid.c
@@ -99,6 +99,7 @@ static int get_ranges (bool sys_user, uid_t *min_id, uid_t *max_id,
  *
  * On success, return 0
  * If the ID is in use, return EEXIST
+ * If the ID might clash with -1, return EINVAL
  * If the ID is outside the range, return ERANGE
  * In other cases, return errno from getpwuid()
  */
@@ -110,6 +111,11 @@ static int check_uid(const uid_t uid,
 	/* First test that the preferred ID is in the range */
 	if (uid < uid_min || uid > uid_max) {
 		return ERANGE;
+	}
+
+	/* Check for compatibility with 16b and 32b uid_t error codes */
+	if (uid == UINT16_MAX || uid == UINT32_MAX) {
+		return EINVAL;
 	}
 
 	/*
@@ -183,10 +189,10 @@ int find_new_uid(bool sys_user,
 			 * pw_locate_uid() found the UID in an as-yet uncommitted
 			 * entry. We'll proceed below and auto-set an UID.
 			 */
-		} else if (result == EEXIST || result == ERANGE) {
+		} else if (result == EEXIST || result == ERANGE || result == EINVAL) {
 			/*
 			 * Continue on below. At this time, we won't
-			 * treat these two cases differently.
+			 * treat these three cases differently.
 			 */
 		} else {
 			/*
@@ -297,8 +303,11 @@ int find_new_uid(bool sys_user,
 				*uid = id;
 				free (used_uids);
 				return 0;
-			} else if (result == EEXIST) {
-				/* This UID is in use, we'll continue to the next */
+			} else if (result == EEXIST || result == EINVAL) {
+				/*
+				 * This GID is in use or unusable, we'll
+				 * continue to the next.
+				 */
 			} else {
 				/*
 				 * An unexpected error occurred.
@@ -340,8 +349,11 @@ int find_new_uid(bool sys_user,
 					*uid = id;
 					free (used_uids);
 					return 0;
-				} else if (result == EEXIST) {
-					/* This UID is in use, we'll continue to the next */
+				} else if (result == EEXIST || result == EINVAL) {
+					/*
+					 * This GID is in use or unusable, we'll
+					 * continue to the next.
+					 */
 				} else {
 					/*
 					 * An unexpected error occurred.
@@ -400,8 +412,11 @@ int find_new_uid(bool sys_user,
 				*uid = id;
 				free (used_uids);
 				return 0;
-			} else if (result == EEXIST) {
-				/* This UID is in use, we'll continue to the next */
+			} else if (result == EEXIST || result == EINVAL) {
+				/*
+				 * This GID is in use or unusable, we'll
+				 * continue to the next.
+				 */
 			} else {
 				/*
 				 * An unexpected error occurred.
@@ -443,8 +458,11 @@ int find_new_uid(bool sys_user,
 					*uid = id;
 					free (used_uids);
 					return 0;
-				} else if (result == EEXIST) {
-					/* This UID is in use, we'll continue to the next */
+				} else if (result == EEXIST || result == EINVAL) {
+					/*
+					 * This GID is in use or unusable, we'll
+					 * continue to the next.
+					 */
 				} else {
 					/*
 					 * An unexpected error occurred.


### PR DESCRIPTION
Due to compatibility reasons neither UID nor GID should overflow to -1, be it on systems with 16-bit or 32-bit uid_t/gid_t since -1 is special.  It has different meaning for example as a chown(2) parameter, could become 65535 in programs compiled when uid_t was 16bit and possibly more issues.