### PR TITLE
commonio.c: Simplification

### DIFF
--- a/lib/commonio.c
+++ b/lib/commonio.c
@@ -231,36 +231,18 @@ int do_fcntl_lock (const char *file, bool log, short type)
 
 int commonio_lock_nowait (struct commonio_db *db, bool log)
 {
-	char* file = NULL;
-	char* lock = NULL;
-	size_t lock_file_len;
-	size_t file_len;
 	int err = 0;
 
 	if (db->locked) {
 		return 1;
 	}
-	file_len = strlen(db->filename) + 11;/* %lu max size */
-	lock_file_len = strlen(db->filename) + 6; /* sizeof ".lock" */
-	file = MALLOCARRAY(file_len, char);
-	if (file == NULL) {
-		goto cleanup_ENOMEM;
-	}
-	lock = MALLOCARRAY(lock_file_len, char);
-	if (lock == NULL) {
-		goto cleanup_ENOMEM;
-	}
-	snprintf (file, file_len, "%s.%lu",
-	          db->filename, (unsigned long) getpid ());
 
 	if (do_fcntl_lock (db->filename, log, F_WRLCK | F_RDLCK) != 0) {
 		db->locked = true;
 		lock_count++;
 		err = 1;
 	}
-cleanup_ENOMEM:
-	free(file);
-	free(lock);
+
 	return err;
 }
 

--- a/lib/commonio.c
+++ b/lib/commonio.c
@@ -462,7 +462,7 @@ int commonio_open (struct commonio_db *db, int mode)
 
 	fd = open (db->filename,
 	             (db->readonly ? O_RDONLY : O_RDWR)
-	           | O_NOCTTY | O_NONBLOCK | O_NOFOLLOW);
+	           | O_NOCTTY | O_NONBLOCK | O_NOFOLLOW | O_CLOEXEC);
 	saved_errno = errno;
 	db->fp = NULL;
 	if (fd >= 0) {
@@ -492,9 +492,6 @@ int commonio_open (struct commonio_db *db, int mode)
 		}
 		return 0;
 	}
-
-	/* Do not inherit fd in spawned processes (e.g. nscd) */
-	fcntl (fileno (db->fp), F_SETFD, FD_CLOEXEC);
 
 	buflen = BUFLEN;
 	buf = MALLOCARRAY (buflen, char);


### PR DESCRIPTION
I have removed some obsolete code. Also, since POSIX.1-2008 is a requirement for shadow, O_CLOEXEC can be used which removes the need to call fcntl for a file descriptor.