### PR TITLE
Use the shiny new GCC14 `[[gnu::null_terminated_string_arg()]]` to mark functions receiving a string parameter

### DIFF
--- a/lib/defines.h
+++ b/lib/defines.h
@@ -223,6 +223,12 @@
 # define ATTR_MALLOC(deallocator)
 #endif
 
+#if (__GNUC__ >= 14)
+# define ATTR_STRING(...)  [[gnu::null_terminated_string_arg(__VA_ARGS__)]]
+#else
+# define ATTR_STRING(...)
+#endif
+
 #ifdef HAVE_SECURE_GETENV
 #  define shadow_getenv(name) secure_getenv(name)
 # else

--- a/lib/stpecpy.h
+++ b/lib/stpecpy.h
@@ -17,7 +17,10 @@
 #include <stddef.h>
 #include <string.h>
 
+#include "defines.h"
 
+
+ATTR_STRING(3)
 inline char *stpecpy(char *dst, char *end, const char *restrict src);
 
 

--- a/lib/strtcpy.h
+++ b/lib/strtcpy.h
@@ -15,6 +15,7 @@
 #include <string.h>
 #include <sys/types.h>
 
+#include "defines.h"
 #include "sizeof.h"
 
 
@@ -47,6 +48,7 @@
 #define STRTCPY(dst, src)  strtcpy(dst, src, SIZEOF_ARRAY(dst))
 
 
+ATTR_STRING(2)
 inline ssize_t strtcpy(char *restrict dst, const char *restrict src,
     size_t dsize);
 


### PR DESCRIPTION
It only marks input strings, not output ones, so there are few places to use it.  So far, I've only marked the generic functions for copying strings.  We could and should use it for other functions that receive strings too, but that'll be a work for another day.