### PR TITLE
useradd: Set proper SELinux labels for def_usrtemplate

### DIFF
--- a/src/useradd.c
+++ b/src/useradd.c
@@ -2788,7 +2788,7 @@ int main (int argc, char **argv)
 		if (home_added) {
 			copy_tree (def_template, prefix_user_home, false, true,
 			           (uid_t)-1, user_id, (gid_t)-1, user_gid);
-			copy_tree (def_usrtemplate, prefix_user_home, false, false,
+			copy_tree (def_usrtemplate, prefix_user_home, false, true,
 			           (uid_t)-1, user_id, (gid_t)-1, user_gid);
 		} else {
 			fprintf (stderr,


### PR DESCRIPTION
currently content in this directory will have labels derived from /usr/etc, leading to strange errors for user operations later on