### PR TITLE
lib: two fixes in bit.h

### DIFF
--- a/lib/bit.h
+++ b/lib/bit.h
@@ -39,7 +39,7 @@ bit_ceil_wrapul(unsigned long x)
 	if (x == 0)
 		return 0;
 
-	return bit_ceil_wrapul(x);
+	return bit_ceilul(x);
 }
 
 /* stdc_leading_zerosul(3) */

--- a/lib/bit.h
+++ b/lib/bit.h
@@ -14,6 +14,11 @@
 #include <limits.h>
 
 
+#ifndef ULONG_WIDTH
+#define ULONG_WIDTH (sizeof(unsigned long) * CHAR_BIT)
+#endif
+
+
 inline unsigned long bit_ceilul(unsigned long x);
 inline unsigned long bit_ceil_wrapul(unsigned long x);
 inline int leading_zerosul(unsigned long x);


### PR DESCRIPTION
* Define ULONG_WIDTH if non-existent
* bit_ceil_wrapul(): stop recursion and call bit_ceilul() instead