### PR TITLE
lib/defines.h: Remove ITI_AGING

### DIFF
--- a/lib/defines.h
+++ b/lib/defines.h
@@ -149,11 +149,7 @@
 
 #define WEEK (7*DAY)
 
-#ifdef ITI_AGING
-#define SCALE 1
-#else
 #define SCALE DAY
-#endif
 
 #ifndef PASSWD_FILE
 #define PASSWD_FILE "/etc/passwd"


### PR DESCRIPTION
ITI_AGING is not set through any build environment. If it would be set, then timings in /etc/shadow would not fit anymore.

I didn't find anything online about `ITI_AGING` either. Perhaps it was meant as a way to test large numbers.

If SCALE is fixed to DAY (which means that SCALE can disappear), then many calculations can be simplified in the code base. Consider this PR as a way of asking if IT_AGING can disappear so I can simplify these calculations in a next step.