### PR TITLE
lib/string/sprintf.h: Add SNPRINTF() macro

### DIFF
--- a/lib/commonio.c
+++ b/lib/commonio.c
@@ -32,6 +32,7 @@
 #include "prototypes.h"
 #include "commonio.h"
 #include "shadowlog_internal.h"
+#include "string/sprintf.h"
 
 
 /* local function prototypes */
@@ -123,11 +124,11 @@ static int check_link_count (const char *file, bool log)
 
 static int do_lock_file (const char *file, const char *lock, bool log)
 {
-	int fd;
-	pid_t pid;
-	ssize_t len;
-	int retval;
-	char buf[32];
+	int      fd;
+	int      retval;
+	char     buf[32];
+	pid_t    pid;
+	ssize_t  len;
 
 	fd = open (file, O_CREAT | O_TRUNC | O_WRONLY, 0600);
 	if (-1 == fd) {
@@ -140,7 +141,7 @@ static int do_lock_file (const char *file, const char *lock, bool log)
 	}
 
 	pid = getpid ();
-	snprintf (buf, sizeof buf, "%lu", (unsigned long) pid);
+	SNPRINTF(buf, "%lu", (unsigned long) pid);
 	len = (ssize_t) strlen (buf) + 1;
 	if (write_full(fd, buf, len) == -1) {
 		if (log) {
@@ -341,7 +342,7 @@ static void free_linked_list (struct commonio_db *db)
 
 int commonio_setname (struct commonio_db *db, const char *name)
 {
-	snprintf (db->filename, sizeof (db->filename), "%s", name);
+	SNPRINTF(db->filename, "%s", name);
 	db->setname = true;
 	return 1;
 }
@@ -467,7 +468,7 @@ static void dec_lock_count (void)
 
 int commonio_unlock (struct commonio_db *db)
 {
-	char lock[1029];
+	char  lock[1029];
 
 	if (db->isopen) {
 		db->readonly = true;
@@ -484,7 +485,7 @@ int commonio_unlock (struct commonio_db *db)
 		 * then call ulckpwdf() (if used) on last unlock.
 		 */
 		db->locked = false;
-		snprintf (lock, sizeof lock, "%s.lock", db->filename);
+		SNPRINTF(lock, "%s.lock", db->filename);
 		unlink (lock);
 		dec_lock_count ();
 		return 1;
@@ -893,7 +894,7 @@ static int write_all (const struct commonio_db *db)
 
 int commonio_close (struct commonio_db *db)
 {
-	int          errors = 0, r;
+	int          errors = 0;
 	char         buf[1024];
 	struct stat  sb;
 
@@ -926,8 +927,7 @@ int commonio_close (struct commonio_db *db)
 		/*
 		 * Create backup file.
 		 */
-		r = snprintf (buf, sizeof buf, "%s-", db->filename);
-		if (r < 0 || (size_t)r >= sizeof buf) {
+		if (SNPRINTF(buf, "%s-", db->filename) == -1) {
 			(void) fclose (db->fp);
 			db->fp = NULL;
 			goto fail;
@@ -964,8 +964,7 @@ int commonio_close (struct commonio_db *db)
 		sb.st_gid = db->st_gid;
 	}
 
-	r = snprintf (buf, sizeof buf, "%s+", db->filename);
-	if (r < 0 || (size_t)r >= sizeof buf)
+	if (SNPRINTF(buf, "%s+", db->filename) == -1)
 		goto fail;
 
 #ifdef WITH_SELINUX

--- a/lib/env.c
+++ b/lib/env.c
@@ -166,9 +166,9 @@ void addenv (const char *string, /*@null@*/const char *value)
  */
 void set_env (int argc, char *const *argv)
 {
-	int noname = 1;
-	char variable[1024];
-	char *cp;
+	int   noname = 1;
+	char  variable[1024];
+	char  *cp;
 
 	for (; argc > 0; argc--, argv++) {
 		if (strlen (*argv) >= sizeof variable) {
@@ -177,9 +177,7 @@ void set_env (int argc, char *const *argv)
 
 		cp = strchr (*argv, '=');
 		if (NULL == cp) {
-			int wlen;
-			wlen = snprintf (variable, sizeof variable, "L%d", noname);
-			assert (wlen < (int) sizeof(variable));
+			assert(SNPRINTF(variable, "L%d", noname) != -1);
 			noname++;
 			addenv (variable, *argv);
 		} else {

--- a/lib/get_pid.c
+++ b/lib/get_pid.c
@@ -14,6 +14,9 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 
+#include "string/sprintf.h"
+
+
 int get_pid (const char *pidstr, pid_t *pid)
 {
 	long long  val;
@@ -76,7 +79,6 @@ int get_pidfd_from_fd(const char *pidfdstr)
 int open_pidfd(const char *pidstr)
 {
 	int    proc_dir_fd;
-	int    written;
 	char   proc_dir_name[32];
 	pid_t  target;
 
@@ -84,9 +86,7 @@ int open_pidfd(const char *pidstr)
 		return -ENOENT;
 
 	/* max string length is 6 + 10 + 1 + 1 = 18, allocate 32 bytes */
-	written = snprintf(proc_dir_name, sizeof(proc_dir_name), "/proc/%u/",
-		target);
-	if ((written <= 0) || ((size_t)written >= sizeof(proc_dir_name))) {
+	if (SNPRINTF(proc_dir_name, "/proc/%u/", target) == -1) {
 		fprintf(stderr, "snprintf of proc path failed for %u: %s\n",
 			target, strerror(errno));
 		return -EINVAL;

--- a/lib/hushed.c
+++ b/lib/hushed.c
@@ -18,6 +18,9 @@
 #include "defines.h"
 #include "prototypes.h"
 #include "getdef.h"
+#include "string/sprintf.h"
+
+
 /*
  * hushed - determine if a user receives login messages
  *
@@ -26,11 +29,11 @@
  */
 bool hushed (const char *username)
 {
-	struct passwd *pw;
-	const char *hushfile;
-	char buf[BUFSIZ];
-	bool found;
-	FILE *fp;
+	bool           found;
+	char           buf[BUFSIZ];
+	FILE           *fp;
+	const char     *hushfile;
+	struct passwd  *pw;
 
 	/*
 	 * Get the name of the file to use.  If this option is not
@@ -53,7 +56,7 @@ bool hushed (const char *username)
 	 */
 
 	if (hushfile[0] != '/') {
-		(void) snprintf (buf, sizeof (buf), "%s/%s", pw->pw_dir, hushfile);
+		SNPRINTF(buf, "%s/%s", pw->pw_dir, hushfile);
 		return (access (buf, F_OK) == 0);
 	}
 

--- a/lib/nss.c
+++ b/lib/nss.c
@@ -14,6 +14,8 @@
 #include "../libsubid/subid.h"
 #include "shadowlog_internal.h"
 #include "shadowlog.h"
+#include "string/sprintf.h"
+
 
 #define NSSWITCH "/etc/nsswitch.conf"
 
@@ -45,7 +47,7 @@ static void nss_exit(void) {
 // nsswitch_path is an argument only to support testing.
 void nss_init(const char *nsswitch_path) {
 	char    *line = NULL, *p, *token, *saveptr;
-	char    libname[65];
+	char    libname[64];
 	FILE    *nssfp = NULL;
 	FILE    *shadow_logfd = log_get_logfd();
 	void    *h;
@@ -103,7 +105,7 @@ void nss_init(const char *nsswitch_path) {
 		fprintf(shadow_logfd, "Using files\n");
 		goto null_subid;
 	}
-	snprintf(libname, 64,  "libsubid_%s.so", token);
+	SNPRINTF(libname, "libsubid_%s.so", token);
 	h = dlopen(libname, RTLD_LAZY);
 	if (!h) {
 		fprintf(shadow_logfd, "Error opening %s: %s\n", libname, dlerror());

--- a/lib/pwauth.c
+++ b/lib/pwauth.c
@@ -25,6 +25,7 @@
 #include "prototypes.h"
 #include "pwauth.h"
 #include "getdef.h"
+#include "string/sprintf.h"
 
 #ifdef SKEY
 #include <skey.h>
@@ -51,16 +52,16 @@ int pw_auth (const char *cipher,
              int reason,
              /*@null@*/const char *input)
 {
-	char prompt[1024];
-	char *clear = NULL;
-	const char *cp;
-	const char *encrypted;
-	int retval;
+	int          retval;
+	char         prompt[1024];
+	char         *clear = NULL;
+	const char   *cp;
+	const char   *encrypted;
 
 #ifdef	SKEY
-	bool use_skey = false;
-	char challenge_info[40];
-	struct skey skey;
+	bool         use_skey = false;
+	char         challenge_info[40];
+	struct skey  skey;
 #endif
 
 	/*
@@ -141,7 +142,7 @@ int pw_auth (const char *cipher,
 		}
 #endif
 
-		snprintf (prompt, sizeof prompt, cp, user);
+		SNPRINTF(prompt, cp, user);
 		clear = agetpass(prompt);
 		input = (clear == NULL) ? "" : clear;
 	}

--- a/lib/shell.c
+++ b/lib/shell.c
@@ -15,6 +15,9 @@
 #include <errno.h>
 #include "prototypes.h"
 #include "defines.h"
+#include "string/sprintf.h"
+
+
 extern char **newenvp;
 extern size_t newenvc;
 
@@ -45,7 +48,7 @@ int shell (const char *file, /*@null@*/const char *arg, char *const envp[])
 	 * don't want to tell us what it is themselves.
 	 */
 	if (arg == NULL) {
-		snprintf(arg0, sizeof(arg0), "-%s", Basename(file));
+		SNPRINTF(arg0, "-%s", Basename(file));
 		arg = arg0;
 	}
 
@@ -71,7 +74,7 @@ int shell (const char *file, /*@null@*/const char *arg, char *const envp[])
 	 * how to execute this stupid shell, so I might as well give
 	 * up in disgust ...
 	 */
-	(void) snprintf (arg0, sizeof arg0, _("Cannot execute %s"), file);
+	SNPRINTF(arg0, _("Cannot execute %s"), file);
 	errno = err;
 	perror (arg0);
 	return err;

--- a/lib/string/sprintf.c
+++ b/lib/string/sprintf.c
@@ -17,3 +17,8 @@
 extern inline int xasprintf(char **restrict s, const char *restrict fmt, ...);
 extern inline int xvasprintf(char **restrict s, const char *restrict fmt,
     va_list ap);
+
+extern inline int snprintf_(char *restrict s, size_t size,
+    const char *restrict fmt, ...);
+extern inline int vsnprintf_(char *restrict s, size_t size,
+    const char *restrict fmt, va_list ap);

--- a/lib/string/sprintf.h
+++ b/lib/string/sprintf.h
@@ -16,6 +16,18 @@
 
 #include "attr.h"
 #include "defines.h"
+#include "sizeof.h"
+
+
+#define SNPRINTF(s, fmt, ...)                                                 \
+({                                                                            \
+	size_t  sz_, len_;                                                    \
+                                                                              \
+	sz_ = NITEMS(s);                                                      \
+	len_ = snprintf(s, sz_, fmt __VA_OPT__(,) __VA_ARGS__);               \
+                                                                              \
+	(len_ >= sz_) ? -1 : len_;                                            \
+})
 
 
 format_attr(printf, 2, 3)

--- a/lib/string/sprintf.h
+++ b/lib/string/sprintf.h
@@ -20,20 +20,20 @@
 
 
 #define SNPRINTF(s, fmt, ...)                                                 \
-({                                                                            \
-	size_t  sz_, len_;                                                    \
-                                                                              \
-	sz_ = NITEMS(s);                                                      \
-	len_ = snprintf(s, sz_, fmt __VA_OPT__(,) __VA_ARGS__);               \
-                                                                              \
-	(len_ >= sz_) ? -1 : len_;                                            \
-})
+	snprintf_(s, NITEMS(s), fmt __VA_OPT__(,) __VA_ARGS__)
 
 
 format_attr(printf, 2, 3)
 inline int xasprintf(char **restrict s, const char *restrict fmt, ...);
 format_attr(printf, 2, 0)
 inline int xvasprintf(char **restrict s, const char *restrict fmt, va_list ap);
+
+format_attr(printf, 3, 4)
+inline int snprintf_(char *restrict s, size_t size, const char *restrict fmt,
+    ...);
+format_attr(printf, 3, 0)
+inline int vsnprintf_(char *restrict s, size_t size, const char *restrict fmt,
+    va_list ap);
 
 
 inline int
@@ -60,6 +60,35 @@ xvasprintf(char **restrict s, const char *restrict fmt, va_list ap)
 		perror("asprintf");
 		exit(EXIT_FAILURE);
 	}
+
+	return len;
+}
+
+
+inline int
+snprintf_(char *restrict s, size_t size, const char *restrict fmt, ...)
+{
+	int      len;
+	va_list  ap;
+
+	va_start(ap, fmt);
+	len = vsnprintf_(s, size, fmt, ap);
+	va_end(ap);
+
+	return len;
+}
+
+
+inline int
+vsnprintf_(char *restrict s, size_t size, const char *restrict fmt, va_list ap)
+{
+	int  len;
+
+	len = vsnprintf(s, size, fmt, ap);
+	if (len == -1)
+		return -1;
+	if ((size_t) len >= size)
+		return -1;
 
 	return len;
 }

--- a/lib/subordinateio.c
+++ b/lib/subordinateio.c
@@ -18,6 +18,8 @@
 #include <fcntl.h>
 
 #include "alloc.h"
+#include "string/sprintf.h"
+
 
 #define ID_SIZE 31
 
@@ -220,10 +222,9 @@ static const struct subordinate_range *find_range(struct commonio_db *db,
          * (It may be specified as literal UID or as another username which
          * has the same UID as the username we are looking for.)
          */
-        struct passwd *pwd;
-        uid_t          owner_uid;
         char           owner_uid_string[33];
-        int ret;
+        uid_t          owner_uid;
+        struct passwd  *pwd;
 
 
         /* Get UID of the username we are looking for */
@@ -233,8 +234,7 @@ static const struct subordinate_range *find_range(struct commonio_db *db,
                 return NULL;
         }
         owner_uid = pwd->pw_uid;
-        ret = snprintf(owner_uid_string, sizeof (owner_uid_string), "%lu", (unsigned long)owner_uid);
-        if (ret < 0 || (size_t)ret >= sizeof (owner_uid_string))
+        if (SNPRINTF(owner_uid_string, "%lu", (unsigned long) owner_uid) == -1)
                 return NULL;
 
         commonio_rewind(db);

--- a/lib/user_busy.c
+++ b/lib/user_busy.c
@@ -23,6 +23,8 @@
 #include "subordinateio.h"
 #endif				/* ENABLE_SUBIDS */
 #include "shadowlog.h"
+#include "string/sprintf.h"
+
 
 #ifdef __linux__
 static int check_status (const char *name, const char *sname, uid_t uid);
@@ -83,11 +85,11 @@ static int user_busy_utmp (const char *name)
 static int different_namespace (const char *sname)
 {
 	/* 41: /proc/xxxxxxxxxx/task/xxxxxxxxxx/ns/user + \0 */
-	char path[41];
-	char buf[512], buf2[512];
-	ssize_t llen1, llen2;
+	char     path[41];
+	char     buf[512], buf2[512];
+	ssize_t  llen1, llen2;
 
-	snprintf (path, 41, "/proc/%s/ns/user", sname);
+	SNPRINTF(path, "/proc/%s/ns/user", sname);
 
 	if ((llen1 = readlink (path, buf, sizeof(buf))) == -1)
 		return 0;
@@ -106,11 +108,11 @@ static int different_namespace (const char *sname)
 static int check_status (const char *name, const char *sname, uid_t uid)
 {
 	/* 40: /proc/xxxxxxxxxx/task/xxxxxxxxxx/status + \0 */
-	char status[40];
-	char line[1024];
-	FILE *sfile;
+	char  status[40];
+	char  line[1024];
+	FILE  *sfile;
 
-	snprintf (status, 40, "/proc/%s/status", sname);
+	SNPRINTF(status, "/proc/%s/status", sname);
 
 	sfile = fopen (status, "r");
 	if (NULL == sfile) {
@@ -205,7 +207,7 @@ static int user_busy_processes (const char *name, uid_t uid)
 		}
 
 		/* Check if the process is in our chroot */
-		snprintf(root_path, sizeof(root_path), "/proc/%lu/root", (unsigned long) pid);
+		SNPRINTF(root_path, "/proc/%lu/root", (unsigned long) pid);
 		if (stat (root_path, &sbroot_process) != 0) {
 			continue;
 		}
@@ -225,7 +227,7 @@ static int user_busy_processes (const char *name, uid_t uid)
 			return 1;
 		}
 
-		snprintf(task_path, sizeof(task_path), "/proc/%lu/task", (unsigned long) pid);
+		SNPRINTF(task_path, "/proc/%lu/task", (unsigned long) pid);
 		task_dir = opendir (task_path);
 		if (task_dir != NULL) {
 			while ((ent = readdir (task_dir)) != NULL) {

--- a/src/chage.c
+++ b/src/chage.c
@@ -33,12 +33,14 @@
 #include "pwio.h"
 #include "shadowio.h"
 #include "shadowlog.h"
+#include "string/sprintf.h"
 #include "string/strtcpy.h"
 #ifdef WITH_TCB
 #include "tcbfuncs.h"
 #endif
 /*@-exitarg@*/
 #include "exitcodes.h"
+
 
 /*
  * Global variables
@@ -158,19 +160,19 @@ usage (int status)
  */
 static int new_fields (void)
 {
-	char buf[200];
+	char  buf[200];
 
 	(void) puts (_("Enter the new value, or press ENTER for the default"));
 	(void) puts ("");
 
-	(void) snprintf (buf, sizeof buf, "%ld", mindays);
+	SNPRINTF(buf, "%ld", mindays);
 	change_field (buf, sizeof buf, _("Minimum Password Age"));
 	if (   (getlong (buf, &mindays) == 0)
 	    || (mindays < -1)) {
 		return 0;
 	}
 
-	(void) snprintf (buf, sizeof buf, "%ld", maxdays);
+	SNPRINTF(buf, "%ld", maxdays);
 	change_field (buf, sizeof buf, _("Maximum Password Age"));
 	if (   (getlong (buf, &maxdays) == 0)
 	    || (maxdays < -1)) {
@@ -194,14 +196,14 @@ static int new_fields (void)
 		}
 	}
 
-	(void) snprintf (buf, sizeof buf, "%ld", warndays);
+	SNPRINTF(buf, "%ld", warndays);
 	change_field (buf, sizeof buf, _("Password Expiration Warning"));
 	if (   (getlong (buf, &warndays) == 0)
 	    || (warndays < -1)) {
 		return 0;
 	}
 
-	(void) snprintf (buf, sizeof buf, "%ld", inactdays);
+	SNPRINTF(buf, "%ld", inactdays);
 	change_field (buf, sizeof buf, _("Password Inactive"));
 	if (   (getlong (buf, &inactdays) == 0)
 	    || (inactdays < -1)) {

--- a/src/chfn.c
+++ b/src/chfn.c
@@ -32,7 +32,9 @@
 /*@-exitarg@*/
 #include "exitcodes.h"
 #include "shadowlog.h"
+#include "string/sprintf.h"
 #include "string/strtcpy.h"
+
 
 /*
  * Global variables.
@@ -614,9 +616,9 @@ static void check_fields (void)
  */
 int main (int argc, char **argv)
 {
-	const struct passwd *pw;	/* password file entry               */
-	char new_gecos[BUFSIZ];	/* buffer for new GECOS fields       */
-	char *user;
+	char                 new_gecos[BUFSIZ];
+	char                 *user;
+	const struct passwd  *pw;
 
 	/*
 	 * Get the program name. The program name is used as a
@@ -723,9 +725,9 @@ int main (int argc, char **argv)
 		fprintf (stderr, _("%s: fields too long\n"), Prog);
 		fail_exit (E_NOPERM);
 	}
-	snprintf (new_gecos, sizeof new_gecos, "%s,%s,%s,%s%s%s",
-	          fullnm, roomno, workph, homeph,
-	          ('\0' != slop[0]) ? "," : "", slop);
+	SNPRINTF(new_gecos, "%s,%s,%s,%s%s%s",
+	         fullnm, roomno, workph, homeph,
+	         ('\0' != slop[0]) ? "," : "", slop);
 
 	/* Rewrite the user's gecos in the passwd file */
 	update_gecos (user, new_gecos);

--- a/src/gpasswd.c
+++ b/src/gpasswd.c
@@ -35,7 +35,9 @@
 /*@-exitarg@*/
 #include "exitcodes.h"
 #include "shadowlog.h"
+#include "string/sprintf.h"
 #include "string/strtcpy.h"
+
 
 /*
  * Global variables
@@ -385,13 +387,13 @@ static void log_gpasswd_failure (const char *suffix)
 #ifdef WITH_AUDIT
 	char  buf[1024];
 #endif
+
 	if (aflg) {
 		SYSLOG ((LOG_ERR,
 		         "%s failed to add user %s to group %s%s",
 		         myname, user, group, suffix));
 #ifdef WITH_AUDIT
-		snprintf(buf, sizeof(buf),
-		         "%s failed to add user %s to group %s%s",
+		SNPRINTF(buf, "%s failed to add user %s to group %s%s",
 		         myname, user, group, suffix);
 		audit_logger (AUDIT_USER_ACCT, Prog,
 		              buf,
@@ -403,8 +405,7 @@ static void log_gpasswd_failure (const char *suffix)
 		         "%s failed to remove user %s from group %s%s",
 		         myname, user, group, suffix));
 #ifdef WITH_AUDIT
-		snprintf(buf, sizeof(buf),
-		         "%s failed to remove user %s from group %s%s",
+		SNPRINTF(buf, "%s failed to remove user %s from group %s%s",
 		         myname, user, group, suffix);
 		audit_logger (AUDIT_USER_ACCT, Prog,
 		              buf,
@@ -416,8 +417,7 @@ static void log_gpasswd_failure (const char *suffix)
 		         "%s failed to remove password of group %s%s",
 		         myname, group, suffix));
 #ifdef WITH_AUDIT
-		snprintf(buf, sizeof(buf),
-		         "%s failed to remove password of group %s%s",
+		SNPRINTF(buf, "%s failed to remove password of group %s%s",
 		         myname, group, suffix);
 		audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
 		              buf,
@@ -429,8 +429,7 @@ static void log_gpasswd_failure (const char *suffix)
 		         "%s failed to restrict access to group %s%s",
 		         myname, group, suffix));
 #ifdef WITH_AUDIT
-		snprintf(buf, sizeof(buf),
-		         "%s failed to restrict access to group %s%s",
+		SNPRINTF(buf, "%s failed to restrict access to group %s%s",
 		         myname, group, suffix);
 		audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
 		              buf,
@@ -444,8 +443,7 @@ static void log_gpasswd_failure (const char *suffix)
 			         "%s failed to set the administrators of group %s to %s%s",
 			         myname, group, admins, suffix));
 #ifdef WITH_AUDIT
-			snprintf(buf, sizeof(buf),
-			         "%s failed to set the administrators of group %s to %s%s",
+			SNPRINTF(buf, "%s failed to set the administrators of group %s to %s%s",
 			         myname, group, admins, suffix);
 			audit_logger (AUDIT_USER_ACCT, Prog,
 			              buf,
@@ -459,8 +457,7 @@ static void log_gpasswd_failure (const char *suffix)
 			         "%s failed to set the members of group %s to %s%s",
 			         myname, group, members, suffix));
 #ifdef WITH_AUDIT
-			snprintf(buf, sizeof(buf),
-			         "%s failed to set the members of group %s to %s%s",
+			SNPRINTF(buf, "%s failed to set the members of group %s to %s%s",
 			         myname, group, members, suffix);
 			audit_logger (AUDIT_USER_ACCT, Prog,
 			              buf,
@@ -473,8 +470,7 @@ static void log_gpasswd_failure (const char *suffix)
 		         "%s failed to change password of group %s%s",
 		         myname, group, suffix));
 #ifdef WITH_AUDIT
-		snprintf(buf, sizeof(buf),
-		         "%s failed to change password of group %s%s",
+		SNPRINTF(buf, "%s failed to change password of group %s%s",
 		         myname, group, suffix);
 		audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
 		              buf,
@@ -493,7 +489,7 @@ static void log_gpasswd_failure_group (unused void *arg)
 {
 	char  buf[1024];
 
-	snprintf(buf, sizeof(buf), " in %s", gr_dbname());
+	SNPRINTF(buf, " in %s", gr_dbname());
 	log_gpasswd_failure (buf);
 }
 
@@ -502,7 +498,7 @@ static void log_gpasswd_failure_gshadow (unused void *arg)
 {
 	char  buf[1024];
 
-	snprintf(buf, sizeof(buf), " in %s", sgr_dbname());
+	SNPRINTF(buf, " in %s", sgr_dbname());
 	log_gpasswd_failure (buf);
 }
 #endif				/* SHADOWGRP */
@@ -512,13 +508,13 @@ static void log_gpasswd_success (const char *suffix)
 #ifdef WITH_AUDIT
 	char  buf[1024];
 #endif
+
 	if (aflg) {
 		SYSLOG ((LOG_INFO,
 		         "user %s added by %s to group %s%s",
 		         user, myname, group, suffix));
 #ifdef WITH_AUDIT
-		snprintf(buf, sizeof(buf),
-		         "user %s added by %s to group %s%s",
+		SNPRINTF(buf, "user %s added by %s to group %s%s",
 		         user, myname, group, suffix);
 		audit_logger (AUDIT_USER_ACCT, Prog,
 		              buf,
@@ -530,8 +526,7 @@ static void log_gpasswd_success (const char *suffix)
 		         "user %s removed by %s from group %s%s",
 		         user, myname, group, suffix));
 #ifdef WITH_AUDIT
-		snprintf(buf, sizeof(buf),
-		         "user %s removed by %s from group %s%s",
+		SNPRINTF(buf, "user %s removed by %s from group %s%s",
 		         user, myname, group, suffix);
 		audit_logger (AUDIT_USER_ACCT, Prog,
 		              buf,
@@ -543,8 +538,7 @@ static void log_gpasswd_success (const char *suffix)
 		         "password of group %s removed by %s%s",
 		         group, myname, suffix));
 #ifdef WITH_AUDIT
-		snprintf(buf, sizeof(buf),
-		         "password of group %s removed by %s%s",
+		SNPRINTF(buf, "password of group %s removed by %s%s",
 		         group, myname, suffix);
 		audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
 		              buf,
@@ -556,8 +550,7 @@ static void log_gpasswd_success (const char *suffix)
 		         "access to group %s restricted by %s%s",
 		         group, myname, suffix));
 #ifdef WITH_AUDIT
-		snprintf(buf, sizeof(buf),
-		         "access to group %s restricted by %s%s",
+		SNPRINTF(buf, "access to group %s restricted by %s%s",
 		         group, myname, suffix);
 		audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
 		              buf,
@@ -571,8 +564,7 @@ static void log_gpasswd_success (const char *suffix)
 			         "administrators of group %s set by %s to %s%s",
 			         group, myname, admins, suffix));
 #ifdef WITH_AUDIT
-			snprintf(buf, sizeof(buf),
-			         "administrators of group %s set by %s to %s%s",
+			SNPRINTF(buf, "administrators of group %s set by %s to %s%s",
 			         group, myname, admins, suffix);
 			audit_logger (AUDIT_USER_ACCT, Prog,
 			              buf,
@@ -586,8 +578,7 @@ static void log_gpasswd_success (const char *suffix)
 			         "members of group %s set by %s to %s%s",
 			         group, myname, members, suffix));
 #ifdef WITH_AUDIT
-			snprintf(buf, sizeof(buf),
-			         "members of group %s set by %s to %s%s",
+			SNPRINTF(buf, "members of group %s set by %s to %s%s",
 			         group, myname, members, suffix);
 			audit_logger (AUDIT_USER_ACCT, Prog,
 			              buf,
@@ -600,8 +591,7 @@ static void log_gpasswd_success (const char *suffix)
 		         "password of group %s changed by %s%s",
 		         group, myname, suffix));
 #ifdef WITH_AUDIT
-		snprintf(buf, sizeof(buf),
-		         "password of group %s changed by %s%s",
+		SNPRINTF(buf, "password of group %s changed by %s%s",
 		         group, myname, suffix);
 		audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
 		              buf,
@@ -620,7 +610,7 @@ static void log_gpasswd_success_group (unused void *arg)
 {
 	char  buf[1024];
 
-	snprintf(buf, sizeof(buf), " in %s", gr_dbname());
+	SNPRINTF(buf, " in %s", gr_dbname());
 	log_gpasswd_success (buf);
 }
 

--- a/src/login.c
+++ b/src/login.c
@@ -37,6 +37,7 @@
 /*@-exitarg@*/
 #include "exitcodes.h"
 #include "shadowlog.h"
+#include "string/sprintf.h"
 #include "string/strtcpy.h"
 
 #ifdef USE_PAM
@@ -476,34 +477,34 @@ static /*@observer@*/const char *get_failent_user (/*@returned@*/const char *use
  */
 int main (int argc, char **argv)
 {
-	const char *tmptty;
-	char tty[BUFSIZ];
-	unsigned int delay;
-	unsigned int retries;
-	bool subroot = false;
-	int err;
-	unsigned int timeout;
-	const char *cp;
-	const char *tmp;
-	char fromhost[512];
-	struct passwd *pwd = NULL;
-	char **envp = environ;
-	const char *failent_user;
-	char *host = NULL;
+	int            err;
+	bool           subroot = false;
+	char           **envp = environ;
+	char           *host = NULL;
+	char           tty[BUFSIZ];
+	char           fromhost[512];
+	const char     *failent_user;
+	const char     *tmptty;
+	const char     *cp;
+	const char     *tmp;
+	unsigned int   delay;
+	unsigned int   retries;
+	unsigned int   timeout;
+	struct passwd  *pwd = NULL;
 
 #if defined(USE_PAM)
-	int retcode;
-	pid_t child;
-	char *pam_user = NULL;
+	int            retcode;
+	char           *pam_user = NULL;
+	pid_t          child;
 #else
 	bool is_console;
 	struct spwd *spwd = NULL;
 # if defined(ENABLE_LASTLOG)
-	char ptime[80];
+	char           ptime[80];
 # endif
 #endif
 #if defined(RLOGIN)
-	char term[128] = "";
+	char           term[128] = "";
 #endif
 
 	/*
@@ -647,19 +648,16 @@ int main (int argc, char **argv)
 	}
 
 	if ('\0' != *cp) {
-		snprintf (fromhost, sizeof fromhost,
-		          " on '%.100s' from '%.200s'", tty, cp);
+		SNPRINTF(fromhost, " on '%.100s' from '%.200s'", tty, cp);
 	} else {
-		snprintf (fromhost, sizeof fromhost,
-		          " on '%.100s'", tty);
+		SNPRINTF(fromhost, " on '%.100s'", tty);
 	}
 	free(host);
 
       top:
 	/* only allow ALARM sec. for login */
 	timeout = getdef_unum ("LOGIN_TIMEOUT", ALARM);
-	snprintf (tmsg, sizeof tmsg,
-	          _("\nLogin timed out after %u seconds.\n"), timeout);
+	SNPRINTF(tmsg, _("\nLogin timed out after %u seconds.\n"), timeout);
 	(void) signal (SIGALRM, alarm_handler);
 	if (timeout > 0) {
 		(void) alarm (timeout);
@@ -698,15 +696,13 @@ int main (int argc, char **argv)
 #endif
 	/* if fflg, then the user has already been authenticated */
 	if (!fflg) {
-		unsigned int failcount = 0;
-		char hostn[256];
-		char loginprompt[256];	/* That's one hell of a prompt :) */
+		char          hostn[256];
+		char          loginprompt[256]; //That's one hell of a prompt :)
+		unsigned int  failcount = 0;
 
 		/* Make the login prompt look like we want it */
 		if (gethostname (hostn, sizeof (hostn)) == 0) {
-			snprintf (loginprompt,
-			          sizeof (loginprompt),
-			          _("%s login: "), hostn);
+			SNPRINTF(loginprompt, _("%s login: "), hostn);
 		} else {
 			STRTCPY(loginprompt, _("login: "));
 		}

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -25,6 +25,8 @@
 /*@-exitarg@*/
 #include "exitcodes.h"
 #include "shadowlog.h"
+#include "string/sprintf.h"
+
 
 /*
  * Global variables
@@ -186,9 +188,8 @@ static void check_perms (const struct group *grp,
 		if (grp->gr_passwd[0] == '\0' ||
 		    strcmp (cpasswd, grp->gr_passwd) != 0) {
 #ifdef WITH_AUDIT
-			snprintf (audit_buf, sizeof(audit_buf),
-			          "authentication new-gid=%lu",
-			          (unsigned long) grp->gr_gid);
+			SNPRINTF(audit_buf, "authentication new-gid=%lu",
+			         (unsigned long) grp->gr_gid);
 			audit_logger (AUDIT_GRP_AUTH, Prog,
 			              audit_buf, NULL, getuid (), 0);
 #endif
@@ -200,9 +201,8 @@ static void check_perms (const struct group *grp,
 			goto failure;
 		}
 #ifdef WITH_AUDIT
-		snprintf (audit_buf, sizeof(audit_buf),
-		          "authentication new-gid=%lu",
-		          (unsigned long) grp->gr_gid);
+		SNPRINTF(audit_buf, "authentication new-gid=%lu",
+		         (unsigned long) grp->gr_gid);
 		audit_logger (AUDIT_GRP_AUTH, Prog,
 		              audit_buf, NULL, getuid (), 1);
 #endif
@@ -217,8 +217,7 @@ failure:
 	closelog ();
 #ifdef WITH_AUDIT
 	if (groupname) {
-		snprintf (audit_buf, sizeof(audit_buf),
-		          "changing new-group=%s", groupname);
+		SNPRINTF(audit_buf, "changing new-group=%s", groupname);
 		audit_logger (AUDIT_CHGRP_ID, Prog,
 		              audit_buf, NULL, getuid (), 0);
 	} else {
@@ -299,8 +298,8 @@ static void syslog_sg (const char *name, const char *group)
 				 is_newgrp ? "newgrp" : "sg", strerror (errno));
 #ifdef WITH_AUDIT
 			if (group) {
-				snprintf (audit_buf, sizeof(audit_buf),
-				          "changing new-group=%s", group);
+				SNPRINTF(audit_buf,
+				         "changing new-group=%s", group);
 				audit_logger (AUDIT_CHGRP_ID, Prog,
 				              audit_buf, NULL, getuid (), 0);
 			} else {
@@ -557,8 +556,7 @@ int main (int argc, char **argv)
 		perror ("getgroups");
 #ifdef WITH_AUDIT
 		if (group) {
-			snprintf (audit_buf, sizeof(audit_buf),
-			          "changing new-group=%s", group);
+			SNPRINTF(audit_buf, "changing new-group=%s", group);
 			audit_logger (AUDIT_CHGRP_ID, Prog,
 			              audit_buf, NULL, getuid (), 0);
 		} else {
@@ -717,8 +715,7 @@ int main (int argc, char **argv)
 	if (setgid (gid) != 0) {
 		perror ("setgid");
 #ifdef WITH_AUDIT
-		snprintf (audit_buf, sizeof(audit_buf),
-		          "changing new-gid=%lu", (unsigned long) gid);
+		SNPRINTF(audit_buf, "changing new-gid=%lu", (unsigned long) gid);
 		audit_logger (AUDIT_CHGRP_ID, Prog,
 		              audit_buf, NULL, getuid (), 0);
 #endif
@@ -728,8 +725,7 @@ int main (int argc, char **argv)
 	if (setuid (getuid ()) != 0) {
 		perror ("setuid");
 #ifdef WITH_AUDIT
-		snprintf (audit_buf, sizeof(audit_buf),
-		          "changing new-gid=%lu", (unsigned long) gid);
+		SNPRINTF(audit_buf, "changing new-gid=%lu", (unsigned long) gid);
 		audit_logger (AUDIT_CHGRP_ID, Prog,
 		              audit_buf, NULL, getuid (), 0);
 #endif
@@ -744,8 +740,7 @@ int main (int argc, char **argv)
 		closelog ();
 		execl (SHELL, "sh", "-c", command, (char *) NULL);
 #ifdef WITH_AUDIT
-		snprintf (audit_buf, sizeof(audit_buf),
-		          "changing new-gid=%lu", (unsigned long) gid);
+		SNPRINTF(audit_buf, "changing new-gid=%lu", (unsigned long) gid);
 		audit_logger (AUDIT_CHGRP_ID, Prog,
 		              audit_buf, NULL, getuid (), 0);
 #endif
@@ -811,8 +806,7 @@ int main (int argc, char **argv)
 	}
 
 #ifdef WITH_AUDIT
-	snprintf (audit_buf, sizeof(audit_buf), "changing new-gid=%lu",
-	          (unsigned long) gid);
+	SNPRINTF(audit_buf, "changing new-gid=%lu", (unsigned long) gid);
 	audit_logger (AUDIT_CHGRP_ID, Prog,
 	              audit_buf, NULL, getuid (), 1);
 #endif
@@ -838,8 +832,7 @@ int main (int argc, char **argv)
 	closelog ();
 #ifdef WITH_AUDIT
 	if (NULL != group) {
-		snprintf (audit_buf, sizeof(audit_buf),
-		          "changing new-group=%s", group);
+		SNPRINTF(audit_buf, "changing new-group=%s", group);
 		audit_logger (AUDIT_CHGRP_ID, Prog,
 		              audit_buf, NULL, getuid (), 0);
 	} else {

--- a/src/newusers.c
+++ b/src/newusers.c
@@ -50,6 +50,8 @@
 #endif				/* ENABLE_SUBIDS */
 #include "chkname.h"
 #include "shadowlog.h"
+#include "string/sprintf.h"
+
 
 /*
  * Global variables
@@ -709,8 +711,9 @@ static void process_flags (int argc, char **argv)
 
 	if (argv[optind] != NULL) {
 		if (freopen (argv[optind], "r", stdin) == NULL) {
-			char buf[BUFSIZ];
-			snprintf (buf, sizeof buf, "%s: %s", Prog, argv[1]);
+			char  buf[BUFSIZ];
+
+			SNPRINTF(buf, "%s: %s", Prog, argv[1]);
 			perror (buf);
 			fail_exit (EXIT_FAILURE);
 		}

--- a/src/su.c
+++ b/src/su.c
@@ -58,7 +58,9 @@
 /*@-exitarg@*/
 #include "exitcodes.h"
 #include "shadowlog.h"
+#include "string/sprintf.h"
 #include "string/strtcpy.h"
+
 
 /*
  * Global variables
@@ -387,8 +389,8 @@ static void prepare_pam_close_session (void)
 		              stderr);
 		(void) kill (-pid_child, caught);
 
-		snprintf (kill_msg, sizeof kill_msg, _(" ...killed.\n"));
-		snprintf (wait_msg, sizeof wait_msg, _(" ...waiting for child to terminate.\n"));
+		SNPRINTF(kill_msg, _(" ...killed.\n"));
+		SNPRINTF(wait_msg, _(" ...waiting for child to terminate.\n"));
 
 		/* Any signals other than SIGCHLD and SIGALRM will no longer have any effect,
 		 * so it's time to block all of them. */

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -525,7 +525,6 @@ static void show_defaults (void)
 static int set_defaults (void)
 {
 	int   ofd;
-	int   wlen;
 	int   ret = -1;
 	bool  out_group = false;
 	bool  out_groups = false;
@@ -711,8 +710,7 @@ static int set_defaults (void)
 	/*
 	 * Rename the current default file to its backup name.
 	 */
-	wlen = snprintf (buf, sizeof buf, "%s-", default_file);
-	assert (wlen < (int) sizeof buf);
+	assert(SNPRINTF(buf, "%s-", default_file) != -1);
 	unlink (buf);
 	if ((link (default_file, buf) != 0) && (ENOENT != errno)) {
 		int err = errno;

--- a/src/vipw.c
+++ b/src/vipw.c
@@ -205,7 +205,7 @@ vipwedit (const char *file, int (*file_lock) (void), int (*file_unlock) (void))
 	/* FIXME: the following should have variable sizes */
 	char         filebackup[1024], fileedit[1024];
 
-	snprintf (filebackup, sizeof filebackup, "%s-", file);
+	SNPRINTF(filebackup, "%s-", file);
 #ifdef WITH_TCB
 	if (tcb_mode) {
 		if (   (mkdir (TCB_DIR "/" SHADOWTCB_SCRATCHDIR, 0700) != 0)
@@ -215,12 +215,12 @@ vipwedit (const char *file, int (*file_lock) (void), int (*file_unlock) (void))
 		if (shadowtcb_drop_priv () == SHADOWTCB_FAILURE) {
 			vipwexit (_("failed to drop privileges"), errno, 1);
 		}
-		snprintf (fileedit, sizeof fileedit,
-		          TCB_DIR "/" SHADOWTCB_SCRATCHDIR "/.vipw.shadow.%s",
-		          user);
+		SNPRINTF(fileedit,
+		         TCB_DIR "/" SHADOWTCB_SCRATCHDIR "/.vipw.shadow.%s",
+		         user);
 	} else {
 #endif				/* WITH_TCB */
-		snprintf (fileedit, sizeof fileedit, "%s.edit", file);
+		SNPRINTF(fileedit, "%s.edit", file);
 #ifdef WITH_TCB
 	}
 #endif				/* WITH_TCB */

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -5,6 +5,7 @@ TESTS = $(check_PROGRAMS)
 
 check_PROGRAMS = \
     test_chkname \
+    test_sprintf \
     test_strncpy \
     test_strtcpy \
     test_xasprintf
@@ -45,6 +46,19 @@ test_logind_LDFLAGS = \
 test_logind_LDADD = \
     $(CMOCKA_LIBS) \
     $(LIBSYSTEMD) \
+    $(NULL)
+
+test_sprintf_SOURCES = \
+    ../../lib/string/sprintf.c \
+    test_sprintf.c \
+    $(NULL)
+test_sprintf_CFLAGS = \
+    $(AM_FLAGS) \
+    $(NULL)
+test_sprintf_LDFLAGS = \
+    $(NULL)
+test_sprintf_LDADD = \
+    $(CMOCKA_LIBS) \
     $(NULL)
 
 test_strncpy_SOURCES = \

--- a/tests/unit/test_sprintf.c
+++ b/tests/unit/test_sprintf.c
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2023, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#include <config.h>
+
+#include <stdio.h>
+#include <string.h>
+
+#include <stdarg.h>  // Required by <cmocka.h>
+#include <stddef.h>  // Required by <cmocka.h>
+#include <setjmp.h>  // Required by <cmocka.h>
+#include <stdint.h>  // Required by <cmocka.h>
+#include <cmocka.h>
+
+#include "sizeof.h"
+#include "string/sprintf.h"
+
+
+static void test_SNPRINTF_trunc(void **state);
+static void test_SNPRINTF_ok(void **state);
+
+
+int
+main(void)
+{
+    const struct CMUnitTest  tests[] = {
+        cmocka_unit_test(test_SNPRINTF_trunc),
+        cmocka_unit_test(test_SNPRINTF_ok),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}
+
+
+static void
+test_SNPRINTF_trunc(void **state)
+{
+	char  buf[NITEMS("foo")];
+
+	// Test that we're not returning SIZE_MAX
+	assert_true(SNPRINTF(buf, "f%su", "oo") < 0);
+	assert_true(strcmp(buf, "foo") == 0);
+
+	assert_true(SNPRINTF(buf, "barbaz") == -1);
+	assert_true(strcmp(buf, "bar") == 0);
+}
+
+
+static void
+test_SNPRINTF_ok(void **state)
+{
+	char  buf[NITEMS("foo")];
+
+	assert_true(SNPRINTF(buf, "%s", "foo") == strlen("foo"));
+	assert_true(strcmp(buf, "foo") == 0);
+
+	assert_true(SNPRINTF(buf, "%do", 1) == strlen("1o"));
+	assert_true(strcmp(buf, "1o") == 0);
+
+	assert_true(SNPRINTF(buf, "f") == strlen("f"));
+	assert_true(strcmp(buf, "f") == 0);
+
+	assert_true(SNPRINTF(buf, "") == strlen(""));
+	assert_true(strcmp(buf, "") == 0);
+}


### PR DESCRIPTION
It wraps snprintf(3) so that it performs some steps that one might forget, or might be prone to accidents:

-  It calculates the size of the destination buffer, and makes sure it's an array (otherwise, using sizeof(s) would be very bad).

-  It calculates if there's truncation or an error, returning -1 if so.

BTW, this macro doesn't have any issues of double evaluation, because sizeof() doesn't evaluate its argument (unless it's a VLA, but then the static_assert(3) within NITEMS() makes sure VLAs are not allowed).

This macro is very similar to STRTCPY(), defined in lib/string/strtcpy.h.