### PR TITLE
man/: Support compiling in build directory

### DIFF
--- a/man/generate_mans.mak
+++ b/man/generate_mans.mak
@@ -56,7 +56,7 @@ man1/% man3/% man5/% man8/%: %.xml-config Makefile config.xml
 	            --stringparam vendordir "$(VENDORDIR)" \
 	            --param "man.output.in.separate.dir" "1" \
 	            --path "$(srcdir)/login.defs.d" \
-	            -nonet $(top_builddir)/man/shadow-man.xsl $<
+	            -nonet $(top_srcdir)/man/shadow-man.xsl $<
 
 clean-local:
 	rm -rf man1 man3 man5 man8

--- a/man/generate_translations.mak
+++ b/man/generate_translations.mak
@@ -17,7 +17,7 @@ login.defs.d:
 	else \
 	    sed -e 's/^\(<!DOCTYPE .*docbookx.dtd"\)>/\1 [<!ENTITY % config SYSTEM "config.xml">%config;]>/' $< > $@; \
 	fi
-	itstool -i ../its.rules -d -l $(LANG) -m messages.mo -o . $@
+	itstool -i $(srcdir)/../its.rules -d -l $(LANG) -m messages.mo -o . $@
 	sed -i 's:\(^<refentry .*\)>:\1 lang="$(LANG)">:' $@
 
 include ../generate_mans.mak


### PR DESCRIPTION
Having a dedicated build directory breaks manual page creation.

Failing command sequence:
```
mkdir build; cd build
../configure --enable-man
make -C man
```