### PR TITLE
Singular badname

### DIFF
--- a/man/po/de.po
+++ b/man/po/de.po
@@ -458,8 +458,8 @@ msgid "Add the user to the supplementary group(s). Use only with the <option>-G<
 msgstr "verleiht dem Benutzer zusätzliche, ergänzende Gruppenzugehörigkeiten. Kann nur zusammen mit der Option <option>-G</option> verwendet werden."
 
 #: usermod.8.xml:112(term)
-msgid "<option>-b</option>, <option>--badnames</option>"
-msgstr "<option>-b</option>, <option>--badnames</option>"
+msgid "<option>-b</option>, <option>--badname</option>"
+msgstr "<option>-b</option>, <option>--badname</option>"
 
 #: usermod.8.xml:116(para) useradd.8.xml:135(para) pwck.8.xml:190(para) newusers.8.xml:276(para)
 msgid "Allow names that do not conform to standards."

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -980,6 +980,7 @@ static void process_flags (int argc, char **argv)
 		int c;
 		static struct option long_options[] = {
 			{"append",       no_argument,       NULL, 'a'},
+			{"badname",      no_argument,       NULL, 'b'},
 			{"badnames",     no_argument,       NULL, 'b'},
 			{"comment",      required_argument, NULL, 'c'},
 			{"home",         required_argument, NULL, 'd'},

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -1002,8 +1002,8 @@ static void process_flags (int argc, char **argv)
 #ifdef ENABLE_SUBIDS
 			{"add-subuids",  required_argument, NULL, 'v'},
 			{"del-subuids",  required_argument, NULL, 'V'},
- 			{"add-subgids",  required_argument, NULL, 'w'},
- 			{"del-subgids",  required_argument, NULL, 'W'},
+			{"add-subgids",  required_argument, NULL, 'w'},
+			{"del-subgids",  required_argument, NULL, 'W'},
 #endif				/* ENABLE_SUBIDS */
 #ifdef WITH_SELINUX
 			{"selinux-user",  required_argument, NULL, 'Z'},


### PR DESCRIPTION
Fix badname option to be singular just like useradd.

Fixes: [45d6746219](https://github.com/shadow-maint/shadow/commit/45d674621918664c8736f94f862e86bddf4c3fd4) ("src: correct "badname" option")
