### PR TITLE
libmisc/yesno.c: Fix regression

### DIFF
--- a/libmisc/yesno.c
+++ b/libmisc/yesno.c
@@ -50,8 +50,9 @@ static int rpmatch(const char *response);
 bool
 yes_or_no(bool read_only)
 {
-	bool  ret;
-	char  *buf;
+	bool   ret;
+	char   *buf;
+	size_t size;
 
 	if (read_only) {
 		puts(_("No"));
@@ -60,8 +61,10 @@ yes_or_no(bool read_only)
 
 	fflush(stdout);
 
+	buf = NULL;
 	ret = false;
-	if (getline(&buf, NULL, stdin) != NULL)
+	size = 0;
+	if (getline(&buf, &size, stdin) != -1)
 		ret = rpmatch(buf) == 1;
 
 	free(buf);


### PR DESCRIPTION
The getline function does not return a pointer but the amount of read characters. The error return value to check for is -1.

Set buf to NULL to avoid dereference of an uninitialized stack value.

The getline function returns -1 if size argument is NULL. Always use a valid pointer even if size is unimportant.