### PR TITLE
libmisc, man: Drop old check and advice for complex character sets in passwords

### DIFF
--- a/libmisc/obscure.c
+++ b/libmisc/obscure.c
@@ -75,57 +75,6 @@ static bool similar (/*@notnull@*/const char *old, /*@notnull@*/const char *new)
 	return true;
 }
 
-/*
- * a nice mix of characters.
- */
-
-static bool simple (unused const char *old, const char *new)
-{
-	bool digits = false;
-	bool uppers = false;
-	bool lowers = false;
-	bool others = false;
-	int size;
-	int i;
-
-	for (i = 0; '\0' != new[i]; i++) {
-		if (isdigit (new[i])) {
-			digits = true;
-		} else if (isupper (new[i])) {
-			uppers = true;
-		} else if (islower (new[i])) {
-			lowers = true;
-		} else {
-			others = true;
-		}
-	}
-
-	/*
-	 * The scam is this - a password of only one character type
-	 * must be 8 letters long.  Two types, 7, and so on.
-	 */
-
-	size = 9;
-	if (digits) {
-		size--;
-	}
-	if (uppers) {
-		size--;
-	}
-	if (lowers) {
-		size--;
-	}
-	if (others) {
-		size--;
-	}
-
-	if (size <= i) {
-		return false;
-	}
-
-	return true;
-}
-
 static char *str_lower (/*@returned@*/char *string)
 {
 	char *cp;
@@ -170,8 +119,6 @@ static /*@observer@*//*@null@*/const char *password_check (
 		msg = _("case changes only");
 	} else if (similar (oldmono, newmono)) {
 		msg = _("too similar");
-	} else if (simple (old, new)) {
-		msg = _("too simple");
 	} else if (strstr (wrapped, newmono) != NULL) {
 		msg = _("rotated");
 	} else {

--- a/man/passwd.1.xml
+++ b/man/passwd.1.xml
@@ -94,27 +94,10 @@
       </para>
 
       <para>
-	Then, the password is tested for complexity. As a general guideline,
-	passwords should consist of 6 to 8 characters including one or more
-	characters from each of the following sets:
-      </para>
-
-      <itemizedlist mark='bullet'>
-	<listitem>
-	  <para>lower case alphabetics</para>
-	</listitem>
-	<listitem>
-	  <para>digits 0 thru 9</para>
-	</listitem>
-	<listitem>
-	  <para>punctuation marks</para>
-	</listitem>
-      </itemizedlist>
-
-      <para>
-	Care must be taken not to include the system default erase or kill
-	characters. <command>passwd</command> will reject any password which
-	is not suitably complex.
+	Then, the password is tested for complexity.
+	<command>passwd</command> will reject any password which is not
+	suitably complex.  Care must be taken not to include the system
+	default erase or kill characters.
       </para>
 
     </refsect2>
@@ -137,6 +120,17 @@
 	written down. The password should also not be a proper name, your
 	license number, birth date, or street address. Any of these may be
 	used as guesses to violate system security.
+      </para>
+
+      <para>
+	As a general guideline, passwords should be long and random.  It's
+	fine to use simple character sets, such as passwords consisting
+	only of lowercase letters, if that helps memorizing longer
+	passwords.  For a password consisting only of lowercase English
+	letters randomly chosen, and a length of 32, there are 26^32
+	(approximately 2^150) different possible combinations.  Being an
+	exponential equation, it's apparent that the exponent (the length)
+	is more important than the base (the size of the character set).
       </para>
 
       <para>
@@ -474,6 +468,9 @@
 	<refentrytitle>chpasswd</refentrytitle><manvolnum>8</manvolnum>
       </citerefentry>,
       <citerefentry>
+	<refentrytitle>makepasswd</refentrytitle><manvolnum>1</manvolnum>
+      </citerefentry>,
+      <citerefentry>
 	<refentrytitle>passwd</refentrytitle><manvolnum>5</manvolnum>
       </citerefentry>,
       <citerefentry>
@@ -487,6 +484,12 @@
       <citerefentry>
 	<refentrytitle>usermod</refentrytitle><manvolnum>8</manvolnum>
       </citerefentry>.
+    </para>
+
+    <para>
+	The following web page comically (yet correctly) compares the
+	strength of two different methods for choosing a password:
+	"https://xkcd.com/936/"
     </para>
   </refsect1>
 </refentry>


### PR DESCRIPTION
I kept the minimum length as 8, since it was what we had for the simplest passwords already.  8 is probably not what you really want from a password, but I believe it should be up to users to chose what they want.  If we raise this too much, we may upset some people, so let's be cautious.

Add the relevant XKCD to the passwd(1) manual page.  It already explains most of the rationale behind this patch.

The strength of a password is an exponential formula, where the base is the size of the character set, and the exponent is the length of the password.  That already shows why long passwords of just lowercase letters are better than short Pa$sw0rdZ3.  But an even more important point is that humans, when forced to use symbols in a password, are more likely to do trivial substitutions on simple passwords, which doesn't increase strength, and can instead give a false sense of strength, which is dangerous.

Closes: <https://github.com/shadow-maint/shadow/issues/688>
Link: <https://xkcd.com/936/>