### PR TITLE
Contributions documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ There are several ways to contact us:
   https://alioth-lists-archive.debian.net/pipermail/pkg-shadow-commits/),
   only used for historical purposes
 
+## Contributions
+
+Contributions are welcome. Follow the
+[guidelines](doc/contributions/introduction.md) before posting any patches.
+
 ## Authors and maintainers
 Authors and maintainers are listed in [AUTHORS.md](
 https://github.com/shadow-maint/shadow/blob/master/AUTHORS.md).

--- a/doc/contributions/build_install.md
+++ b/doc/contributions/build_install.md
@@ -1,0 +1,68 @@
+# Build & install
+
+The following page explains how to build and install the shadow project.
+Additional information on how to do this in a container environment is provided
+at the end of the page.
+
+## Local
+
+### Dependency installation
+
+This projects depends on other software packages that need to be installed
+before building it. We recommend using the dependency installation commands
+provided by the distributions to install them. Some examples below.
+
+Debian:
+```
+apt-get build-dep shadow
+```
+
+Fedora:
+```
+dnf builddep shadow-utils
+```
+
+### Configure
+
+The first step is to configure it. You can use the
+`autogen.sh` script provided by the project. Example:
+
+```
+./autogen.sh --without-selinux --enable-man --with-yescrypt
+```
+
+### Build
+
+The next step is to build the project:
+
+```
+make -j4
+```
+
+### Install
+
+The last step is to install it. We recommend avoiding this step and using a
+disposable system like a VM or a container instead.
+
+```
+make install
+```
+
+## Containers
+
+Alternatively, you can use any of the preconfigured container images builders
+to build and install shadow.
+
+You can either generate a single image by running the following command from
+the root folder of the project (i.e. Alpine):
+
+```
+docker build -f share/containers/alpine.dockerfile . --output build-out/alpine
+```
+
+Or generate all of the images with the `container-build.sh` script, as if you
+were running some of the CI checks locally:
+
+```
+share/container-build.sh
+```

--- a/doc/contributions/ci.md
+++ b/doc/contributions/ci.md
@@ -1,0 +1,25 @@
+# Continuous Integration (CI)
+
+Shadow runs a CI workflow every time a pull-request (PR) is updated. This
+workflow contains several checks to assure the quality of the project, and
+only pull-requests with green results are merged.
+
+## Build & install
+
+The project is built & installed on Ubuntu, Alpine, Debian and Fedora. The last
+three distributions are built & installed on containers, and the workflow can
+be triggered locally by following the instructions specified in the
+[Build & install](build_install.md#containers) page.
+
+## System tests
+
+The project is tested on Ubuntu. For that purpose it is built & installed in
+this distribution in a VM. You can run this step locally by following the
+instructions provided in the [Tests](tests.md#system-tests) page.
+
+## Static code analysis
+
+C and shell static code analysis is also executed. For that purpose
+[CodeQL](https://codeql.github.com/) and
+[Differential ShellCheck](https://github.com/marketplace/actions/differential-shellcheck)
+are used.

--- a/doc/contributions/coding_style.md
+++ b/doc/contributions/coding_style.md
@@ -1,0 +1,12 @@
+# Coding style
+
+* For a general guidance refer to the
+[Linux kernel coding style](https://www.kernel.org/doc/html/latest/process/coding-style.html)
+
+* Patches that change the existing coding style are not welcome, as they make
+downstream porting harder for the distributions
+
+## Indentation
+
+Tabs are preferred over spaces for indentation. Loading the `.editorconfig`
+file in your preferred IDE may help you configure it.

--- a/doc/contributions/introduction.md
+++ b/doc/contributions/introduction.md
@@ -1,0 +1,77 @@
+# Introduction
+
+## Git and Github
+
+We recommend you to get familiar with the
+[git](https://guides.github.com/introduction/git-handbook) and
+[Github](https://guides.github.com) workflows before posting any changes.
+
+### Set up in a nut shell
+
+The following steps describe the process in a nut shell to provide you a basic
+template:
+
+* Create an account on [GitHub](https://github.com)
+* Fork the [shadow repository](https://github.com/shadow-maint/shadow)
+* Clone the shadow repository
+
+```
+git clone https://github.com/shadow-maint/shadow.git
+```
+
+* Add your fork as an extra remote
+
+```
+git remote add $ghusername git@github.com:$ghusername/shadow.git
+```
+
+* Setup your name contact e-mail that you want to use for the development
+
+```
+git config user.name "John Smith"
+git config user.email "john.smith@home.com"
+```
+
+**Note**: this will setup the user information only for this repository. You
+can also add `--global` switch to the `git config` command to setup these
+options globally and thus making them available in every git repository.
+
+* Create a working branch
+
+```
+git checkout -b my-changes
+```
+
+* Commit changes
+
+```
+vim change-what-you-need
+git commit -s
+```
+
+Check
+[the kernel patches guide](https://www.kernel.org/doc/html/v4.14/process/submitting-patches.html#describe-your-changes)
+to get an idea on how to write a good commit message.
+
+* Push your changes to your GitHub repository
+
+```
+git push $ghusername my-changes --force
+```
+
+* Open a Pull Request against shadow project by clicking on the link provided
+in the output of the previous step
+
+* Make sure that all Continuous Integration checks are green and wait review
+
+## Internal guidelines
+
+Additionally, you should also check the following internal guidelines to
+understand the project's development model:
+
+* [Build & install](build_install.md)
+* [Coding style](coding_style.md)
+* [Tests](tests.md)
+* [Continuous Integration](CI.md)
+* [Releases](releases.md)
+* [License](license.md)

--- a/doc/contributions/license.md
+++ b/doc/contributions/license.md
@@ -1,0 +1,10 @@
+# License
+
+All new source code committed to the shadow project is assumed to be made
+available under the [BSD-3-Clause](../../COPYING) license unless the submitter
+specifies another license at that time. The shadow maintainers reserve the
+right to refuse a submission if the license is deemed incompatible with the
+goals of the project.
+
+**Note**: old code may be made available under another license, check the
+license tag for each file to get additional information.

--- a/doc/contributions/releases.md
+++ b/doc/contributions/releases.md
@@ -1,0 +1,7 @@
+# Releases
+
+The shadow project doesn't follow any specific timeline to release new software
+versions. Usually, they are released when a major milestone is finished.
+
+Released source code, alongside the release notes, are provided in the
+[release Github page](https://github.com/shadow-maint/shadow/releases).

--- a/doc/contributions/tests.md
+++ b/doc/contributions/tests.md
@@ -1,0 +1,18 @@
+# Tests
+
+Currently, shadow only provides system tests.
+
+## System tests
+
+These type of tests are written in shell. Unfortunately, the testing framework
+is tightly coupled to the Ubuntu distribution and it can only be run in this
+distribution. Besides, if anything fails during the execution the system can
+be left in an unstable state. Taking that into account you shouldn't run this
+workflow in your host machine, we recommend to use a disposable system like a
+VM or a container instead.
+
+You can execute system tests by running:
+
+```
+cd tests && ./run_all`.
+```


### PR DESCRIPTION
I have created the following documentation to define how to contribute to this project. I think it's best to centralize all our documentation in one place and make it as simple as possible to reduce the maintenance burden. http://shadow-maint.github.io/shadow-www/ should be doing that, but it isn't updated, so in my opinion we should close it.

As a summary, this project has two type of consumers: developers and sysadmins. The former will expect to have all the meaningful documentation (development guidelines, release notes, etc.) in the development repository. This PR will take care of them. The latter is interested in how to configure and use the commands, which can be checked in the man pages. And in the release notes, which are already up-to-date in the Github page.

Having said that, I don't mind moving the information from this PR to https://github.com/shadow-maint/shadow-www, but I don't think anybody will check it as it seems abandoned. The last commit dates from 2011.

Finally, there are two things missing in the documentation: the coding style and the workflow for mailing patches. @hallyn do you mind providing a general guidance on how to do that? I guess that for mailing patches we could use the same workflow as the Kernel?