### PR TITLE
Fix yescrypt support

### DIFF
--- a/src/newusers.c
+++ b/src/newusers.c
@@ -60,7 +60,7 @@ static bool rflg = false;	/* create a system account */
 #ifndef USE_PAM
 static /*@null@*//*@observer@*/char *crypt_method = NULL;
 #define cflg (NULL != crypt_method)
-#if defined(USE_SHA_CRYPT) || defined(USE_BCRYPT)
+#if defined(USE_SHA_CRYPT) || defined(USE_BCRYPT) || defined(USE_YESCRYPT)
 static bool sflg = false;
 #endif
 #ifdef USE_SHA_CRYPT


### PR DESCRIPTION
Fixes build error:
newusers.c: In function 'update_passwd':
newusers.c:433:21: error: 'sflg' undeclared (first use in this function); did you mean 'rflg'?

introduced by
https://github.com/shadow-maint/shadow/commit/5cd04d03f94622c12220d4a6352824af081b8531 which forgot to define sflg for these configure options:

--without-sha-crypt --without-bcrypt --with-yescrypt