### PR TITLE
process_prefix_flag: Drop privileges

### DIFF
--- a/libmisc/prefix_flag.c
+++ b/libmisc/prefix_flag.c
@@ -85,6 +85,15 @@ extern const char* process_prefix_flag (const char* short_opt, int argc, char **
 
 
 	if (prefix != NULL) {
+		/* Drop privileges */
+		if (   (setregid (getgid (), getgid ()) != 0)
+		    || (setreuid (getuid (), getuid ()) != 0)) {
+			fprintf (log_get_logfd(),
+			         _("%s: failed to drop privileges (%s)\n"),
+			         log_get_progname(), strerror (errno));
+			exit (EXIT_FAILURE);
+		}
+
 		if ( prefix[0] == '\0' || !strcmp(prefix, "/"))
 			return ""; /* if prefix is "/" then we ignore the flag option */
 		/* should we prevent symbolic link from being used as a prefix? */


### PR DESCRIPTION
Using --prefix in a setuid binary is quite dangerous. An unprivileged user could prepare a custom shadow file in home directory. During a data race the user could exchange directories with links which could lead to exchange of shadow file in system's /etc directory.

This could be used for local privilege escalation.