### PR TITLE
CI: fix Fedora 39 build

### DIFF
--- a/share/containers/fedora.dockerfile
+++ b/share/containers/fedora.dockerfile
@@ -10,7 +10,7 @@ WORKDIR /usr/local/src/shadow/
 
 RUN ./autogen.sh --enable-shadowgrp --enable-man --with-audit \
         --with-sha-crypt --with-bcrypt --with-yescrypt --with-selinux \
-        --without-libcrack --without-libpam --enable-shared \
+        --without-libcrack --without-libpam --enable-shared --without-libbsd \
         --with-group-name-max-length=32 --enable-lastlog --enable-logind=no
 RUN make -kj4 || true
 RUN make


### PR DESCRIPTION
libbsd is unwanted in Fedora and RHEL, and the recently released Fedora 39 doesn't contain this dependency. Let's build without it to avoid the compilation error.

Resolves: https://github.com/shadow-maint/shadow/issues/839