### PR TITLE
utmp: call prepare_utmp() even if utent is NULL

### DIFF
--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -370,17 +370,16 @@ int update_utmp (const char *user,
 	struct utmp *utent, *ut;
 
 	utent = get_current_utmp ();
-	if (utent == NULL) {
-		return -1;
-	}
-
 	ut = prepare_utmp  (user, tty, host, utent);
 
 	(void) setutmp  (ut);	/* make entry in the utmp & wtmp files */
-	free (utent);
+
+	if (utent != NULL) {
+		free (utent);
+	}
 	free (ut);
 
-	return 1;
+	return 0;
 }
 
 void record_failure(const char *failent_user,


### PR DESCRIPTION
update_utmp() should also return 0 when success.

Fixes: 1f368e1c1838de9d476a36897d7c53394569de08 ("utmp: update `update_utmp()")
Resolves: https://github.com/shadow-maint/shadow/issues/805