### PR TITLE
-1

### DIFF
--- a/lib/commonio.c
+++ b/lib/commonio.c
@@ -195,7 +195,7 @@ static int do_lock_file (const char *file, const char *lock, bool log)
 		return 0;
 	}
 	buf[len] = '\0';
-	if (get_pid (buf, &pid) == 0) {
+	if (get_pid(buf, &pid) == -1) {
 		if (log) {
 			(void) fprintf (shadow_logfd,
 			                "%s: existing lock file %s with an invalid PID '%s'\n",

--- a/lib/get_gid.c
+++ b/lib/get_gid.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+
 #include <config.h>
 
 #ident "$Id$"
@@ -11,7 +12,9 @@
 #include "prototypes.h"
 #include "defines.h"
 
-int get_gid (const char *gidstr, gid_t *gid)
+
+int
+get_gid(const char *gidstr, gid_t *gid)
 {
 	long long  val;
 	char *endptr;
@@ -22,10 +25,10 @@ int get_gid (const char *gidstr, gid_t *gid)
 	    || ('\0' != *endptr)
 	    || (0 != errno)
 	    || (/*@+longintegral@*/val != (gid_t)val)/*@=longintegral@*/) {
-		return 0;
+		return -1;
 	}
 
 	*gid = val;
-	return 1;
+	return 0;
 }
 

--- a/lib/get_pid.c
+++ b/lib/get_pid.c
@@ -29,11 +29,11 @@ int get_pid (const char *pidstr, pid_t *pid)
 	    || (0 != errno)
 	    || (val < 1)
 	    || (/*@+longintegral@*/val != (pid_t)val)/*@=longintegral@*/) {
-		return 0;
+		return -1;
 	}
 
 	*pid = val;
-	return 1;
+	return 0;
 }
 
 /*
@@ -82,7 +82,7 @@ int open_pidfd(const char *pidstr)
 	char   proc_dir_name[32];
 	pid_t  target;
 
-	if (get_pid(pidstr, &target) == 0)
+	if (get_pid(pidstr, &target) == -1)
 		return -ENOENT;
 
 	/* max string length is 6 + 10 + 1 + 1 = 18, allocate 32 bytes */

--- a/lib/get_uid.c
+++ b/lib/get_uid.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+
 #include <config.h>
 
 #ident "$Id$"
@@ -11,7 +12,9 @@
 #include "prototypes.h"
 #include "defines.h"
 
-int get_uid (const char *uidstr, uid_t *uid)
+
+int
+get_uid(const char *uidstr, uid_t *uid)
 {
 	long long  val;
 	char *endptr;
@@ -22,10 +25,10 @@ int get_uid (const char *uidstr, uid_t *uid)
 	    || ('\0' != *endptr)
 	    || (0 != errno)
 	    || (/*@+longintegral@*/val != (uid_t)val)/*@=longintegral@*/) {
-		return 0;
+		return -1;
 	}
 
 	*uid = val;
-	return 1;
+	return 0;
 }
 

--- a/lib/getdef.c
+++ b/lib/getdef.c
@@ -347,7 +347,7 @@ unsigned long getdef_ulong (const char *item, unsigned long dflt)
 		return dflt;
 	}
 
-	if (getulong (d->value, &val) == 0) {
+	if (getulong(d->value, &val) == -1) {
 		fprintf (shadow_logfd,
 		         _("configuration error - cannot parse %s value: '%s'"),
 		         item, d->value);

--- a/lib/getdef.c
+++ b/lib/getdef.c
@@ -245,7 +245,7 @@ int getdef_num (const char *item, int dflt)
 		return dflt;
 	}
 
-	if (   (getlong (d->value, &val) == 0)
+	if (   (getlong(d->value, &val) == -1)
 	    || (val > INT_MAX)
 	    || (val < -1)) {
 		fprintf (shadow_logfd,
@@ -280,7 +280,7 @@ unsigned int getdef_unum (const char *item, unsigned int dflt)
 		return dflt;
 	}
 
-	if (   (getlong (d->value, &val) == 0)
+	if (   (getlong(d->value, &val) == -1)
 	    || (val < 0)
 	    || (val > INT_MAX)) {
 		fprintf (shadow_logfd,
@@ -315,8 +315,7 @@ long getdef_long (const char *item, long dflt)
 		return dflt;
 	}
 
-	if (   (getlong (d->value, &val) == 0)
-	    || (val < -1)) {
+	if (getlong(d->value, &val) == -1 || val < -1) {
 		fprintf (shadow_logfd,
 		         _("configuration error - cannot parse %s value: '%s'"),
 		         item, d->value);

--- a/lib/getlong.c
+++ b/lib/getlong.c
@@ -4,33 +4,33 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+
 #include <config.h>
 
 #ident "$Id$"
 
 #include <stdlib.h>
 #include <errno.h>
+
 #include "prototypes.h"
+
 
 /*
  * getlong - extract a long integer provided by the numstr string in *result
  *
  * It supports decimal, hexadecimal or octal representations.
- *
- * Returns 0 on failure, 1 on success.
  */
-int getlong (const char *numstr, /*@out@*/long *result)
+int
+getlong(const char *numstr, /*@out@*/long *result)
 {
-	long val;
-	char *endptr;
+	char  *endptr;
+	long  val;
 
 	errno = 0;
 	val = strtol(numstr, &endptr, 0);
-	if (('\0' == *numstr) || ('\0' != *endptr) || (0 != errno)) {
-		return 0;
-	}
+	if (('\0' == *numstr) || ('\0' != *endptr) || (0 != errno))
+		return -1;
 
 	*result = val;
-	return 1;
+	return 0;
 }
-

--- a/lib/getrange.c
+++ b/lib/getrange.c
@@ -59,40 +59,40 @@ int getrange (const char *range,
 			return 0;
 		}
 		switch (*endptr) {
-			case '\0':
-				/* <long> */
+		case '\0':
+			/* <long> */
+			*has_min = true;
+			*has_max = true;
+			*min = n;
+			*max = n;
+			break;
+		case '-':
+			endptr++;
+			if ('\0' == *endptr) {
+				/* <long>- */
 				*has_min = true;
-				*has_max = true;
+				*has_max = false;
 				*min = n;
-				*max = n;
-				break;
-			case '-':
-				endptr++;
-				if ('\0' == *endptr) {
-					/* <long>- */
-					*has_min = true;
-					*has_max = false;
-					*min = n;
-				} else if (!isdigit (*endptr)) {
+			} else if (!isdigit (*endptr)) {
+				/* invalid */
+				return 0;
+			} else {
+				*has_min = true;
+				*min = n;
+				errno = 0;
+				n = strtoul(endptr, &endptr, 10);
+				if (   ('\0' != *endptr)
+				    || (0 != errno)) {
 					/* invalid */
 					return 0;
-				} else {
-					*has_min = true;
-					*min = n;
-					errno = 0;
-					n = strtoul(endptr, &endptr, 10);
-					if (   ('\0' != *endptr)
-					    || (0 != errno)) {
-						/* invalid */
-						return 0;
-					}
-					/* <long>-<long> */
-					*has_max = true;
-					*max = n;
 				}
-				break;
-			default:
-				return 0;
+				/* <long>-<long> */
+				*has_max = true;
+				*max = n;
+			}
+			break;
+		default:
+			return 0;
 		}
 	}
 

--- a/lib/getrange.c
+++ b/lib/getrange.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+
 #include <config.h>
 
 #ident "$Id: $"
@@ -14,6 +15,7 @@
 #include "defines.h"
 #include "prototypes.h"
 
+
 /*
  * Parse a range and indicate if the range is valid.
  * Valid ranges are in the form:
@@ -21,32 +23,27 @@
  *     -<long>         -> max=long            !has_min  has_max
  *     <long>-         -> min=long             has_min !has_max
  *     <long1>-<long2> -> min=long1 max=long2  has_min  has_max
- *
- * If the range is valid, getrange returns 1.
- * If the range is not valid, getrange returns 0.
  */
-int getrange (const char *range,
-              unsigned long *min, bool *has_min,
-              unsigned long *max, bool *has_max)
+int
+getrange(const char *range,
+         unsigned long *min, bool *has_min,
+         unsigned long *max, bool *has_max)
 {
 	char *endptr;
 	unsigned long n;
 
-	if (NULL == range) {
-		return 0;
-	}
+	if (NULL == range)
+		return -1;
 
 	if ('-' == range[0]) {
-		if (!isdigit(range[1])) {
-			/* invalid */
-			return 0;
-		}
+		if (!isdigit(range[1]))
+			return -1;
+
 		errno = 0;
 		n = strtoul(&range[1], &endptr, 10);
-		if (('\0' != *endptr) || (0 != errno)) {
-			/* invalid */
-			return 0;
-		}
+		if (('\0' != *endptr) || (0 != errno))
+			return -1;
+
 		/* -<long> */
 		*has_min = false;
 		*has_max = true;
@@ -54,10 +51,9 @@ int getrange (const char *range,
 	} else {
 		errno = 0;
 		n = strtoul(range, &endptr, 10);
-		if (endptr == range || 0 != errno) {
-			/* invalid */
-			return 0;
-		}
+		if (endptr == range || 0 != errno)
+			return -1;
+
 		switch (*endptr) {
 		case '\0':
 			/* <long> */
@@ -74,28 +70,24 @@ int getrange (const char *range,
 				*has_max = false;
 				*min = n;
 			} else if (!isdigit (*endptr)) {
-				/* invalid */
-				return 0;
+				return -1;
 			} else {
 				*has_min = true;
 				*min = n;
 				errno = 0;
 				n = strtoul(endptr, &endptr, 10);
-				if (   ('\0' != *endptr)
-				    || (0 != errno)) {
-					/* invalid */
-					return 0;
-				}
+				if ('\0' != *endptr || 0 != errno)
+					return -1;
+
 				/* <long>-<long> */
 				*has_max = true;
 				*max = n;
 			}
 			break;
 		default:
-			return 0;
+			return -1;
 		}
 	}
 
-	return 1;
+	return 0;
 }
-

--- a/lib/getulong.c
+++ b/lib/getulong.c
@@ -4,36 +4,33 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+
 #include <config.h>
 
 #ident "$Id: getlong.c 2763 2009-04-23 09:57:03Z nekral-guest $"
 
 #include <stdlib.h>
 #include <errno.h>
+
 #include "prototypes.h"
+
 
 /*
  * getulong - extract an unsigned long integer provided by the numstr string in *result
  *
  * It supports decimal, hexadecimal or octal representations.
- *
- * Returns 0 on failure, 1 on success.
  */
-int getulong (const char *numstr, /*@out@*/unsigned long *result)
+int
+getulong(const char *numstr, /*@out@*/unsigned long *result)
 {
+	char           *endptr;
 	unsigned long  val;
-	char *endptr;
 
 	errno = 0;
 	val = strtoul(numstr, &endptr, 0);
-	if (    ('\0' == *numstr)
-	     || ('\0' != *endptr)
-	     || (0 != errno)
-	   ) {
-		return 0;
-	}
+	if (('\0' == *numstr) || ('\0' != *endptr) || (0 != errno))
+		return -1;
 
 	*result = val;
-	return 1;
+	return 0;
 }
-

--- a/lib/idmapping.c
+++ b/lib/idmapping.c
@@ -58,15 +58,15 @@ struct map_range *get_map_ranges(int ranges, int argc, char **argv)
 	/* Gather up the ranges from the command line */
 	mapping = mappings;
 	for (idx = 0, argidx = 0; idx < ranges; idx++, argidx += 3, mapping++) {
-		if (!getulong(argv[argidx + 0], &mapping->upper)) {
+		if (getulong(argv[argidx + 0], &mapping->upper) == -1) {
 			free(mappings);
 			return NULL;
 		}
-		if (!getulong(argv[argidx + 1], &mapping->lower)) {
+		if (getulong(argv[argidx + 1], &mapping->lower) == -1) {
 			free(mappings);
 			return NULL;
 		}
-		if (!getulong(argv[argidx + 2], &mapping->count)) {
+		if (getulong(argv[argidx + 2], &mapping->count) == -1) {
 			free(mappings);
 			return NULL;
 		}

--- a/lib/limits.c
+++ b/lib/limits.c
@@ -89,7 +89,7 @@ static int set_prio (const char *value)
 {
 	long prio;
 
-	if (   (getlong (value, &prio) == 0)
+	if (   (getlong(value, &prio) == -1)
 	    || (prio != (int) prio)) {
 		return 0;
 	}
@@ -482,7 +482,7 @@ void setup_limits (const struct passwd *info)
 			if (strncmp (cp, "pri=", 4) == 0) {
 				long  inc;
 
-				if (   (getlong (cp + 4, &inc) == 1)
+				if (   (getlong(cp + 4, &inc) == 0)
 				    && (inc >= -20) && (inc <= 20)) {
 					errno = 0;
 					if (   (nice (inc) != -1)
@@ -500,8 +500,7 @@ void setup_limits (const struct passwd *info)
 			}
 			if (strncmp (cp, "ulimit=", 7) == 0) {
 				long  blocks;
-
-				if (   (getlong (cp + 7, &blocks) == 0)
+				if (   (getlong(cp + 7, &blocks) == -1)
 				    || (blocks != (int) blocks)
 				    || (set_filesize_limit (blocks) != 0)) {
 					SYSLOG ((LOG_WARN,

--- a/lib/limits.c
+++ b/lib/limits.c
@@ -104,7 +104,7 @@ static int set_umask (const char *value)
 {
 	unsigned long  mask;
 
-	if (   (getulong (value, &mask) == 0)
+	if (   (getulong(value, &mask) == -1)
 	    || (mask != (mode_t) mask)) {
 		return 0;
 	}
@@ -119,7 +119,7 @@ static int check_logins (const char *name, const char *maxlogins)
 {
 	unsigned long limit, count;
 
-	if (getulong (maxlogins, &limit) == 0) {
+	if (getulong(maxlogins, &limit) == -1) {
 		return 0;
 	}
 
@@ -512,7 +512,7 @@ void setup_limits (const struct passwd *info)
 			if (strncmp (cp, "umask=", 6) == 0) {
 				unsigned long  mask;
 
-				if (   (getulong (cp + 6, &mask) == 0)
+				if (   (getulong(cp + 6, &mask) == -1)
 				    || (mask != (mode_t) mask)) {
 					SYSLOG ((LOG_WARN,
 					         "Can't set umask value for user %s",

--- a/lib/rlogin.c
+++ b/lib/rlogin.c
@@ -78,7 +78,7 @@ do_rlogin (const char *remote_host, char *name, size_t namelen, char *term,
 		*cp = '\0';
 		cp++;
 
-		if (getulong (cp, &remote_speed) == 0) {
+		if (getulong(cp, &remote_speed) == -1) {
 			remote_speed = 9600;
 		}
 	}

--- a/lib/sgetgrent.c
+++ b/lib/sgetgrent.c
@@ -105,7 +105,7 @@ struct group *sgetgrent (const char *buf)
 	}
 	grent.gr_name = grpfields[0];
 	grent.gr_passwd = grpfields[1];
-	if (get_gid (grpfields[2], &grent.gr_gid) == 0) {
+	if (get_gid(grpfields[2], &grent.gr_gid) == -1) {
 		return NULL;
 	}
 	grent.gr_mem = list (grpfields[3]);

--- a/lib/sgetpwent.c
+++ b/lib/sgetpwent.c
@@ -94,7 +94,7 @@ struct passwd *sgetpwent (const char *buf)
 
 	pwent.pw_name = fields[0];
 	pwent.pw_passwd = fields[1];
-	if (get_uid (fields[2], &pwent.pw_uid) == 0) {
+	if (get_uid(fields[2], &pwent.pw_uid) == -1) {
 		return NULL;
 	}
 	if (get_gid(fields[3], &pwent.pw_gid) == -1) {

--- a/lib/sgetpwent.c
+++ b/lib/sgetpwent.c
@@ -97,7 +97,7 @@ struct passwd *sgetpwent (const char *buf)
 	if (get_uid (fields[2], &pwent.pw_uid) == 0) {
 		return NULL;
 	}
-	if (get_gid (fields[3], &pwent.pw_gid) == 0) {
+	if (get_gid(fields[3], &pwent.pw_gid) == -1) {
 		return NULL;
 	}
 	pwent.pw_gecos = fields[4];

--- a/lib/sgetspent.c
+++ b/lib/sgetspent.c
@@ -92,7 +92,7 @@ struct spwd *sgetspent (const char *string)
 
 	if (fields[2][0] == '\0') {
 		spwd.sp_lstchg = -1;
-	} else if (   (getlong (fields[2], &spwd.sp_lstchg) == 0)
+	} else if (   (getlong(fields[2], &spwd.sp_lstchg) == -1)
 	           || (spwd.sp_lstchg < 0)) {
 		return 0;
 	}
@@ -103,7 +103,7 @@ struct spwd *sgetspent (const char *string)
 
 	if (fields[3][0] == '\0') {
 		spwd.sp_min = -1;
-	} else if (   (getlong (fields[3], &spwd.sp_min) == 0)
+	} else if (   (getlong(fields[3], &spwd.sp_min) == -1)
 	           || (spwd.sp_min < 0)) {
 		return 0;
 	}
@@ -114,7 +114,7 @@ struct spwd *sgetspent (const char *string)
 
 	if (fields[4][0] == '\0') {
 		spwd.sp_max = -1;
-	} else if (   (getlong (fields[4], &spwd.sp_max) == 0)
+	} else if (   (getlong(fields[4], &spwd.sp_max) == -1)
 	           || (spwd.sp_max < 0)) {
 		return 0;
 	}
@@ -139,7 +139,7 @@ struct spwd *sgetspent (const char *string)
 
 	if (fields[5][0] == '\0') {
 		spwd.sp_warn = -1;
-	} else if (   (getlong (fields[5], &spwd.sp_warn) == 0)
+	} else if (   (getlong(fields[5], &spwd.sp_warn) == -1)
 	           || (spwd.sp_warn < 0)) {
 		return 0;
 	}
@@ -151,7 +151,7 @@ struct spwd *sgetspent (const char *string)
 
 	if (fields[6][0] == '\0') {
 		spwd.sp_inact = -1;
-	} else if (   (getlong (fields[6], &spwd.sp_inact) == 0)
+	} else if (   (getlong(fields[6], &spwd.sp_inact) == -1)
 	           || (spwd.sp_inact < 0)) {
 		return 0;
 	}
@@ -163,7 +163,7 @@ struct spwd *sgetspent (const char *string)
 
 	if (fields[7][0] == '\0') {
 		spwd.sp_expire = -1;
-	} else if (   (getlong (fields[7], &spwd.sp_expire) == 0)
+	} else if (   (getlong(fields[7], &spwd.sp_expire) == -1)
 	           || (spwd.sp_expire < 0)) {
 		return 0;
 	}

--- a/lib/sgetspent.c
+++ b/lib/sgetspent.c
@@ -175,7 +175,7 @@ struct spwd *sgetspent (const char *string)
 
 	if (fields[8][0] == '\0') {
 		spwd.sp_flag = SHADOW_SP_FLAG_UNSET;
-	} else if (getulong (fields[8], &spwd.sp_flag) == 0) {
+	} else if (getulong(fields[8], &spwd.sp_flag) == -1) {
 		return 0;
 	}
 

--- a/lib/shadow.c
+++ b/lib/shadow.c
@@ -166,7 +166,7 @@ static struct spwd *my_sgetspent (const char *string)
 	if (fields[2][0] == '\0') {
 		spwd.sp_lstchg = -1;
 	} else {
-		if (getlong (fields[2], &spwd.sp_lstchg) == 0) {
+		if (getlong(fields[2], &spwd.sp_lstchg) == -1) {
 #ifdef	USE_NIS
 			if (nis_used) {
 				spwd.sp_lstchg = -1;
@@ -185,7 +185,7 @@ static struct spwd *my_sgetspent (const char *string)
 	if (fields[3][0] == '\0') {
 		spwd.sp_min = -1;
 	} else {
-		if (getlong (fields[3], &spwd.sp_min) == 0) {
+		if (getlong(fields[3], &spwd.sp_min) == -1) {
 #ifdef	USE_NIS
 			if (nis_used) {
 				spwd.sp_min = -1;
@@ -206,7 +206,7 @@ static struct spwd *my_sgetspent (const char *string)
 	if (fields[4][0] == '\0') {
 		spwd.sp_max = -1;
 	} else {
-		if (getlong (fields[4], &spwd.sp_max) == 0) {
+		if (getlong(fields[4], &spwd.sp_max) == -1) {
 #ifdef	USE_NIS
 			if (nis_used) {
 				spwd.sp_max = -1;
@@ -239,7 +239,7 @@ static struct spwd *my_sgetspent (const char *string)
 	if (fields[5][0] == '\0') {
 		spwd.sp_warn = -1;
 	} else {
-		if (getlong (fields[5], &spwd.sp_warn) == 0) {
+		if (getlong(fields[5], &spwd.sp_warn) == -1) {
 #ifdef	USE_NIS
 			if (nis_used) {
 				spwd.sp_warn = -1;
@@ -261,7 +261,7 @@ static struct spwd *my_sgetspent (const char *string)
 	if (fields[6][0] == '\0') {
 		spwd.sp_inact = -1;
 	} else {
-		if (getlong (fields[6], &spwd.sp_inact) == 0) {
+		if (getlong(fields[6], &spwd.sp_inact) == -1) {
 #ifdef	USE_NIS
 			if (nis_used) {
 				spwd.sp_inact = -1;
@@ -283,7 +283,7 @@ static struct spwd *my_sgetspent (const char *string)
 	if (fields[7][0] == '\0') {
 		spwd.sp_expire = -1;
 	} else {
-		if (getlong (fields[7], &spwd.sp_expire) == 0) {
+		if (getlong(fields[7], &spwd.sp_expire) == -1) {
 #ifdef	USE_NIS
 			if (nis_used) {
 				spwd.sp_expire = -1;

--- a/lib/shadow.c
+++ b/lib/shadow.c
@@ -305,7 +305,7 @@ static struct spwd *my_sgetspent (const char *string)
 	if (fields[8][0] == '\0') {
 		spwd.sp_flag = SHADOW_SP_FLAG_UNSET;
 	} else {
-		if (getulong (fields[8], &spwd.sp_flag) == 0) {
+		if (getulong(fields[8], &spwd.sp_flag) == -1) {
 #ifdef	USE_NIS
 			if (nis_used) {
 				spwd.sp_flag = SHADOW_SP_FLAG_UNSET;

--- a/lib/strtoday.c
+++ b/lib/strtoday.c
@@ -62,7 +62,7 @@ long strtoday (const char *str)
 	}
 	if (isnum) {
 		long retdate;
-		if (getlong (str, &retdate) == 0) {
+		if (getlong(str, &retdate) == -1) {
 			return -2;
 		}
 		return retdate;

--- a/lib/subordinateio.c
+++ b/lib/subordinateio.c
@@ -115,9 +115,9 @@ static void *subordinate_parse (const char *line)
 	if (i != SUBID_NFIELDS || *fields[0] == '\0' || *fields[1] == '\0' || *fields[2] == '\0')
 		return NULL;
 	range.owner = fields[0];
-	if (getulong (fields[1], &range.start) == 0)
+	if (getulong(fields[1], &range.start) == -1)
 		return NULL;
-	if (getulong (fields[2], &range.count) == 0)
+	if (getulong(fields[2], &range.count) == -1)
 		return NULL;
 
 	return &range;

--- a/lib/user_busy.c
+++ b/lib/user_busy.c
@@ -202,7 +202,7 @@ static int user_busy_processes (const char *name, uid_t uid)
 		}
 
 		/* Check if this is a valid PID */
-		if (get_pid (tmp_d_name, &pid) == 0) {
+		if (get_pid(tmp_d_name, &pid) == -1) {
 			continue;
 		}
 
@@ -232,7 +232,7 @@ static int user_busy_processes (const char *name, uid_t uid)
 		if (task_dir != NULL) {
 			while ((ent = readdir (task_dir)) != NULL) {
 				pid_t tid;
-				if (get_pid (ent->d_name, &tid) == 0) {
+				if (get_pid(ent->d_name, &tid) == -1) {
 					continue;
 				}
 				if (tid == pid) {

--- a/src/chage.c
+++ b/src/chage.c
@@ -167,14 +167,14 @@ static int new_fields (void)
 
 	SNPRINTF(buf, "%ld", mindays);
 	change_field (buf, sizeof buf, _("Minimum Password Age"));
-	if (   (getlong (buf, &mindays) == 0)
+	if (   (getlong(buf, &mindays) == -1)
 	    || (mindays < -1)) {
 		return 0;
 	}
 
 	SNPRINTF(buf, "%ld", maxdays);
 	change_field (buf, sizeof buf, _("Maximum Password Age"));
-	if (   (getlong (buf, &maxdays) == 0)
+	if (   (getlong(buf, &maxdays) == -1)
 	    || (maxdays < -1)) {
 		return 0;
 	}
@@ -198,14 +198,14 @@ static int new_fields (void)
 
 	SNPRINTF(buf, "%ld", warndays);
 	change_field (buf, sizeof buf, _("Password Expiration Warning"));
-	if (   (getlong (buf, &warndays) == 0)
+	if (   (getlong(buf, &warndays) == -1)
 	    || (warndays < -1)) {
 		return 0;
 	}
 
 	SNPRINTF(buf, "%ld", inactdays);
 	change_field (buf, sizeof buf, _("Password Inactive"));
-	if (   (getlong (buf, &inactdays) == 0)
+	if (   (getlong(buf, &inactdays) == -1)
 	    || (inactdays < -1)) {
 		return 0;
 	}
@@ -393,7 +393,7 @@ static void process_flags (int argc, char **argv)
 			break;
 		case 'I':
 			Iflg = true;
-			if (   (getlong (optarg, &inactdays) == 0)
+			if (   (getlong(optarg, &inactdays) == -1)
 			    || (inactdays < -1)) {
 				fprintf (stderr,
 				         _("%s: invalid numeric argument '%s'\n"),
@@ -406,7 +406,7 @@ static void process_flags (int argc, char **argv)
 			break;
 		case 'm':
 			mflg = true;
-			if (   (getlong (optarg, &mindays) == 0)
+			if (   (getlong(optarg, &mindays) == -1)
 			    || (mindays < -1)) {
 				fprintf (stderr,
 				         _("%s: invalid numeric argument '%s'\n"),
@@ -416,7 +416,7 @@ static void process_flags (int argc, char **argv)
 			break;
 		case 'M':
 			Mflg = true;
-			if (   (getlong (optarg, &maxdays) == 0)
+			if (   (getlong(optarg, &maxdays) == -1)
 			    || (maxdays < -1)) {
 				fprintf (stderr,
 				         _("%s: invalid numeric argument '%s'\n"),
@@ -430,7 +430,7 @@ static void process_flags (int argc, char **argv)
 			break;
 		case 'W':
 			Wflg = true;
-			if (   (getlong (optarg, &warndays) == 0)
+			if (   (getlong(optarg, &warndays) == -1)
 			    || (warndays < -1)) {
 				fprintf (stderr,
 				         _("%s: invalid numeric argument '%s'\n"),

--- a/src/chgpasswd.c
+++ b/src/chgpasswd.c
@@ -195,19 +195,19 @@ static void process_flags (int argc, char **argv)
 			}
 #if defined(USE_SHA_CRYPT)
 			if (  (   ((0 == strcmp (crypt_method, "SHA256")) || (0 == strcmp (crypt_method, "SHA512")))
-			       && (0 == getlong(optarg, &sha_rounds)))) {
+			       && (-1 == getlong(optarg, &sha_rounds)))) {
                             bad_s = 1;
                         }
 #endif				/* USE_SHA_CRYPT */
 #if defined(USE_BCRYPT)
                         if ((   (0 == strcmp (crypt_method, "BCRYPT"))
-			       && (0 == getlong(optarg, &bcrypt_rounds)))) {
+			       && (-1 == getlong(optarg, &bcrypt_rounds)))) {
                             bad_s = 1;
                         }
 #endif				/* USE_BCRYPT */
 #if defined(USE_YESCRYPT)
                         if ((   (0 == strcmp (crypt_method, "YESCRYPT"))
-			       && (0 == getlong(optarg, &yescrypt_cost)))) {
+			       && (-1 == getlong(optarg, &yescrypt_cost)))) {
                             bad_s = 1;
                         }
 #endif				/* USE_YESCRYPT */

--- a/src/chpasswd.c
+++ b/src/chpasswd.c
@@ -190,19 +190,19 @@ static void process_flags (int argc, char **argv)
                         bad_s = 0;
 #if defined(USE_SHA_CRYPT)
 			if ((IS_CRYPT_METHOD("SHA256") || IS_CRYPT_METHOD("SHA512"))
-			    && (0 == getlong(optarg, &sha_rounds))) {
+			    && (-1 == getlong(optarg, &sha_rounds))) {
                             bad_s = 1;
                         }
 #endif				/* USE_SHA_CRYPT */
 #if defined(USE_BCRYPT)
                         if (IS_CRYPT_METHOD("BCRYPT")
-			    && (0 == getlong(optarg, &bcrypt_rounds))) {
+			    && (-1 == getlong(optarg, &bcrypt_rounds))) {
                             bad_s = 1;
                         }
 #endif				/* USE_BCRYPT */
 #if defined(USE_YESCRYPT)
                         if (IS_CRYPT_METHOD("YESCRYPT")
-			    && (0 == getlong(optarg, &yescrypt_cost))) {
+			    && (-1 == getlong(optarg, &yescrypt_cost))) {
                             bad_s = 1;
                         }
 #endif				/* USE_YESCRYPT */

--- a/src/faillog.c
+++ b/src/faillog.c
@@ -547,7 +547,7 @@ int main (int argc, char **argv)
 				usage (E_SUCCESS);
 				/*@notreached@*/break;
 			case 'l':
-				if (getlong (optarg, &fail_locktime) == 0) {
+				if (getlong(optarg, &fail_locktime) == -1) {
 					fprintf (stderr,
 					         _("%s: invalid numeric argument '%s'\n"),
 					         Prog, optarg);
@@ -559,7 +559,7 @@ int main (int argc, char **argv)
 			{
 				long  lmax;
 
-				if (   (getlong (optarg, &lmax) == 0)
+				if (   (getlong(optarg, &lmax) == -1)
 				    || ((long)(short) lmax != lmax)) {
 					fprintf (stderr,
 					         _("%s: invalid numeric argument '%s'\n"),
@@ -576,7 +576,7 @@ int main (int argc, char **argv)
 			case 'R': /* no-op, handled in process_root_flag () */
 				break;
 			case 't':
-				if (getlong (optarg, &days) == 0) {
+				if (getlong(optarg, &days) == -1) {
 					fprintf (stderr,
 					         _("%s: invalid numeric argument '%s'\n"),
 					         Prog, optarg);

--- a/src/faillog.c
+++ b/src/faillog.c
@@ -605,9 +605,9 @@ int main (int argc, char **argv)
 					umax = umin;
 					has_umax = true;
 				} else {
-					if (getrange (optarg,
-					              &umin, &has_umin,
-					              &umax, &has_umax) == 0) {
+					if (getrange(optarg,
+					             &umin, &has_umin,
+					             &umax, &has_umax) == -1) {
 						fprintf (stderr,
 						         _("%s: Unknown user or range: %s\n"),
 						         Prog, optarg);

--- a/src/groupadd.c
+++ b/src/groupadd.c
@@ -403,7 +403,7 @@ static void process_flags (int argc, char **argv)
 			break;
 		case 'g':
 			gflg = true;
-			if (   (get_gid (optarg, &group_id) == 0)
+			if (   (get_gid(optarg, &group_id) == -1)
 			    || (group_id == (gid_t)-1)) {
 				fprintf (stderr,
 				         _("%s: invalid group ID '%s'\n"),

--- a/src/groupmod.c
+++ b/src/groupmod.c
@@ -414,7 +414,7 @@ static void process_flags (int argc, char **argv)
 			break;
 		case 'g':
 			gflg = true;
-			if (   (get_gid (optarg, &group_newid) == 0)
+			if (   (get_gid(optarg, &group_newid) == -1)
 			    || (group_newid == (gid_t)-1)) {
 				fprintf (stderr,
 				         _("%s: invalid group ID '%s'\n"),

--- a/src/lastlog.c
+++ b/src/lastlog.c
@@ -324,7 +324,7 @@ int main (int argc, char **argv)
 			case 'b':
 			{
 				unsigned long inverse_days;
-				if (getulong (optarg, &inverse_days) == 0) {
+				if (getulong(optarg, &inverse_days) == -1) {
 					fprintf (stderr,
 					         _("%s: invalid numeric argument '%s'\n"),
 					         Prog, optarg);
@@ -352,7 +352,7 @@ int main (int argc, char **argv)
 			case 't':
 			{
 				unsigned long days;
-				if (getulong (optarg, &days) == 0) {
+				if (getulong(optarg, &days) == -1) {
 					fprintf (stderr,
 					         _("%s: invalid numeric argument '%s'\n"),
 					         Prog, optarg);

--- a/src/lastlog.c
+++ b/src/lastlog.c
@@ -381,9 +381,9 @@ int main (int argc, char **argv)
 					umax = umin;
 					has_umax = true;
 				} else {
-					if (getrange (optarg,
-					              &umin, &has_umin,
-					              &umax, &has_umax) == 0) {
+					if (getrange(optarg,
+					             &umin, &has_umin,
+					             &umax, &has_umax) == -1) {
 						fprintf (stderr,
 						         _("%s: Unknown user or range: %s\n"),
 						         Prog, optarg);

--- a/src/newusers.c
+++ b/src/newusers.c
@@ -239,7 +239,7 @@ static int add_group (const char *name, const char *gid, gid_t *ngid, uid_t uid)
 		 * new group, or an existing group.
 		 */
 
-		if (get_gid (gid, &grent.gr_gid) == 0) {
+		if (get_gid(gid, &grent.gr_gid) == -1) {
 			fprintf (stderr,
 			         _("%s: invalid group ID '%s'\n"),
 			         Prog, gid);

--- a/src/newusers.c
+++ b/src/newusers.c
@@ -343,7 +343,7 @@ static int get_user_id (const char *uid, uid_t *nuid) {
 	 * caller provided, or the next available UID.
 	 */
 	if (isdigit (uid[0])) {
-		if ((get_uid (uid, nuid) == 0) || (*nuid == (uid_t)-1)) {
+		if ((get_uid(uid, nuid) == -1) || (*nuid == (uid_t)-1)) {
 			fprintf (stderr,
 			         _("%s: invalid user ID '%s'\n"),
 			         Prog, uid);

--- a/src/newusers.c
+++ b/src/newusers.c
@@ -673,19 +673,19 @@ static void process_flags (int argc, char **argv)
 			}
 #if defined(USE_SHA_CRYPT)
 			if (  (   ((0 == strcmp (crypt_method, "SHA256")) || (0 == strcmp (crypt_method, "SHA512")))
-			       && (0 == getlong(optarg, &sha_rounds)))) {
+			       && (-1 == getlong(optarg, &sha_rounds)))) {
                             bad_s = 1;
                         }
 #endif				/* USE_SHA_CRYPT */
 #if defined(USE_BCRYPT)
                         if ((   (0 == strcmp (crypt_method, "BCRYPT"))
-			       && (0 == getlong(optarg, &bcrypt_rounds)))) {
+			       && (-1 == getlong(optarg, &bcrypt_rounds)))) {
                             bad_s = 1;
                         }
 #endif				/* USE_BCRYPT */
 #if defined(USE_YESCRYPT)
                         if ((   (0 == strcmp (crypt_method, "YESCRYPT"))
-			       && (0 == getlong(optarg, &yescrypt_cost)))) {
+			       && (-1 == getlong(optarg, &yescrypt_cost)))) {
                             bad_s = 1;
                         }
 #endif				/* USE_YESCRYPT */

--- a/src/passwd.c
+++ b/src/passwd.c
@@ -776,7 +776,7 @@ int main (int argc, char **argv)
 				usage (E_SUCCESS);
 				/*@notreached@*/break;
 			case 'i':
-				if (   (getlong (optarg, &inact) == 0)
+				if (   (getlong(optarg, &inact) == -1)
 				    || (inact < -1)) {
 					fprintf (stderr,
 					         _("%s: invalid numeric argument '%s'\n"),
@@ -795,7 +795,7 @@ int main (int argc, char **argv)
 				anyflag = true;
 				break;
 			case 'n':
-				if (   (getlong (optarg, &age_min) == 0)
+				if (   (getlong(optarg, &age_min) == -1)
 				    || (age_min < -1)) {
 					fprintf (stderr,
 					         _("%s: invalid numeric argument '%s'\n"),
@@ -830,7 +830,7 @@ int main (int argc, char **argv)
 				anyflag = true;
 				break;
 			case 'w':
-				if (   (getlong (optarg, &warn) == 0)
+				if (   (getlong(optarg, &warn) == -1)
 				    || (warn < -1)) {
 					(void) fprintf (stderr,
 					                _("%s: invalid numeric argument '%s'\n"),
@@ -841,7 +841,7 @@ int main (int argc, char **argv)
 				anyflag = true;
 				break;
 			case 'x':
-				if (   (getlong (optarg, &age_max) == 0)
+				if (   (getlong(optarg, &age_max) == -1)
 				    || (age_max < -1)) {
 					(void) fprintf (stderr,
 					                _("%s: invalid numeric argument '%s'\n"),

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -1457,7 +1457,7 @@ static void process_flags (int argc, char **argv)
 				sflg = true;
 				break;
 			case 'u':
-				if (   (get_uid (optarg, &user_id) == 0)
+				if (   (get_uid(optarg, &user_id) == -1)
 				    || (user_id == (gid_t)-1)) {
 					fprintf (stderr,
 					         _("%s: invalid user ID '%s'\n"),

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -413,7 +413,7 @@ static void get_defaults (void)
 		 * Default Password Inactive value
 		 */
 		else if (MATCH (buf, DINACT)) {
-			if (   (getlong (cp, &def_inactive) == 0)
+			if (   (getlong(cp, &def_inactive) == -1)
 			    || (def_inactive < -1)) {
 				fprintf (stderr,
 				         _("%s: invalid numeric argument '%s'\n"),
@@ -1325,7 +1325,7 @@ static void process_flags (int argc, char **argv)
 				eflg = true;
 				break;
 			case 'f':
-				if (   (getlong (optarg, &def_inactive) == 0)
+				if (   (getlong(optarg, &def_inactive) == -1)
 				    || (def_inactive < -1)) {
 					fprintf (stderr,
 					         _("%s: invalid numeric argument '%s'\n"),

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -1068,7 +1068,7 @@ static void process_flags (int argc, char **argv)
 				eflg = true;
 				break;
 			case 'f':
-				if (   (getlong (optarg, &user_newinactive) == 0)
+				if (   (getlong(optarg, &user_newinactive) == -1)
 				    || (user_newinactive < -1)) {
 					fprintf (stderr,
 					         _("%s: invalid numeric argument '%s'\n"),

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -1152,7 +1152,7 @@ static void process_flags (int argc, char **argv)
 				sflg = true;
 				break;
 			case 'u':
-				if (   (get_uid (optarg, &user_newid) ==0)
+				if (   (get_uid(optarg, &user_newid) == -1)
 				    || (user_newid == (uid_t)-1)) {
 					fprintf (stderr,
 					         _("%s: invalid user ID '%s'\n"),


### PR DESCRIPTION
Convert some atoi-related functions to use the standard error code, instead of the kind-of-boolean-but-not-really-while-returning-an-int weirdo.

Queued after <https://github.com/shadow-maint/shadow/pull/856>.