### PR TITLE
lib/defines.h: Use 'time_t' for DAY

### DIFF
--- a/lib/defines.h
+++ b/lib/defines.h
@@ -144,7 +144,7 @@
 
 /* Solaris defines this in shadow.h */
 #ifndef DAY
-#define DAY (24L*3600L)
+#define DAY  ((time_t) 24 * 3600)
 #endif
 
 #define WEEK (7*DAY)


### PR DESCRIPTION
Special care has to be taken for 32 bit systems with a 64 bit time_t, since their long data type is still 32 bit.

Reported-by: @stoeckmann 