### PR TITLE
newgrp/useradd: always set SIGCHLD to default

### DIFF
--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -288,6 +288,9 @@ static void syslog_sg (const char *name, const char *group)
 		(void) signal (SIGTSTP, SIG_IGN);
 		(void) signal (SIGTTIN, SIG_IGN);
 		(void) signal (SIGTTOU, SIG_IGN);
+		/* set SIGCHLD to default for waitpid */
+		(void) signal(SIGCHLD, SIG_DFL);
+
 		child = fork ();
 		if ((pid_t)-1 == child) {
 			/* error in fork() */

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -20,6 +20,7 @@
 #include <lastlog.h>
 #include <libgen.h>
 #include <pwd.h>
+#include <signal.h>
 #ifdef ACCT_TOOLS_SETUID
 #ifdef USE_PAM
 #include "pam_defs.h"
@@ -2155,6 +2156,9 @@ static void tallylog_reset (const char *user_name)
 
 	if (access(pam_tally2, X_OK) == -1)
 		return;
+
+	/* set SIGCHLD to default for waitpid */
+	signal(SIGCHLD, SIG_DFL);
 
 	failed = 0;
 	switch (childpid = fork())


### PR DESCRIPTION
The tools newgrp and useradd expect waitpid to behave as described in its manual page. But the notes indicate that if SIGCHLD is ignored, waitpid behaves differently.

A user could set SIGCHLD to ignore before starting newgrp through exec. Children of newgrp would not become zombies and their PIDs could be reassigned before newgrp could call kill with the child pid and SIGCONT.

The useradd tool is not installed setuid, but I have added the default there as well (copied from vipw).