### PR TITLE
Remove some static char arrays

### DIFF
--- a/libmisc/setupenv.c
+++ b/libmisc/setupenv.c
@@ -196,8 +196,6 @@ void setup_env (struct passwd *info)
 	 */
 
 	if (chdir (info->pw_dir) == -1) {
-		static char temp_pw_dir[] = "/";
-
 		if (!getdef_bool ("DEFAULT_HOME") || chdir ("/") == -1) {
 			fprintf (log_get_logfd(), _("Unable to cd to '%s'\n"),
 				 info->pw_dir);
@@ -209,7 +207,7 @@ void setup_env (struct passwd *info)
 		}
 		(void) puts (_("No directory, logging in with HOME=/"));
 		free (info->pw_dir);
-		info->pw_dir = xstrdup (temp_pw_dir);
+		info->pw_dir = xstrdup ("/");
 	}
 
 	/*
@@ -223,10 +221,8 @@ void setup_env (struct passwd *info)
 	 */
 
 	if ((NULL == info->pw_shell) || ('\0' == *info->pw_shell)) {
-		static char temp_pw_shell[] = SHELL;
-
 		free (info->pw_shell);
-		info->pw_shell = xstrdup (temp_pw_shell);
+		info->pw_shell = xstrdup (SHELL);
 	}
 
 	addenv ("SHELL", info->pw_shell);

--- a/src/sulogin.c
+++ b/src/sulogin.c
@@ -29,7 +29,6 @@
  */
 const char *Prog;
 
-static char name[BUFSIZ];
 static char pass[BUFSIZ];
 
 static struct passwd pwent;
@@ -119,14 +118,12 @@ static void catch_signals (unused int sig)
 	}
 #endif				/* !USE_PAM */
 
-	(void) strcpy (name, "root");	/* KLUDGE!!! */
-
 	(void) signal (SIGALRM, catch_signals);	/* exit if the timer expires */
 	(void) alarm (ALARM);		/* only wait so long ... */
 
 	while (true) {		/* repeatedly get login/password pairs */
 		char *cp;
-		pw_entry (name, &pwent);	/* get entry from password file */
+		pw_entry ("root", &pwent);	/* get entry from password file */
 		if (pwent.pw_name == NULL) {
 			/*
 			 * Fail secure


### PR DESCRIPTION
Some strings are first written into static char arrays before passed to functions which expect a const char pointer anyway.

It is easier to pass these strings directly as arguments.