### PR TITLE
get_pid.c: Use tighter validation checks

### DIFF
--- a/lib/get_pid.c
+++ b/lib/get_pid.c
@@ -24,6 +24,7 @@ int get_pid (const char *pidstr, pid_t *pid)
 	if (   ('\0' == *pidstr)
 	    || ('\0' != *endptr)
 	    || (ERANGE == errno)
+	    || (val < 1)
 	    || (/*@+longintegral@*/val != (pid_t)val)/*@=longintegral@*/) {
 		return 0;
 	}
@@ -49,7 +50,8 @@ int get_pidfd_from_fd(const char *pidfdstr)
 	if (   ('\0' == *pidfdstr)
 	    || ('\0' != *endptr)
 	    || (ERANGE == errno)
-	    || (/*@+longintegral@*/val != (pid_t)val)/*@=longintegral@*/) {
+	    || (val < 0)
+	    || (/*@+longintegral@*/val != (int)val)/*@=longintegral@*/) {
 		return -1;
 	}
 


### PR DESCRIPTION
Neither a pid_t below 1 nor a negative fd could be valid in this context.

Proof of Concept:

$ newuidmap -1 1 1 1
newuidmap: Could not open proc directory for target 4294967295