### PR TITLE
xgetXXbyYY: Improve error handling

### DIFF
--- a/libmisc/xgetXXbyYY.c
+++ b/libmisc/xgetXXbyYY.c
@@ -69,6 +69,12 @@
 			/* Build a result structure that can be freed by
 			 * the shadow *_free functions. */
 			LOOKUP_TYPE *ret_result = DUP_FUNCTION(result);
+			if (NULL == result) {
+				fprintf (log_get_logfd(),
+				         _("%s: out of memory\n"),
+				         "x" STRINGIZE(FUNCTION_NAME));
+				exit (13);
+			}
 			free(buffer);
 			free(result);
 			return ret_result;

--- a/libmisc/xgetXXbyYY.c
+++ b/libmisc/xgetXXbyYY.c
@@ -81,9 +81,7 @@
 		}
 
 		if (ERANGE != status) {
-			free (buffer);
-			free (result);
-			return NULL;
+			break;
 		}
 
 		if (length <= ((size_t)-1 / 4)) {


### PR DESCRIPTION
- Treat another out of memory condition and fail with exit(13) consistently within the file.
- Avoid duplicated code in error handling