### PR TITLE
ci: remove explicit fedora dependencies

### DIFF
--- a/share/containers/fedora.dockerfile
+++ b/share/containers/fedora.dockerfile
@@ -4,7 +4,6 @@ FROM "${OS_IMAGE}" AS build
 
 RUN dnf install -y dnf-plugins-core
 RUN dnf builddep -y shadow-utils
-RUN dnf install -y libbsd-devel libeconf-devel
 
 COPY ./ /usr/local/src/shadow/
 WORKDIR /usr/local/src/shadow/


### PR DESCRIPTION
libbsd-devel libeconf-devel have already been added to the spec file and they should be installed by the `dnf builddep` command.