### PR TITLE
Fix null dereference in basename

### DIFF
--- a/libmisc/basename.c
+++ b/libmisc/basename.c
@@ -21,6 +21,10 @@
 #include "prototypes.h"
 /*@observer@*/const char *Basename (const char *str)
 {
+	if (str == NULL) {
+		abort ();
+	}
+
 	char *cp = strrchr (str, '/');
 
 	return (NULL != cp) ? cp + 1 : str;


### PR DESCRIPTION
On older kernels (<=linux-5.17), argv[0] can be null. Basename would call strrchr with null if argc==0.