### PR TITLE
Various fixes related to string copying

### DIFF
--- a/lib/defines.h
+++ b/lib/defines.h
@@ -171,6 +171,7 @@ static inline void memzero(void *ptr, size_t size)
 
 #define WIDTHOF(x)   (sizeof(x) * CHAR_BIT)
 #define NITEMS(arr)  (sizeof((arr)) / sizeof((arr)[0]))
+#define STRLEN(s)    (NITEMS(s) - 1)
 
 /* Copy string pointed by B to array A with size checking.  It was originally
    in lmain.c but is _very_ useful elsewhere.  Some setuid root programs with

--- a/lib/fields.c
+++ b/lib/fields.c
@@ -91,8 +91,9 @@ void change_field (char *buf, size_t maxsize, const char *prompt)
 		 * entering a space.  --marekm
 		 */
 
-		while (--cp >= newf && isspace (*cp));
-		cp++;
+		while (newf < cp && isspace (cp[-1])) {
+			cp--;
+		}
 		*cp = '\0';
 
 		cp = newf;

--- a/lib/fields.c
+++ b/lib/fields.c
@@ -100,7 +100,6 @@ void change_field (char *buf, size_t maxsize, const char *prompt)
 			cp++;
 		}
 
-		strlcpy (buf, cp, maxsize);
+		strcpy (buf, cp);
 	}
 }
-

--- a/lib/fields.c
+++ b/lib/fields.c
@@ -96,7 +96,7 @@ void change_field (char *buf, size_t maxsize, const char *prompt)
 		*cp = '\0';
 
 		cp = newf;
-		while (('\0' != *cp) && isspace (*cp)) {
+		while (isspace (*cp)) {
 			cp++;
 		}
 

--- a/lib/gshadow.c
+++ b/lib/gshadow.c
@@ -128,7 +128,7 @@ void endsgent (void)
 		sgrbuflen = len;
 	}
 
-	strlcpy (sgrbuf, string, len);
+	strcpy (sgrbuf, string);
 
 	cp = strrchr (sgrbuf, '\n');
 	if (NULL != cp) {

--- a/libmisc/date_to_str.c
+++ b/libmisc/date_to_str.c
@@ -33,15 +33,24 @@
 
 #include "prototypes.h"
 
-void date_to_str (size_t size, char buf[size], long date)
+void
+date_to_str(size_t size, char buf[size], long date)
 {
-	time_t t;
+	time_t           t;
+	const struct tm  *tm;
 
 	t = date;
 	if (date < 0) {
-		(void) strlcpy (buf, "never", size);
-	} else {
-		(void) strftime (buf, size, "%Y-%m-%d", gmtime (&t));
-		buf[size - 1] = '\0';
+		(void) strlcpy(buf, "never", size);
+		return;
 	}
+
+	tm = gmtime(&t);
+	if (tm == NULL) {
+		(void) strlcpy(buf, "future", size);
+		return;
+	}
+
+	(void) strftime(buf, size, "%Y-%m-%d", tm);
+	buf[size - 1] = '\0';
 }

--- a/libmisc/utmp.c
+++ b/libmisc/utmp.c
@@ -32,7 +32,7 @@ static bool is_my_tty (const char tty[UT_LINESIZE])
 {
 	char         full_tty[STRLEN("/dev/") + UT_LINESIZE + 1];
 	/* tmptty shall be bigger than full_tty */
-	static char  tmptty[sizeof (full_tty)+1];
+	static char  tmptty[sizeof(full_tty) + 1];
 
 	full_tty[0] = '\0';
 	if (tty[0] != '/')
@@ -42,17 +42,15 @@ static bool is_my_tty (const char tty[UT_LINESIZE])
 	if ('\0' == tmptty[0]) {
 		const char *tname = ttyname (STDIN_FILENO);
 		if (NULL != tname)
-			(void) strlcpy (tmptty, tname, sizeof tmptty);
+			(void) strlcpy (tmptty, tname, sizeof(tmptty));
 	}
 
 	if ('\0' == tmptty[0]) {
 		(void) puts (_("Unable to determine your tty name."));
 		exit (EXIT_FAILURE);
-	} else if (strncmp (full_tty, tmptty, sizeof (tmptty)) != 0) {
-		return false;
-	} else {
-		return true;
 	}
+
+	return strcmp (full_tty, tmptty) == 0;
 }
 
 /*

--- a/libmisc/utmp.c
+++ b/libmisc/utmp.c
@@ -28,17 +28,16 @@
 /*
  * is_my_tty -- determine if "tty" is the same TTY stdin is using
  */
-static bool is_my_tty (const char *tty)
+static bool is_my_tty (const char tty[UT_LINESIZE])
 {
-	/* full_tty shall be at least sizeof utmp.ut_line + 5 */
-	char full_tty[200];
+	char         full_tty[STRLEN("/dev/") + UT_LINESIZE + 1];
 	/* tmptty shall be bigger than full_tty */
-	static char tmptty[sizeof (full_tty)+1];
+	static char  tmptty[sizeof (full_tty)+1];
 
-	if ('/' != *tty) {
-		(void) snprintf (full_tty, sizeof full_tty, "/dev/%s", tty);
-		tty = &full_tty[0];
-	}
+	full_tty[0] = '\0';
+	if (tty[0] != '/')
+		strcpy (full_tty, "/dev/");
+	strncat (full_tty, tty, UT_LINESIZE);
 
 	if ('\0' == tmptty[0]) {
 		const char *tname = ttyname (STDIN_FILENO);
@@ -49,7 +48,7 @@ static bool is_my_tty (const char *tty)
 	if ('\0' == tmptty[0]) {
 		(void) puts (_("Unable to determine your tty name."));
 		exit (EXIT_FAILURE);
-	} else if (strncmp (tty, tmptty, sizeof (tmptty)) != 0) {
+	} else if (strncmp (full_tty, tmptty, sizeof (tmptty)) != 0) {
 		return false;
 	} else {
 		return true;

--- a/src/su.c
+++ b/src/su.c
@@ -658,7 +658,13 @@ static /*@only@*/struct passwd * check_perms (void)
 		SYSLOG ((LOG_INFO,
 		         "Change user from '%s' to '%s' as requested by PAM",
 		         name, tmp_name));
-		strlcpy (name, tmp_name, sizeof(name));
+		if (strlcpy (name, tmp_name, sizeof(name)) >= sizeof(name)) {
+			fprintf (stderr, _("Overlong user name '%s'\n"),
+			         tmp_name);
+			SYSLOG ((LOG_NOTICE, "Overlong user name '%s'",
+			         tmp_name));
+			su_failure (caller_tty, true);
+		}
 		pw = xgetpwnam (name);
 		if (NULL == pw) {
 			(void) fprintf (stderr,


### PR DESCRIPTION
This consists of some patches from @eggert, and some patches of mine which have been more or less based on his suggestions.  See the origin of the discussion at Debbugs: <https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1032393#159>.

I didn't intend to remove strlcpy(3), since the bugs are independent of the use of strlcpy(3).  I opted for fixing the bugs, and keeping strlcpy(3) where it's (IMO) the most appropriate call.

We might want to drop strlcpy(3), but I think that should be addressed separately, and after having fixed the bugs.

There's one patch from Paul that I didn't take or write an alternative, and that's because I didn't yet understand it.  It's `Avoid silent truncation of console file data` (see Debbugs above).