### PR TITLE
lastlog: fix alignment of Latest header

### DIFF
--- a/src/lastlog.c
+++ b/src/lastlog.c
@@ -143,7 +143,7 @@ static void print_one (/*@null@*/const struct passwd *pw)
 	/* Print the header only once */
 	if (!once) {
 #ifdef HAVE_LL_HOST
-		printf (_("Username         Port     From%*sLatest\n"), maxIPv6Addrlen-3, " ");
+		printf (_("Username         Port     From%*sLatest\n"), maxIPv6Addrlen-4, " ");
 #else
 		puts (_("Username                Port     Latest"));
 #endif


### PR DESCRIPTION
b1282224 (Add maximum padding to fit IPv6-Addresses, 2020-05-24) pads the From field header using `maxIPv6Addrlen - 3`.  This leaves the Latest field header misaligned.  Subtract 4 (the length of "From").

Before:
```
$ lastlog -t 2
Username         Port     From                                       Latest
gdm              tty1                                               Sun Jul 16 17:21:02 -0400 2023
test             tty2                                               Sun Jul 16 02:51:11 -0400 2023
```

After:
```
$ lastlog -t 2
Username         Port     From                                      Latest
gdm              tty1                                               Sun Jul 16 17:21:02 -0400 2023
test             tty2                                               Sun Jul 16 02:51:11 -0400 2023
```