### PR TITLE
lib/chkname.c: Update regex for valid names

### DIFF
--- a/lib/chkname.c
+++ b/lib/chkname.c
@@ -32,8 +32,8 @@ static bool is_valid_name (const char *name)
 	}
 
 	/*
-         * User/group names must match gnu e-regex:
-         *    [a-zA-Z0-9_.][a-zA-Z0-9_.-]{0,30}[a-zA-Z0-9_.$-]?
+         * User/group names must match BRE regex:
+         *    [a-zA-Z0-9_.][a-zA-Z0-9_.-]*$\?
          *
          * as a non-POSIX, extension, allow "$" as the last char for
          * sake of Samba 3.x "add machine script"


### PR DESCRIPTION
The maximum length of 32 wasn't being enforced in the code, and POSIX doesn't specify that maximum length either, so it seems it was an arbitrary limit of the past that doesn't exist any more.  Use a regex that has no length limit.

Closes: <https://github.com/shadow-maint/shadow/issues/836>