### PR TITLE
usermod: respect --prefix for --gid option

### DIFF
--- a/src/usermod.c
+++ b/src/usermod.c
@@ -1072,7 +1072,7 @@ static void process_flags (int argc, char **argv)
 				fflg = true;
 				break;
 			case 'g':
-				grp = getgr_nam_gid (optarg);
+				grp = prefix_getgr_nam_gid (optarg);
 				if (NULL == grp) {
 					fprintf (stderr,
 					         _("%s: group '%s' does not exist\n"),


### PR DESCRIPTION
The --gid option accepts a group name or id. When a name is provided, it is resolved to an id by looking up the name in the group database (/etc/group).

The --prefix option overides the location of the passwd and group databases. I suspect the --gid option was overlooked when wiring up the --prefix option.

useradd --gid already respects --prefix; this change makes usermod behave the same way.

Fixes: https://github.com/shadow-maint/shadow/commit/b6b2c756c91806b1c3e150ea0ee4721c6cdaf9d0