### PR TITLE
run_parts updates

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,7 +45,7 @@ AC_CHECK_HEADERS(crypt.h utmp.h \
 dnl shadow now uses the libc's shadow implementation
 AC_CHECK_HEADER([shadow.h],,[AC_MSG_ERROR([You need a libc with shadow.h])])
 
-AC_CHECK_FUNCS(arc4random_buf futimes \
+AC_CHECK_FUNCS(arc4random_buf execveat futimes \
 	getentropy getrandom getspnam getusershell \
 	initgroups lckpwdf lutimes mempcpy \
 	setgroups updwtmp updwtmpx innetgr \

--- a/lib/run_part.c
+++ b/lib/run_part.c
@@ -1,5 +1,8 @@
+#include <config.h>
+
 #include <dirent.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -13,12 +16,16 @@
 #include "run_part.h"
 #include "shadowlog_internal.h"
 
-int run_part (char *script_path, const char *name, const char *action)
+#ifdef HAVE_EXECVEAT
+int run_part (int script_fd, const char *script_name, const char *name, const char *action)
+#else
+int run_part (const char *script_path, const char *script_name, const char *name, const char *action)
+#endif			/* HAVE_EXECVEAT */
 {
 	int pid;
 	int wait_status;
 	int pid_status;
-	char *args[] = { script_path, NULL };
+	char *args[] = { (char *) script_name, NULL };
 
 	pid=fork();
 	if (pid==-1) {
@@ -28,7 +35,11 @@ int run_part (char *script_path, const char *name, const char *action)
 	if (pid==0) {
 		setenv ("ACTION",action,1);
 		setenv ("SUBJECT",name,1);
-		execv (script_path,args);
+#ifdef HAVE_EXECVEAT
+		execveat (script_fd, "", args, environ, AT_EMPTY_PATH);
+#else
+		execv (script_path, args);
+#endif			/* HAVE_EXECVEAT */
 		perror ("execv");
 		exit(1);
 	}
@@ -49,16 +60,38 @@ int run_parts (const char *directory, const char *name, const char *action)
 	int n;
 	int execute_result = 0;
 
+#ifdef HAVE_EXECVEAT
+	int dfd = open (directory, O_PATH | O_DIRECTORY | O_CLOEXEC);
+	if (dfd == -1) {
+		perror ("open");
+		return (1);
+	}
+#endif			/* HAVE_EXECVEAT */
+
 	scanlist = scandir (directory, &namelist, 0, alphasort);
 	if (scanlist<=0) {
+#ifdef HAVE_EXECVEAT
+		(void) close (dfd);
+#endif			/* HAVE_EXECVEAT */
 		return (0);
 	}
 
 	for (n=0; n<scanlist; n++) {
-		int path_length;
 		struct stat sb;
 
-		path_length=strlen(directory) + strlen(namelist[n]->d_name) + 2;
+#ifdef HAVE_EXECVEAT
+		int fd = openat (dfd, namelist[n]->d_name, O_PATH | O_CLOEXEC);
+		if (fd == -1) {
+			perror ("open");
+			for (; n<scanlist; n++) {
+				free (namelist[n]);
+			}
+			free (namelist);
+			(void) close (dfd);
+			return (1);
+		}
+#else
+		int path_length=strlen(directory) + strlen(namelist[n]->d_name) + 2;
 		char *s = MALLOCARRAY(path_length, char);
 		if (!s) {
 			fprintf (shadow_logfd, "could not allocate memory\n");
@@ -69,11 +102,20 @@ int run_parts (const char *directory, const char *name, const char *action)
 			return (1);
 		}
 		snprintf (s, path_length, "%s/%s", directory, namelist[n]->d_name);
+#endif			/* HAVE_EXECVEAT */
 
-		execute_result = 0;
+#ifdef HAVE_EXECVEAT
+		if (fstat (fd, &sb) == -1) {
+#else
 		if (stat (s, &sb) == -1) {
+#endif			/* HAVE_EXECVEAT */
 			perror ("stat");
+#ifdef HAVE_EXECVEAT
+			(void) close (fd);
+			(void) close (dfd);
+#else
 			free (s);
+#endif			/* HAVE_EXECVEAT */
 			for (; n<scanlist; n++) {
 				free (namelist[n]);
 			}
@@ -82,7 +124,11 @@ int run_parts (const char *directory, const char *name, const char *action)
 		}
 
 		if (!S_ISREG (sb.st_mode)) {
-			free(s);
+#ifdef HAVE_EXECVEAT
+			(void) close (fd);
+#else
+			free (s);
+#endif			/* HAVE_EXECVEAT */
 			free (namelist[n]);
 			continue;
 		}
@@ -92,14 +138,22 @@ int run_parts (const char *directory, const char *name, const char *action)
 		    (sb.st_mode & 0002)) {
 			fprintf (shadow_logfd, "skipping %s due to insecure ownership/permission\n",
 			         namelist[n]->d_name);
-			free(s);
+#ifdef HAVE_EXECVEAT
+			(void) close (fd);
+#else
+			free (s);
+#endif			/* HAVE_EXECVEAT */
 			free (namelist[n]);
 			continue;
 		}
 
-		execute_result = run_part (s, name, action);
-
+#ifdef HAVE_EXECVEAT
+		execute_result = run_part (fd, namelist[n]->d_name, name, action);
+		(void) close (fd);
+#else
+		execute_result = run_part (s, namelist[n]->d_name, name, action);
 		free (s);
+#endif			/* HAVE_EXECVEAT */
 
 		if (execute_result!=0) {
 			fprintf (shadow_logfd,
@@ -114,6 +168,10 @@ int run_parts (const char *directory, const char *name, const char *action)
 		free (namelist[n]);
 	}
 	free (namelist);
+
+#ifdef HAVE_EXECVEAT
+	(void) close (dfd);
+#endif			/* HAVE_EXECVEAT */
 
 	return (execute_result);
 }

--- a/lib/run_part.c
+++ b/lib/run_part.c
@@ -81,9 +81,23 @@ int run_parts (const char *directory, const char *name, const char *action)
 			return (1);
 		}
 
-		if (S_ISREG (sb.st_mode)) {
-			execute_result = run_part (s, name, action);
+		if (!S_ISREG (sb.st_mode)) {
+			free(s);
+			free (namelist[n]);
+			continue;
 		}
+
+		if ((sb.st_uid != 0 && sb.st_uid != getuid()) ||
+		    (sb.st_gid != 0 && sb.st_gid != getgid()) ||
+		    (sb.st_mode & 0002)) {
+			fprintf (shadow_logfd, "skipping %s due to insecure ownership/permission\n",
+			         namelist[n]->d_name);
+			free(s);
+			free (namelist[n]);
+			continue;
+		}
+
+		execute_result = run_part (s, name, action);
 
 		free (s);
 

--- a/lib/run_part.c
+++ b/lib/run_part.c
@@ -61,7 +61,7 @@ int run_parts (const char *directory, const char *name, const char *action)
 		path_length=strlen(directory) + strlen(namelist[n]->d_name) + 2;
 		char *s = MALLOCARRAY(path_length, char);
 		if (!s) {
-			printf ("could not allocate memory\n");
+			fprintf (shadow_logfd, "could not allocate memory\n");
 			for (; n<scanlist; n++) {
 				free (namelist[n]);
 			}

--- a/lib/run_part.c
+++ b/lib/run_part.c
@@ -81,7 +81,7 @@ int run_parts (const char *directory, const char *name, const char *action)
 			return (1);
 		}
 
-		if (S_ISREG (sb.st_mode) || S_ISLNK (sb.st_mode)) {
+		if (S_ISREG (sb.st_mode)) {
 			execute_result = run_part (s, name, action);
 		}
 

--- a/lib/run_part.h
+++ b/lib/run_part.h
@@ -1,7 +1,6 @@
 #ifndef _RUN_PART_H
 #define _RUN_PART_H
 
-int run_part (char *script_path, const char *name, const char *action);
 int run_parts (const char *directory, const char *name, const char *action);
 
 #endif /* _RUN_PART_H */


### PR DESCRIPTION
* use shadow_logfd instead of stdout

  Similar to execution failure message.

* run_part: drop void symlink check

  Since stat(2) is used the result can never be a symbolic link.

* skip scripts with insecure ownership/permission

  Skip scripts that are either
    - not owned be the executing user or root,
    - not owned by the executing group or root,
    - world-writable.

* use execveat(2) to avoid toctou issues

  Pin the script to execute before gathering its information to avoid any potential time-of-check-time-of-use issues.