### PR TITLE
man/: Remove more login.defs items if PAM is in use

### DIFF
--- a/man/login.1.xml
+++ b/man/login.1.xml
@@ -277,7 +277,7 @@
       &CONSOLE;
       &CONSOLE_GROUPS;
       &DEFAULT_HOME;
-      <phrase condition="no_pam">&ENV_HZ;</phrase>
+      &ENV_HZ;
       <phrase>&ENV_PATH;</phrase>
       <phrase>&ENV_SUPATH;</phrase>
       &ENV_TZ;

--- a/man/login.defs.5.xml
+++ b/man/login.defs.5.xml
@@ -449,12 +449,12 @@
 	  </para>
 	</listitem>
       </varlistentry>
-      <varlistentry>
+      <varlistentry condition="no_pam">
 	<term>sulogin</term>
 	<listitem>
 	  <para>
 	    ENV_HZ
-	    <phrase condition="no_pam">ENV_TZ</phrase>
+	    ENV_TZ
 	  </para>
 	</listitem>
       </varlistentry>

--- a/man/login.defs.d/CONSOLE_GROUPS.xml
+++ b/man/login.defs.d/CONSOLE_GROUPS.xml
@@ -4,7 +4,7 @@
    SPDX-FileCopyrightText: 2007 - 2008, Nicolas François
    SPDX-License-Identifier: BSD-3-Clause
 -->
-<varlistentry>
+<varlistentry condition="no_pam">
   <term><option>CONSOLE_GROUPS</option> (string)</term>
   <listitem>
     <para>

--- a/man/login.defs.d/ENV_HZ.xml
+++ b/man/login.defs.d/ENV_HZ.xml
@@ -4,8 +4,7 @@
    SPDX-FileCopyrightText: 2007 - 2008, Nicolas François
    SPDX-License-Identifier: BSD-3-Clause
 -->
-<varlistentry>
-  <!-- XXX: When compiled with PAM support, only sulogin uses ENV_HZ -->
+<varlistentry condition="no_pam">
   <term><option>ENV_HZ</option> (string)</term>
   <listitem>
     <para>
@@ -13,10 +12,6 @@
       a user login. The value must be preceded by
       <replaceable>HZ=</replaceable>. A common value on Linux is
       <replaceable>HZ=100</replaceable>.
-    </para>
-    <para condition="pam">
-      The <envar>HZ</envar> environment variable is only set when the user
-      (the superuser) logs in with <command>sulogin</command>.
     </para>
     <!-- TODO: it can in fact be used to set any other variable-->
   </listitem>

--- a/man/su.1.xml
+++ b/man/su.1.xml
@@ -321,7 +321,7 @@
       &CONSOLE;
       &CONSOLE_GROUPS;
       &DEFAULT_HOME;
-      <phrase condition="no_pam">&ENV_HZ;</phrase>
+      &ENV_HZ;
       &ENVIRON_FILE;
       &ENV_PATH;
       &ENV_SUPATH;

--- a/man/sulogin.8.xml
+++ b/man/sulogin.8.xml
@@ -106,7 +106,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='configuration'>
+  <refsect1 condition="no_pam" id='configuration'>
     <title>CONFIGURATION</title>
     <para>
       The following configuration variables in


### PR DESCRIPTION
CONSOLE_GROUPS and ENV_HZ are not used if PAM is enabled. Remove them (and even whole paragraphs since they would be empty now) if PAM is enabled.