### PR TITLE
Improve the login.defs unknown item error message

### DIFF
--- a/lib/getdef.c
+++ b/lib/getdef.c
@@ -361,7 +361,7 @@ unsigned long getdef_ulong (const char *item, unsigned long dflt)
  * (also used when loading the initial defaults)
  */
 
-int putdef_str (const char *name, const char *value)
+int putdef_str (const char *name, const char *value, const char *srcfile)
 {
 	struct itemdef *d;
 	char *cp;
@@ -376,6 +376,8 @@ int putdef_str (const char *name, const char *value)
 	 */
 	d = def_find (name);
 	if (NULL == d) {
+		if (NULL != srcfile)
+			SYSLOG ((LOG_CRIT, "shadow: unknown configuration item '%s' in '%s'", name, srcfile));
 		return -1;
 	}
 
@@ -429,7 +431,6 @@ static /*@observer@*/ /*@null@*/struct itemdef *def_find (const char *name)
 	fprintf (shadow_logfd,
 	         _("configuration error - unknown item '%s' (notify administrator)\n"),
 	         name);
-	SYSLOG ((LOG_CRIT, "unknown configuration item `%s'", name));
 
 out:
 	return NULL;
@@ -519,7 +520,7 @@ static void def_load (void)
 		 * The error was already reported to the user and to
 		 * syslog. The tools will just use their default values.
 		 */
-		(void)putdef_str (keys[i], value);
+		(void)putdef_str (keys[i], value, econf_getPath(defs_file));
 
 		free(value);
 	}
@@ -592,7 +593,7 @@ static void def_load (void)
 		 * The error was already reported to the user and to
 		 * syslog. The tools will just use their default values.
 		 */
-		(void)putdef_str (name, value);
+		(void)putdef_str (name, value, def_fname);
 	}
 
 	if (ferror (fp) != 0) {

--- a/lib/getdef.h
+++ b/lib/getdef.h
@@ -16,7 +16,7 @@ extern int getdef_num (const char *, int);
 extern unsigned long getdef_ulong (const char *, unsigned long);
 extern unsigned int getdef_unum (const char *, unsigned int);
 extern /*@observer@*/ /*@null@*/const char *getdef_str (const char *);
-extern int putdef_str (const char *, const char *);
+extern int putdef_str (const char *, const char *, const char *);
 extern void setdef_config_file (const char* file);
 
 /* default UMASK value if not specified in /etc/login.defs */

--- a/src/groupadd.c
+++ b/src/groupadd.c
@@ -429,7 +429,7 @@ static void process_flags (int argc, char **argv)
 			}
 			/* terminate name, point to value */
 			*cp++ = '\0';
-			if (putdef_str (optarg, cp) < 0) {
+			if (putdef_str (optarg, cp, NULL) < 0) {
 				exit (E_BAD_ARG);
 			}
 			break;

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -1424,7 +1424,7 @@ static void process_flags (int argc, char **argv)
 				/* terminate name, point to value */
 				*cp = '\0';
 				cp++;
-				if (putdef_str (optarg, cp) < 0) {
+				if (putdef_str (optarg, cp, NULL) < 0) {
 					exit (E_BAD_ARG);
 				}
 				break;


### PR DESCRIPTION
Closes #746

Only print the 'unknown item' message to syslog if we are actually parsing a login.defs.  Prefix it with "shadow:" to make it clear in syslog where it came from.

Also add the source filename to the console message.  I'm not quite clear on the econf API, so not sure whether in that path we will end up actually having the path, or printing ''.