### PR TITLE
lib/btrfs: avoid NULL-dereference

### DIFF
--- a/libmisc/btrfs.c
+++ b/libmisc/btrfs.c
@@ -39,7 +39,7 @@ static int run_btrfs_subvolume_cmd(const char *subcmd, const char *arg1, const c
 		NULL
 	};
 
-	if (access(cmd, X_OK)) {
+	if (!cmd || access(cmd, X_OK)) {
 		return 1;
 	}
 


### PR DESCRIPTION
    btrfs.c:42:13: warning: use of NULL 'cmd' where non-null expected [CWE-476] [-Wanalyzer-null-argument]

Cherry-picked from #639.