### PR TITLE
lib/defines.h: Remove condition on __STRICT_ANSI__

### DIFF
--- a/lib/defines.h
+++ b/lib/defines.h
@@ -204,7 +204,7 @@
 #endif
 
 /* To be used for verified unused parameters */
-#if defined(__GNUC__) && !defined(__STRICT_ANSI__)
+#if defined(__GNUC__)
 # define unused    __attribute__((unused))
 # define NORETURN  __attribute__((__noreturn__))
 # define format_attr(type, index, check) __attribute__((format (type, index, check)))


### PR DESCRIPTION
We require C11 since a few releases ago.  It seems I missed this reminder of ANSI C (C89) back then.