### PR TITLE
Day and time cleanups for shadow file entries

### DIFF
--- a/lib/age.c
+++ b/lib/age.c
@@ -13,11 +13,14 @@
 #include <stdio.h>
 #include <time.h>
 #include <errno.h>
-#include "prototypes.h"
-#include "defines.h"
-#include "exitcodes.h"
 #include <pwd.h>
 #include <grp.h>
+
+#include "adds.h"
+#include "defines.h"
+#include "exitcodes.h"
+#include "prototypes.h"
+
 
 #ident "$Id$"
 
@@ -162,7 +165,8 @@ void agecheck (/*@null@*/const struct spwd *sp)
 		return;
 	}
 
-	remain = sp->sp_lstchg + sp->sp_max - now;
+	remain = addsl(sp->sp_lstchg, sp->sp_max, -now);
+
 	if (remain <= sp->sp_warn) {
 		if (remain > 1) {
 			(void) printf (_("Your password will expire in %ld days.\n"),

--- a/lib/isexpired.c
+++ b/lib/isexpired.c
@@ -15,10 +15,12 @@
 #include <config.h>
 
 #include <sys/types.h>
-#include "prototypes.h"
-#include "defines.h"
 #include <pwd.h>
 #include <time.h>
+
+#include "adds.h"
+#include "defines.h"
+#include "prototypes.h"
 
 #ident "$Id$"
 
@@ -38,7 +40,7 @@
  */
 int isexpired (const struct passwd *pw, /*@null@*/const struct spwd *sp)
 {
-	long now;
+	long  now;
 
 	now = time(NULL) / DAY;
 
@@ -72,7 +74,8 @@ int isexpired (const struct passwd *pw, /*@null@*/const struct spwd *sp)
 	if (   (sp->sp_lstchg > 0)
 	    && (sp->sp_max >= 0)
 	    && (sp->sp_inact >= 0)
-	    && (now >= (sp->sp_lstchg + sp->sp_max + sp->sp_inact))) {
+	    && (now >= addsl(sp->sp_lstchg, sp->sp_max, sp->sp_inact)))
+	{
 		return 2;
 	}
 
@@ -94,9 +97,9 @@ int isexpired (const struct passwd *pw, /*@null@*/const struct spwd *sp)
 	 * the password has expired.
 	 */
 
-	if (now >= (sp->sp_lstchg + sp->sp_max)) {
+	if (now >= addsl(sp->sp_lstchg, sp->sp_max))
 		return 1;
-	}
+
 	return 0;
 }
 

--- a/src/chage.c
+++ b/src/chage.c
@@ -76,7 +76,7 @@ static long expdate;
 /* local function prototypes */
 NORETURN static void usage (int status);
 static int new_fields (void);
-static void print_date (time_t date);
+static void print_day_as_date (long day);
 static void list_fields (void);
 static void process_flags (int argc, char **argv);
 static void check_flags (int argc, int opt_index);
@@ -231,10 +231,22 @@ static int new_fields (void)
 	return 1;
 }
 
-static void print_date (time_t date)
+
+static void
+print_day_as_date(long day)
 {
-	struct tm *tp;
-	char buf[80];
+	char       buf[80];
+	time_t     date;
+	struct tm  *tp;
+
+	if (day < 0) {
+		puts(_("never"));
+		return;
+	}
+	if (__builtin_mul_overflow(day, DAY, &date)) {
+		puts(_("future"));
+		return;
+	}
 
 	tp = gmtime (&date);
 	if (NULL == tp) {
@@ -245,6 +257,7 @@ static void print_date (time_t date)
 	}
 }
 
+
 /*
  * list_fields - display the current values of the expiration fields
  *
@@ -254,21 +267,15 @@ static void print_date (time_t date)
  */
 static void list_fields (void)
 {
-	long changed = 0;
-	long expires;
-
 	/*
 	 * The "last change" date is either "never" or the date the password
 	 * was last modified. The date is the number of days since 1/1/1970.
 	 */
 	(void) fputs (_("Last password change\t\t\t\t\t: "), stdout);
-	if (lstchgdate < 0 || lstchgdate > LONG_MAX / DAY) {
-		(void) puts (_("never"));
-	} else if (lstchgdate == 0) {
+	if (lstchgdate == 0) {
 		(void) puts (_("password must be changed"));
 	} else {
-		changed = lstchgdate * DAY;
-		print_date (changed);
+		print_day_as_date(lstchgdate);
 	}
 
 	/*
@@ -281,11 +288,11 @@ static void list_fields (void)
 	} else if (   (lstchgdate < 0)
 	           || (maxdays >= 10000)
 	           || (maxdays < 0)
-	           || ((LONG_MAX - changed) / DAY < maxdays)) {
+	           || (LONG_MAX - lstchgdate < maxdays))
+	{
 		(void) puts (_("never"));
 	} else {
-		expires = changed + maxdays * DAY;
-		print_date (expires);
+		print_day_as_date(lstchgdate + maxdays);
 	}
 
 	/*
@@ -301,12 +308,12 @@ static void list_fields (void)
 	           || (inactdays < 0)
 	           || (maxdays >= 10000)
 	           || (maxdays < 0)
-	           || (maxdays > LONG_MAX - inactdays)
-	           || ((LONG_MAX - changed) / DAY < maxdays + inactdays)) {
+	           || (LONG_MAX - inactdays < maxdays)
+	           || (LONG_MAX - lstchgdate < maxdays + inactdays))
+	{
 		(void) puts (_("never"));
 	} else {
-		expires = changed + (maxdays + inactdays) * DAY;
-		print_date (expires);
+		print_day_as_date(lstchgdate + maxdays + inactdays);
 	}
 
 	/*
@@ -314,12 +321,7 @@ static void list_fields (void)
 	 * password expiring or not.
 	 */
 	(void) fputs (_("Account expires\t\t\t\t\t\t: "), stdout);
-	if (expdate < 0 || LONG_MAX / DAY < expdate) {
-		(void) puts (_("never"));
-	} else {
-		expires = expdate * DAY;
-		print_date (expires);
-	}
+	print_day_as_date(expdate);
 
 	/*
 	 * Start with the easy numbers - the number of days before the


### PR DESCRIPTION
The first commit is about SCALE removal:
- SCALE is always DAY, so drop the definition
- With SCALE being gone, drop unneeded calculations

The other commits clean up calculations based on days per epoch and seconds per epoch. It is much easier to calculate with days (in a long) than with seconds (in a time_t) because the former is already the native encoding in shadow files and LONG_MAX exists, while TIME_T_MAX does not exist everywhere.

- Use proper casts which become relevant for 32 bit systems with 64 bit time_t, e.g. musl-based distributions
- Let `passwd` work with day precision instead of seconds since epoch to allow easier range checking
- Unify integer overflow checks in `chage`
- Add LONG_MAX range checks when working with sp_max etc.


Proof of Concept (for 64 bit systems):
1. Compile and definitely use an `sgetspent` implementation which gets long parsing right (glibc does not)
```
ac_cv_func_getspnam=no \
ac_cv_func_sgetspent=no \
CFLAGS="-fsanitize=undefined" \
./configure --without-libpam
```
2. Setup users with large shadow entries
```
# chage -m 10 user1
# chage -d 9223372036854775807 user1
```
```
# chage -M 10 user2
# chage -d 9223372036854775807 user2
```
```
# chage -M 10 user3
# chage -I 20 user3
# chage -d 9223372036854775807 user3
```
```
# chage -I 20 user4
# chage -W 1 user4
# chage -d 123 user4
# chage -M 9223372036854775807 user4
```
3. Change password as user1
```
$ passwd
../../src/passwd.c:393:6: runtime error: signed integer overflow: 9223372036854775807 * 86400 cannot be represented in type 'long int'
```
4. Run expiry as user2
```
$ expiry -c
../../lib/isexpired.c:97:28: runtime error: signed integer overflow: 9223372036854775807 + 10 cannot be represented in type 'long int'
```
5. Run expiry as user3
```
$ expiry -c
../../lib/age.c:165:25: runtime error: signed integer overflow: 9223372036854775807 + 99999 cannot be represented in type 'long int'
../../lib/isexpired.c:75:32: runtime error: signed integer overflow: 9223372036854775807 + 99999 cannot be represented in type 'long int'
```
6. Run expiry as user4
```
$ expiry -c
../../lib/age.c:165:25: runtime error: signed integer overflow: 123 + 9223372036854775807 cannot be represented in type 'long int'
../../lib/age.c:165:9: runtime error: signed integer overflow: -9223372036854775686 - 19709 cannot be represented in type 'long int'
../../lib/isexpired.c:75:32: runtime error: signed integer overflow: 123 + 9223372036854775807 cannot be represented in type 'long int'
```

The user1 password change should not be allowed because the minimum wait time since last change (in the future) is not reached yet.

As a solution I have capped these calculations at `LONG_MAX` since we are talking, even for 32 bit systems, about a time span of more than 6 million years before this capping becomes a problem. Rather... Theoretical... I hope. :)