### PR TITLE
Plug econf memory leaks

### DIFF
--- a/lib/getdef.c
+++ b/lib/getdef.c
@@ -522,6 +522,8 @@ static void def_load (void)
 		 * syslog. The tools will just use their default values.
 		 */
 		(void)putdef_str (keys[i], value);
+
+		free(value);
 	}
 
 	econf_free (keys);

--- a/src/chsh.c
+++ b/src/chsh.c
@@ -180,6 +180,7 @@ static bool shell_is_listed (const char *sh)
 			break;
 		}
 	}
+	econf_free (keys);
 	econf_free (key_file);
 
 	return found;


### PR DESCRIPTION
You can see the memory leaks with address sanitizer if shadow is compiled with `--enable-vendordir=/usr/etc`.

How to reproduce:

1. Prepare a custom shell file as root
```
mkdir -p /etc/shells.d
echo /bin/myshell > /etc/shells.d/custom
```

2. Run chsh as regular user
```
chsh
```