### PR TITLE
ch(g)passwd: Check selinux permissions upon startup

### DIFF
--- a/src/chgpasswd.c
+++ b/src/chgpasswd.c
@@ -424,6 +424,12 @@ int main (int argc, char **argv)
 	(void) bindtextdomain (PACKAGE, LOCALEDIR);
 	(void) textdomain (PACKAGE);
 
+#ifdef WITH_SELINUX
+	if (check_selinux_permit ("passwd") != 0) {
+		return (E_NOPERM);
+	}
+#endif				/* WITH_SELINUX */
+
 	process_root_flag ("-R", argc, argv);
 
 	process_flags (argc, argv);

--- a/src/chpasswd.c
+++ b/src/chpasswd.c
@@ -452,6 +452,12 @@ int main (int argc, char **argv)
 	(void) bindtextdomain (PACKAGE, LOCALEDIR);
 	(void) textdomain (PACKAGE);
 
+#ifdef WITH_SELINUX
+	if (check_selinux_permit ("passwd") != 0) {
+		return (E_NOPERM);
+	}
+#endif				/* WITH_SELINUX */
+
 	process_flags (argc, argv);
 
 	salt = get_salt();


### PR DESCRIPTION
The permission also need to be checked before process_root_flag() since that can chroot into non-selinux environment (unavailable selinux mount point for example).