### PR TITLE
Simplify allocation APIs.

### DIFF
--- a/lib/alloc.h
+++ b/lib/alloc.h
@@ -20,17 +20,12 @@
 #include "defines.h"
 
 
-#define CALLOC(n, type)        ((type *) calloc(n, sizeof(type)))
-#define XCALLOC(n, type)       ((type *) xcalloc(n, sizeof(type)))
-#define MALLOCARRAY(n, type)   ((type *) mallocarray(n, sizeof(type)))
-#define XMALLOCARRAY(n, type)  ((type *) xmallocarray(n, sizeof(type)))
+#define CALLOC(n, type)   ((type *) calloc(n, sizeof(type)))
+#define XCALLOC(n, type)  ((type *) xcalloc(n, sizeof(type)))
+#define MALLOC(n, type)   ((type *) mallocarray(n, sizeof(type)))
+#define XMALLOC(n, type)  ((type *) xmallocarray(n, sizeof(type)))
 
-#define MALLOC(type)           MALLOCARRAY(1, type)
-#define XMALLOC(type)          XMALLOCARRAY(1, type)
-#define REALLOC(ptr, type)     REALLOCARRAY(ptr, 1, type)
-#define REALLOCF(ptr, type)    REALLOCARRAYF(ptr, 1, type)
-
-#define REALLOCARRAY(ptr, n, type)                                            \
+#define REALLOC(ptr, n, type)                                                 \
 ({                                                                            \
 	__auto_type  p_ = (ptr);                                              \
                                                                               \
@@ -39,7 +34,7 @@
 	(type *) reallocarray(p_, n, sizeof(type));                           \
 })
 
-#define REALLOCARRAYF(ptr, n, type)                                           \
+#define REALLOCF(ptr, n, type)                                                \
 ({                                                                            \
 	__auto_type  p_ = (ptr);                                              \
                                                                               \
@@ -48,7 +43,7 @@
 	(type *) reallocarrayf(p_, n, sizeof(type));                          \
 })
 
-#define XREALLOCARRAY(ptr, n, type)                                           \
+#define XREALLOC(ptr, n, type)                                                \
 ({                                                                            \
 	__auto_type  p_ = (ptr);                                              \
                                                                               \
@@ -113,7 +108,7 @@ reallocarrayf(void *p, size_t nmemb, size_t size)
 inline char *
 xstrdup(const char *str)
 {
-	return strcpy(XMALLOCARRAY(strlen(str) + 1, char), str);
+	return strcpy(XMALLOC(strlen(str) + 1, char), str);
 }
 
 

--- a/lib/alloc.h
+++ b/lib/alloc.h
@@ -20,13 +20,11 @@
 #include "defines.h"
 
 
-#define ALLOCARRAY(n, type)    ((type *) alloca(sizeof(type) * (n)))
 #define CALLOC(n, type)        ((type *) calloc(n, sizeof(type)))
 #define XCALLOC(n, type)       ((type *) xcalloc(n, sizeof(type)))
 #define MALLOCARRAY(n, type)   ((type *) mallocarray(n, sizeof(type)))
 #define XMALLOCARRAY(n, type)  ((type *) xmallocarray(n, sizeof(type)))
 
-#define ALLOCA(type)           ALLOCARRAY(1, type)
 #define MALLOC(type)           MALLOCARRAY(1, type)
 #define XMALLOC(type)          XMALLOCARRAY(1, type)
 #define REALLOC(ptr, type)     REALLOCARRAY(ptr, 1, type)

--- a/lib/commonio.c
+++ b/lib/commonio.c
@@ -364,11 +364,11 @@ int commonio_lock_nowait (struct commonio_db *db, bool log)
 	}
 	file_len = strlen(db->filename) + 11;/* %lu max size */
 	lock_file_len = strlen(db->filename) + 6; /* sizeof ".lock" */
-	file = MALLOCARRAY(file_len, char);
+	file = MALLOC(file_len, char);
 	if (file == NULL) {
 		goto cleanup_ENOMEM;
 	}
-	lock = MALLOCARRAY(lock_file_len, char);
+	lock = MALLOC(lock_file_len, char);
 	if (lock == NULL) {
 		goto cleanup_ENOMEM;
 	}
@@ -640,7 +640,7 @@ int commonio_open (struct commonio_db *db, int mode)
 	}
 
 	buflen = BUFLEN;
-	buf = MALLOCARRAY (buflen, char);
+	buf = MALLOC(buflen, char);
 	if (NULL == buf) {
 		goto cleanup_ENOMEM;
 	}
@@ -651,7 +651,7 @@ int commonio_open (struct commonio_db *db, int mode)
 			size_t len;
 
 			buflen += BUFLEN;
-			cp = REALLOCARRAY (buf, buflen, char);
+			cp = REALLOC(buf, buflen, char);
 			if (NULL == cp) {
 				goto cleanup_buf;
 			}
@@ -685,7 +685,7 @@ int commonio_open (struct commonio_db *db, int mode)
 			}
 		}
 
-		p = MALLOC (struct commonio_entry);
+		p = MALLOC(1, struct commonio_entry);
 		if (NULL == p) {
 			goto cleanup_entry;
 		}
@@ -762,7 +762,7 @@ commonio_sort (struct commonio_db *db, int (*cmp) (const void *, const void *))
 		return 0;
 	}
 
-	entries = MALLOCARRAY (n, struct commonio_entry *);
+	entries = MALLOC(n, struct commonio_entry *);
 	if (entries == NULL) {
 		return -1;
 	}
@@ -1081,7 +1081,7 @@ int commonio_update (struct commonio_db *db, const void *eptr)
 		return 1;
 	}
 	/* not found, new entry */
-	p = MALLOC (struct commonio_entry);
+	p = MALLOC(1, struct commonio_entry);
 	if (NULL == p) {
 		db->ops->free (nentry);
 		errno = ENOMEM;
@@ -1118,7 +1118,7 @@ int commonio_append (struct commonio_db *db, const void *eptr)
 		return 0;
 	}
 	/* new entry */
-	p = MALLOC (struct commonio_entry);
+	p = MALLOC(1, struct commonio_entry);
 	if (NULL == p) {
 		db->ops->free (nentry);
 		errno = ENOMEM;

--- a/lib/getdef.c
+++ b/lib/getdef.c
@@ -448,14 +448,14 @@ void setdef_config_file (const char* file)
 	char* cp;
 
 	len = strlen(file) + strlen(sysconfdir) + 2;
-	cp = MALLOCARRAY(len, char);
+	cp = MALLOC(len, char);
 	if (cp == NULL)
 		exit (13);
 	snprintf(cp, len, "%s/%s", file, sysconfdir);
 	sysconfdir = cp;
 #ifdef VENDORDIR
 	len = strlen(file) + strlen(vendordir) + 2;
-	cp = MALLOCARRAY(len, char);
+	cp = MALLOC(len, char);
 	if (cp == NULL)
 		exit (13);
 	snprintf(cp, len, "%s/%s", file, vendordir);

--- a/lib/groupio.c
+++ b/lib/groupio.c
@@ -312,7 +312,7 @@ static /*@null@*/struct commonio_entry *merge_group_entries (
 
 	/* Concatenate the 2 lines */
 	new_line_len = strlen (gr1->line) + strlen (gr2->line) +1;
-	new_line = MALLOCARRAY (new_line_len + 1, char);
+	new_line = MALLOC(new_line_len + 1, char);
 	if (NULL == new_line) {
 		return NULL;
 	}
@@ -394,7 +394,7 @@ static int split_groups (unsigned int max_members)
 			continue;
 		}
 
-		new = MALLOC (struct commonio_entry);
+		new = MALLOC(1, struct commonio_entry);
 		if (NULL == new) {
 			return 0;
 		}

--- a/lib/groupmem.c
+++ b/lib/groupmem.c
@@ -22,7 +22,7 @@
 	struct group *gr;
 	int i;
 
-	gr = MALLOC (struct group);
+	gr = MALLOC(1, struct group);
 	if (NULL == gr) {
 		return NULL;
 	}
@@ -47,7 +47,7 @@
 	for (i = 0; grent->gr_mem[i]; i++);
 
 	/*@-mustfreeonly@*/
-	gr->gr_mem = MALLOCARRAY (i + 1, char *);
+	gr->gr_mem = MALLOC(i + 1, char *);
 	/*@=mustfreeonly@*/
 	if (NULL == gr->gr_mem) {
 		gr_free(gr);

--- a/lib/gshadow.c
+++ b/lib/gshadow.c
@@ -66,7 +66,7 @@ static /*@null@*/char **build_list (char *s, char **list[], size_t * nlist)
 
 	while (s != NULL && *s != '\0') {
 		size = (nelem + 1) * sizeof (ptr);
-		ptr = REALLOCARRAY (*list, size, char *);
+		ptr = REALLOC(*list, size, char *);
 		if (NULL != ptr) {
 			ptr[nelem] = s;
 			nelem++;
@@ -80,7 +80,7 @@ static /*@null@*/char **build_list (char *s, char **list[], size_t * nlist)
 		}
 	}
 	size = (nelem + 1) * sizeof (ptr);
-	ptr = REALLOCARRAY (*list, size, char *);
+	ptr = REALLOC(*list, size, char *);
 	if (NULL != ptr) {
 		ptr[nelem] = NULL;
 		*list = ptr;
@@ -120,7 +120,7 @@ void endsgent (void)
 	size_t len = strlen (string) + 1;
 
 	if (len > sgrbuflen) {
-		char *buf = REALLOCARRAY (sgrbuf, len, char);
+		char *buf = REALLOC(sgrbuf, len, char);
 		if (NULL == buf) {
 			return NULL;
 		}
@@ -198,7 +198,7 @@ void endsgent (void)
 	char *cp;
 
 	if (0 == buflen) {
-		buf = MALLOCARRAY (BUFSIZ, char);
+		buf = MALLOC(BUFSIZ, char);
 		if (NULL == buf) {
 			return NULL;
 		}
@@ -219,7 +219,7 @@ void endsgent (void)
 		       && (feof (fp) == 0)) {
 			size_t len;
 
-			cp = REALLOCARRAY (buf, buflen * 2, char);
+			cp = REALLOC(buf, buflen * 2, char);
 			if (NULL == cp) {
 				return NULL;
 			}
@@ -440,7 +440,7 @@ int putsgent (const struct sgrp *sgrp, FILE * fp)
 		size += strlen (sgrp->sg_mem[i]) + 1;
 	}
 
-	buf = MALLOCARRAY (size, char);
+	buf = MALLOC(size, char);
 	if (NULL == buf) {
 		return -1;
 	}

--- a/lib/nss.c
+++ b/lib/nss.c
@@ -108,7 +108,7 @@ void nss_init(const char *nsswitch_path) {
 		fprintf(shadow_logfd, "Using files\n");
 		goto null_subid;
 	}
-	subid_nss = MALLOC(struct subid_nss_ops);
+	subid_nss = MALLOC(1, struct subid_nss_ops);
 	if (!subid_nss) {
 		goto close_lib;
 	}

--- a/lib/run_part.c
+++ b/lib/run_part.c
@@ -59,7 +59,7 @@ int run_parts (const char *directory, const char *name, const char *action)
 		struct stat sb;
 
 		path_length=strlen(directory) + strlen(namelist[n]->d_name) + 2;
-		char *s = MALLOCARRAY(path_length, char);
+		char *s = MALLOC(path_length, char);
 		if (!s) {
 			printf ("could not allocate memory\n");
 			for (; n<scanlist; n++) {

--- a/lib/sgetgrent.c
+++ b/lib/sgetgrent.c
@@ -46,7 +46,7 @@ static char **list (char *s)
 		   member name, or terminating NULL).  */
 		if (i >= size) {
 			size = i + 100;	/* at least: i + 1 */
-			members = REALLOCARRAYF(members, size, char *);
+			members = REALLOCF(members, size, char *);
 			if (!members)
 				return NULL;
 		}
@@ -79,7 +79,7 @@ struct group *sgetgrent (const char *buf)
 		   allocate a larger block */
 		free (grpbuf);
 		size = strlen (buf) + 1000;	/* at least: strlen(buf) + 1 */
-		grpbuf = MALLOCARRAY (size, char);
+		grpbuf = MALLOC(size, char);
 		if (grpbuf == NULL) {
 			size = 0;
 			return NULL;

--- a/lib/sgroupio.c
+++ b/lib/sgroupio.c
@@ -50,7 +50,7 @@
 
 	for (i = 0; NULL != sgent->sg_adm[i]; i++);
 	/*@-mustfreeonly@*/
-	sg->sg_adm = MALLOCARRAY (i + 1, char *);
+	sg->sg_adm = MALLOC(i + 1, char *);
 	/*@=mustfreeonly@*/
 	if (NULL == sg->sg_adm) {
 		free (sg->sg_passwd);
@@ -75,7 +75,7 @@
 
 	for (i = 0; NULL != sgent->sg_mem[i]; i++);
 	/*@-mustfreeonly@*/
-	sg->sg_mem = MALLOCARRAY (i + 1, char *);
+	sg->sg_mem = MALLOC(i + 1, char *);
 	/*@=mustfreeonly@*/
 	if (NULL == sg->sg_mem) {
 		for (i = 0; NULL != sg->sg_adm[i]; i++) {

--- a/lib/sssd.c
+++ b/lib/sssd.c
@@ -32,7 +32,7 @@ int sssd_flush_cache (int dbflags)
 	if (rv == -1 && errno == ENOENT)
 		return 0;
 
-	sss_cache_args = MALLOCARRAY(4, char);
+	sss_cache_args = MALLOC(4, char);
 	if (sss_cache_args == NULL) {
 	    return -1;
 	}

--- a/lib/subordinateio.c
+++ b/lib/subordinateio.c
@@ -315,17 +315,13 @@ static bool have_range(struct commonio_db *db,
 
 static bool append_range(struct subid_range **ranges, const struct subordinate_range *new, int n)
 {
-	if (!*ranges) {
-		*ranges = MALLOC(1, struct subid_range);
-		if (!*ranges)
-			return false;
-	} else {
-		struct subid_range *alloced;
-		alloced = REALLOC(*ranges, n + 1, struct subid_range);
-		if (!alloced)
-			return false;
-		*ranges = alloced;
-	}
+	struct subid_range  *alloced;
+
+	alloced = REALLOC(*ranges, n + 1, struct subid_range);
+	if (!alloced)
+		return false;
+	*ranges = alloced;
+
 	(*ranges)[n].start = new->start;
 	(*ranges)[n].count = new->count;
 	return true;

--- a/lib/subordinateio.c
+++ b/lib/subordinateio.c
@@ -315,15 +315,16 @@ static bool have_range(struct commonio_db *db,
 
 static bool append_range(struct subid_range **ranges, const struct subordinate_range *new, int n)
 {
-	struct subid_range  *alloced;
+	struct subid_range  *sr;
 
-	alloced = REALLOC(*ranges, n + 1, struct subid_range);
-	if (!alloced)
+	sr = REALLOC(*ranges, n + 1, struct subid_range);
+	if (!sr)
 		return false;
-	*ranges = alloced;
 
-	(*ranges)[n].start = new->start;
-	(*ranges)[n].count = new->count;
+	sr[n].start = new->start;
+	sr[n].count = new->count;
+	*ranges = sr;
+
 	return true;
 }
 

--- a/lib/subordinateio.c
+++ b/lib/subordinateio.c
@@ -34,7 +34,7 @@ static /*@null@*/ /*@only@*/void *subordinate_dup (const void *ent)
 	const struct subordinate_range *rangeent = ent;
 	struct subordinate_range *range;
 
-	range = MALLOC (struct subordinate_range);
+	range = MALLOC(1, struct subordinate_range);
 	if (NULL == range) {
 		return NULL;
 	}
@@ -316,12 +316,12 @@ static bool have_range(struct commonio_db *db,
 static bool append_range(struct subid_range **ranges, const struct subordinate_range *new, int n)
 {
 	if (!*ranges) {
-		*ranges = MALLOC(struct subid_range);
+		*ranges = MALLOC(1, struct subid_range);
 		if (!*ranges)
 			return false;
 	} else {
 		struct subid_range *alloced;
-		alloced = REALLOCARRAY(*ranges, n + 1, struct subid_range);
+		alloced = REALLOC(*ranges, n + 1, struct subid_range);
 		if (!alloced)
 			return false;
 		*ranges = alloced;
@@ -935,7 +935,7 @@ static int append_uids(uid_t **uids, const char *owner, int n)
 			return n;
 	}
 
-	ret = REALLOCARRAY(*uids, n + 1, uid_t);
+	ret = REALLOC(*uids, n + 1, uid_t);
 	if (!ret) {
 		free(*uids);
 		return -1;

--- a/libmisc/addgrps.c
+++ b/libmisc/addgrps.c
@@ -48,7 +48,7 @@ int add_groups (const char *list)
 
 	i = 16;
 	for (;;) {
-		grouplist = MALLOCARRAY (i, GETGROUPS_T);
+		grouplist = MALLOC(i, GETGROUPS_T);
 		if (NULL == grouplist) {
 			return -1;
 		}
@@ -90,7 +90,7 @@ int add_groups (const char *list)
 			fputs (_("Warning: too many groups\n"), shadow_logfd);
 			break;
 		}
-		grouplist = REALLOCARRAYF(grouplist, (size_t) ngroups + 1, GETGROUPS_T);
+		grouplist = REALLOCF(grouplist, (size_t) ngroups + 1, GETGROUPS_T);
 		if (grouplist == NULL) {
 			return -1;
 		}

--- a/libmisc/agetpass.c
+++ b/libmisc/agetpass.c
@@ -102,7 +102,7 @@ agetpass(const char *prompt)
 	 * Let's add one more byte, and if the password uses it, it
 	 * means the introduced password was longer than PASS_MAX.
 	 */
-	pass = MALLOCARRAY(PASS_MAX + 2, char);
+	pass = MALLOC(PASS_MAX + 2, char);
 	if (pass == NULL)
 		return NULL;
 

--- a/libmisc/copydir.c
+++ b/libmisc/copydir.c
@@ -228,7 +228,7 @@ static /*@exposed@*/ /*@null@*/struct link_name *check_link (const char *name, c
 		return NULL;
 	}
 
-	lp = XMALLOC (struct link_name);
+	lp = XMALLOC(1, struct link_name);
 	src_len = strlen (src_orig);
 	dst_len = strlen (dst_orig);
 	name_len = strlen (name);
@@ -236,7 +236,7 @@ static /*@exposed@*/ /*@null@*/struct link_name *check_link (const char *name, c
 	lp->ln_ino = sb->st_ino;
 	lp->ln_count = sb->st_nlink;
 	len = name_len - src_len + dst_len + 1;
-	lp->ln_name = XMALLOCARRAY (len, char);
+	lp->ln_name = XMALLOC(len, char);
 	(void) snprintf (lp->ln_name, len, "%s%s", dst_orig, name + src_len);
 	lp->ln_next = links;
 	links = lp;
@@ -326,8 +326,8 @@ static int copy_tree_impl (const struct path_info *src, const struct path_info *
 			src_len += strlen (src->full_path);
 			dst_len += strlen (dst->full_path);
 
-			src_name = MALLOCARRAY (src_len, char);
-			dst_name = MALLOCARRAY (dst_len, char);
+			src_name = MALLOC(src_len, char);
+			dst_name = MALLOC(dst_len, char);
 
 			if ((NULL == src_name) || (NULL == dst_name)) {
 				err = -1;
@@ -561,7 +561,7 @@ static /*@null@*/char *readlink_malloc (const char *filename)
 
 	while (true) {
 		ssize_t nchars;
-		char *buffer = MALLOCARRAY (size, char);
+		char *buffer = MALLOC(size, char);
 		if (NULL == buffer) {
 			return NULL;
 		}
@@ -626,7 +626,7 @@ static int copy_symlink (const struct path_info *src, const struct path_info *ds
 	 */
 	if (strncmp (oldlink, src_orig, strlen (src_orig)) == 0) {
 		size_t len = strlen (dst_orig) + strlen (oldlink) - strlen (src_orig) + 1;
-		char *dummy = XMALLOCARRAY (len, char);
+		char *dummy = XMALLOC(len, char);
 		(void) snprintf (dummy, len, "%s%s",
 		                 dst_orig,
 		                 oldlink + strlen (src_orig));

--- a/libmisc/env.c
+++ b/libmisc/env.c
@@ -60,7 +60,7 @@ static const char *const noslash[] = {
  */
 void initenv (void)
 {
-	newenvp = XMALLOCARRAY (NEWENVP_STEP, char *);
+	newenvp = XMALLOC(NEWENVP_STEP, char *);
 	*newenvp = NULL;
 }
 
@@ -74,7 +74,7 @@ void addenv (const char *string, /*@null@*/const char *value)
 	if (NULL != value) {
 		size_t len = strlen (string) + strlen (value) + 2;
 		int wlen;
-		newstring = XMALLOCARRAY (len, char);
+		newstring = XMALLOC(len, char);
 		wlen = snprintf (newstring, len, "%s=%s", string, value);
 		assert (wlen == (int) len -1);
 	} else {
@@ -137,7 +137,7 @@ void addenv (const char *string, /*@null@*/const char *value)
 		 */
 		update_environ = (environ == newenvp);
 
-		__newenvp = REALLOCARRAY(newenvp, newenvc + NEWENVP_STEP, char *);
+		__newenvp = REALLOC(newenvp, newenvc + NEWENVP_STEP, char *);
 
 		if (NULL != __newenvp) {
 			/*

--- a/libmisc/find_new_uid.c
+++ b/libmisc/find_new_uid.c
@@ -232,7 +232,7 @@ int find_new_uid(bool sys_user,
 	 */
 
 	/* Create an array to hold all of the discovered UIDs */
-	used_uids = MALLOCARRAY (uid_max + 1, bool);
+	used_uids = MALLOC(uid_max + 1, bool);
 	if (NULL == used_uids) {
 		fprintf (log_get_logfd(),
 			 _("%s: failed to allocate memory: %s\n"),

--- a/libmisc/getdate.y
+++ b/libmisc/getdate.y
@@ -12,9 +12,6 @@
 
 #ifdef HAVE_CONFIG_H
 # include <config.h>
-# ifdef FORCE_ALLOCA_H
-#  include <alloca.h>
-# endif
 #endif
 
 /* Since the code of getdate.y is not included in the Emacs executable

--- a/libmisc/idmapping.c
+++ b/libmisc/idmapping.c
@@ -191,7 +191,7 @@ void write_mapping(int proc_dir_fd, int ranges, const struct map_range *mappings
 #endif
 
 	bufsize = ranges * ((ULONG_DIGITS + 1) * 3);
-	pos = buf = XMALLOCARRAY(bufsize, char);
+	pos = buf = XMALLOC(bufsize, char);
 	end = buf + bufsize;
 
 	/* Build the mapping command */

--- a/libmisc/list.c
+++ b/libmisc/list.c
@@ -46,7 +46,7 @@
 	 * old entries, and the new entries as well.
 	 */
 
-	tmp = XMALLOCARRAY (i + 2, char *);
+	tmp = XMALLOC(i + 2, char *);
 
 	/*
 	 * Copy the original list to the new list, then append the
@@ -100,7 +100,7 @@
 	 * old entries.
 	 */
 
-	tmp = XMALLOCARRAY (j + 1, char *);
+	tmp = XMALLOC(j + 1, char *);
 
 	/*
 	 * Copy the original list except the deleted members to the
@@ -135,7 +135,7 @@
 
 	for (i = 0; NULL != list[i]; i++);
 
-	tmp = XMALLOCARRAY (i + 1, char *);
+	tmp = XMALLOC(i + 1, char *);
 
 	i = 0;
 	while (NULL != *list) {
@@ -212,7 +212,7 @@ bool is_on_list (char *const *list, const char *member)
 	 * Allocate the array we're going to store the pointers into.
 	 */
 
-	array = XMALLOCARRAY (i, char *);
+	array = XMALLOC(i, char *);
 
 	/*
 	 * Empty list is special - 0 members, not 1 empty member.  --marekm

--- a/libmisc/mail.c
+++ b/libmisc/mail.c
@@ -39,7 +39,7 @@ void mailcheck (void)
 		size_t len = strlen (mailbox) + 5;
 		int wlen;
 
-		newmail = XMALLOCARRAY (len, char);
+		newmail = XMALLOC(len, char);
 		wlen = snprintf (newmail, len, "%s/new", mailbox);
 		assert (wlen == (int) len - 1);
 

--- a/libmisc/obscure.c
+++ b/libmisc/obscure.c
@@ -109,7 +109,7 @@ static /*@observer@*//*@null@*/const char *password_check (
 
 	newmono = str_lower (xstrdup (new));
 	oldmono = str_lower (xstrdup (old));
-	wrapped = XMALLOCARRAY (strlen (oldmono) * 2 + 1, char);
+	wrapped = XMALLOC(strlen(oldmono) * 2 + 1, char);
 	strcpy (wrapped, oldmono);
 	strcat (wrapped, oldmono);
 

--- a/libmisc/prefix_flag.c
+++ b/libmisc/prefix_flag.c
@@ -106,18 +106,18 @@ extern const char* process_prefix_flag (const char* short_opt, int argc, char **
 		}
 		size_t len;
 		len = strlen(prefix) + strlen(PASSWD_FILE) + 2;
-		passwd_db_file = XMALLOCARRAY(len, char);
+		passwd_db_file = XMALLOC(len, char);
 		snprintf(passwd_db_file, len, "%s/%s", prefix, PASSWD_FILE);
 		pw_setdbname(passwd_db_file);
 
 		len = strlen(prefix) + strlen(GROUP_FILE) + 2;
-		group_db_file = XMALLOCARRAY(len, char);
+		group_db_file = XMALLOC(len, char);
 		snprintf(group_db_file, len, "%s/%s", prefix, GROUP_FILE);
 		gr_setdbname(group_db_file);
 
 #ifdef  SHADOWGRP
 		len = strlen(prefix) + strlen(SGROUP_FILE) + 2;
-		sgroup_db_file = XMALLOCARRAY(len, char);
+		sgroup_db_file = XMALLOC(len, char);
 		snprintf(sgroup_db_file, len, "%s/%s", prefix, SGROUP_FILE);
 		sgr_setdbname(sgroup_db_file);
 #endif
@@ -126,18 +126,18 @@ extern const char* process_prefix_flag (const char* short_opt, int argc, char **
 #endif
 
 		len = strlen(prefix) + strlen(SHADOW_FILE) + 2;
-		spw_db_file = XMALLOCARRAY(len, char);
+		spw_db_file = XMALLOC(len, char);
 		snprintf(spw_db_file, len, "%s/%s", prefix, SHADOW_FILE);
 		spw_setdbname(spw_db_file);
 
 #ifdef ENABLE_SUBIDS
 		len = strlen(prefix) + strlen("/etc/subuid") + 2;
-		suid_db_file = XMALLOCARRAY(len, char);
+		suid_db_file = XMALLOC(len, char);
 		snprintf(suid_db_file, len, "%s/%s", prefix, "/etc/subuid");
 		sub_uid_setdbname(suid_db_file);
 
 		len = strlen(prefix) + strlen("/etc/subgid") + 2;
-		sgid_db_file = XMALLOCARRAY(len, char);
+		sgid_db_file = XMALLOC(len, char);
 		snprintf(sgid_db_file, len, "%s/%s", prefix, "/etc/subgid");
 		sub_gid_setdbname(sgid_db_file);
 #endif
@@ -146,7 +146,7 @@ extern const char* process_prefix_flag (const char* short_opt, int argc, char **
 		setdef_config_file(prefix);
 #else
 		len = strlen(prefix) + strlen("/etc/login.defs") + 2;
-		def_conf_file = XMALLOCARRAY(len, char);
+		def_conf_file = XMALLOC(len, char);
 		snprintf(def_conf_file, len, "%s/%s", prefix, "/etc/login.defs");
 		setdef_config_file(def_conf_file);
 #endif

--- a/libmisc/setupenv.c
+++ b/libmisc/setupenv.c
@@ -36,7 +36,7 @@ addenv_path (const char *varname, const char *dirname, const char *filename)
 	size_t len = strlen (dirname) + strlen (filename) + 2;
 	int wlen;
 
-	buf = XMALLOCARRAY (len, char);
+	buf = XMALLOC(len, char);
 	wlen = snprintf (buf, len, "%s/%s", dirname, filename);
 	assert (wlen == (int) len - 1);
 

--- a/libmisc/utmp.c
+++ b/libmisc/utmp.c
@@ -92,7 +92,7 @@ static bool is_my_tty (const char tty[UT_LINESIZE])
 	}
 
 	if (NULL != ut) {
-		ret = XMALLOC (struct utmp);
+		ret = XMALLOC(1, struct utmp);
 		memcpy (ret, ut, sizeof (*ret));
 	}
 
@@ -157,12 +157,12 @@ static void updwtmp (const char *filename, const struct utmp *ut)
 
 	if (   (NULL != host)
 	    && ('\0' != host[0])) {
-		hostname = XMALLOCARRAY (strlen (host) + 1, char);
+		hostname = XMALLOC(strlen(host) + 1, char);
 		strcpy (hostname, host);
 #ifdef HAVE_STRUCT_UTMP_UT_HOST
 	} else if (   (NULL != ut)
 	           && ('\0' != ut->ut_host[0])) {
-		hostname = XMALLOCARRAY (sizeof (ut->ut_host) + 1, char);
+		hostname = XMALLOC(sizeof(ut->ut_host) + 1, char);
 		strncpy (hostname, ut->ut_host, sizeof (ut->ut_host));
 		hostname[sizeof (ut->ut_host)] = '\0';
 #endif				/* HAVE_STRUCT_UTMP_UT_HOST */

--- a/libmisc/xgetXXbyYY.c
+++ b/libmisc/xgetXXbyYY.c
@@ -52,7 +52,7 @@
 	/* we have to start with something */
 	size_t length = 0x100;
 
-	result = MALLOC(LOOKUP_TYPE);
+	result = MALLOC(1, LOOKUP_TYPE);
 	if (NULL == result) {
 		goto oom;
 	}
@@ -60,7 +60,7 @@
 	while (true) {
 		int status;
 		LOOKUP_TYPE *resbuf = NULL;
-		buffer = XREALLOCARRAY (buffer, length, char);
+		buffer = XREALLOC(buffer, length, char);
 		status = REENTRANT_NAME(ARG_NAME, result, buffer,
 		                        length, &resbuf);
 		if ((0 == status) && (resbuf == result)) {

--- a/src/gpasswd.c
+++ b/src/gpasswd.c
@@ -836,7 +836,7 @@ static void get_group (struct group *gr)
 
 			sg->sg_mem = dup_list (gr->gr_mem);
 
-			sg->sg_adm = XMALLOCARRAY (2, char *);
+			sg->sg_adm = XMALLOC(2, char *);
 #ifdef FIRST_MEMBER_IS_ADMIN
 			if (sg->sg_mem[0]) {
 				sg->sg_adm[0] = xstrdup (sg->sg_mem[0]);

--- a/src/groupmems.c
+++ b/src/groupmems.c
@@ -127,7 +127,7 @@ static void add_user (const char *user,
 			static struct sgrp sgrent;
 			sgrent.sg_name = xstrdup (newgrp->gr_name);
 			sgrent.sg_mem = dup_list (newgrp->gr_mem);
-			sgrent.sg_adm = XMALLOC (char *);
+			sgrent.sg_adm = XMALLOC(1, char *);
 #ifdef FIRST_MEMBER_IS_ADMIN
 			if (sgrent.sg_mem[0]) {
 				sgrent.sg_adm[0] = xstrdup (sgrent.sg_mem[0]);
@@ -210,7 +210,7 @@ static void remove_user (const char *user,
 			static struct sgrp sgrent;
 			sgrent.sg_name = xstrdup (newgrp->gr_name);
 			sgrent.sg_mem = dup_list (newgrp->gr_mem);
-			sgrent.sg_adm = XMALLOC (char *);
+			sgrent.sg_adm = XMALLOC(1, char *);
 #ifdef FIRST_MEMBER_IS_ADMIN
 			if (sgrent.sg_mem[0]) {
 				sgrent.sg_adm[0] = xstrdup (sgrent.sg_mem[0]);
@@ -283,9 +283,9 @@ static void purge_members (const struct group *grp)
 			/* Create a shadow group based on this group */
 			static struct sgrp sgrent;
 			sgrent.sg_name = xstrdup (newgrp->gr_name);
-			sgrent.sg_mem = XMALLOC (char *);
+			sgrent.sg_mem = XMALLOC(1, char *);
 			sgrent.sg_mem[0] = NULL;
-			sgrent.sg_adm = XMALLOC (char *);
+			sgrent.sg_adm = XMALLOC(1, char *);
 			sgrent.sg_adm[0] = NULL;
 
 			/* Move any password to gshadow */

--- a/src/groupmod.c
+++ b/src/groupmod.c
@@ -251,7 +251,7 @@ static void grp_update (void)
 			// requested to replace the existing groups
 			if (NULL != grp.gr_mem[0])
 				gr_free_members(&grp);
-			grp.gr_mem = XMALLOC(char *);
+			grp.gr_mem = XMALLOC(1, char *);
 			grp.gr_mem[0] = NULL;
 		} else {
 			// append to existing groups
@@ -559,15 +559,15 @@ static void prepare_failure_reports (void)
 #endif
 	info_passwd.name  = group_name;
 
-	gr                     = XMALLOCARRAY(512, char);
+	gr                     = XMALLOC(512, char);
 	info_group.audit_msg   = gr;
 	gr_end                 = gr + 512;
 #ifdef	SHADOWGRP
-	sgr                    = XMALLOCARRAY(512, char);
+	sgr                    = XMALLOC(512, char);
 	info_gshadow.audit_msg = sgr;
 	sgr_end                = sgr + 512;
 #endif
-	pw                     = XMALLOCARRAY(512, char);
+	pw                     = XMALLOC(512, char);
 	info_passwd.audit_msg  = pw;
 	pw_end                 = pw + 512;
 

--- a/src/groups.c
+++ b/src/groups.c
@@ -91,7 +91,7 @@ int main (int argc, char **argv)
 	GETGROUPS_T *groups;
 
 	sys_ngroups = sysconf (_SC_NGROUPS_MAX);
-	groups = MALLOCARRAY (sys_ngroups, GETGROUPS_T);
+	groups = MALLOC(sys_ngroups, GETGROUPS_T);
 
 	(void) setlocale (LC_ALL, "");
 	(void) bindtextdomain (PACKAGE, LOCALEDIR);

--- a/src/id.c
+++ b/src/id.c
@@ -66,7 +66,7 @@ static void usage (void)
 	 * work if the system library is recompiled.
 	 */
 	sys_ngroups = sysconf (_SC_NGROUPS_MAX);
-	groups = MALLOCARRAY (sys_ngroups, GETGROUPS_T);
+	groups = MALLOC(sys_ngroups, GETGROUPS_T);
 
 	/*
 	 * See if the -a flag has been given to print out the concurrent

--- a/src/login.c
+++ b/src/login.c
@@ -591,7 +591,7 @@ int main (int argc, char **argv)
 #ifdef RLOGIN
 	if (rflg) {
 		assert (NULL == username);
-		username = XMALLOCARRAY (USER_NAME_MAX_LENGTH + 1, char);
+		username = XMALLOC(USER_NAME_MAX_LENGTH + 1, char);
 		username[USER_NAME_MAX_LENGTH] = '\0';
 		if (do_rlogin (hostname, username, USER_NAME_MAX_LENGTH, term, sizeof term)) {
 			preauth_flag = true;
@@ -908,7 +908,7 @@ int main (int argc, char **argv)
 				exit (1);
 			}
 			preauth_flag = false;
-			username = XMALLOCARRAY (USER_NAME_MAX_LENGTH + 1, char);
+			username = XMALLOC(USER_NAME_MAX_LENGTH + 1, char);
 			username[USER_NAME_MAX_LENGTH] = '\0';
 			login_prompt (username, USER_NAME_MAX_LENGTH);
 

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -536,7 +536,7 @@ int main (int argc, char **argv)
 	/* don't use getgroups(0, 0) - it doesn't work on some systems */
 	i = 16;
 	for (;;) {
-		grouplist = XMALLOCARRAY (i, GETGROUPS_T);
+		grouplist = XMALLOC(i, GETGROUPS_T);
 		ngroups = getgroups (i, grouplist);
 		if (i > ngroups && !(ngroups == -1 && errno == EINVAL)) {
 			break;

--- a/src/newusers.c
+++ b/src/newusers.c
@@ -1196,9 +1196,9 @@ int main (int argc, char **argv)
 #ifdef USE_PAM
 		/* keep the list of user/password for later update by PAM */
 		nusers++;
-		lines     = REALLOCARRAYF(lines, nusers, int);
-		usernames = REALLOCARRAYF(usernames, nusers, char *);
-		passwords = REALLOCARRAYF(passwords, nusers, char *);
+		lines     = REALLOCF(lines, nusers, int);
+		usernames = REALLOCF(usernames, nusers, char *);
+		passwords = REALLOCF(passwords, nusers, char *);
 		if (lines == NULL || usernames == NULL || passwords == NULL) {
 			fprintf (stderr,
 			         _("%s: line %d: %s\n"),

--- a/src/passwd.c
+++ b/src/passwd.c
@@ -526,7 +526,7 @@ static char *update_crypt_pw (char *cp)
 	}
 
 	if (lflg && *cp != '!') {
-		char *newpw = XMALLOCARRAY (strlen (cp) + 2, char);
+		char *newpw = XMALLOC(strlen(cp) + 2, char);
 
 		strcpy (newpw, "!");
 		strcat (newpw, cp);

--- a/src/su.c
+++ b/src/su.c
@@ -241,7 +241,7 @@ static void execve_shell (const char *shellname,
 		while (NULL != args[n_args]) {
 			n_args++;
 		}
-		targs = XMALLOCARRAY (n_args + 3, char *);
+		targs = XMALLOC(n_args + 3, char *);
 		targs[0] = "sh";
 		targs[1] = "-";
 		targs[2] = xstrdup (shellname);
@@ -1200,7 +1200,7 @@ int main (int argc, char **argv)
 			cp = Basename (shellstr);
 		}
 
-		arg0 = XMALLOCARRAY (strlen (cp) + 2, char);
+		arg0 = XMALLOC(strlen(cp) + 2, char);
 		arg0[0] = '-';
 		strcpy (arg0 + 1, cp);
 		cp = arg0;

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -2435,6 +2435,7 @@ static void create_mail (void)
 	if (strcasecmp (create_mail_spool, "yes") == 0) {
 		const char *spool;
 		char *file;
+		size_t size;
 		int fd;
 		struct group *gr;
 		gid_t gid;
@@ -2449,7 +2450,8 @@ static void create_mail (void)
 		if (NULL == spool) {
 			return;
 		}
-		file = ALLOCARRAY (strlen (prefix) + strlen (spool) + strlen (user_name) + 3, char);
+		size = strlen(prefix) + strlen(spool) + strlen(user_name) + 3;
+		file = XMALLOCARRAY(size, char);
 		if (prefix[0])
 			sprintf (file, "%s/%s/%s", prefix, spool, user_name);
 		else
@@ -2465,6 +2467,8 @@ static void create_mail (void)
 #endif
 
 		fd = open (file, O_CREAT | O_WRONLY | O_TRUNC | O_EXCL, 0);
+		free(file);
+
 		if (fd < 0) {
 			perror (_("Creating mailbox file"));
 			return;

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -359,7 +359,7 @@ static void get_defaults (void)
 		int wlen;
 
 		len = strlen(prefix) + strlen(USER_DEFAULTS_FILE) + 2;
-		default_file = MALLOCARRAY(len, char);
+		default_file = MALLOC(len, char);
                 if (default_file == NULL)
                        return;
 		wlen = snprintf(default_file, len, "%s/%s", prefix, USER_DEFAULTS_FILE);
@@ -472,7 +472,7 @@ static void get_defaults (void)
 				char* _def_template; /* avoid const warning */
 
 				len = strlen(prefix) + strlen(cp) + 2;
-				_def_template = XMALLOCARRAY(len, char);
+				_def_template = XMALLOC(len, char);
 				wlen = snprintf(_def_template, len, "%s/%s", prefix, cp);
 				assert (wlen == (int) len -1);
 				def_template = _def_template;
@@ -496,7 +496,7 @@ static void get_defaults (void)
 				char* _def_usrtemplate; /* avoid const warning */
 
 				len = strlen(prefix) + strlen(cp) + 2;
-				_def_usrtemplate = XMALLOCARRAY(len, char);
+				_def_usrtemplate = XMALLOC(len, char);
 				wlen = snprintf(_def_usrtemplate, len, "%s/%s", prefix, cp);
 				assert (wlen == (int) len -1);
 				def_usrtemplate = _def_usrtemplate;
@@ -586,7 +586,7 @@ static int set_defaults (void)
 
 
 	len = strlen(prefix) + strlen(NEW_USER_FILE) + 2;
-	new_file = MALLOCARRAY(len, char);
+	new_file = MALLOC(len, char);
         if (new_file == NULL) {
 		fprintf (stderr,
 		         _("%s: cannot create new defaults file: %s\n"),
@@ -598,7 +598,7 @@ static int set_defaults (void)
 
 	if (prefix[0]) {
 		len = strlen(prefix) + strlen(USER_DEFAULTS_FILE) + 2;
-		default_file = MALLOCARRAY(len, char);
+		default_file = MALLOC(len, char);
 		if (default_file == NULL) {
 			fprintf (stderr,
 			         _("%s: cannot create new defaults file: %s\n"),
@@ -1627,7 +1627,7 @@ static void process_flags (int argc, char **argv)
 			size_t len = strlen (def_home) + strlen (user_name) + 2;
 			int wlen;
 
-			uh = XMALLOCARRAY (len, char);
+			uh = XMALLOC(len, char);
 			wlen = snprintf (uh, len, "%s/%s", def_home, user_name);
 			assert (wlen == (int) len -1);
 
@@ -1637,7 +1637,7 @@ static void process_flags (int argc, char **argv)
 			size_t len = strlen(prefix) + strlen(user_home) + 2;
 			int wlen;
 			char* _prefix_user_home; /* to avoid const warning */
-			_prefix_user_home = XMALLOCARRAY(len, char);
+			_prefix_user_home = XMALLOC(len, char);
 			wlen = snprintf(_prefix_user_home, len, "%s/%s", prefix, user_home);
 			assert (wlen == (int) len -1);
 			prefix_user_home = _prefix_user_home;
@@ -2451,7 +2451,7 @@ static void create_mail (void)
 			return;
 		}
 		size = strlen(prefix) + strlen(spool) + strlen(user_name) + 3;
-		file = XMALLOCARRAY(size, char);
+		file = XMALLOC(size, char);
 		if (prefix[0])
 			sprintf (file, "%s/%s/%s", prefix, spool, user_name);
 		else
@@ -2563,7 +2563,7 @@ int main (int argc, char **argv)
 #endif
 
 	sys_ngroups = sysconf (_SC_NGROUPS_MAX);
-	user_groups = XMALLOCARRAY (1 + sys_ngroups, char *);
+	user_groups = XMALLOC(1 + sys_ngroups, char *);
 	/*
 	 * Initialize the list to be empty
 	 */

--- a/src/userdel.c
+++ b/src/userdel.c
@@ -805,7 +805,7 @@ static int remove_mailbox (void)
 	}
 
 	len = strlen (prefix) + strlen (maildir) + strlen (user_name) + 2;
-	mailfile = XMALLOCARRAY (len, char);
+	mailfile = XMALLOC(len, char);
 
 	if (prefix[0]) {
 		(void) snprintf (mailfile, len, "%s/%s/%s",
@@ -919,7 +919,7 @@ static int remove_tcbdir (const char *user_name, uid_t user_id)
 		return 0;
 	}
 
-	buf = MALLOCARRAY (buflen, char);
+	buf = MALLOC(buflen, char);
 	if (NULL == buf) {
 		fprintf (stderr, _("%s: Can't allocate memory, "
 		                   "tcb entry for %s not removed.\n"),
@@ -1131,7 +1131,7 @@ int main (int argc, char **argv)
 
 			size_t len = strlen(prefix) + strlen(pwd->pw_dir) + 2;
 			int wlen;
-			user_home = XMALLOCARRAY(len, char);
+			user_home = XMALLOC(len, char);
 			wlen = snprintf(user_home, len, "%s/%s", prefix, pwd->pw_dir);
 			assert (wlen == (int) len -1);
 		}

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -2034,10 +2034,9 @@ static void move_mailbox (void)
 {
 	const char *maildir;
 	char* mailfile;
-	char* newmailfile;
 	int fd;
 	struct stat st;
-	size_t len;
+	size_t size;
 
 	maildir = getdef_str ("MAIL_DIR");
 #ifdef MAIL_SPOOL_DIR
@@ -2048,8 +2047,8 @@ static void move_mailbox (void)
 	if (NULL == maildir) {
 		return;
 	}
-	len = strlen (prefix) + strlen (maildir) + strlen (user_name) + 3;
-	mailfile = ALLOCARRAY (len, char);
+	size = strlen(prefix) + strlen(maildir) + strlen(user_name) + 3;
+	mailfile = XMALLOCARRAY(size, char);
 
 	/*
 	 * O_NONBLOCK is to make sure open won't hang on mandatory locks.
@@ -2058,14 +2057,13 @@ static void move_mailbox (void)
 	 * between stat and chown).  --marekm
 	 */
 	if (prefix[0]) {
-		(void) snprintf (mailfile, len, "%s/%s/%s",
+		(void) snprintf (mailfile, size, "%s/%s/%s",
 	    	             prefix, maildir, user_name);
 	}
 	else {
-		(void) snprintf (mailfile, len, "%s/%s",
+		(void) snprintf (mailfile, size, "%s/%s",
 	    	             maildir, user_name);
 	}
-	mailfile[len-1] = '\0';
 
 	fd = open (mailfile, O_RDONLY | O_NONBLOCK, 0);
 	if (fd < 0) {
@@ -2073,11 +2071,13 @@ static void move_mailbox (void)
 		if (errno != ENOENT) {
 			perror (mailfile);
 		}
+		free(mailfile);
 		return;
 	}
 	if (fstat (fd, &st) < 0) {
 		perror ("fstat");
 		(void) close (fd);
+		free(mailfile);
 		return;
 	}
 	if (st.st_uid != user_id) {
@@ -2085,6 +2085,7 @@ static void move_mailbox (void)
 		fprintf (stderr, _("%s: warning: %s not owned by %s\n"),
 		         Prog, mailfile, user_name);
 		(void) close (fd);
+		free(mailfile);
 		return;
 	}
 	if (uflg) {
@@ -2103,17 +2104,19 @@ static void move_mailbox (void)
 	(void) close (fd);
 
 	if (lflg) {
-		len = strlen (prefix) + strlen (maildir) + strlen (user_newname) + 3;
-		newmailfile = ALLOCARRAY(len, char);
+		char* newmailfile;
+		size_t newsize;
+
+		newsize = strlen(prefix) + strlen(maildir) + strlen(user_newname) + 3;
+		newmailfile = XMALLOCARRAY(newsize, char);
 		if (prefix[0]) {
-			(void) snprintf (newmailfile, len, "%s/%s/%s",
+			(void) snprintf (newmailfile, newsize, "%s/%s/%s",
 			                 prefix, maildir, user_newname);
 		}
 		else {
-			(void) snprintf (newmailfile, len, "%s/%s",
+			(void) snprintf (newmailfile, newsize, "%s/%s",
 			                 maildir, user_newname);
 		}
-		newmailfile[len - 1] = '\0';
 		if (   (link (mailfile, newmailfile) != 0)
 		    || (unlink (mailfile) != 0)) {
 			perror (_("failed to rename mailbox"));
@@ -2124,8 +2127,12 @@ static void move_mailbox (void)
 			              "changing mail file name",
 			              user_newname, user_newid, 1);
 		}
+
+		free(newmailfile);
 #endif
 	}
+
+	free(mailfile);
 }
 #endif
 

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -2048,7 +2048,7 @@ static void move_mailbox (void)
 	if (NULL == maildir) {
 		return;
 	}
-	len = strlen (prefix) + strlen (maildir) + strlen (user_name) + 2;
+	len = strlen (prefix) + strlen (maildir) + strlen (user_name) + 3;
 	mailfile = ALLOCARRAY (len, char);
 
 	/*
@@ -2103,7 +2103,7 @@ static void move_mailbox (void)
 	(void) close (fd);
 
 	if (lflg) {
-		len = strlen (prefix) + strlen (maildir) + strlen (user_newname) + 2;
+		len = strlen (prefix) + strlen (maildir) + strlen (user_newname) + 3;
 		newmailfile = ALLOCARRAY(len, char);
 		if (prefix[0]) {
 			(void) snprintf (newmailfile, len, "%s/%s/%s",

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -345,7 +345,7 @@ static int prepend_range(const char *str, struct ulong_range_list_entry **head)
 	if (range.first > range.last)
 		return 0;
 
-	entry = MALLOC(struct ulong_range_list_entry);
+	entry = MALLOC(1, struct ulong_range_list_entry);
 	if (!entry) {
 		fprintf (stderr,
 			_("%s: failed to allocate memory: %s\n"),
@@ -419,7 +419,7 @@ usage (int status)
 static char *new_pw_passwd (char *pw_pass)
 {
 	if (Lflg && ('!' != pw_pass[0])) {
-		char *buf = XMALLOCARRAY (strlen (pw_pass) + 2, char);
+		char *buf = XMALLOC(strlen(pw_pass) + 2, char);
 
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
@@ -1260,12 +1260,12 @@ static void process_flags (int argc, char **argv)
 	if (prefix[0]) {
 		size_t len = strlen(prefix) + strlen(user_home) + 2;
 		int wlen;
-		prefix_user_home = XMALLOCARRAY(len, char);
+		prefix_user_home = XMALLOC(len, char);
 		wlen = snprintf(prefix_user_home, len, "%s/%s", prefix, user_home);
 		assert (wlen == (int) len -1);
 		if (user_newhome) {
 			len = strlen(prefix) + strlen(user_newhome) + 2;
-			prefix_user_newhome = XMALLOCARRAY(len, char);
+			prefix_user_newhome = XMALLOC(len, char);
 			wlen = snprintf(prefix_user_newhome, len, "%s/%s", prefix, user_newhome);
 			assert (wlen == (int) len -1);
 		}
@@ -2048,7 +2048,7 @@ static void move_mailbox (void)
 		return;
 	}
 	size = strlen(prefix) + strlen(maildir) + strlen(user_name) + 3;
-	mailfile = XMALLOCARRAY(size, char);
+	mailfile = XMALLOC(size, char);
 
 	/*
 	 * O_NONBLOCK is to make sure open won't hang on mandatory locks.
@@ -2108,7 +2108,7 @@ static void move_mailbox (void)
 		size_t newsize;
 
 		newsize = strlen(prefix) + strlen(maildir) + strlen(user_newname) + 3;
-		newmailfile = XMALLOCARRAY(newsize, char);
+		newmailfile = XMALLOC(newsize, char);
 		if (prefix[0]) {
 			(void) snprintf (newmailfile, newsize, "%s/%s/%s",
 			                 prefix, maildir, user_newname);
@@ -2168,7 +2168,7 @@ int main (int argc, char **argv)
 #endif
 
 	sys_ngroups = sysconf (_SC_NGROUPS_MAX);
-	user_groups = MALLOCARRAY (sys_ngroups + 1, char *);
+	user_groups = MALLOC(sys_ngroups + 1, char *);
 	user_groups[0] = NULL;
 
 	is_shadow_pwd = spw_file_present ();

--- a/src/vipw.c
+++ b/src/vipw.c
@@ -304,7 +304,7 @@ vipwedit (const char *file, int (*file_lock) (void), int (*file_unlock) (void))
 				continue;
 		}
 
-		buf = MALLOCARRAY(strlen(editor) + strlen(fileedit) + 2, char);
+		buf = MALLOC(strlen(editor) + strlen(fileedit) + 2, char);
 		snprintf (buf, strlen (editor) + strlen (fileedit) + 2,
 		          "%s %s", editor, fileedit);
 		status = system (buf);
@@ -420,7 +420,7 @@ vipwedit (const char *file, int (*file_lock) (void), int (*file_unlock) (void))
 		if (stat (file, &st1) != 0) {
 			vipwexit (_("failed to stat edited file"), errno, 1);
 		}
-		to_rename = MALLOCARRAY (strlen (file) + 2, char);
+		to_rename = MALLOC(strlen(file) + 2, char);
 		if (NULL == to_rename) {
 			vipwexit (_("failed to allocate memory"), errno, 1);
 		}

--- a/tests/libsubid/04_nss/libsubid_zzz.c
+++ b/tests/libsubid/04_nss/libsubid_zzz.c
@@ -77,7 +77,7 @@ static uid_t getnamuid(const char *name) {
 }
 
 static int alloc_uid(uid_t **uids, uid_t id) {
-	*uids = MALLOC(uid_t);
+	*uids = MALLOC(1, uid_t);
 	if (!*uids)
 		return -1;
 	*uids[0] = id;
@@ -122,7 +122,7 @@ enum subid_status shadow_subid_list_owner_ranges(const char *owner, enum subid_t
 		return SUBID_STATUS_SUCCESS;
 	if (id_type == ID_TYPE_UID && strcmp(owner, "group1") == 0)
 		return SUBID_STATUS_SUCCESS;
-	ranges = MALLOC(struct subid_range);
+	ranges = MALLOC(1, struct subid_range);
 	if (!ranges)
 		return SUBID_STATUS_ERROR;
 	if (strcmp(owner, "user1") == 0 || strcmp(owner, "group1") == 0) {


### PR DESCRIPTION
```
    Simplify allocation APIs
    
    If we consider simple objects as arrays of size 1, we can considerably
    simplify these APIs, merging the *ARRAY and the non-array variants.
    
    That will produce more readable code, since lines will be shorter (by
    not having ARRAY in the macro names, as all macros will consistently
    handle arrays), and the allocated size will be also more explicit.
    
    The syntax will now be of the form:
    
        p = MALLOC(42, foo_t);  // allocate 42 elements of type foo_t.
        p = MALLOC(1, bar_t);   // allocate 1 element of type foo_t.
    
    The _array() allocation functions should _never_ be called directly, and
    instead these macros should be used.
    
    The non-array functions (e.g., malloc(3)) still have their place, but
    are limited to allocating structures with flexible array members.  For
    any other uses, the macros should be used.
    
    Thus, we don't use any array or ARRAY variants in any code any more, and
    they are only used as implementation details of these macros.
    
    Link: <https://software.codidact.com/posts/285898/288023#answer-288023>
```
```
    Drop alloca(3)
    
    alloca(3) fails silently if not enough memory can be allocated on the
    stack.  Use checked dynamic allocation instead.
```

To avoid rebasing issues when picking Christian's "Drop alloca(3) patch", I picked another patch from @cgzones  that fixes unrelated off-by-one bugs.  I also merged some other transformation of an alloca(3) call that was in another one of his patches into the "Drop alloca(3)" one.