### PR TITLE
lib/utmp.c: Don't check for NULL before free(3)

### DIFF
--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -374,10 +374,8 @@ int update_utmp (const char *user,
 
 	(void) setutmp  (ut);	/* make entry in the utmp & wtmp files */
 
-	if (utent != NULL) {
-		free (utent);
-	}
-	free (ut);
+	free(utent);
+	free(ut);
 
 	return 0;
 }


### PR DESCRIPTION
```
free(NULL) is valid; there's no need to check for NULL.  Simplify.

Fixes: 5178f8c5afb6 ("utmp: call prepare_utmp() even if utent is NULL")
```