### PR TITLE
lib/, src/: The only useful errno after strto[u][l]l(3) is ERANGE

### DIFF
--- a/lib/get_gid.c
+++ b/lib/get_gid.c
@@ -20,7 +20,7 @@ int get_gid (const char *gidstr, gid_t *gid)
 	val = strtoll(gidstr, &endptr, 10);
 	if (   ('\0' == *gidstr)
 	    || ('\0' != *endptr)
-	    || (0 != errno)
+	    || (ERANGE == errno)
 	    || (/*@+longintegral@*/val != (gid_t)val)/*@=longintegral@*/) {
 		return 0;
 	}

--- a/lib/get_pid.c
+++ b/lib/get_pid.c
@@ -23,7 +23,7 @@ int get_pid (const char *pidstr, pid_t *pid)
 	val = strtoll(pidstr, &endptr, 10);
 	if (   ('\0' == *pidstr)
 	    || ('\0' != *endptr)
-	    || (0 != errno)
+	    || (ERANGE == errno)
 	    || (val < 1)
 	    || (/*@+longintegral@*/val != (pid_t)val)/*@=longintegral@*/) {
 		return 0;
@@ -49,7 +49,7 @@ int get_pidfd_from_fd(const char *pidfdstr)
 	val = strtoll(pidfdstr, &endptr, 10);
 	if (   ('\0' == *pidfdstr)
 	    || ('\0' != *endptr)
-	    || (0 != errno)
+	    || (ERANGE == errno)
 	    || (val < 0)
 	    || (/*@+longintegral@*/val != (int)val)/*@=longintegral@*/) {
 		return -1;

--- a/lib/get_uid.c
+++ b/lib/get_uid.c
@@ -20,7 +20,7 @@ int get_uid (const char *uidstr, uid_t *uid)
 	val = strtoll(uidstr, &endptr, 10);
 	if (   ('\0' == *uidstr)
 	    || ('\0' != *endptr)
-	    || (0 != errno)
+	    || (ERANGE == errno)
 	    || (/*@+longintegral@*/val != (uid_t)val)/*@=longintegral@*/) {
 		return 0;
 	}

--- a/lib/getgr_nam_gid.c
+++ b/lib/getgr_nam_gid.c
@@ -34,7 +34,7 @@ extern /*@only@*//*@null@*/struct group *getgr_nam_gid (/*@null@*/const char *gr
 	gid = strtoll(grname, &endptr, 10);
 	if (   ('\0' != *grname)
 	    && ('\0' == *endptr)
-	    && (0 == errno)
+	    && (ERANGE != errno)
 	    && (/*@+longintegral@*/gid == (gid_t)gid)/*@=longintegral@*/) {
 		return xgetgrgid (gid);
 	}

--- a/lib/getlong.c
+++ b/lib/getlong.c
@@ -26,7 +26,7 @@ int getlong (const char *numstr, /*@out@*/long *result)
 
 	errno = 0;
 	val = strtol(numstr, &endptr, 0);
-	if (('\0' == *numstr) || ('\0' != *endptr) || (0 != errno)) {
+	if (('\0' == *numstr) || ('\0' != *endptr) || (ERANGE == errno)) {
 		return 0;
 	}
 

--- a/lib/getrange.c
+++ b/lib/getrange.c
@@ -43,7 +43,7 @@ int getrange (const char *range,
 		}
 		errno = 0;
 		n = strtoul(&range[1], &endptr, 10);
-		if (('\0' != *endptr) || (0 != errno)) {
+		if (('\0' != *endptr) || (ERANGE == errno)) {
 			/* invalid */
 			return 0;
 		}
@@ -54,7 +54,7 @@ int getrange (const char *range,
 	} else {
 		errno = 0;
 		n = strtoul(range, &endptr, 10);
-		if (endptr == range || 0 != errno) {
+		if (endptr == range || ERANGE == errno) {
 			/* invalid */
 			return 0;
 		}
@@ -82,7 +82,7 @@ int getrange (const char *range,
 					errno = 0;
 					n = strtoul(endptr, &endptr, 10);
 					if (   ('\0' != *endptr)
-					    || (0 != errno)) {
+					    || (ERANGE == errno)) {
 						/* invalid */
 						return 0;
 					}

--- a/lib/gettime.c
+++ b/lib/gettime.c
@@ -38,7 +38,7 @@
 
 	errno = 0;
 	epoch = strtoull(source_date_epoch, &endptr, 10);
-	if (errno != 0) {
+	if (errno == ERANGE) {
 		fprintf (shadow_logfd,
 			 _("Environment variable $SOURCE_DATE_EPOCH: strtoull: %s\n"),
 			 strerror(errno));

--- a/lib/getulong.c
+++ b/lib/getulong.c
@@ -28,7 +28,7 @@ int getulong (const char *numstr, /*@out@*/unsigned long *result)
 	val = strtoul(numstr, &endptr, 0);
 	if (    ('\0' == *numstr)
 	     || ('\0' != *endptr)
-	     || (0 != errno)
+	     || (ERANGE == errno)
 	   ) {
 		return 0;
 	}

--- a/lib/limits.c
+++ b/lib/limits.c
@@ -65,7 +65,7 @@ static int setrlimit_value (unsigned int resource,
 		errno = 0;
 		l = strtol(value, &endptr, 10);
 
-		if (value == endptr || errno != 0)
+		if (value == endptr || errno == ERANGE)
 			return 0;  // FIXME: We could instead throw an error, though.
 
 		if (__builtin_mul_overflow(l, multiplier, &limit)) {

--- a/lib/prefix_flag.c
+++ b/lib/prefix_flag.c
@@ -352,7 +352,7 @@ extern struct group *prefix_getgr_nam_gid(const char *grname)
 	gid = strtoll(grname, &endptr, 10);
 	if (   ('\0' != *grname)
 	    && ('\0' == *endptr)
-	    && (0 == errno)
+	    && (ERANGE != errno)
 	    && (gid == (gid_t)gid))
 	{
 		return prefix_getgrgid(gid);

--- a/src/check_subid_range.c
+++ b/src/check_subid_range.c
@@ -36,10 +36,10 @@ int main(int argc, char **argv)
 	check_uids = argv[2][0] == 'u';
 	errno = 0;
 	start = strtoul(argv[3], NULL, 10);
-	if (errno != 0)
+	if (errno == ERANGE)
 		exit(1);
 	count = strtoul(argv[4], NULL, 10);
-	if (errno != 0)
+	if (errno == ERANGE)
 		exit(1);
 	if (check_uids) {
 		if (have_sub_uids(owner, start, count))

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -318,13 +318,13 @@ static struct ulong_range getulong_range(const char *str)
 
 	errno = 0;
 	first = strtoll(str, &pos, 10);
-	if (('\0' == *str) || ('-' != *pos ) || (0 != errno) ||
+	if (('\0' == *str) || ('-' != *pos ) || (ERANGE == errno) ||
 	    (first != (unsigned long)first))
 		goto out;
 
 	errno = 0;
 	last = strtoll(pos + 1, &pos, 10);
-	if (('\0' != *pos ) || (0 != errno) ||
+	if (('\0' != *pos ) || (ERANGE == errno) ||
 	    (last != (unsigned long)last))
 		goto out;
 


### PR DESCRIPTION
```
EINVAL should be tested in a call where the string is known to contain a valid number and nothing else; otherwise, it's very easy to trigger Undefined Behavior.

Also, we're using 0 and 10 as bases, which cannot EINVAL.

Fixes: 1c464d9a2df7 ("lib/, src/: Fix error handling after strto[u]l[l](3)")
```
Link: <https://git.kernel.org/pub/scm/docs/man-pages/man-pages.git/commit/?id=628d27c3c1d8362a7e73198460b8c6a739be4973>

Please merge, not rebase, so it's right after the commit that it fixes, which will help see the overall diff of both commits (`git diff HEAD^^`).