### PR TITLE
Overhaul valid_field()

### DIFF
--- a/lib/fields.c
+++ b/lib/fields.c
@@ -37,23 +37,19 @@ int valid_field (const char *field, const char *illegal)
 
 	/* For each character of field, search if it appears in the list
 	 * of illegal characters. */
-	for (cp = field; '\0' != *cp; cp++) {
-		if (strchr (illegal, *cp) != NULL) {
-			err = -1;
-			break;
-		}
+	if (illegal && NULL != strpbrk (field, illegal)) {
+		return -1;
 	}
 
-	if (0 == err) {
-		/* Search if there are non-printable or control characters */
-		for (cp = field; '\0' != *cp; cp++) {
-			if (!isprint (*cp)) {
-				err = 1;
-			}
-			if (!iscntrl (*cp)) {
-				err = -1;
-				break;
-			}
+	/* Search if there are non-printable or control characters */
+	for (cp = field; '\0' != *cp; cp++) {
+		unsigned char c = *cp;
+		if (!isprint (c)) {
+			err = 1;
+		}
+		if (iscntrl (c)) {
+			err = -1;
+			break;
 		}
 	}
 


### PR DESCRIPTION
e5905c4b ("Added control character check") introduced checking for control characters but had the logic inverted, so it rejects all characters that are not control ones.

Cast the character to `unsigned char` before passing to the character checking functions to avoid UB.

Use strpbrk(3) for the illegal character test and return early.