### PR TITLE
Many getrange() fixes

### DIFF
--- a/lib/atoi/a2i.c
+++ b/lib/atoi/a2i.c
@@ -7,20 +7,40 @@
 #include "atoi/a2i.h"
 
 
-extern inline int a2sh(short *restrict n, const char *s,
+extern inline int a2sh_c(short *restrict n, const char *s,
+    const char **restrict endp, int base, short min, short max);
+extern inline int a2si_c(int *restrict n, const char *s,
+    const char **restrict endp, int base, int min, int max);
+extern inline int a2sl_c(long *restrict n, const char *s,
+    const char **restrict endp, int base, long min, long max);
+extern inline int a2sll_c(long long *restrict n, const char *s,
+    const char **restrict endp, int base, long long min, long long max);
+extern inline int a2uh_c(unsigned short *restrict n, const char *s,
+    const char **restrict endp, int base, unsigned short min,
+    unsigned short max);
+extern inline int a2ui_c(unsigned int *restrict n, const char *s,
+    const char **restrict endp, int base, unsigned int min, unsigned int max);
+extern inline int a2ul_c(unsigned long *restrict n, const char *s,
+    const char **restrict endp, int base, unsigned long min, unsigned long max);
+extern inline int a2ull_c(unsigned long long *restrict n, const char *s,
+    const char **restrict endp, int base, unsigned long long min,
+    unsigned long long max);
+
+
+extern inline int a2sh_nc(short *restrict n, char *s,
     char **restrict endp, int base, short min, short max);
-extern inline int a2si(int *restrict n, const char *s,
+extern inline int a2si_nc(int *restrict n, char *s,
     char **restrict endp, int base, int min, int max);
-extern inline int a2sl(long *restrict n, const char *s,
+extern inline int a2sl_nc(long *restrict n, char *s,
     char **restrict endp, int base, long min, long max);
-extern inline int a2sll(long long *restrict n, const char *s,
+extern inline int a2sll_nc(long long *restrict n, char *s,
     char **restrict endp, int base, long long min, long long max);
-extern inline int a2uh(unsigned short *restrict n, const char *s,
+extern inline int a2uh_nc(unsigned short *restrict n, char *s,
     char **restrict endp, int base, unsigned short min, unsigned short max);
-extern inline int a2ui(unsigned int *restrict n, const char *s,
+extern inline int a2ui_nc(unsigned int *restrict n, char *s,
     char **restrict endp, int base, unsigned int min, unsigned int max);
-extern inline int a2ul(unsigned long *restrict n, const char *s,
+extern inline int a2ul_nc(unsigned long *restrict n, char *s,
     char **restrict endp, int base, unsigned long min, unsigned long max);
-extern inline int a2ull(unsigned long long *restrict n, const char *s,
+extern inline int a2ull_nc(unsigned long long *restrict n, char *s,
     char **restrict endp, int base, unsigned long long min,
     unsigned long long max);

--- a/lib/atoi/a2i.h
+++ b/lib/atoi/a2i.h
@@ -15,51 +15,255 @@
 #include "attr.h"
 
 
-#define a2i(TYPE, ...)                                                        \
+/*
+ * See the manual of these macros in liba2i's documentation:
+ * <http://www.alejandro-colomar.es/share/dist/liba2i/git/HEAD/liba2i-HEAD.pdf>
+ */
+
+
+#define a2i(TYPE, n, s, ...)                                                  \
 (                                                                             \
-	_Generic((TYPE) 0,                                                    \
-		short:              a2sh,                                     \
-		int:                a2si,                                     \
-		long:               a2sl,                                     \
-		long long:          a2sll,                                    \
-		unsigned short:     a2uh,                                     \
-		unsigned int:       a2ui,                                     \
-		unsigned long:      a2ul,                                     \
-		unsigned long long: a2ull                                     \
-	)(__VA_ARGS__)                                                        \
+	_Generic((void (*)(TYPE, typeof(s))) 0,                               \
+		void (*)(short,              const char *):  a2sh_c,          \
+		void (*)(short,              const void *):  a2sh_c,          \
+		void (*)(short,              char *):        a2sh_nc,         \
+		void (*)(short,              void *):        a2sh_nc,         \
+		void (*)(int,                const char *):  a2si_c,          \
+		void (*)(int,                const void *):  a2si_c,          \
+		void (*)(int,                char *):        a2si_nc,         \
+		void (*)(int,                void *):        a2si_nc,         \
+		void (*)(long,               const char *):  a2sl_c,          \
+		void (*)(long,               const void *):  a2sl_c,          \
+		void (*)(long,               char *):        a2sl_nc,         \
+		void (*)(long,               void *):        a2sl_nc,         \
+		void (*)(long long,          const char *):  a2sll_c,         \
+		void (*)(long long,          const void *):  a2sll_c,         \
+		void (*)(long long,          char *):        a2sll_nc,        \
+		void (*)(long long,          void *):        a2sll_nc,        \
+		void (*)(unsigned short,     const char *):  a2uh_c,          \
+		void (*)(unsigned short,     const void *):  a2uh_c,          \
+		void (*)(unsigned short,     char *):        a2uh_nc,         \
+		void (*)(unsigned short,     void *):        a2uh_nc,         \
+		void (*)(unsigned int,       const char *):  a2ui_c,          \
+		void (*)(unsigned int,       const void *):  a2ui_c,          \
+		void (*)(unsigned int,       char *):        a2ui_nc,         \
+		void (*)(unsigned int,       void *):        a2ui_nc,         \
+		void (*)(unsigned long,      const char *):  a2ul_c,          \
+		void (*)(unsigned long,      const void *):  a2ul_c,          \
+		void (*)(unsigned long,      char *):        a2ul_nc,         \
+		void (*)(unsigned long,      void *):        a2ul_nc,         \
+		void (*)(unsigned long long, const char *):  a2ull_c,         \
+		void (*)(unsigned long long, const void *):  a2ull_c,         \
+		void (*)(unsigned long long, char *):        a2ull_nc,        \
+		void (*)(unsigned long long, void *):        a2ull_nc         \
+	)(n, s, __VA_ARGS__)                                                  \
+)
+
+
+#define a2sh(n, s, ...)                                                       \
+(                                                                             \
+	_Generic(s,                                                           \
+		const char *:  a2sh_c,                                        \
+		const void *:  a2sh_c,                                        \
+		char *:        a2sh_nc,                                       \
+		void *:        a2sh_nc                                        \
+	)(n, s, __VA_ARGS__)                                                  \
+)
+
+#define a2si(n, s, ...)                                                       \
+(                                                                             \
+	_Generic(s,                                                           \
+		const char *:  a2si_c,                                        \
+		const void *:  a2si_c,                                        \
+		char *:        a2si_nc,                                       \
+		void *:        a2si_nc                                        \
+	)(n, s, __VA_ARGS__)                                                  \
+)
+
+#define a2sl(n, s, ...)                                                       \
+(                                                                             \
+	_Generic(s,                                                           \
+		const char *:  a2sl_c,                                        \
+		const void *:  a2sl_c,                                        \
+		char *:        a2sl_nc,                                       \
+		void *:        a2sl_nc                                        \
+	)(n, s, __VA_ARGS__)                                                  \
+)
+
+#define a2sll(n, s, ...)                                                      \
+(                                                                             \
+	_Generic(s,                                                           \
+		const char *:  a2sll_c,                                       \
+		const void *:  a2sll_c,                                       \
+		char *:        a2sll_nc,                                      \
+		void *:        a2sll_nc                                       \
+	)(n, s, __VA_ARGS__)                                                  \
+)
+
+#define a2uh(n, s, ...)                                                       \
+(                                                                             \
+	_Generic(s,                                                           \
+		const char *:  a2uh_c,                                        \
+		const void *:  a2uh_c,                                        \
+		char *:        a2uh_nc,                                       \
+		void *:        a2uh_nc                                        \
+	)(n, s, __VA_ARGS__)                                                  \
+)
+
+#define a2ui(n, s, ...)                                                       \
+(                                                                             \
+	_Generic(s,                                                           \
+		const char *:  a2ui_c,                                        \
+		const void *:  a2ui_c,                                        \
+		char *:        a2ui_nc,                                       \
+		void *:        a2ui_nc                                        \
+	)(n, s, __VA_ARGS__)                                                  \
+)
+
+#define a2ul(n, s, ...)                                                       \
+(                                                                             \
+	_Generic(s,                                                           \
+		const char *:  a2ul_c,                                        \
+		const void *:  a2ul_c,                                        \
+		char *:        a2ul_nc,                                       \
+		void *:        a2ul_nc                                        \
+	)(n, s, __VA_ARGS__)                                                  \
+)
+
+#define a2ull(n, s, ...)                                                      \
+(                                                                             \
+	_Generic(s,                                                           \
+		const char *:  a2ull_c,                                       \
+		const void *:  a2ull_c,                                       \
+		char *:        a2ull_nc,                                      \
+		void *:        a2ull_nc                                       \
+	)(n, s, __VA_ARGS__)                                                  \
 )
 
 
 ATTR_STRING(2) ATTR_ACCESS(write_only, 1) ATTR_ACCESS(write_only, 3)
-inline int a2sh(short *restrict n, const char *s,
+inline int a2sh_c(short *restrict n, const char *s,
+    const char **restrict endp, int base, short min, short max);
+ATTR_STRING(2) ATTR_ACCESS(write_only, 1) ATTR_ACCESS(write_only, 3)
+inline int a2si_c(int *restrict n, const char *s,
+    const char **restrict endp, int base, int min, int max);
+ATTR_STRING(2) ATTR_ACCESS(write_only, 1) ATTR_ACCESS(write_only, 3)
+inline int a2sl_c(long *restrict n, const char *s,
+    const char **restrict endp, int base, long min, long max);
+ATTR_STRING(2) ATTR_ACCESS(write_only, 1) ATTR_ACCESS(write_only, 3)
+inline int a2sll_c(long long *restrict n, const char *s,
+    const char **restrict endp, int base, long long min, long long max);
+ATTR_STRING(2) ATTR_ACCESS(write_only, 1) ATTR_ACCESS(write_only, 3)
+inline int a2uh_c(unsigned short *restrict n, const char *s,
+    const char **restrict endp, int base, unsigned short min,
+    unsigned short max);
+ATTR_STRING(2) ATTR_ACCESS(write_only, 1) ATTR_ACCESS(write_only, 3)
+inline int a2ui_c(unsigned int *restrict n, const char *s,
+    const char **restrict endp, int base, unsigned int min, unsigned int max);
+ATTR_STRING(2) ATTR_ACCESS(write_only, 1) ATTR_ACCESS(write_only, 3)
+inline int a2ul_c(unsigned long *restrict n, const char *s,
+    const char **restrict endp, int base, unsigned long min, unsigned long max);
+ATTR_STRING(2) ATTR_ACCESS(write_only, 1) ATTR_ACCESS(write_only, 3)
+inline int a2ull_c(unsigned long long *restrict n, const char *s,
+    const char **restrict endp, int base, unsigned long long min,
+    unsigned long long max);
+
+ATTR_STRING(2) ATTR_ACCESS(write_only, 1) ATTR_ACCESS(write_only, 3)
+inline int a2sh_nc(short *restrict n, char *s,
     char **restrict endp, int base, short min, short max);
 ATTR_STRING(2) ATTR_ACCESS(write_only, 1) ATTR_ACCESS(write_only, 3)
-inline int a2si(int *restrict n, const char *s,
+inline int a2si_nc(int *restrict n, char *s,
     char **restrict endp, int base, int min, int max);
 ATTR_STRING(2) ATTR_ACCESS(write_only, 1) ATTR_ACCESS(write_only, 3)
-inline int a2sl(long *restrict n, const char *s,
+inline int a2sl_nc(long *restrict n, char *s,
     char **restrict endp, int base, long min, long max);
 ATTR_STRING(2) ATTR_ACCESS(write_only, 1) ATTR_ACCESS(write_only, 3)
-inline int a2sll(long long *restrict n, const char *s,
+inline int a2sll_nc(long long *restrict n, char *s,
     char **restrict endp, int base, long long min, long long max);
 ATTR_STRING(2) ATTR_ACCESS(write_only, 1) ATTR_ACCESS(write_only, 3)
-inline int a2uh(unsigned short *restrict n, const char *s,
+inline int a2uh_nc(unsigned short *restrict n, char *s,
     char **restrict endp, int base, unsigned short min, unsigned short max);
 ATTR_STRING(2) ATTR_ACCESS(write_only, 1) ATTR_ACCESS(write_only, 3)
-inline int a2ui(unsigned int *restrict n, const char *s,
+inline int a2ui_nc(unsigned int *restrict n, char *s,
     char **restrict endp, int base, unsigned int min, unsigned int max);
 ATTR_STRING(2) ATTR_ACCESS(write_only, 1) ATTR_ACCESS(write_only, 3)
-inline int a2ul(unsigned long *restrict n, const char *s,
+inline int a2ul_nc(unsigned long *restrict n, char *s,
     char **restrict endp, int base, unsigned long min, unsigned long max);
 ATTR_STRING(2) ATTR_ACCESS(write_only, 1) ATTR_ACCESS(write_only, 3)
-inline int a2ull(unsigned long long *restrict n, const char *s,
+inline int a2ull_nc(unsigned long long *restrict n, char *s,
     char **restrict endp, int base, unsigned long long min,
     unsigned long long max);
 
 
 inline int
-a2sh(short *restrict n, const char *s, char **restrict endp,
-    int base, short min, short max)
+a2sh_c(short *restrict n, const char *s,
+    const char **restrict endp, int base, short min, short max)
+{
+	return a2sh(n, (char *) s, (char **) endp, base, min, max);
+}
+
+
+inline int
+a2si_c(int *restrict n, const char *s,
+    const char **restrict endp, int base, int min, int max)
+{
+	return a2si(n, (char *) s, (char **) endp, base, min, max);
+}
+
+
+inline int
+a2sl_c(long *restrict n, const char *s,
+    const char **restrict endp, int base, long min, long max)
+{
+	return a2sl(n, (char *) s, (char **) endp, base, min, max);
+}
+
+
+inline int
+a2sll_c(long long *restrict n, const char *s,
+    const char **restrict endp, int base, long long min, long long max)
+{
+	return a2sll(n, (char *) s, (char **) endp, base, min, max);
+}
+
+
+inline int
+a2uh_c(unsigned short *restrict n, const char *s,
+    const char **restrict endp, int base, unsigned short min,
+    unsigned short max)
+{
+	return a2uh(n, (char *) s, (char **) endp, base, min, max);
+}
+
+
+inline int
+a2ui_c(unsigned int *restrict n, const char *s,
+    const char **restrict endp, int base, unsigned int min, unsigned int max)
+{
+	return a2ui(n, (char *) s, (char **) endp, base, min, max);
+}
+
+
+inline int
+a2ul_c(unsigned long *restrict n, const char *s,
+    const char **restrict endp, int base, unsigned long min, unsigned long max)
+{
+	return a2ul(n, (char *) s, (char **) endp, base, min, max);
+}
+
+
+inline int
+a2ull_c(unsigned long long *restrict n, const char *s,
+    const char **restrict endp, int base, unsigned long long min,
+    unsigned long long max)
+{
+	return a2ull(n, (char *) s, (char **) endp, base, min, max);
+}
+
+
+inline int
+a2sh_nc(short *restrict n, char *s,
+    char **restrict endp, int base, short min, short max)
 {
 	int  status;
 
@@ -73,8 +277,8 @@ a2sh(short *restrict n, const char *s, char **restrict endp,
 
 
 inline int
-a2si(int *restrict n, const char *s, char **restrict endp,
-    int base, int min, int max)
+a2si_nc(int *restrict n, char *s,
+    char **restrict endp, int base, int min, int max)
 {
 	int  status;
 
@@ -88,8 +292,8 @@ a2si(int *restrict n, const char *s, char **restrict endp,
 
 
 inline int
-a2sl(long *restrict n, const char *s, char **restrict endp,
-    int base, long min, long max)
+a2sl_nc(long *restrict n, char *s,
+    char **restrict endp, int base, long min, long max)
 {
 	int  status;
 
@@ -103,8 +307,8 @@ a2sl(long *restrict n, const char *s, char **restrict endp,
 
 
 inline int
-a2sll(long long *restrict n, const char *s, char **restrict endp,
-    int base, long long min, long long max)
+a2sll_nc(long long *restrict n, char *s,
+    char **restrict endp, int base, long long min, long long max)
 {
 	int  status;
 
@@ -118,8 +322,9 @@ a2sll(long long *restrict n, const char *s, char **restrict endp,
 
 
 inline int
-a2uh(unsigned short *restrict n, const char *s, char **restrict endp,
-    int base, unsigned short min, unsigned short max)
+a2uh_nc(unsigned short *restrict n, char *s,
+    char **restrict endp, int base, unsigned short min,
+    unsigned short max)
 {
 	int  status;
 
@@ -133,8 +338,8 @@ a2uh(unsigned short *restrict n, const char *s, char **restrict endp,
 
 
 inline int
-a2ui(unsigned int *restrict n, const char *s, char **restrict endp,
-    int base, unsigned int min, unsigned int max)
+a2ui_nc(unsigned int *restrict n, char *s,
+    char **restrict endp, int base, unsigned int min, unsigned int max)
 {
 	int  status;
 
@@ -148,8 +353,8 @@ a2ui(unsigned int *restrict n, const char *s, char **restrict endp,
 
 
 inline int
-a2ul(unsigned long *restrict n, const char *s, char **restrict endp,
-    int base, unsigned long min, unsigned long max)
+a2ul_nc(unsigned long *restrict n, char *s,
+    char **restrict endp, int base, unsigned long min, unsigned long max)
 {
 	int  status;
 
@@ -163,8 +368,9 @@ a2ul(unsigned long *restrict n, const char *s, char **restrict endp,
 
 
 inline int
-a2ull(unsigned long long *restrict n, const char *s, char **restrict endp,
-    int base, unsigned long long min, unsigned long long max)
+a2ull_nc(unsigned long long *restrict n, char *s,
+    char **restrict endp, int base, unsigned long long min,
+    unsigned long long max)
 {
 	int  status;
 

--- a/lib/getrange.c
+++ b/lib/getrange.c
@@ -33,6 +33,7 @@ getrange(const char *range,
 	if (NULL == range)
 		return -1;
 
+	*min = 0;
 	*has_min = false;
 	*has_max = false;
 
@@ -58,7 +59,7 @@ parse_max:
 		if (!isdigit((unsigned char) *end))
 			return -1;
 
-		if (a2ul(max, end, NULL, 10, 0, ULONG_MAX) == -1)
+		if (a2ul(max, end, NULL, 10, *min, ULONG_MAX) == -1)
 			return -1;
 		*has_max = true;
 

--- a/lib/getrange.c
+++ b/lib/getrange.c
@@ -28,7 +28,7 @@ getrange(const char *range,
          unsigned long *min, bool *has_min,
          unsigned long *max, bool *has_max)
 {
-	char  *end;
+	const char  *end;
 
 	if (NULL == range)
 		return -1;

--- a/lib/getrange.c
+++ b/lib/getrange.c
@@ -1,8 +1,6 @@
-/*
- * SPDX-FileCopyrightText: 2008       , Nicolas François
- *
- * SPDX-License-Identifier: BSD-3-Clause
- */
+// SPDX-FileCopyrightText: 2008, Nicolas François
+// SPDX-FileCopyrightText: 2023-2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 
 #include <config.h>
@@ -12,7 +10,7 @@
 #include <ctype.h>
 #include <stdlib.h>
 
-#include "atoi/strtou_noneg.h"
+#include "atoi/a2i.h"
 #include "defines.h"
 #include "prototypes.h"
 
@@ -43,9 +41,7 @@ getrange(const char *range,
 		goto parse_max;
 	}
 
-	errno = 0;
-	*min = strtoul_noneg(range, &end, 10);
-	if (end == range || 0 != errno)
+	if (a2ul(min, range, &end, 10, 0, ULONG_MAX) == -1 && errno != ENOTSUP)
 		return -1;
 	*has_min = true;
 
@@ -62,9 +58,7 @@ parse_max:
 		if (!isdigit(*end))
 			return -1;
 
-		errno = 0;
-		*max = strtoul_noneg(end, &end, 10);
-		if ('\0' != *end || 0 != errno)
+		if (a2ul(max, end, NULL, 10, 0, ULONG_MAX) == -1)
 			return -1;
 		*has_max = true;
 

--- a/lib/getrange.c
+++ b/lib/getrange.c
@@ -55,7 +55,7 @@ getrange(const char *range,
 		if ('\0' == *end)
 			return 0;  /* <long>- */
 parse_max:
-		if (!isdigit(*end))
+		if (!isdigit((unsigned char) *end))
 			return -1;
 
 		if (a2ul(max, end, NULL, 10, 0, ULONG_MAX) == -1)


### PR DESCRIPTION
---

Revisions (to see revisions before v9, see the threads below):

<details>
<summary>v9</summary>

v9 changes:

-  Rebase

```
$ git range-diff gr2..gh/getrange shadow/master..getrange 
1:  fc6bfaa7 = 1:  fca2ece3 lib/atoi/a2i.[ch]: Add const-generic macros
2:  61c128d9 = 2:  46466828 lib/getrange.c: getrange(): Use a2ul() instead of strtoul_noneg()
3:  06ac2307 = 3:  4ed6db3c lib/getrange.c: getrange(): Add const to pointer
4:  4141c586 = 4:  54c16a8a lib/getrange.c: getrange(): Add missing cast
5:  0e6a67cc = 5:  50917d95 lib/getrange.c: getrange(): Report an ERANGE error when min>max
```
</details>
<details>
<summary>v9b</summary>

v9b changes:

-  Reword attribution to @uecker 

```
$ git range-diff shadow/master gh/getrange getrange 
1:  fca2ece3 ! 1:  ed2ec57d lib/atoi/a2i.[ch]: Add const-generic macros
    @@ Commit message
         endp, and will call the appropriate function.  This kind of const
         overloading has prior art in C23's string functions, such as memchr(3).
     
    -    The idea of using an artificial function pointer in _Generic(3) was from
    -    Martin Uecker.  It allows switching on various types at the same time.
    +    Martin suggested using an artificial function pointer in _Generic(3); it
    +    allows switching on various types at the same time.
     
         Link: <https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3096.pdf#subsubsection.7.26.5.2>
         Link: <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114731>
    -    Cc: Martin Uecker <muecker@gwdg.de>
    +    Co-developed-by: Martin Uecker <muecker@gwdg.de>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/atoi/a2i.c ##
2:  46466828 = 2:  cd505bbe lib/getrange.c: getrange(): Use a2ul() instead of strtoul_noneg()
3:  4ed6db3c = 3:  ca8d8d55 lib/getrange.c: getrange(): Add const to pointer
4:  54c16a8a = 4:  ee02e414 lib/getrange.c: getrange(): Add missing cast
5:  50917d95 = 5:  bf207295 lib/getrange.c: getrange(): Report an ERANGE error when min>max
```
</details>

<details>
<summary>v10</summary>
v10 changes:

-  Consider both `s` and `endp` in the const-generic macros.  Switch on the former, and let the latter follow.

```
$ git range-diff shadow/master gh/getrange getrange 
1:  ed2ec57d ! 1:  78c27e06 lib/atoi/a2i.[ch]: Add const-generic macros
    @@ lib/atoi/a2i.c
     +    unsigned long long max);
     +
     +
    -+extern inline int a2sh_nc(short *restrict n, const char *s,
    ++extern inline int a2sh_nc(short *restrict n, char *s,
          char **restrict endp, int base, short min, short max);
     -extern inline int a2si(int *restrict n, const char *s,
    -+extern inline int a2si_nc(int *restrict n, const char *s,
    ++extern inline int a2si_nc(int *restrict n, char *s,
          char **restrict endp, int base, int min, int max);
     -extern inline int a2sl(long *restrict n, const char *s,
    -+extern inline int a2sl_nc(long *restrict n, const char *s,
    ++extern inline int a2sl_nc(long *restrict n, char *s,
          char **restrict endp, int base, long min, long max);
     -extern inline int a2sll(long long *restrict n, const char *s,
    -+extern inline int a2sll_nc(long long *restrict n, const char *s,
    ++extern inline int a2sll_nc(long long *restrict n, char *s,
          char **restrict endp, int base, long long min, long long max);
     -extern inline int a2uh(unsigned short *restrict n, const char *s,
    -+extern inline int a2uh_nc(unsigned short *restrict n, const char *s,
    ++extern inline int a2uh_nc(unsigned short *restrict n, char *s,
          char **restrict endp, int base, unsigned short min, unsigned short max);
     -extern inline int a2ui(unsigned int *restrict n, const char *s,
    -+extern inline int a2ui_nc(unsigned int *restrict n, const char *s,
    ++extern inline int a2ui_nc(unsigned int *restrict n, char *s,
          char **restrict endp, int base, unsigned int min, unsigned int max);
     -extern inline int a2ul(unsigned long *restrict n, const char *s,
    -+extern inline int a2ul_nc(unsigned long *restrict n, const char *s,
    ++extern inline int a2ul_nc(unsigned long *restrict n, char *s,
          char **restrict endp, int base, unsigned long min, unsigned long max);
     -extern inline int a2ull(unsigned long long *restrict n, const char *s,
    -+extern inline int a2ull_nc(unsigned long long *restrict n, const char *s,
    ++extern inline int a2ull_nc(unsigned long long *restrict n, char *s,
          char **restrict endp, int base, unsigned long long min,
          unsigned long long max);
     
    @@ lib/atoi/a2i.h
      
      
     -#define a2i(TYPE, ...)                                                        \
    -+#define a2i(TYPE, n, s, endp, ...)                                            \
    ++#define a2i(TYPE, n, s, ...)                                                  \
      (                                                                             \
     -  _Generic((TYPE) 0,                                                    \
     -          short:              a2sh,                                     \
    @@ lib/atoi/a2i.h
     -          unsigned long:      a2ul,                                     \
     -          unsigned long long: a2ull                                     \
     -  )(__VA_ARGS__)                                                        \
    -+  _Generic((void (*)(TYPE, typeof(endp))) 0,                            \
    -+          void (*)(short,              const char **):  a2sh_c,         \
    -+          void (*)(short,              char **):        a2sh_nc,        \
    -+          void (*)(short,              void *):         a2sh_nc,        \
    -+          void (*)(int,                const char **):  a2si_c,         \
    -+          void (*)(int,                char **):        a2si_nc,        \
    -+          void (*)(int,                void *):         a2si_nc,        \
    -+          void (*)(long,               const char **):  a2sl_c,         \
    -+          void (*)(long,               char **):        a2sl_nc,        \
    -+          void (*)(long,               void *):         a2sl_nc,        \
    -+          void (*)(long long,          const char **):  a2sll_c,        \
    -+          void (*)(long long,          char **):        a2sll_nc,       \
    -+          void (*)(long long,          void *):         a2sll_nc,       \
    -+          void (*)(unsigned short,     const char **):  a2uh_c,         \
    -+          void (*)(unsigned short,     char **):        a2uh_nc,        \
    -+          void (*)(unsigned short,     void *):         a2uh_nc,        \
    -+          void (*)(unsigned int,       const char **):  a2ui_c,         \
    -+          void (*)(unsigned int,       char **):        a2ui_nc,        \
    -+          void (*)(unsigned int,       void *):         a2ui_nc,        \
    -+          void (*)(unsigned long,      const char **):  a2ul_c,         \
    -+          void (*)(unsigned long,      char **):        a2ul_nc,        \
    -+          void (*)(unsigned long,      void *):         a2ul_nc,        \
    -+          void (*)(unsigned long long, const char **):  a2ull_c,        \
    -+          void (*)(unsigned long long, char **):        a2ull_nc,       \
    -+          void (*)(unsigned long long, void *):         a2ull_nc        \
    -+  )(n, s, endp, __VA_ARGS__)                                            \
    ++  _Generic((void (*)(TYPE, typeof(s))) 0,                               \
    ++          void (*)(short,              const char *):  a2sh_c,          \
    ++          void (*)(short,              const void *):  a2sh_c,          \
    ++          void (*)(short,              char *):        a2sh_nc,         \
    ++          void (*)(short,              void *):        a2sh_nc,         \
    ++          void (*)(int,                const char *):  a2si_c,          \
    ++          void (*)(int,                const void *):  a2si_c,          \
    ++          void (*)(int,                char *):        a2si_nc,         \
    ++          void (*)(int,                void *):        a2si_nc,         \
    ++          void (*)(long,               const char *):  a2sl_c,          \
    ++          void (*)(long,               const void *):  a2sl_c,          \
    ++          void (*)(long,               char *):        a2sl_nc,         \
    ++          void (*)(long,               void *):        a2sl_nc,         \
    ++          void (*)(long long,          const char *):  a2sll_c,         \
    ++          void (*)(long long,          const void *):  a2sll_c,         \
    ++          void (*)(long long,          char *):        a2sll_nc,        \
    ++          void (*)(long long,          void *):        a2sll_nc,        \
    ++          void (*)(unsigned short,     const char *):  a2uh_c,          \
    ++          void (*)(unsigned short,     const void *):  a2uh_c,          \
    ++          void (*)(unsigned short,     char *):        a2uh_nc,         \
    ++          void (*)(unsigned short,     void *):        a2uh_nc,         \
    ++          void (*)(unsigned int,       const char *):  a2ui_c,          \
    ++          void (*)(unsigned int,       const void *):  a2ui_c,          \
    ++          void (*)(unsigned int,       char *):        a2ui_nc,         \
    ++          void (*)(unsigned int,       void *):        a2ui_nc,         \
    ++          void (*)(unsigned long,      const char *):  a2ul_c,          \
    ++          void (*)(unsigned long,      const void *):  a2ul_c,          \
    ++          void (*)(unsigned long,      char *):        a2ul_nc,         \
    ++          void (*)(unsigned long,      void *):        a2ul_nc,         \
    ++          void (*)(unsigned long long, const char *):  a2ull_c,         \
    ++          void (*)(unsigned long long, const void *):  a2ull_c,         \
    ++          void (*)(unsigned long long, char *):        a2ull_nc,        \
    ++          void (*)(unsigned long long, void *):        a2ull_nc         \
    ++  )(n, s, __VA_ARGS__)                                                  \
     +)
     +
     +
    -+#define a2sh(n, s, endp, ...)                                                 \
    ++#define a2sh(n, s, ...)                                                       \
     +(                                                                             \
    -+  _Generic(endp,                                                        \
    -+          const char **:  a2sh_c,                                       \
    -+          char **:        a2sh_nc,                                      \
    -+          void *:         a2sh_c                                        \
    -+  )(n, s, endp, __VA_ARGS__)                                            \
    ++  _Generic(s,                                                           \
    ++          const char *:  a2sh_c,                                        \
    ++          const void *:  a2sh_c,                                        \
    ++          char *:        a2sh_nc,                                       \
    ++          void *:        a2sh_nc                                        \
    ++  )(n, s, __VA_ARGS__)                                                  \
     +)
     +
    -+#define a2si(n, s, endp, ...)                                                 \
    ++#define a2si(n, s, ...)                                                       \
     +(                                                                             \
    -+  _Generic(endp,                                                        \
    -+          const char **:  a2si_c,                                       \
    -+          char **:        a2si_nc,                                      \
    -+          void *:         a2si_c                                        \
    -+  )(n, s, endp, __VA_ARGS__)                                            \
    ++  _Generic(s,                                                           \
    ++          const char *:  a2si_c,                                        \
    ++          const void *:  a2si_c,                                        \
    ++          char *:        a2si_nc,                                       \
    ++          void *:        a2si_nc                                        \
    ++  )(n, s, __VA_ARGS__)                                                  \
     +)
     +
    -+#define a2sl(n, s, endp, ...)                                                 \
    ++#define a2sl(n, s, ...)                                                       \
     +(                                                                             \
    -+  _Generic(endp,                                                        \
    -+          const char **:  a2sl_c,                                       \
    -+          char **:        a2sl_nc,                                      \
    -+          void *:         a2sl_c                                        \
    -+  )(n, s, endp, __VA_ARGS__)                                            \
    ++  _Generic(s,                                                           \
    ++          const char *:  a2sl_c,                                        \
    ++          const void *:  a2sl_c,                                        \
    ++          char *:        a2sl_nc,                                       \
    ++          void *:        a2sl_nc                                        \
    ++  )(n, s, __VA_ARGS__)                                                  \
     +)
     +
    -+#define a2sll(n, s, endp, ...)                                                \
    ++#define a2sll(n, s, ...)                                                      \
     +(                                                                             \
    -+  _Generic(endp,                                                        \
    -+          const char **:  a2sll_c,                                      \
    -+          char **:        a2sll_nc,                                     \
    -+          void *:         a2sll_c                                       \
    -+  )(n, s, endp, __VA_ARGS__)                                            \
    ++  _Generic(s,                                                           \
    ++          const char *:  a2sll_c,                                       \
    ++          const void *:  a2sll_c,                                       \
    ++          char *:        a2sll_nc,                                      \
    ++          void *:        a2sll_nc                                       \
    ++  )(n, s, __VA_ARGS__)                                                  \
     +)
     +
    -+#define a2uh(n, s, endp, ...)                                                 \
    ++#define a2uh(n, s, ...)                                                       \
     +(                                                                             \
    -+  _Generic(endp,                                                        \
    -+          const char **:  a2uh_c,                                       \
    -+          char **:        a2uh_nc,                                      \
    -+          void *:         a2uh_c                                        \
    -+  )(n, s, endp, __VA_ARGS__)                                            \
    ++  _Generic(s,                                                           \
    ++          const char *:  a2uh_c,                                        \
    ++          const void *:  a2uh_c,                                        \
    ++          char *:        a2uh_nc,                                       \
    ++          void *:        a2uh_nc                                        \
    ++  )(n, s, __VA_ARGS__)                                                  \
     +)
     +
    -+#define a2ui(n, s, endp, ...)                                                 \
    ++#define a2ui(n, s, ...)                                                       \
     +(                                                                             \
    -+  _Generic(endp,                                                        \
    -+          const char **:  a2ui_c,                                       \
    -+          char **:        a2ui_nc,                                      \
    -+          void *:         a2ui_c                                        \
    -+  )(n, s, endp, __VA_ARGS__)                                            \
    ++  _Generic(s,                                                           \
    ++          const char *:  a2ui_c,                                        \
    ++          const void *:  a2ui_c,                                        \
    ++          char *:        a2ui_nc,                                       \
    ++          void *:        a2ui_nc                                        \
    ++  )(n, s, __VA_ARGS__)                                                  \
     +)
     +
    -+#define a2ul(n, s, endp, ...)                                                 \
    ++#define a2ul(n, s, ...)                                                       \
     +(                                                                             \
    -+  _Generic(endp,                                                        \
    -+          const char **:  a2ul_c,                                       \
    -+          char **:        a2ul_nc,                                      \
    -+          void *:         a2ul_c                                        \
    -+  )(n, s, endp, __VA_ARGS__)                                            \
    ++  _Generic(s,                                                           \
    ++          const char *:  a2ul_c,                                        \
    ++          const void *:  a2ul_c,                                        \
    ++          char *:        a2ul_nc,                                       \
    ++          void *:        a2ul_nc                                        \
    ++  )(n, s, __VA_ARGS__)                                                  \
     +)
     +
    -+#define a2ull(n, s, endp, ...)                                                \
    ++#define a2ull(n, s, ...)                                                      \
     +(                                                                             \
    -+  _Generic(endp,                                                        \
    -+          const char **:  a2ull_c,                                      \
    -+          char **:        a2ull_nc,                                     \
    -+          void *:         a2ull_c                                       \
    -+  )(n, s, endp, __VA_ARGS__)                                            \
    ++  _Generic(s,                                                           \
    ++          const char *:  a2ull_c,                                       \
    ++          const void *:  a2ull_c,                                       \
    ++          char *:        a2ull_nc,                                      \
    ++          void *:        a2ull_nc                                       \
    ++  )(n, s, __VA_ARGS__)                                                  \
      )
      
      
    @@ lib/atoi/a2i.h
     +    unsigned long long max);
     +
     +ATTR_STRING(2) ATTR_ACCESS(write_only, 1) ATTR_ACCESS(write_only, 3)
    -+inline int a2sh_nc(short *restrict n, const char *s,
    ++inline int a2sh_nc(short *restrict n, char *s,
          char **restrict endp, int base, short min, short max);
      ATTR_STRING(2) ATTR_ACCESS(write_only, 1) ATTR_ACCESS(write_only, 3)
     -inline int a2si(int *restrict n, const char *s,
    -+inline int a2si_nc(int *restrict n, const char *s,
    ++inline int a2si_nc(int *restrict n, char *s,
          char **restrict endp, int base, int min, int max);
      ATTR_STRING(2) ATTR_ACCESS(write_only, 1) ATTR_ACCESS(write_only, 3)
     -inline int a2sl(long *restrict n, const char *s,
    -+inline int a2sl_nc(long *restrict n, const char *s,
    ++inline int a2sl_nc(long *restrict n, char *s,
          char **restrict endp, int base, long min, long max);
      ATTR_STRING(2) ATTR_ACCESS(write_only, 1) ATTR_ACCESS(write_only, 3)
     -inline int a2sll(long long *restrict n, const char *s,
    -+inline int a2sll_nc(long long *restrict n, const char *s,
    ++inline int a2sll_nc(long long *restrict n, char *s,
          char **restrict endp, int base, long long min, long long max);
      ATTR_STRING(2) ATTR_ACCESS(write_only, 1) ATTR_ACCESS(write_only, 3)
     -inline int a2uh(unsigned short *restrict n, const char *s,
    -+inline int a2uh_nc(unsigned short *restrict n, const char *s,
    ++inline int a2uh_nc(unsigned short *restrict n, char *s,
          char **restrict endp, int base, unsigned short min, unsigned short max);
      ATTR_STRING(2) ATTR_ACCESS(write_only, 1) ATTR_ACCESS(write_only, 3)
     -inline int a2ui(unsigned int *restrict n, const char *s,
    -+inline int a2ui_nc(unsigned int *restrict n, const char *s,
    ++inline int a2ui_nc(unsigned int *restrict n, char *s,
          char **restrict endp, int base, unsigned int min, unsigned int max);
      ATTR_STRING(2) ATTR_ACCESS(write_only, 1) ATTR_ACCESS(write_only, 3)
     -inline int a2ul(unsigned long *restrict n, const char *s,
    -+inline int a2ul_nc(unsigned long *restrict n, const char *s,
    ++inline int a2ul_nc(unsigned long *restrict n, char *s,
          char **restrict endp, int base, unsigned long min, unsigned long max);
      ATTR_STRING(2) ATTR_ACCESS(write_only, 1) ATTR_ACCESS(write_only, 3)
     -inline int a2ull(unsigned long long *restrict n, const char *s,
    -+inline int a2ull_nc(unsigned long long *restrict n, const char *s,
    ++inline int a2ull_nc(unsigned long long *restrict n, char *s,
          char **restrict endp, int base, unsigned long long min,
          unsigned long long max);
      
    @@ lib/atoi/a2i.h
     +a2sh_c(short *restrict n, const char *s,
     +    const char **restrict endp, int base, short min, short max)
     +{
    -+  return a2sh_nc(n, s, (char **) endp, base, min, max);
    ++  return a2sh(n, (char *) s, (char **) endp, base, min, max);
     +}
     +
     +
    @@ lib/atoi/a2i.h
     +a2si_c(int *restrict n, const char *s,
     +    const char **restrict endp, int base, int min, int max)
     +{
    -+  return a2si_nc(n, s, (char **) endp, base, min, max);
    ++  return a2si(n, (char *) s, (char **) endp, base, min, max);
     +}
     +
     +
    @@ lib/atoi/a2i.h
     +a2sl_c(long *restrict n, const char *s,
     +    const char **restrict endp, int base, long min, long max)
     +{
    -+  return a2sl_nc(n, s, (char **) endp, base, min, max);
    ++  return a2sl(n, (char *) s, (char **) endp, base, min, max);
     +}
     +
     +
    @@ lib/atoi/a2i.h
     +a2sll_c(long long *restrict n, const char *s,
     +    const char **restrict endp, int base, long long min, long long max)
     +{
    -+  return a2sll_nc(n, s, (char **) endp, base, min, max);
    ++  return a2sll(n, (char *) s, (char **) endp, base, min, max);
     +}
     +
     +
    @@ lib/atoi/a2i.h
     +    const char **restrict endp, int base, unsigned short min,
     +    unsigned short max)
     +{
    -+  return a2uh_nc(n, s, (char **) endp, base, min, max);
    ++  return a2uh(n, (char *) s, (char **) endp, base, min, max);
     +}
     +
     +
    @@ lib/atoi/a2i.h
     +a2ui_c(unsigned int *restrict n, const char *s,
     +    const char **restrict endp, int base, unsigned int min, unsigned int max)
     +{
    -+  return a2ui_nc(n, s, (char **) endp, base, min, max);
    ++  return a2ui(n, (char *) s, (char **) endp, base, min, max);
     +}
     +
     +
    @@ lib/atoi/a2i.h
     +a2ul_c(unsigned long *restrict n, const char *s,
     +    const char **restrict endp, int base, unsigned long min, unsigned long max)
     +{
    -+  return a2ul_nc(n, s, (char **) endp, base, min, max);
    ++  return a2ul(n, (char *) s, (char **) endp, base, min, max);
     +}
     +
     +
    @@ lib/atoi/a2i.h
     +    const char **restrict endp, int base, unsigned long long min,
     +    unsigned long long max)
     +{
    -+  return a2ull_nc(n, s, (char **) endp, base, min, max);
    ++  return a2ull(n, (char *) s, (char **) endp, base, min, max);
     +}
     +
     +
     +inline int
    -+a2sh_nc(short *restrict n, const char *s,
    ++a2sh_nc(short *restrict n, char *s,
     +    char **restrict endp, int base, short min, short max)
      {
        int  status;
    @@ lib/atoi/a2i.h: a2sh(short *restrict n, const char *s, char **restrict endp,
      inline int
     -a2si(int *restrict n, const char *s, char **restrict endp,
     -    int base, int min, int max)
    -+a2si_nc(int *restrict n, const char *s,
    ++a2si_nc(int *restrict n, char *s,
     +    char **restrict endp, int base, int min, int max)
      {
        int  status;
    @@ lib/atoi/a2i.h: a2si(int *restrict n, const char *s, char **restrict endp,
      inline int
     -a2sl(long *restrict n, const char *s, char **restrict endp,
     -    int base, long min, long max)
    -+a2sl_nc(long *restrict n, const char *s,
    ++a2sl_nc(long *restrict n, char *s,
     +    char **restrict endp, int base, long min, long max)
      {
        int  status;
    @@ lib/atoi/a2i.h: a2sl(long *restrict n, const char *s, char **restrict endp,
      inline int
     -a2sll(long long *restrict n, const char *s, char **restrict endp,
     -    int base, long long min, long long max)
    -+a2sll_nc(long long *restrict n, const char *s,
    ++a2sll_nc(long long *restrict n, char *s,
     +    char **restrict endp, int base, long long min, long long max)
      {
        int  status;
    @@ lib/atoi/a2i.h: a2sll(long long *restrict n, const char *s, char **restrict endp
      inline int
     -a2uh(unsigned short *restrict n, const char *s, char **restrict endp,
     -    int base, unsigned short min, unsigned short max)
    -+a2uh_nc(unsigned short *restrict n, const char *s,
    ++a2uh_nc(unsigned short *restrict n, char *s,
     +    char **restrict endp, int base, unsigned short min,
     +    unsigned short max)
      {
    @@ lib/atoi/a2i.h: a2uh(unsigned short *restrict n, const char *s, char **restrict
      inline int
     -a2ui(unsigned int *restrict n, const char *s, char **restrict endp,
     -    int base, unsigned int min, unsigned int max)
    -+a2ui_nc(unsigned int *restrict n, const char *s,
    ++a2ui_nc(unsigned int *restrict n, char *s,
     +    char **restrict endp, int base, unsigned int min, unsigned int max)
      {
        int  status;
    @@ lib/atoi/a2i.h: a2ui(unsigned int *restrict n, const char *s, char **restrict en
      inline int
     -a2ul(unsigned long *restrict n, const char *s, char **restrict endp,
     -    int base, unsigned long min, unsigned long max)
    -+a2ul_nc(unsigned long *restrict n, const char *s,
    ++a2ul_nc(unsigned long *restrict n, char *s,
     +    char **restrict endp, int base, unsigned long min, unsigned long max)
      {
        int  status;
    @@ lib/atoi/a2i.h: a2ul(unsigned long *restrict n, const char *s, char **restrict e
      inline int
     -a2ull(unsigned long long *restrict n, const char *s, char **restrict endp,
     -    int base, unsigned long long min, unsigned long long max)
    -+a2ull_nc(unsigned long long *restrict n, const char *s,
    ++a2ull_nc(unsigned long long *restrict n, char *s,
     +    char **restrict endp, int base, unsigned long long min,
     +    unsigned long long max)
      {
2:  cd505bbe = 2:  864c66b9 lib/getrange.c: getrange(): Use a2ul() instead of strtoul_noneg()
3:  ca8d8d55 = 3:  33961983 lib/getrange.c: getrange(): Add const to pointer
4:  ee02e414 = 4:  655d06b2 lib/getrange.c: getrange(): Add missing cast
5:  bf207295 = 5:  e8039e7f lib/getrange.c: getrange(): Report an ERANGE error when min>max
```
</details>

<details>
<summary>v10b</summary>

-  wfix commit message [@ikerexxe ]

```
$ git range-diff shadow/master gh/getrange getrange 
1:  78c27e06 = 1:  78c27e06 lib/atoi/a2i.[ch]: Add const-generic macros
2:  864c66b9 = 2:  864c66b9 lib/getrange.c: getrange(): Use a2ul() instead of strtoul_noneg()
3:  33961983 = 3:  33961983 lib/getrange.c: getrange(): Add const to pointer
4:  655d06b2 = 4:  655d06b2 lib/getrange.c: getrange(): Add missing cast
5:  e8039e7f ! 5:  23aef628 lib/getrange.c: getrange(): Report an ERANGE error when min>max
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/getrange.c: getrange(): Report an ERANGE error when min>max
    +    lib/getrange.c: getrange(): Report an error when min>max
     
         Cc: Serge Hallyn <serge@hallyn.com>
    +    Cc: Iker Pedrosa <ipedrosa@redhat.com>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/getrange.c ##
```
</details>

<details>
<summary>v10c</summary>

-  Add lint to liba2i's documentation  [@ikerexxe ]

```
$ git range-diff shadow/master gh/getrange getrange 
1:  78c27e06 ! 1:  9ced1444 lib/atoi/a2i.[ch]: Add const-generic macros
    @@ Commit message
         Martin suggested using an artificial function pointer in _Generic(3); it
         allows switching on various types at the same time.
     
    +    Also add a comment referring to liba2i's PDF manual for documentation.
    +
         Link: <https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3096.pdf#subsubsection.7.26.5.2>
         Link: <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114731>
    +    Link: <http://www.alejandro-colomar.es/share/dist/liba2i/git/HEAD/liba2i-HEAD.pdf>
         Co-developed-by: Martin Uecker <muecker@gwdg.de>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    @@ lib/atoi/a2i.h
      
      
     -#define a2i(TYPE, ...)                                                        \
    ++/*
    ++ * See the manual of these macros in liba2i's documentation:
    ++ * <http://www.alejandro-colomar.es/share/dist/liba2i/git/HEAD/liba2i-HEAD.pdf>
    ++ */
    ++
    ++
     +#define a2i(TYPE, n, s, ...)                                                  \
      (                                                                             \
     -  _Generic((TYPE) 0,                                                    \
2:  864c66b9 = 2:  7e1a1d28 lib/getrange.c: getrange(): Use a2ul() instead of strtoul_noneg()
3:  33961983 = 3:  70508314 lib/getrange.c: getrange(): Add const to pointer
4:  655d06b2 = 4:  dd661c31 lib/getrange.c: getrange(): Add missing cast
5:  23aef628 = 5:  0b4402f4 lib/getrange.c: getrange(): Report an error when min>max
```
</details>