### PR TITLE
Extend Subsystem Protection

### DIFF
--- a/libmisc/root_flag.c
+++ b/libmisc/root_flag.c
@@ -91,16 +91,16 @@ static void change_root (const char* newroot)
 		exit (E_BAD_ARG);
 	}
 
-	if (chdir (newroot) != 0) {
+	if (chroot (newroot) != 0) {
 		fprintf(log_get_logfd(),
-				_("%s: cannot chdir to chroot directory %s: %s\n"),
+			        _("%s: unable to chroot to directory %s: %s\n"),
 				log_get_progname(), newroot, strerror (errno));
 		exit (E_BAD_ARG);
 	}
 
-	if (chroot (newroot) != 0) {
+	if (chdir ("/") != 0) {
 		fprintf(log_get_logfd(),
-		        _("%s: unable to chroot to directory %s: %s\n"),
+			_("%s: cannot chdir in chroot directory %s: %s\n"),
 		        log_get_progname(), newroot, strerror (errno));
 		exit (E_BAD_ARG);
 	}

--- a/libmisc/sub.c
+++ b/libmisc/sub.c
@@ -15,8 +15,10 @@
 #include <sys/types.h>
 #include "prototypes.h"
 #include "defines.h"
+#define	MAX_SUBROOT2	"maximum subsystem depth reached\n"
 #define	BAD_SUBROOT2	"invalid root `%s' for user `%s'\n"
 #define	NO_SUBROOT2	"no subsystem root `%s' for user `%s'\n"
+#define	MAX_DEPTH	1024
 /*
  * subsystem - change to subsystem root
  *
@@ -27,6 +29,18 @@
  */
 void subsystem (const struct passwd *pw)
 {
+	static int depth = 0;
+
+	/*
+	 * Prevent endless loop on misconfigured systems.
+	 */
+	if (++depth > MAX_DEPTH) {
+		printf (_("Maximum subsystem depth reached\n"));
+		SYSLOG ((LOG_WARN, MAX_SUBROOT2));
+		closelog ();
+		exit (EXIT_FAILURE);
+	}
+
 	/*
 	 * The new root directory must begin with a "/" character.
 	 */

--- a/libmisc/sub.c
+++ b/libmisc/sub.c
@@ -57,8 +57,8 @@ void subsystem (const struct passwd *pw)
 	 * must be able to change into it.
 	 */
 
-	if (   (chdir (pw->pw_dir) != 0)
-	    || (chroot (pw->pw_dir) != 0)) {
+	if (   (chroot (pw->pw_dir) != 0)
+	    || (chdir ("/") != 0)) {
 		(void) printf (_("Can't change root directory to '%s'\n"),
 		               pw->pw_dir);
 		SYSLOG ((LOG_WARN, NO_SUBROOT2, pw->pw_dir, pw->pw_name));


### PR DESCRIPTION
These commits do not address any real security issues and are merely defensive measurements against faulty configurations:

- login and su could run into infinite loops if subsystems address each other (easiest form: home directory is root)
- check_perms in su is recursive. Nested subsystems could trigger a stack overflow
- chroot/chdir should be called in that order to avoid races