### PR TITLE
src/logoutd.c: Fix theoretical buffer overrun

### DIFF
--- a/src/logoutd.c
+++ b/src/logoutd.c
@@ -43,17 +43,19 @@ static void send_mesg_to_tty (int tty_fd);
  */
 static int check_login (const struct utmp *ut)
 {
-	char user[sizeof (ut->ut_user) + 1];
-	time_t now;
+	char    user[sizeof(ut->ut_user) + 1];
+	char    line[sizeof(ut->ut_line) + 1];
+	time_t  now;
 
 	ZUSTR2STP(user, ut->ut_user);
+	ZUSTR2STP(line, ut->ut_line);
 
 	(void) time (&now);
 
 	/*
 	 * Check if they are allowed to be logged in right now.
 	 */
-	if (!isttytime (user, ut->ut_line, now)) {
+	if (!isttytime(user, line, now)) {
 		return 0;
 	}
 	return 1;


### PR DESCRIPTION
ut_line doesn't hold a string.  It is a null-padded fixed-width array. Luckily, I don't think there has ever existed a ut_line ("/dev/tty*") that was 32 bytes long.  That would have resulted in a buffer overrun. Anyway, do the right thing, which is copying into a temporary string.