### PR TITLE
chsh: Verify that login shell path is absolute

### DIFF
--- a/src/chsh.c
+++ b/src/chsh.c
@@ -574,7 +574,8 @@ int main (int argc, char **argv)
 		fail_exit (1);
 	}
 	if (   !amroot
-	    && (   is_restricted_shell (loginsh)
+	    && (   loginsh[0] != '/'
+	        || is_restricted_shell (loginsh)
 	        || (access (loginsh, X_OK) != 0))) {
 		fprintf (stderr, _("%s: %s is an invalid shell\n"), Prog, loginsh);
 		fail_exit (1);


### PR DESCRIPTION
The getusershell implementation of musl returns every line within the /etc/shells file, which even includes comments. Only consider absolute paths for login shells.

Never allow a user to set a shell starting with `*` because that would lead to security issues (login and su would treat the home directory as a subsystem root).