### PR TITLE
CI: Make build logs more readable

### DIFF
--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -32,7 +32,10 @@ jobs:
     - name: Build shadow-utils
       run: |
         PROCESSORS=$(/usr/bin/getconf _NPROCESSORS_ONLN)
-        make -j$PROCESSORS
+        make -kj$PROCESSORS || true
+
+    - name: Check build errors
+      run: make
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ addons:
     notification_email: christian.brauner@ubuntu.com,serge@hallyn.com
 
     build_command_prepend: "./autogen.sh --without-selinux --disable-man"
-    build_command: "make -j4"
+    build_command: "make -kj4 || make"
     branch_pattern: master
 
 script:

--- a/share/containers/alpine.dockerfile
+++ b/share/containers/alpine.dockerfile
@@ -9,7 +9,8 @@ COPY ./ /usr/local/src/shadow/
 WORKDIR /usr/local/src/shadow/
 
 RUN ./autogen.sh --without-selinux --disable-man --disable-nls --with-yescrypt
-RUN make -j4
+RUN make -kj4 || true
+RUN make
 RUN make install
 
 FROM scratch AS export

--- a/share/containers/debian.dockerfile
+++ b/share/containers/debian.dockerfile
@@ -16,7 +16,8 @@ COPY ./ /usr/local/src/shadow/
 WORKDIR /usr/local/src/shadow/
 
 RUN ./autogen.sh --without-selinux --enable-man --with-yescrypt
-RUN make -j4
+RUN make -kj4 || true
+RUN make
 RUN make install
 
 FROM scratch AS export

--- a/share/containers/fedora.dockerfile
+++ b/share/containers/fedora.dockerfile
@@ -13,7 +13,8 @@ RUN ./autogen.sh --enable-shadowgrp --enable-man --with-audit \
         --with-sha-crypt --with-bcrypt --with-yescrypt --with-selinux \
         --without-libcrack --without-libpam --enable-shared \
         --with-group-name-max-length=32
-RUN make -j4
+RUN make -kj4 || true
+RUN make
 RUN make install
 
 FROM scratch AS export


### PR DESCRIPTION
If make fails in a multi-process invocation, the log is pretty much unreadable.  To make it readable, build as much as can be built without failing.  If it succeeds, then we're done.  If there was a failure, run a single-process make again, which we know should fail at its first target; that will print the few lines we're really interested in, and they will be at the very end of the log.

This has some side effects:  Now we build as much as we can, instead of failing as early as possible; this may make CI a bit slower.  However, it also has the benefit that you see _all_ the error messages that could be given, instead of needing to fix the first error to see the next and so on.