### PR TITLE
lib/addsl.[ch]: Add addsl() and addsl3()

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -23,6 +23,8 @@ libshadow_la_CFLAGS = $(LIBBSD_CFLAGS) $(LIBCRYPT_PAM) $(LIBSYSTEMD)
 
 libshadow_la_SOURCES = \
 	addgrps.c \
+	adds.c \
+	adds.h \
 	age.c \
 	agetpass.c \
 	agetpass.h \

--- a/lib/adds.c
+++ b/lib/adds.c
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2023, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#include <config.h>
+
+#include "adds.h"
+
+
+extern inline long addsl(long a, long b);
+extern inline long addsl3(long a, long b, long c);
+
+extern inline int cmpl(const void *p1, const void *p2);

--- a/lib/adds.h
+++ b/lib/adds.h
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2023, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#ifndef SHADOW_INCLUDE_LIB_ADDS_H_
+#define SHADOW_INCLUDE_LIB_ADDS_H_
+
+
+#include <config.h>
+
+#include <errno.h>
+#include <limits.h>
+#include <stdlib.h>
+
+#include "sizeof.h"
+
+
+inline long addsl(long a, long b);
+inline long addsl3(long a, long b, long c);
+
+inline int cmpl(const void *p1, const void *p2);
+
+
+inline long
+addsl(long a, long b)
+{
+	if (a > 0 && b > LONG_MAX - a) {
+		errno = EOVERFLOW;
+		return LONG_MAX;
+	}
+	if (a < 0 && b < LONG_MIN - a) {
+		errno = EOVERFLOW;
+		return LONG_MIN;
+	}
+	return a + b;
+}
+
+
+inline long
+addsl3(long a, long b, long c)
+{
+	int   e;
+	long  sum;
+	long  n[3] = {a, b, c};
+
+	e = errno;
+	qsort(n, NITEMS(n), sizeof(n[0]), cmpl);
+
+	errno = 0;
+	sum = addsl(n[0], n[2]);
+	if (errno == EOVERFLOW)
+		return sum;
+	errno = e;
+	return addsl(sum, n[1]);
+}
+
+
+inline int
+cmpl(const void *p1, const void *p2)
+{
+	const long  *l1 = p1;
+	const long  *l2 = p2;
+
+	if (*l1 < *l2)
+		return -1;
+	if (*l1 > *l2)
+		return +1;
+	return 0;
+}
+
+
+#endif  // include guard

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -4,6 +4,7 @@ if HAVE_CMOCKA
 TESTS = $(check_PROGRAMS)
 
 check_PROGRAMS = \
+    test_adds \
     test_chkname \
     test_sprintf \
     test_strncpy \
@@ -16,6 +17,19 @@ check_PROGRAMS += \
 endif # ENABLE_LOGIND
 
 check_PROGRAMS += \
+    $(NULL)
+
+test_adds_SOURCES = \
+    ../../lib/adds.c \
+    test_adds.c \
+    $(NULL)
+test_adds_CFLAGS = \
+    $(AM_FLAGS) \
+    $(NULL)
+test_adds_LDFLAGS = \
+    $(NULL)
+test_adds_LDADD = \
+    $(CMOCKA_LIBS) \
     $(NULL)
 
 test_chkname_SOURCES = \

--- a/tests/unit/test_adds.c
+++ b/tests/unit/test_adds.c
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: 2023, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#include <limits.h>
+
+#include <stdarg.h>  // Required by <cmocka.h>
+#include <stddef.h>  // Required by <cmocka.h>
+#include <setjmp.h>  // Required by <cmocka.h>
+#include <stdint.h>  // Required by <cmocka.h>
+#include <cmocka.h>
+
+#include "adds.h"
+
+
+static void test_addsl_ok(void **state);
+static void test_addsl_underflow(void **state);
+static void test_addsl_overflow(void **state);
+static void test_addsl3_ok(void **state);
+static void test_addsl3_underflow(void **state);
+static void test_addsl3_overflow(void **state);
+
+
+int
+main(void)
+{
+    const struct CMUnitTest  tests[] = {
+        cmocka_unit_test(test_addsl_ok),
+        cmocka_unit_test(test_addsl_underflow),
+        cmocka_unit_test(test_addsl_overflow),
+        cmocka_unit_test(test_addsl3_ok),
+        cmocka_unit_test(test_addsl3_underflow),
+        cmocka_unit_test(test_addsl3_overflow),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}
+
+
+static void
+test_addsl_ok(void **state)
+{
+	assert_true(addsl(1, 3)			== 1 + 3);
+	assert_true(addsl(-4321, 7)		== -4321 + 7);
+	assert_true(addsl(1, 1)			== 1 + 1);
+	assert_true(addsl(-1, -2)		== -1 - 2);
+	assert_true(addsl(LONG_MAX, -1)		== LONG_MAX - 1);
+	assert_true(addsl(LONG_MIN, 1)		== LONG_MIN + 1);
+	assert_true(addsl(LONG_MIN, LONG_MAX)	== LONG_MIN + LONG_MAX);
+	assert_true(addsl(0, 0)			== 0);
+}
+
+
+static void
+test_addsl_underflow(void **state)
+{
+	assert_true(addsl(LONG_MIN, -1)		== LONG_MIN);
+	assert_true(addsl(LONG_MIN + 3, -7)	== LONG_MIN);
+	assert_true(addsl(LONG_MIN, LONG_MIN)	== LONG_MIN);
+}
+
+
+static void
+test_addsl_overflow(void **state)
+{
+	assert_true(addsl(LONG_MAX, 1)		== LONG_MAX);
+	assert_true(addsl(LONG_MAX - 3, 7)	== LONG_MAX);
+	assert_true(addsl(LONG_MAX, LONG_MAX)	== LONG_MAX);
+}
+
+
+static void
+test_addsl3_ok(void **state)
+{
+	assert_true(addsl3(1, 2, 3)		== 1 + 2 + 3);
+	assert_true(addsl3(LONG_MIN, -3, 4)	== LONG_MIN + 4 - 3);
+	assert_true(addsl3(LONG_MAX, LONG_MAX, LONG_MIN)
+						== LONG_MAX + LONG_MIN + LONG_MAX);
+}
+
+
+static void
+test_addsl3_underflow(void **state)
+{
+	assert_true(addsl3(LONG_MIN, 2, -3)	== LONG_MIN);
+	assert_true(addsl3(LONG_MIN, -1, 0)	== LONG_MIN);
+}
+
+
+static void
+test_addsl3_overflow(void **state)
+{
+	assert_true(addsl3(LONG_MAX, -1, 2)	== LONG_MAX);
+	assert_true(addsl3(LONG_MAX, +1, 0)	== LONG_MAX);
+	assert_true(addsl3(LONG_MAX, LONG_MAX, 0)== LONG_MAX);
+}


### PR DESCRIPTION
These functions add 2 or 3 longs, saturating to LONG_{MIN,MAX} instead of overflowing.

Cc: @stoeckmann 