### PR TITLE
src: add missing declaration of `getdef_bool`

### DIFF
--- a/src/pwunconv.c
+++ b/src/pwunconv.c
@@ -18,6 +18,7 @@
 #include <unistd.h>
 #include <getopt.h>
 #include "defines.h"
+#include "getdef.h"
 #include "nscd.h"
 #include "sssd.h"
 #include "prototypes.h"

--- a/src/vipw.c
+++ b/src/vipw.c
@@ -29,6 +29,7 @@
 
 #include "alloc.h"
 #include "defines.h"
+#include "getdef.h"
 #include "groupio.h"
 #include "nscd.h"
 #include "sssd.h"


### PR DESCRIPTION
Upcoming `gcc-14` enabled a few warnings into errors, like `-Wimplicit-function-declaration`. This caused `shadow` build to fail as:

    pwunconv.c: In function 'main':
    pwunconv.c:132:13: error: implicit declaration of function 'getdef_bool' [-Wimplicit-function-declaration]
      132 |         if (getdef_bool("USE_TCB")) {
          |             ^~~~~~~~~~~

The change adds missing include headers.