### PR TITLE
subuid.5: reference newusers(8) rather than newusers(1)

### DIFF
--- a/man/subuid.5.xml
+++ b/man/subuid.5.xml
@@ -130,7 +130,7 @@
 	<refentrytitle>newuidmap</refentrytitle><manvolnum>1</manvolnum>
       </citerefentry>,
       <citerefentry>
-	<refentrytitle>newusers</refentrytitle><manvolnum>1</manvolnum>
+	<refentrytitle>newusers</refentrytitle><manvolnum>8</manvolnum>
       </citerefentry>,
       <citerefentry>
 	<refentrytitle>subgid</refentrytitle><manvolnum>5</manvolnum>


### PR DESCRIPTION
Resolves: https://github.com/shadow-maint/shadow/issues/752

Fixes typo in `subuid(5)` that referenced "newusers(1)" rather than "newusers(8)".
