### PR TITLE
Check if crypt_method null before dereferencing

### DIFF
--- a/src/newusers.c
+++ b/src/newusers.c
@@ -665,7 +665,7 @@ static void process_flags (int argc, char **argv)
 
 			if (!crypt_method){
 				fprintf(stderr,
-						_("%s: Give crypt-method before number of rounds\n"),
+						_("%s: Provide '--crypt-method'\n"),
 						Prog);
 				usage (EXIT_FAILURE);
 			}

--- a/src/newusers.c
+++ b/src/newusers.c
@@ -662,6 +662,13 @@ static void process_flags (int argc, char **argv)
 		case 's':
 			sflg = true;
                         bad_s = 0;
+
+			if (!crypt_method){
+				fprintf(stderr,
+						_("%s: Give crypt-method before number of rounds\n"),
+						Prog);
+				usage (EXIT_FAILURE);
+			}
 #if defined(USE_SHA_CRYPT)
 			if (  (   ((0 == strcmp (crypt_method, "SHA256")) || (0 == strcmp (crypt_method, "SHA512")))
 			       && (0 == getlong(optarg, &sha_rounds)))) {


### PR DESCRIPTION
Make sure crypto_method set before sha-rounds. Only effects newusers.