### PR TITLE
login: use strlcpy to always NUL terminate

### DIFF
--- a/src/login.c
+++ b/src/login.c
@@ -709,7 +709,7 @@ int main (int argc, char **argv)
 			          sizeof (loginprompt),
 			          _("%s login: "), hostn);
 		} else {
-			strncpy (loginprompt, _("login: "),
+			strlcpy (loginprompt, _("login: "),
 			         sizeof (loginprompt));
 		}
 


### PR DESCRIPTION
    login.c:712:25: warning: ‘strncpy’ specified bound 256 equals destination size [-Wstringop-truncation]

Cherry-picked from #639.