### PR TITLE
Declare usage and failure handler noreturn

### DIFF
--- a/src/chgpasswd.c
+++ b/src/chgpasswd.c
@@ -62,7 +62,7 @@ static bool sgr_locked = false;
 static bool gr_locked = false;
 
 /* local function prototypes */
-static void fail_exit (int code);
+NORETURN static void fail_exit (int code);
 NORETURN static void usage (int status);
 static void process_flags (int argc, char **argv);
 static void check_flags (void);

--- a/src/groupmems.c
+++ b/src/groupmems.c
@@ -71,7 +71,7 @@ static void display_members (const char *const *members);
 NORETURN static void usage (int status);
 static void process_flags (int argc, char **argv);
 static void check_perms (void);
-static void fail_exit (int code);
+NORETURN static void fail_exit (int code);
 #define isroot()		(getuid () == 0)
 
 static char *whoami (void)

--- a/src/su.c
+++ b/src/su.c
@@ -433,6 +433,7 @@ static void prepare_pam_close_session (void)
 /*
  * usage - print command line syntax and exit
  */
+NORETURN
 static void usage (int status)
 {
 	(void)

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -205,13 +205,13 @@ static bool home_added = false;
 #define DLOG_INIT	"LOG_INIT="
 
 /* local function prototypes */
-static void fail_exit (int);
+NORETURN static void fail_exit (int);
 static void get_defaults (void);
 static void show_defaults (void);
 static int set_defaults (void);
 static int get_groups (char *);
 static struct group * get_local_group (char * grp_name);
-static void usage (int status);
+NORETURN static void usage (int status);
 static void new_pwent (struct passwd *);
 
 static long scale_age (long);


### PR DESCRIPTION
Assist static analyzers in understanding final code paths.

Cherry-picked from #639.