### PR TITLE
login_prompt: Fix implementation issues

### DIFF
--- a/lib/prototypes.h
+++ b/lib/prototypes.h
@@ -233,7 +233,7 @@ extern void dolastlog (
 extern int login_access (const char *user, const char *from);
 
 /* loginprompt.c */
-extern void login_prompt (const char *, char *, int);
+extern void login_prompt (char *, int);
 
 /* mail.c */
 extern void mailcheck (void);

--- a/libmisc/loginprompt.c
+++ b/libmisc/loginprompt.c
@@ -22,7 +22,7 @@
 
 static void login_exit (unused int sig)
 {
-	exit (EXIT_FAILURE);
+	_exit (EXIT_FAILURE);
 }
 
 /*

--- a/libmisc/loginprompt.c
+++ b/libmisc/loginprompt.c
@@ -32,7 +32,7 @@ static void login_exit (unused int sig)
  * is set in login.defs, this file is displayed before the prompt.
  */
 
-void login_prompt (const char *prompt, char *name, int namesize)
+void login_prompt (char *name, int namesize)
 {
 	char buf[1024];
 
@@ -41,6 +41,7 @@ void login_prompt (const char *prompt, char *name, int namesize)
 	char *cp;
 	int i;
 	FILE *fp;
+	const char *fname = getdef_str ("ISSUE_FILE");
 
 	sighandler_t sigquit;
 	sighandler_t sigtstp;
@@ -59,22 +60,19 @@ void login_prompt (const char *prompt, char *name, int namesize)
 	 * be displayed and display it before the prompt.
 	 */
 
-	if (NULL != prompt) {
-		const char *fname = getdef_str ("ISSUE_FILE");
-		if (NULL != fname) {
-			fp = fopen (fname, "r");
-			if (NULL != fp) {
-				while ((i = getc (fp)) != EOF) {
-					(void) putc (i, stdout);
-				}
-
-				(void) fclose (fp);
+	if (NULL != fname) {
+		fp = fopen (fname, "r");
+		if (NULL != fp) {
+			while ((i = getc (fp)) != EOF) {
+				(void) putc (i, stdout);
 			}
+
+			(void) fclose (fp);
 		}
-		(void) gethostname (buf, sizeof buf);
-		printf (prompt, buf);
-		(void) fflush (stdout);
 	}
+	(void) gethostname (buf, sizeof buf);
+	printf (_("\n%s login: "), buf);
+	(void) fflush (stdout);
 
 	/*
 	 * Read the user's response.  The trailing newline will be

--- a/src/login.c
+++ b/src/login.c
@@ -910,7 +910,7 @@ int main (int argc, char **argv)
 			preauth_flag = false;
 			username = XMALLOCARRAY (USER_NAME_MAX_LENGTH + 1, char);
 			username[USER_NAME_MAX_LENGTH] = '\0';
-			login_prompt (_("\n%s login: "), username, USER_NAME_MAX_LENGTH);
+			login_prompt (username, USER_NAME_MAX_LENGTH);
 
 			if ('\0' == username[0]) {
 				/* Prompt for a new login */


### PR DESCRIPTION
The `login_prompt` function used in `login` utility allows setting of environment variables when entered next to a user name. These variables still exist in memory even if login attempt failed. A subsequent login from another user takes these environment variables into account.

Also within the privileged code of login running as root a memory leak exists with these environment variables. With default values it would be very hard to trigger an OOM or do other malicious things though.

My suggestion is to remove this undocumented feature.

Also simplified API and fixed a signal unsafe usage while at it.