### PR TITLE
4.14.2-a1:  Candidate for a 2nd bugfix release for 4.14

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ m4_define([libsubid_abi_major], 4)
 m4_define([libsubid_abi_minor], 0)
 m4_define([libsubid_abi_micro], 0)
 m4_define([libsubid_abi], [libsubid_abi_major.libsubid_abi_minor.libsubid_abi_micro])
-AC_INIT([shadow], [4.14.1], [pkg-shadow-devel@lists.alioth.debian.org], [],
+AC_INIT([shadow], [4.14.2], [pkg-shadow-devel@lists.alioth.debian.org], [],
 	[https://github.com/shadow-maint/shadow])
 AM_INIT_AUTOMAKE([1.11 foreign dist-xz])
 AC_CONFIG_MACRO_DIRS([m4])

--- a/lib/btrfs.c
+++ b/lib/btrfs.c
@@ -39,7 +39,7 @@ static int run_btrfs_subvolume_cmd(const char *subcmd, const char *arg1, const c
 		NULL
 	};
 
-	if (access(cmd, X_OK)) {
+	if (!cmd || access(cmd, X_OK)) {
 		return 1;
 	}
 

--- a/lib/readpassphrase.h
+++ b/lib/readpassphrase.h
@@ -36,8 +36,12 @@
 #endif
 #include <sys/types.h>
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 char * readpassphrase(const char *, char *, size_t, int);
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* !LIBBSD_READPASSPHRASE_H */

--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -368,17 +368,16 @@ int update_utmp (const char *user,
 	struct utmp *utent, *ut;
 
 	utent = get_current_utmp ();
-	if (utent == NULL) {
-		return -1;
-	}
-
 	ut = prepare_utmp  (user, tty, host, utent);
 
 	(void) setutmp  (ut);	/* make entry in the utmp & wtmp files */
-	free (utent);
+
+	if (utent != NULL) {
+		free (utent);
+	}
 	free (ut);
 
-	return 1;
+	return 0;
 }
 
 void record_failure(const char *failent_user,

--- a/man/chage.1.xml
+++ b/man/chage.1.xml
@@ -200,6 +200,21 @@
       </varlistentry>
       <varlistentry>
 	<term>
+	  <option>-P</option>, <option>--prefix</option>&nbsp;<replaceable>PREFIX_DIR</replaceable>
+	</term>
+	<listitem>
+	  <para>
+	    Apply changes to configuration files under the root filesystem
+	    found under the directory <replaceable>PREFIX_DIR</replaceable>.
+	    This option does not chroot and is intended for preparing a cross-compilation
+	    target.  Some limitations: NIS and LDAP users/groups are
+	    not verified.  PAM authentication is using the host files.
+	    No SELINUX support.
+	  </para>
+	</listitem>
+      </varlistentry>
+      <varlistentry>
+	<term>
 	  <option>-W</option>, <option>--warndays</option>&nbsp;<replaceable>WARN_DAYS</replaceable>
 	</term>
 	<listitem>

--- a/man/chpasswd.8.xml
+++ b/man/chpasswd.8.xml
@@ -173,6 +173,21 @@
 	  </para>
 	</listitem>
       </varlistentry>
+      <varlistentry>
+	<term>
+	  <option>-P</option>, <option>--prefix</option>&nbsp;<replaceable>PREFIX_DIR</replaceable>
+	</term>
+	<listitem>
+	  <para>
+	    Apply changes to configuration files under the root filesystem
+	    found under the directory <replaceable>PREFIX_DIR</replaceable>.
+	    This option does not chroot and is intended for preparing a cross-compilation
+	    target.  Some limitations: NIS and LDAP users/groups are
+	    not verified.  PAM authentication is using the host files.
+	    No SELINUX support.
+	  </para>
+	</listitem>
+      </varlistentry>
       <varlistentry condition="sha_crypt">
 	<term>
 	  <option>-s</option>, <option>--sha-rounds</option>&nbsp;<replaceable>ROUNDS</replaceable>

--- a/man/passwd.1.xml
+++ b/man/passwd.1.xml
@@ -282,6 +282,21 @@
       </varlistentry>
       <varlistentry>
 	<term>
+	  <option>-P</option>, <option>--prefix</option>&nbsp;<replaceable>PREFIX_DIR</replaceable>
+	</term>
+	<listitem>
+	  <para>
+	    Apply changes to configuration files under the root filesystem
+	    found under the directory <replaceable>PREFIX_DIR</replaceable>.
+	    This option does not chroot and is intended for preparing a cross-compilation
+	    target.  Some limitations: NIS and LDAP users/groups are
+	    not verified.  PAM authentication is using the host files.
+	    No SELINUX support.
+	  </para>
+	</listitem>
+      </varlistentry>
+      <varlistentry>
+	<term>
 	  <option>-S</option>, <option>--status</option>
 	</term>
 	<listitem>

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -2787,7 +2787,7 @@ int main (int argc, char **argv)
 		if (home_added) {
 			copy_tree (def_template, prefix_user_home, false, true,
 			           (uid_t)-1, user_id, (gid_t)-1, user_gid);
-			copy_tree (def_usrtemplate, prefix_user_home, false, false,
+			copy_tree (def_usrtemplate, prefix_user_home, false, true,
 			           (uid_t)-1, user_id, (gid_t)-1, user_gid);
 		} else {
 			fprintf (stderr,


### PR DESCRIPTION
I've cherry-picked 4 commits.  Here's the tentative text for a release:

```
shadow-4.14.2 (Casín) - shadow utils

Bugfix release.  Changes since shadow-4.14.0:

shadow-4.14.2:

-  libshadow:
   -  Fix build with musl libc.
   -  Avoid NULL dereference.
   -  Update utmp at an initial login
-  useradd(8):
   -  Set proper SELinux labels for def_usrtemplate

shadow-4.14.1:

-  Build system:
   -  Merge libshadow and libmisc into a single libshadow.  This fixes
      problems in the linker, which were reported at least in Gentoo.
```

The considerations I took for which commits to cherry-pick was:

-  Include patches that have been reported as bugs by users.
-  Include the fix for a NULL dereference, even if no bug report was open.  The fix is small, and covers a CWE.
-  Exclude other fixes, such as not ignoring truncated paths, since they have not been reported by users, but are rather theoretical bugs (so far), and would introduce larger diffs.

Cc: @heirecka
Cc: @cgzones 
Cc: @ikerexxe 
Cc: @jsegitz 
Cc: @jubalh 