### PR TITLE
chsh: limit acceptable shells to absolute paths

### DIFF
--- a/src/chsh.c
+++ b/src/chsh.c
@@ -204,21 +204,17 @@ static bool shell_is_listed (const char *sh)
 	}
 	endusershell ();
 #else
-	char buf[BUFSIZ];
+	char *buf = NULL;
 	FILE *fp;
+	size_t n = 0;
 
 	fp = fopen (SHELLS_FILE, "r");
 	if (NULL == fp) {
 		return false;
 	}
 
-	while (fgets (buf, sizeof (buf), fp) == buf) {
-		cp = strrchr (buf, '\n');
-		if (NULL != cp) {
-			*cp = '\0';
-		}
-
-		if (buf[0] == '#') {
+	while (getline (&buf, &n, fp) != -1) {
+		if (buf[0] != '/') {
 			continue;
 		}
 
@@ -227,6 +223,8 @@ static bool shell_is_listed (const char *sh)
 			break;
 		}
 	}
+
+	free(buf);
 	fclose (fp);
 #endif
 	return found;


### PR DESCRIPTION
If an entry in /etc/shells is not an absolute path (comments or partial reads due to fgets), the line should not be considered as a valid login shell.

In general all systems should have getusershells, but let's better be safe than sorry.