### PR TITLE
chgpasswd: fix segfault in command-line options

### DIFF
--- a/src/chgpasswd.c
+++ b/src/chgpasswd.c
@@ -186,6 +186,13 @@ static void process_flags (int argc, char **argv)
 		case 's':
 			sflg = true;
                         bad_s = 0;
+
+			if (!crypt_method) {
+				fprintf (stderr,
+				         _("%s: no crypt method defined\n"),
+				         Prog);
+				usage (E_USAGE);
+			}
 #if defined(USE_SHA_CRYPT)
 			if (  (   ((0 == strcmp (crypt_method, "SHA256")) || (0 == strcmp (crypt_method, "SHA512")))
 			       && (0 == getlong(optarg, &sha_rounds)))) {


### PR DESCRIPTION
Using the --sha-rounds option without first giving a crypt method via the --crypt-method option results in comparisons with a NULL pointer and thus make chgpasswd segfault:

$ chgpasswd -s 1
zsh: segmentation fault  chgpasswd -s 1

Current patch add a sanity check before these comparisons to ensure there is a defined encryption method.