### PR TITLE
lib/commonio: drop dead store

### DIFF
--- a/lib/commonio.c
+++ b/lib/commonio.c
@@ -646,7 +646,7 @@ int commonio_open (struct commonio_db *db, int mode)
 	}
 
 	while (db->ops->fgets (buf, buflen, db->fp) == buf) {
-		while (   ((cp = strrchr (buf, '\n')) == NULL)
+		while (   (strrchr (buf, '\n') == NULL)
 		       && (feof (db->fp) == 0)) {
 			size_t len;
 


### PR DESCRIPTION
    commonio.c:522:15: warning: Although the value stored to 'cp' is used in the enclosing expression, the value is never actually read from 'cp' [deadcode.DeadStores]

Cherry-picked from #639.