### PR TITLE
lib: avoid dropping const qualifier during cast

### DIFF
--- a/lib/groupio.c
+++ b/lib/groupio.c
@@ -210,17 +210,25 @@ void __gr_del_entry (const struct commonio_entry *ent)
 
 static int gr_cmp (const void *p1, const void *p2)
 {
+	const struct commonio_entry *const *ce1;
+	const struct commonio_entry *const *ce2;
+	const struct group *g1, *g2;
 	gid_t u1, u2;
 
-	if ((*(struct commonio_entry **) p1)->eptr == NULL) {
+	ce1 = p1;
+	g1 = (*ce1)->eptr;
+	if (g1 == NULL) {
 		return 1;
 	}
-	if ((*(struct commonio_entry **) p2)->eptr == NULL) {
+
+	ce2 = p2;
+	g2 = (*ce2)->eptr;
+	if (g2 == NULL) {
 		return -1;
 	}
 
-	u1 = ((struct group *) (*(struct commonio_entry **) p1)->eptr)->gr_gid;
-	u2 = ((struct group *) (*(struct commonio_entry **) p2)->eptr)->gr_gid;
+	u1 = g1->gr_gid;
+	u2 = g2->gr_gid;
 
 	if (u1 < u2) {
 		return -1;

--- a/lib/pwio.c
+++ b/lib/pwio.c
@@ -182,15 +182,23 @@ struct commonio_db *__pw_get_db (void)
 
 static int pw_cmp (const void *p1, const void *p2)
 {
+	const struct commonio_entry *const *ce1;
+	const struct commonio_entry *const *ce2;
+	const struct passwd *pw1, *pw2;
 	uid_t u1, u2;
 
-	if ((*(struct commonio_entry **) p1)->eptr == NULL)
+	ce1 = p1;
+	pw1 = (*ce1)->eptr;
+	if (pw1 == NULL)
 		return 1;
-	if ((*(struct commonio_entry **) p2)->eptr == NULL)
+
+	ce2 = p2;
+	pw2 = (*ce2)->eptr;
+	if (pw2 == NULL)
 		return -1;
 
-	u1 = ((struct passwd *) (*(struct commonio_entry **) p1)->eptr)->pw_uid;
-	u2 = ((struct passwd *) (*(struct commonio_entry **) p2)->eptr)->pw_uid;
+	u1 = pw1->pw_uid;
+	u2 = pw2->pw_uid;
 
 	if (u1 < u2)
 		return -1;

--- a/lib/subordinateio.c
+++ b/lib/subordinateio.c
@@ -352,14 +352,17 @@ void free_subordinate_ranges(struct subordinate_range **ranges, int count)
  */
 static int subordinate_range_cmp (const void *p1, const void *p2)
 {
-	struct subordinate_range *range1, *range2;
+	const struct commonio_entry *const *ce1;
+	const struct commonio_entry *const *ce2;
+	const struct subordinate_range *range1, *range2;
 
-
-	range1 = (*(struct commonio_entry **) p1)->eptr;
+	ce1 = p1;
+	range1 = (*ce1)->eptr;
 	if (range1 == NULL)
 		return 1;
 
-	range2 = (*(struct commonio_entry **) p2)->eptr;
+	ce2 = p2;
+	range2 = (*ce2)->eptr;
 	if (range2 == NULL)
 		return -1;
 


### PR DESCRIPTION
    subordinateio.c:360:20: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
      360 |         range1 = (*(struct commonio_entry **) p1)->eptr;
          |                    ^
    subordinateio.c:364:20: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
      364 |         range2 = (*(struct commonio_entry **) p2)->eptr;
          |                    ^

    groupio.c:215:15: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
      215 |         if ((*(struct commonio_entry **) p1)->eptr == NULL) {
          |               ^
    groupio.c:218:15: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
      218 |         if ((*(struct commonio_entry **) p2)->eptr == NULL) {
          |               ^
    groupio.c:222:34: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
      222 |         u1 = ((struct group *) (*(struct commonio_entry **) p1)->eptr)->gr_gid;
          |                                  ^
    groupio.c:223:34: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
      223 |         u2 = ((struct group *) (*(struct commonio_entry **) p2)->eptr)->gr_gid;
          |                                  ^

    pwio.c:187:15: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
      187 |         if ((*(struct commonio_entry **) p1)->eptr == NULL)
          |               ^
    pwio.c:189:15: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
      189 |         if ((*(struct commonio_entry **) p2)->eptr == NULL)
          |               ^
    pwio.c:192:35: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
      192 |         u1 = ((struct passwd *) (*(struct commonio_entry **) p1)->eptr)->pw_uid;
          |                                   ^
    pwio.c:193:35: warning: cast discards 'const' qualifier from pointer target type [-Wcast-qual]
      193 |         u2 = ((struct passwd *) (*(struct commonio_entry **) p2)->eptr)->pw_uid;
          |                                   ^


Cherry-picked from #639.