### PR TITLE
tests: Support git-worktree(1)

### DIFF
--- a/tests/common/config.sh
+++ b/tests/common/config.sh
@@ -3,10 +3,10 @@
 set -e
 
 build_path=$(pwd)
-while [ "${build_path}" != "/" -a ! -d "${build_path}/.git" ]; do
+while [ "${build_path}" != "/" -a ! -e "${build_path}/.git" ]; do
 	build_path=$(dirname ${build_path})
 done
-if [ ! -d "${build_path}/.git" ]; then
+if [ ! -e "${build_path}/.git" ]; then
 	echo "Not inside git directory" 1>&2
 	exit 1
 fi


### PR DESCRIPTION
git-worktree(1) uses a regular file for <.git>, instead of a directory.

```
alx@debian:~/src/shadow/shadow$ ls -la
total 24
drwxr-xr-x  6 alx alx 4096 Feb 26 15:37 .
drwxr-xr-x  4 alx alx 4096 Feb 19 18:44 ..
drwxr-xr-x  9 alx alx 4096 Feb 26 15:39 .bare.git
drwxr-xr-x 15 alx alx 4096 Feb 26 14:43 docker
drwxr-xr-x 15 alx alx 4096 Feb 26 15:37 git
drwxr-xr-x 15 alx alx 4096 Feb 19 18:47 master
docker  git  master
alx@debian:~/src/shadow/shadow$ cd docker/
alx@debian:~/src/shadow/shadow/docker$ file .git
.git: ASCII text
alx@debian:~/src/shadow/shadow/docker$ cat .git
gitdir: /home/alx/src/shadow/shadow/.bare.git/worktrees/docker
```