### PR TITLE
autogen.sh: Support out-of-tree builds

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,8 +1,8 @@
 #! /bin/sh
 
-autoreconf -v -f --install || exit 1
+autoreconf -v -f --install "$(dirname "$0")" || exit 1
 
-./configure \
+"$(dirname "$0")"/configure \
 	CFLAGS="-O2 -Wall" \
 	--enable-lastlog \
 	--enable-man \


### PR DESCRIPTION
```
This allows to do the following:
    
~/src/shadow/shadow/master$ mkdir .tmp/ && cd .tmp/
~/src/shadow/shadow/master/.tmp$ ../autogen.sh
```

Link: <https://github.com/shadow-maint/shadow/issues/795>
Cc: @thesamesam 