### PR TITLE
libmisc/yesno.c: Use getline(3) and rpmatch(3)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -50,6 +50,7 @@ AC_CHECK_FUNCS(arc4random_buf futimes \
 	initgroups lckpwdf lutimes mempcpy \
 	setgroups updwtmp updwtmpx innetgr \
 	getspnam_r \
+	rpmatch \
 	memset_explicit explicit_bzero stpecpy stpeprintf)
 AC_SYS_LARGEFILE
 


### PR DESCRIPTION
getline(3) is much more readable than manually looping.  It has some
overhead due to the allocation of a buffer, but that shouldn't be a
problem here.  If that was a problem, we could reuse the buffer (thus
making the function non-reentrant), but I don't think that's worth the
extra complexity.

Using getline(3) has the benefit that the function can then use
rpmatch(3) just by changing one line; note to downstream packagers:
distros that use glibc may be interested in patching that line for i18n
purposes.

While we're at it, apply some other minor improvements to this file:

-  Remove comment saying which files use this function.  That's likely
   to get outdated.  And anyway, it's just a grep(1) away, so it doesn't
   really add any value.

-  Remove unnecessary casts to (void) that were used to verbosely ignore
   errors from stdio calls.  They add clutter without really adding much
   value to the code (or I don't see it).

-  Add in a comment how this code could be implemented using rpmatch(3),
   so that if it becomes more portable in the future, we might just
   replace that line.  It will serve as a remainder of the intention.

-  Remove comments from the function body.  They make the function less
   readable.  Instead, centralize the description of the function into a
   man-page-like comment before the function definition.  This keeps the
   function body short and sweet.

-  Minor whitespace style changes (it doesn't hurt the diff at this
   point, since most of the affected lines were already touched by other
   changes, so I applied my preferred style :).

Cc: @ferivoz 
Cc: @hallyn 
Signed-off-by: @alejandro-colomar 
