### PR TITLE
Fix broken docbook translations

### DIFF
--- a/man/generate_translations.mak
+++ b/man/generate_translations.mak
@@ -17,7 +17,7 @@ login.defs.d:
 	else \
 	    sed -e 's/^\(<!DOCTYPE .*docbookx.dtd"\)>/\1 [<!ENTITY % config SYSTEM "config.xml">%config;]>/' $< > $@; \
 	fi
-	itstool -d -l $(LANG) -m messages.mo -o . $@
+	itstool -i ../its.rules -d -l $(LANG) -m messages.mo -o . $@
 	sed -i 's:\(^<refentry .*\)>:\1 lang="$(LANG)">:' $@
 
 include ../generate_mans.mak

--- a/man/its.rules
+++ b/man/its.rules
@@ -1,0 +1,16 @@
+<its:rules version="2.0" xmlns:its="http://www.w3.org/2005/11/its">
+  <its:withinTextRule withinText="yes"
+  		selector="//b
+			| //em
+			| //i
+			| //citerefentry
+			| //command
+			| //emphasis
+			| //envar
+			| //filename
+			| //manvolnum
+			| //option
+			| //replacable
+			| //replaceable
+			| //refentrytitle"/>
+</its:rules>


### PR DESCRIPTION
its by default does not support xml tags inside translatable units.  Use custom its rules from

https://www.w3.org/TR/xml-i18n-bp/#relating-docbook-plus-its

to enable the tags which are in use by docbook.