### PR TITLE
lib/getdef.c: Adjust getdef_ boundaries

### DIFF
--- a/lib/getdef.c
+++ b/lib/getdef.c
@@ -247,7 +247,7 @@ int getdef_num (const char *item, int dflt)
 
 	if (   (getlong (d->value, &val) == 0)
 	    || (val > INT_MAX)
-	    || (val < INT_MIN)) {
+	    || (val < -1)) {
 		fprintf (shadow_logfd,
 		         _("configuration error - cannot parse %s value: '%s'"),
 		         item, d->value);
@@ -315,7 +315,8 @@ long getdef_long (const char *item, long dflt)
 		return dflt;
 	}
 
-	if (getlong (d->value, &val) == 0) {
+	if (   (getlong (d->value, &val) == 0)
+	    || (val < -1)) {
 		fprintf (shadow_logfd,
 		         _("configuration error - cannot parse %s value: '%s'"),
 		         item, d->value);

--- a/man/login.defs.d/PASS_WARN_AGE.xml
+++ b/man/login.defs.d/PASS_WARN_AGE.xml
@@ -9,8 +9,8 @@
   <listitem>
     <para>
       The number of days warning given before a password expires. A zero
-      means warning is given only upon the day of expiration, a negative
-      value means no warning is given. If not specified, no warning will
+      means warning is given only upon the day of expiration, a value of
+      -1 means no warning is given. If not specified, no warning will
       be provided.
     </para>
   </listitem>


### PR DESCRIPTION
Negative values in login.defs never make sense (except someone wants to forcefully disable a feature with `-1` instead of commenting out a line or start breaking things by using even smaller values, which will be fixed in later PRs).

As a side note, util-linux does not support negative values either. See https://github.com/util-linux/util-linux/blob/master/lib/logindefs.c