### PR TITLE
man/chsh.1: specify what is a restricted shell

### DIFF
--- a/man/chsh.1.xml
+++ b/man/chsh.1.xml
@@ -120,10 +120,11 @@
       name must be listed in <filename>/etc/shells</filename>, unless the
       invoker is the superuser, and then any value may be added. An
       account with a restricted login shell may not change her login shell.
+      A restricted shell is a shell which is not in
+      <filename>/etc/shells</filename>.
       For this reason, placing <filename>/bin/rsh</filename> in
-      <filename>/etc/shells</filename> is discouraged since accidentally
-      changing to a restricted shell would prevent the user from ever
-      changing her login shell back to its original value.
+      <filename>/etc/shells</filename> is discouraged since it would allow a
+      user to change their shell from a restricted shell.
     </para>
     <para condition="with_vendordir">
       The only restriction placed on the login shell is that the command
@@ -137,12 +138,12 @@
       If the invoker is the superuser any value may be added regardless what is
       defined in the configuration files.
       An account with a restricted login shell may not change her login shell.
+      A restricted shell is a shell which is not in the above files.
     </para>
     <para>
       For this reason, placing <filename>/bin/rsh</filename> in
-      <filename>/etc/shells</filename> is discouraged since accidentally
-      changing to a restricted shell would prevent the user from ever
-      changing her login shell back to its original value.
+      <filename>/etc/shells</filename> is discouraged since it would allow the
+      user to change their shell from a restricted shell.
     </para>
   </refsect1>
 


### PR DESCRIPTION
Update the documentation to reflect the the functionally within src/chsh.c
The functionality was in 45c6603cc86c5881b00ac40e0f9fe548c30ff6be so I am unsure why the documentation wasn't updated to reflect this change