### PR TITLE
src/su.c: Fix type of variable

### DIFF
--- a/src/su.c
+++ b/src/su.c
@@ -643,8 +643,8 @@ static /*@only@*/struct passwd * check_perms (void)
 static /*@only@*/struct passwd * do_check_perms (void)
 {
 #ifdef USE_PAM
-	const void *tmp_name;
-	int ret;
+	int         ret;
+	const char  *tmp_name;
 #endif				/* !USE_PAM */
 	/*
 	 * The password file entries for the user is gotten and the account


### PR DESCRIPTION
su.c:678:26: warning: format ‘%s’ expects argument of type ‘char *’, but argument 4 has type ‘const void *’ [-Wformat=]
su.c:681:44: warning: format ‘%s’ expects argument of type ‘char *’, but argument 3 has type ‘const void *’ [-Wformat=]
su.c:683:46: warning: format ‘%s’ expects argument of type ‘char *’, but argument 3 has type ‘const void *’ [-Wformat=]

Reported-by: Christian Göttsche <cgzones@googlemail.com>