### PR TITLE
Uh, get some more numbers

### DIFF
--- a/lib/getdef.c
+++ b/lib/getdef.c
@@ -268,10 +268,11 @@ getdef_num(const char *item, int dflt)
  * values are handled.
  */
 
-unsigned int getdef_unum (const char *item, unsigned int dflt)
+unsigned int
+getdef_unum(const char *item, unsigned int dflt)
 {
-	struct itemdef *d;
-	long val;
+	unsigned int    val;
+	struct itemdef  *d;
 
 	if (!def_loaded) {
 		def_load ();
@@ -282,9 +283,7 @@ unsigned int getdef_unum (const char *item, unsigned int dflt)
 		return dflt;
 	}
 
-	if (   (str2sl(&val, d->value) == -1)
-	    || (val < 0)
-	    || (val > INT_MAX)) {
+	if (a2ui(&val, d->value, NULL, 0, 0, UINT_MAX) == -1) {
 		fprintf (shadow_logfd,
 		         _("configuration error - cannot parse %s value: '%s'"),
 		         item, d->value);

--- a/lib/getdef.c
+++ b/lib/getdef.c
@@ -22,6 +22,7 @@
 #include <libeconf.h>
 #endif
 
+#include "atoi/a2i.h"
 #include "atoi/str2i.h"
 #include "defines.h"
 #include "getdef.h"
@@ -233,10 +234,11 @@ bool getdef_bool (const char *item)
  * values are handled.
  */
 
-int getdef_num (const char *item, int dflt)
+int
+getdef_num(const char *item, int dflt)
 {
-	struct itemdef *d;
-	long val;
+	int             val;
+	struct itemdef  *d;
 
 	if (!def_loaded) {
 		def_load ();
@@ -247,9 +249,7 @@ int getdef_num (const char *item, int dflt)
 		return dflt;
 	}
 
-	if (   (str2sl(&val, d->value) == -1)
-	    || (val > INT_MAX)
-	    || (val < -1)) {
+	if (a2si(&val, d->value, NULL, 0, -1, INT_MAX) == -1) {
 		fprintf (shadow_logfd,
 		         _("configuration error - cannot parse %s value: '%s'"),
 		         item, d->value);

--- a/lib/getdef.c
+++ b/lib/getdef.c
@@ -316,7 +316,7 @@ long getdef_long (const char *item, long dflt)
 		return dflt;
 	}
 
-	if (str2sl(&val, d->value) == -1 || val < -1) {
+	if (a2sl(&val, d->value, NULL, 0, -1, LONG_MAX) == -1) {
 		fprintf (shadow_logfd,
 		         _("configuration error - cannot parse %s value: '%s'"),
 		         item, d->value);

--- a/lib/limits.c
+++ b/lib/limits.c
@@ -478,10 +478,9 @@ void setup_limits (const struct passwd *info)
 			}
 
 			if (strncmp (cp, "pri=", 4) == 0) {
-				long  inc;
+				int  inc;
 
-				if (   (str2sl(&inc, cp + 4) == 0)
-				    && (inc >= -20) && (inc <= 20)) {
+				if (a2si(&inc, cp + 4, NULL, 0, -20, 20) == 0) {
 					errno = 0;
 					if (   (nice (inc) != -1)
 					    || (0 != errno)) {

--- a/lib/limits.c
+++ b/lib/limits.c
@@ -507,10 +507,9 @@ void setup_limits (const struct passwd *info)
 				continue;
 			}
 			if (strncmp (cp, "umask=", 6) == 0) {
-				unsigned long  mask;
+				mode_t  mask;
 
-				if (   (str2ul(&mask, cp + 6) == -1)
-				    || (mask != (mode_t) mask)) {
+				if (str2i(mode_t, &mask, cp + 6) == -1) {
 					SYSLOG ((LOG_WARN,
 					         "Can't set umask value for user %s",
 					         info->pw_name));

--- a/lib/limits.c
+++ b/lib/limits.c
@@ -99,14 +99,13 @@ set_prio(const char *value)
 }
 
 
-static int set_umask (const char *value)
+static int
+set_umask(const char *value)
 {
-	unsigned long  mask;
+	mode_t  mask;
 
-	if (   (str2ul(&mask, value) == -1)
-	    || (mask != (mode_t) mask)) {
+	if (str2i(mode_t, &mask, value) == -1)
 		return 0;
-	}
 
 	(void) umask (mask);
 	return 0;

--- a/lib/limits.c
+++ b/lib/limits.c
@@ -496,9 +496,9 @@ void setup_limits (const struct passwd *info)
 				continue;
 			}
 			if (strncmp (cp, "ulimit=", 7) == 0) {
-				long  blocks;
-				if (   (str2sl(&blocks, cp + 7) == -1)
-				    || (blocks != (int) blocks)
+				int  blocks;
+
+				if (   (str2si(&blocks, cp + 7) == -1)
 				    || (set_filesize_limit (blocks) != 0)) {
 					SYSLOG ((LOG_WARN,
 					         "Can't set the ulimit for user %s",

--- a/lib/limits.c
+++ b/lib/limits.c
@@ -84,14 +84,14 @@ static int setrlimit_value (unsigned int resource,
 }
 
 
-static int set_prio (const char *value)
+static int
+set_prio(const char *value)
 {
-	long prio;
+	int  prio;
 
-	if (   (str2sl(&prio, value) == -1)
-	    || (prio != (int) prio)) {
+	if (str2si(&prio, value) == -1)
 		return 0;
-	}
+
 	if (setpriority (PRIO_PROCESS, 0, prio) != 0) {
 		return LOGIN_ERROR_RLIMIT;
 	}

--- a/lib/sgetspent.c
+++ b/lib/sgetspent.c
@@ -19,6 +19,7 @@
 #include <sys/types.h>
 #include <string.h>
 
+#include "atoi/a2i.h"
 #include "atoi/str2i.h"
 #include "prototypes.h"
 #include "shadowlog_internal.h"
@@ -83,34 +84,28 @@ sgetspent(const char *string)
 	 * incorrectly formatted number.
 	 */
 
-	if (fields[2][0] == '\0') {
+	if (fields[2][0] == '\0')
 		spwd.sp_lstchg = -1;
-	} else if (   (str2sl(&spwd.sp_lstchg, fields[2]) == -1)
-	           || (spwd.sp_lstchg < 0)) {
+	else if (a2sl(&spwd.sp_lstchg, fields[2], NULL, 0, 0, LONG_MAX) == -1)
 		return NULL;
-	}
 
 	/*
 	 * Get the minimum period between password changes.
 	 */
 
-	if (fields[3][0] == '\0') {
+	if (fields[3][0] == '\0')
 		spwd.sp_min = -1;
-	} else if (   (str2sl(&spwd.sp_min, fields[3]) == -1)
-	           || (spwd.sp_min < 0)) {
+	else if (a2sl(&spwd.sp_min, fields[3], NULL, 0, 0, LONG_MAX) == -1)
 		return NULL;
-	}
 
 	/*
 	 * Get the maximum number of days a password is valid.
 	 */
 
-	if (fields[4][0] == '\0') {
+	if (fields[4][0] == '\0')
 		spwd.sp_max = -1;
-	} else if (   (str2sl(&spwd.sp_max, fields[4]) == -1)
-	           || (spwd.sp_max < 0)) {
+	else if (a2sl(&spwd.sp_max, fields[4], NULL, 0, 0, LONG_MAX) == -1)
 		return NULL;
-	}
 
 	/*
 	 * If there are only OFIELDS fields (this is a SVR3.2 /etc/shadow
@@ -130,47 +125,40 @@ sgetspent(const char *string)
 	 * Get the number of days of password expiry warning.
 	 */
 
-	if (fields[5][0] == '\0') {
+	if (fields[5][0] == '\0')
 		spwd.sp_warn = -1;
-	} else if (   (str2sl(&spwd.sp_warn, fields[5]) == -1)
-	           || (spwd.sp_warn < 0)) {
+	else if (a2sl(&spwd.sp_warn, fields[5], NULL, 0, 0, LONG_MAX) == -1)
 		return NULL;
-	}
 
 	/*
 	 * Get the number of days of inactivity before an account is
 	 * disabled.
 	 */
 
-	if (fields[6][0] == '\0') {
+	if (fields[6][0] == '\0')
 		spwd.sp_inact = -1;
-	} else if (   (str2sl(&spwd.sp_inact, fields[6]) == -1)
-	           || (spwd.sp_inact < 0)) {
+	else if (a2sl(&spwd.sp_inact, fields[6], NULL, 0, 0, LONG_MAX) == -1)
 		return NULL;
-	}
 
 	/*
 	 * Get the number of days after the epoch before the account is
 	 * set to expire.
 	 */
 
-	if (fields[7][0] == '\0') {
+	if (fields[7][0] == '\0')
 		spwd.sp_expire = -1;
-	} else if (   (str2sl(&spwd.sp_expire, fields[7]) == -1)
-	           || (spwd.sp_expire < 0)) {
+	else if (a2sl(&spwd.sp_expire, fields[7], NULL, 0, 0, LONG_MAX) == -1)
 		return NULL;
-	}
 
 	/*
 	 * This field is reserved for future use.  But it isn't supposed
 	 * to have anything other than a valid integer in it.
 	 */
 
-	if (fields[8][0] == '\0') {
+	if (fields[8][0] == '\0')
 		spwd.sp_flag = SHADOW_SP_FLAG_UNSET;
-	} else if (str2ul(&spwd.sp_flag, fields[8]) == -1) {
+	else if (str2ul(&spwd.sp_flag, fields[8]) == -1)
 		return NULL;
-	}
 
 	return (&spwd);
 }

--- a/lib/shadow.c
+++ b/lib/shadow.c
@@ -195,8 +195,6 @@ static struct spwd *my_sgetspent (const char *string)
 		spwd.sp_flag = SHADOW_SP_FLAG_UNSET;
 	else if (str2ul(&spwd.sp_flag, fields[8]) == -1)
 		return 0;
-	else if (spwd.sp_flag < 0)
-		return 0;
 
 	return (&spwd);
 }

--- a/lib/shadow.c
+++ b/lib/shadow.c
@@ -18,6 +18,7 @@
 #include <string.h>
 #include <sys/types.h>
 
+#include "atoi/a2i.h"
 #include "atoi/str2i.h"
 #include "defines.h"
 #include "prototypes.h"
@@ -110,9 +111,7 @@ static struct spwd *my_sgetspent (const char *string)
 
 	if (fields[2][0] == '\0')
 		spwd.sp_lstchg = -1;
-	else if (str2sl(&spwd.sp_lstchg, fields[2]) == -1)
-		return 0;
-	else if (spwd.sp_lstchg < 0)
+	else if (a2sl(&spwd.sp_lstchg, fields[2], NULL, 0, 0, LONG_MAX) == -1)
 		return 0;
 
 	/*
@@ -121,9 +120,7 @@ static struct spwd *my_sgetspent (const char *string)
 
 	if (fields[3][0] == '\0')
 		spwd.sp_min = -1;
-	else if (str2sl(&spwd.sp_min, fields[3]) == -1)
-		return 0;
-	else if (spwd.sp_min < 0)
+	else if (a2sl(&spwd.sp_min, fields[3], NULL, 0, 0, LONG_MAX) == -1)
 		return 0;
 
 	/*
@@ -132,9 +129,7 @@ static struct spwd *my_sgetspent (const char *string)
 
 	if (fields[4][0] == '\0')
 		spwd.sp_max = -1;
-	else if (str2sl(&spwd.sp_max, fields[4]) == -1)
-		return 0;
-	else if (spwd.sp_max < 0)
+	else if (a2sl(&spwd.sp_max, fields[4], NULL, 0, 0, LONG_MAX) == -1)
 		return 0;
 
 	/*
@@ -157,9 +152,7 @@ static struct spwd *my_sgetspent (const char *string)
 
 	if (fields[5][0] == '\0')
 		spwd.sp_warn = -1;
-	else if (str2sl(&spwd.sp_warn, fields[5]) == -1)
-		return 0;
-	else if (spwd.sp_warn < 0)
+	else if (a2sl(&spwd.sp_warn, fields[5], NULL, 0, 0, LONG_MAX) == -1)
 		return 0;
 
 	/*
@@ -169,9 +162,7 @@ static struct spwd *my_sgetspent (const char *string)
 
 	if (fields[6][0] == '\0')
 		spwd.sp_inact = -1;
-	else if (str2sl(&spwd.sp_inact, fields[6]) == -1)
-		return 0;
-	else if (spwd.sp_inact < 0)
+	else if (a2sl(&spwd.sp_inact, fields[6], NULL, 0, 0, LONG_MAX) == -1)
 		return 0;
 
 	/*
@@ -181,9 +172,7 @@ static struct spwd *my_sgetspent (const char *string)
 
 	if (fields[7][0] == '\0')
 		spwd.sp_expire = -1;
-	else if (str2sl(&spwd.sp_expire, fields[7]) == -1)
-		return 0;
-	else if (spwd.sp_expire < 0)
+	else if (a2sl(&spwd.sp_expire, fields[7], NULL, 0, 0, LONG_MAX) == -1)
 		return 0;
 
 	/*

--- a/lib/shadow.c
+++ b/lib/shadow.c
@@ -108,40 +108,34 @@ static struct spwd *my_sgetspent (const char *string)
 	 * incorrectly formatted number, unless we are using NIS.
 	 */
 
-	if (fields[2][0] == '\0') {
+	if (fields[2][0] == '\0')
 		spwd.sp_lstchg = -1;
-	} else {
-		if (str2sl(&spwd.sp_lstchg, fields[2]) == -1)
-			return 0;
-		if (spwd.sp_lstchg < 0)
-			return 0;
-	}
+	else if (str2sl(&spwd.sp_lstchg, fields[2]) == -1)
+		return 0;
+	else if (spwd.sp_lstchg < 0)
+		return 0;
 
 	/*
 	 * Get the minimum period between password changes.
 	 */
 
-	if (fields[3][0] == '\0') {
+	if (fields[3][0] == '\0')
 		spwd.sp_min = -1;
-	} else {
-		if (str2sl(&spwd.sp_min, fields[3]) == -1)
-			return 0;
-		if (spwd.sp_min < 0)
-			return 0;
-	}
+	else if (str2sl(&spwd.sp_min, fields[3]) == -1)
+		return 0;
+	else if (spwd.sp_min < 0)
+		return 0;
 
 	/*
 	 * Get the maximum number of days a password is valid.
 	 */
 
-	if (fields[4][0] == '\0') {
+	if (fields[4][0] == '\0')
 		spwd.sp_max = -1;
-	} else {
-		if (str2sl(&spwd.sp_max, fields[4]) == -1)
-			return 0;
-		if (spwd.sp_max < 0)
-			return 0;
-	}
+	else if (str2sl(&spwd.sp_max, fields[4]) == -1)
+		return 0;
+	else if (spwd.sp_max < 0)
+		return 0;
 
 	/*
 	 * If there are only OFIELDS fields (this is a SVR3.2 /etc/shadow
@@ -161,56 +155,48 @@ static struct spwd *my_sgetspent (const char *string)
 	 * Get the number of days of password expiry warning.
 	 */
 
-	if (fields[5][0] == '\0') {
+	if (fields[5][0] == '\0')
 		spwd.sp_warn = -1;
-	} else {
-		if (str2sl(&spwd.sp_warn, fields[5]) == -1)
-			return 0;
-		if (spwd.sp_warn < 0)
-			return 0;
-	}
+	else if (str2sl(&spwd.sp_warn, fields[5]) == -1)
+		return 0;
+	else if (spwd.sp_warn < 0)
+		return 0;
 
 	/*
 	 * Get the number of days of inactivity before an account is
 	 * disabled.
 	 */
 
-	if (fields[6][0] == '\0') {
+	if (fields[6][0] == '\0')
 		spwd.sp_inact = -1;
-	} else {
-		if (str2sl(&spwd.sp_inact, fields[6]) == -1)
-			return 0;
-		if (spwd.sp_inact < 0)
-			return 0;
-	}
+	else if (str2sl(&spwd.sp_inact, fields[6]) == -1)
+		return 0;
+	else if (spwd.sp_inact < 0)
+		return 0;
 
 	/*
 	 * Get the number of days after the epoch before the account is
 	 * set to expire.
 	 */
 
-	if (fields[7][0] == '\0') {
+	if (fields[7][0] == '\0')
 		spwd.sp_expire = -1;
-	} else {
-		if (str2sl(&spwd.sp_expire, fields[7]) == -1)
-			return 0;
-		if (spwd.sp_expire < 0)
-			return 0;
-	}
+	else if (str2sl(&spwd.sp_expire, fields[7]) == -1)
+		return 0;
+	else if (spwd.sp_expire < 0)
+		return 0;
 
 	/*
 	 * This field is reserved for future use.  But it isn't supposed
 	 * to have anything other than a valid integer in it.
 	 */
 
-	if (fields[8][0] == '\0') {
+	if (fields[8][0] == '\0')
 		spwd.sp_flag = SHADOW_SP_FLAG_UNSET;
-	} else {
-		if (str2ul(&spwd.sp_flag, fields[8]) == -1)
-			return 0;
-		if (spwd.sp_flag < 0)
-			return 0;
-	}
+	else if (str2ul(&spwd.sp_flag, fields[8]) == -1)
+		return 0;
+	else if (spwd.sp_flag < 0)
+		return 0;
 
 	return (&spwd);
 }

--- a/src/chage.c
+++ b/src/chage.c
@@ -26,7 +26,7 @@
 #endif				/* ACCT_TOOLS_SETUID */
 #include <pwd.h>
 
-#include "atoi/str2i.h"
+#include "atoi/a2i.h"
 #include "defines.h"
 #include "memzero.h"
 #include "prototypes.h"
@@ -171,17 +171,13 @@ static int new_fields (void)
 
 	SNPRINTF(buf, "%ld", mindays);
 	change_field (buf, sizeof buf, _("Minimum Password Age"));
-	if (   (str2sl(&mindays, buf) == -1)
-	    || (mindays < -1)) {
+	if (a2sl(&mindays, buf, NULL, 0, -1, LONG_MAX) == -1)
 		return 0;
-	}
 
 	SNPRINTF(buf, "%ld", maxdays);
 	change_field (buf, sizeof buf, _("Maximum Password Age"));
-	if (   (str2sl(&maxdays, buf) == -1)
-	    || (maxdays < -1)) {
+	if (a2sl(&maxdays, buf, NULL, 0, -1, LONG_MAX) == -1)
 		return 0;
-	}
 
 	if (-1 == lstchgdate || lstchgdate > LONG_MAX / DAY)
 		strcpy(buf, "-1");
@@ -201,17 +197,13 @@ static int new_fields (void)
 
 	SNPRINTF(buf, "%ld", warndays);
 	change_field (buf, sizeof buf, _("Password Expiration Warning"));
-	if (   (str2sl(&warndays, buf) == -1)
-	    || (warndays < -1)) {
+	if (a2sl(&warndays, buf, NULL, 0, -1, LONG_MAX) == -1)
 		return 0;
-	}
 
 	SNPRINTF(buf, "%ld", inactdays);
 	change_field (buf, sizeof buf, _("Password Inactive"));
-	if (   (str2sl(&inactdays, buf) == -1)
-	    || (inactdays < -1)) {
+	if (a2sl(&inactdays, buf, NULL, 0, -1, LONG_MAX) == -1)
 		return 0;
-	}
 
 	if (-1 == expdate || LONG_MAX / DAY < expdate)
 		strcpy(buf, "-1");
@@ -397,8 +389,7 @@ static void process_flags (int argc, char **argv)
 			break;
 		case 'I':
 			Iflg = true;
-			if (   (str2sl(&inactdays, optarg) == -1)
-			    || (inactdays < -1)) {
+			if (a2sl(&inactdays, optarg, NULL, 0, -1, LONG_MAX) == -1) {
 				fprintf (stderr,
 				         _("%s: invalid numeric argument '%s'\n"),
 				         Prog, optarg);
@@ -410,8 +401,7 @@ static void process_flags (int argc, char **argv)
 			break;
 		case 'm':
 			mflg = true;
-			if (   (str2sl(&mindays, optarg) == -1)
-			    || (mindays < -1)) {
+			if (a2sl(&mindays, optarg, NULL, 0, -1, LONG_MAX) == -1) {
 				fprintf (stderr,
 				         _("%s: invalid numeric argument '%s'\n"),
 				         Prog, optarg);
@@ -420,8 +410,7 @@ static void process_flags (int argc, char **argv)
 			break;
 		case 'M':
 			Mflg = true;
-			if (   (str2sl(&maxdays, optarg) == -1)
-			    || (maxdays < -1)) {
+			if (a2sl(&maxdays, optarg, NULL, 0, -1, LONG_MAX) == -1) {
 				fprintf (stderr,
 				         _("%s: invalid numeric argument '%s'\n"),
 				         Prog, optarg);
@@ -434,8 +423,7 @@ static void process_flags (int argc, char **argv)
 			break;
 		case 'W':
 			Wflg = true;
-			if (   (str2sl(&warndays, optarg) == -1)
-			    || (warndays < -1)) {
+			if (a2sl(&warndays, optarg, NULL, 0, -1, LONG_MAX) == -1) {
 				fprintf (stderr,
 				         _("%s: invalid numeric argument '%s'\n"),
 				         Prog, optarg);

--- a/src/check_subid_range.c
+++ b/src/check_subid_range.c
@@ -13,6 +13,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 
+#include "atoi/getnum.h"
 #include "atoi/str2i.h"
 #include "defines.h"
 #include "prototypes.h"
@@ -20,13 +21,18 @@
 #include "idmapping.h"
 #include "shadowlog.h"
 
+
 static const char Prog[] = "check_subid_range";
 
-int main(int argc, char **argv)
+
+int
+main(int argc, char **argv)
 {
-	char *owner;
-	unsigned long start, count;
-	bool check_uids;
+	bool           check_uids;
+	char           *owner;
+	uid_t          start;
+	unsigned long  count;
+
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
 
@@ -36,7 +42,7 @@ int main(int argc, char **argv)
 	owner = argv[1];
 	check_uids = argv[2][0] == 'u';
 	errno = 0;
-	if (str2ul(&start, argv[3]) == -1)
+	if (get_uid(argv[3], &start) == -1)
 		exit(1);
 	if (str2ul(&count, argv[4]) == -1)
 		exit(1);

--- a/src/faillog.c
+++ b/src/faillog.c
@@ -557,16 +557,12 @@ int main (int argc, char **argv)
 				break;
 			case 'm':
 			{
-				long  lmax;
-
-				if (   (str2sl(&lmax, optarg) == -1)
-				    || ((long)(short) lmax != lmax)) {
+				if (str2sh(&fail_max, optarg) == -1) {
 					fprintf (stderr,
 					         _("%s: invalid numeric argument '%s'\n"),
 					         Prog, optarg);
 					exit (E_BAD_ARG);
 				}
-				fail_max = lmax;
 				mflg = true;
 				break;
 			}

--- a/src/get_subid_owners.c
+++ b/src/get_subid_owners.c
@@ -3,7 +3,7 @@
 
 #include <stdio.h>
 
-#include "atoi/str2i.h"
+#include "atoi/getnum.h"
 #include "subid.h"
 #include "stdlib.h"
 #include "prototypes.h"
@@ -33,12 +33,12 @@ int main(int argc, char *argv[])
 		usage();
 	}
 	if (argc == 3 && strcmp(argv[1], "-g") == 0) {
-		str2i(uid_t, &u, argv[2]);
+		get_uid(argv[2], &u);
 		n = subid_get_gid_owners(u, &uids);
 	} else if (argc == 2 && strcmp(argv[1], "-h") == 0) {
 		usage();
 	} else {
-		str2i(uid_t, &u, argv[1]);
+		get_gid(argv[1], &u);
 		n = subid_get_uid_owners(u, &uids);
 	}
 	if (n < 0) {

--- a/src/passwd.c
+++ b/src/passwd.c
@@ -21,7 +21,7 @@
 #include <time.h>
 
 #include "agetpass.h"
-#include "atoi/str2i.h"
+#include "atoi/a2i.h"
 #include "defines.h"
 #include "getdef.h"
 #include "memzero.h"
@@ -722,7 +722,8 @@ static void update_shadow (void)
  * 	appropriate internal format. For finer resolute the chage
  *	command must be used.
  */
-int main (int argc, char **argv)
+int
+main(int argc, char **argv)
 {
 	const struct passwd *pw;	/* Password file entry for user      */
 
@@ -800,8 +801,9 @@ int main (int argc, char **argv)
 				usage (E_SUCCESS);
 				/*@notreached@*/break;
 			case 'i':
-				if (   (str2sl(&inact, optarg) == -1)
-				    || (inact < -1)) {
+				if (a2sl(&inact, optarg, NULL, 0, -1, LONG_MAX)
+				    == -1)
+				{
 					fprintf (stderr,
 					         _("%s: invalid numeric argument '%s'\n"),
 					         Prog, optarg);
@@ -819,8 +821,9 @@ int main (int argc, char **argv)
 				anyflag = true;
 				break;
 			case 'n':
-				if (   (str2sl(&age_min, optarg) == -1)
-				    || (age_min < -1)) {
+				if (a2sl(&age_min, optarg, NULL, 0, -1, LONG_MAX)
+				    == -1)
+				{
 					fprintf (stderr,
 					         _("%s: invalid numeric argument '%s'\n"),
 					         Prog, optarg);
@@ -854,8 +857,9 @@ int main (int argc, char **argv)
 				anyflag = true;
 				break;
 			case 'w':
-				if (   (str2sl(&warn, optarg) == -1)
-				    || (warn < -1)) {
+				if (a2sl(&warn, optarg, NULL, 0, -1, LONG_MAX)
+				    == -1)
+				{
 					(void) fprintf (stderr,
 					                _("%s: invalid numeric argument '%s'\n"),
 					                Prog, optarg);
@@ -865,8 +869,9 @@ int main (int argc, char **argv)
 				anyflag = true;
 				break;
 			case 'x':
-				if (   (str2sl(&age_max, optarg) == -1)
-				    || (age_max < -1)) {
+				if (a2sl(&age_max, optarg, NULL, 0, -1, LONG_MAX)
+				    == -1)
+				{
 					(void) fprintf (stderr,
 					                _("%s: invalid numeric argument '%s'\n"),
 					                Prog, optarg);

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -37,7 +37,7 @@
 #include <unistd.h>
 
 #include "alloc/x/xmalloc.h"
-#include "atoi/str2i.h"
+#include "atoi/a2i.h"
 #include "atoi/getnum.h"
 #include "chkname.h"
 #include "defines.h"
@@ -419,8 +419,7 @@ static void get_defaults (void)
 		 * Default Password Inactive value
 		 */
 		else if (MATCH (buf, DINACT)) {
-			if (   (str2sl(&def_inactive, ccp) == -1)
-			    || (def_inactive < -1)) {
+			if (a2sl(&def_inactive, ccp, NULL, 0, -1, LONG_MAX) == -1) {
 				fprintf (stderr,
 				         _("%s: invalid numeric argument '%s'\n"),
 				         Prog, ccp);
@@ -1288,8 +1287,9 @@ static void process_flags (int argc, char **argv)
 				eflg = true;
 				break;
 			case 'f':
-				if (   (str2sl(&def_inactive, optarg) == -1)
-				    || (def_inactive < -1)) {
+				if (a2sl(&def_inactive, optarg, NULL, 0, -1, LONG_MAX)
+				    == -1)
+				{
 					fprintf (stderr,
 					         _("%s: invalid numeric argument '%s'\n"),
 					         Prog, optarg);

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -36,7 +36,6 @@
 #include "alloc/x/xmalloc.h"
 #include "atoi/a2i.h"
 #include "atoi/getnum.h"
-#include "atoi/str2i.h"
 #include "chkname.h"
 #include "defines.h"
 #include "faillog.h"
@@ -970,7 +969,8 @@ static void grp_update (void)
  *	values that the user will be created with accordingly. The values
  *	are checked for sanity.
  */
-static void process_flags (int argc, char **argv)
+static void
+process_flags(int argc, char **argv)
 {
 	struct stat st;
 	bool anyflag = false;
@@ -1067,8 +1067,9 @@ static void process_flags (int argc, char **argv)
 				eflg = true;
 				break;
 			case 'f':
-				if (   (str2sl(&user_newinactive, optarg) == -1)
-				    || (user_newinactive < -1)) {
+				if (a2sl(&user_newinactive, optarg, NULL, 0, -1, LONG_MAX)
+				    == -1)
+				{
 					fprintf (stderr,
 					         _("%s: invalid numeric argument '%s'\n"),
 					         Prog, optarg);


### PR DESCRIPTION
---

<details>
<summary>v3</summary>
v3 changes:

-  Rebase

```
$ git range-diff gh/strtoll..gh/getuh strtoll..getuh 
 1:  806f0ff5 =  1:  81c8665d lib/getdef.c: getdef_num(): Simplify, by calling a2si() instead of str2sl()
 2:  f0181f03 =  2:  edff0c98 lib/getdef.c: getdef_unum(): Fix wrong limit check
 3:  6d9d10eb =  3:  fd6cfab8 lib/getdef.c: getdef_long(): Simplify, by calling a2sl() instead of str2sl()
 4:  f4692dc4 =  4:  435aa712 lib/limits.c: set_prio(): Simplify, by calling str2si() instead of str2sl()
 5:  36614d26 =  5:  e4b220b9 lib/limits.c: set_umask(): Simplify, by calling str2i(mode_t, ) instead of str2ul()
 6:  b9dcbb2b =  6:  14c14376 lib/limits.c: setup_limits(): Simplify, by calling a2si() instead of str2sl()
 7:  9df29b9f =  7:  1e642aef lib/limits.c: setup_limits(): Simplify, by calling str2si() instead of str2sl()
 8:  d0f99086 =  8:  c214e9fd lib/limits.c: setup_limits(): Simplify, by calling str2i(mode_t, ) instead of str2ul()
 9:  e143fb48 =  9:  bf67cb06 lib/sgetspent.c: sgetspent(): Simplify, by calling a2sl() instead of str2sl()
10:  402bec05 = 10:  9d802247 lib/shadow.c: my_sgetspent(): Merge 'else {if}' into 'else if'
11:  a88d11a7 = 11:  9ba02c4b lib/shadow.c: my_sgetspent(): Remove dead code
12:  2af1a7bf = 12:  047becc1 lib/shadow.c: my_sgetspent(): Simplify error handling
13:  aff746c6 = 13:  486488d9 src/check_subid_range.c: Call get_uid() instead of str2sl()
14:  dbe51a22 = 14:  49058180 src/useradd.c: Simplify, by calling a2sl() instead of str2sl()
15:  5359d519 = 15:  364e750b src/passwd.c: Simplify, by calling a2sl() instead of str2sl()
16:  321774db = 16:  6e4e8d11 src/usermod.c: Simplify, by calling a2sl() instead of str2sl()
17:  48461308 = 17:  eaa538b6 src/faillog.c: Simplify, by calling str2sh() instead of str2sl()
18:  38704923 = 18:  395b5cdd src/chage.c: Simplify, by calling a2sl() instead of str2sl()
```
</details>

<details>
<summary>v4</summary>
v4 changes:

-  Rebase

```
$ git range-diff 81c8665d^..gh/getuh strtoll..getuh 
 1:  81c8665d =  1:  3b304bae lib/getdef.c: getdef_num(): Simplify, by calling a2si() instead of str2sl()
 2:  edff0c98 =  2:  ff6f6f54 lib/getdef.c: getdef_unum(): Fix wrong limit check
 3:  fd6cfab8 =  3:  943653e5 lib/getdef.c: getdef_long(): Simplify, by calling a2sl() instead of str2sl()
 4:  435aa712 =  4:  a72137c8 lib/limits.c: set_prio(): Simplify, by calling str2si() instead of str2sl()
 5:  e4b220b9 =  5:  33bd3e2d lib/limits.c: set_umask(): Simplify, by calling str2i(mode_t, ) instead of str2ul()
 6:  14c14376 =  6:  8fc11068 lib/limits.c: setup_limits(): Simplify, by calling a2si() instead of str2sl()
 7:  1e642aef =  7:  44e1c015 lib/limits.c: setup_limits(): Simplify, by calling str2si() instead of str2sl()
 8:  c214e9fd =  8:  215349f5 lib/limits.c: setup_limits(): Simplify, by calling str2i(mode_t, ) instead of str2ul()
 9:  bf67cb06 =  9:  f0b9183c lib/sgetspent.c: sgetspent(): Simplify, by calling a2sl() instead of str2sl()
10:  9d802247 = 10:  694cc6b6 lib/shadow.c: my_sgetspent(): Merge 'else {if}' into 'else if'
11:  9ba02c4b = 11:  903b7549 lib/shadow.c: my_sgetspent(): Remove dead code
12:  047becc1 = 12:  7add9a04 lib/shadow.c: my_sgetspent(): Simplify error handling
13:  486488d9 = 13:  5375dd9a src/check_subid_range.c: Call get_uid() instead of str2sl()
14:  49058180 = 14:  08995a95 src/useradd.c: Simplify, by calling a2sl() instead of str2sl()
15:  364e750b = 15:  26ee8c71 src/passwd.c: Simplify, by calling a2sl() instead of str2sl()
16:  6e4e8d11 = 16:  28f4241e src/usermod.c: Simplify, by calling a2sl() instead of str2sl()
17:  eaa538b6 = 17:  3633d2fb src/faillog.c: Simplify, by calling str2sh() instead of str2sl()
18:  395b5cdd = 18:  8a475e05 src/chage.c: Simplify, by calling a2sl() instead of str2sl()
```
</details>

<details>
<summary>v4b</summary>

-  Rebase

```
$ git range-diff gh/strtoll..gh/getuh strtoll..getuh 
 1:  3b304bae =  1:  41f0c592 lib/getdef.c: getdef_num(): Simplify, by calling a2si() instead of str2sl()
 2:  ff6f6f54 =  2:  ada34659 lib/getdef.c: getdef_unum(): Fix wrong limit check
 3:  943653e5 =  3:  f78721ae lib/getdef.c: getdef_long(): Simplify, by calling a2sl() instead of str2sl()
 4:  a72137c8 =  4:  7cc883a5 lib/limits.c: set_prio(): Simplify, by calling str2si() instead of str2sl()
 5:  33bd3e2d =  5:  75cd2c74 lib/limits.c: set_umask(): Simplify, by calling str2i(mode_t, ) instead of str2ul()
 6:  8fc11068 =  6:  4c067739 lib/limits.c: setup_limits(): Simplify, by calling a2si() instead of str2sl()
 7:  44e1c015 =  7:  58392f10 lib/limits.c: setup_limits(): Simplify, by calling str2si() instead of str2sl()
 8:  215349f5 =  8:  4f0ec8bd lib/limits.c: setup_limits(): Simplify, by calling str2i(mode_t, ) instead of str2ul()
 9:  f0b9183c =  9:  a3d361c6 lib/sgetspent.c: sgetspent(): Simplify, by calling a2sl() instead of str2sl()
10:  694cc6b6 = 10:  570dfeff lib/shadow.c: my_sgetspent(): Merge 'else {if}' into 'else if'
11:  903b7549 = 11:  4ef75e09 lib/shadow.c: my_sgetspent(): Remove dead code
12:  7add9a04 = 12:  a03822a9 lib/shadow.c: my_sgetspent(): Simplify error handling
13:  5375dd9a = 13:  210d3ea9 src/check_subid_range.c: Call get_uid() instead of str2sl()
14:  08995a95 = 14:  ad92731f src/useradd.c: Simplify, by calling a2sl() instead of str2sl()
15:  26ee8c71 = 15:  0ffdc740 src/passwd.c: Simplify, by calling a2sl() instead of str2sl()
16:  28f4241e = 16:  72654b15 src/usermod.c: Simplify, by calling a2sl() instead of str2sl()
17:  3633d2fb = 17:  1746843d src/faillog.c: Simplify, by calling str2sh() instead of str2sl()
18:  8a475e05 = 18:  ce4dbcad src/chage.c: Simplify, by calling a2sl() instead of str2sl()
```
</details>

<details>
<summary>v4c</summary>

-  Rebase

```
$ git range-diff gh/strtoll..gh/getuh strtoll..getuh 
 1:  41f0c592 =  1:  451d07a8 lib/getdef.c: getdef_num(): Simplify, by calling a2si() instead of str2sl()
 2:  ada34659 =  2:  6dee8116 lib/getdef.c: getdef_unum(): Fix wrong limit check
 3:  f78721ae =  3:  49c44716 lib/getdef.c: getdef_long(): Simplify, by calling a2sl() instead of str2sl()
 4:  7cc883a5 =  4:  cac5f748 lib/limits.c: set_prio(): Simplify, by calling str2si() instead of str2sl()
 5:  75cd2c74 =  5:  d5ab3b8a lib/limits.c: set_umask(): Simplify, by calling str2i(mode_t, ) instead of str2ul()
 6:  4c067739 =  6:  4e89e524 lib/limits.c: setup_limits(): Simplify, by calling a2si() instead of str2sl()
 7:  58392f10 =  7:  426ac24e lib/limits.c: setup_limits(): Simplify, by calling str2si() instead of str2sl()
 8:  4f0ec8bd =  8:  2ef41f0d lib/limits.c: setup_limits(): Simplify, by calling str2i(mode_t, ) instead of str2ul()
 9:  a3d361c6 =  9:  2b25ce91 lib/sgetspent.c: sgetspent(): Simplify, by calling a2sl() instead of str2sl()
10:  570dfeff = 10:  bca0f25c lib/shadow.c: my_sgetspent(): Merge 'else {if}' into 'else if'
11:  4ef75e09 = 11:  482ce215 lib/shadow.c: my_sgetspent(): Remove dead code
12:  a03822a9 = 12:  f3dc9755 lib/shadow.c: my_sgetspent(): Simplify error handling
13:  210d3ea9 = 13:  68ee8b54 src/check_subid_range.c: Call get_uid() instead of str2sl()
14:  ad92731f = 14:  e6cf1be0 src/useradd.c: Simplify, by calling a2sl() instead of str2sl()
15:  0ffdc740 = 15:  dc887b5f src/passwd.c: Simplify, by calling a2sl() instead of str2sl()
16:  72654b15 = 16:  2f08f7e4 src/usermod.c: Simplify, by calling a2sl() instead of str2sl()
17:  1746843d = 17:  2fb41cd8 src/faillog.c: Simplify, by calling str2sh() instead of str2sl()
18:  ce4dbcad = 18:  07497fbf src/chage.c: Simplify, by calling a2sl() instead of str2sl()
```
</details> 

<details>
<summary>v4d</summary>

-  Rebase

```
$ git range-diff gh/strtoll..gh/getuh strtoll..getuh 
 1:  451d07a8 =  1:  b6dd34d7 lib/getdef.c: getdef_num(): Simplify, by calling a2si() instead of str2sl()
 2:  6dee8116 =  2:  e156e34c lib/getdef.c: getdef_unum(): Fix wrong limit check
 3:  49c44716 =  3:  954c403a lib/getdef.c: getdef_long(): Simplify, by calling a2sl() instead of str2sl()
 4:  cac5f748 =  4:  ecefbdb0 lib/limits.c: set_prio(): Simplify, by calling str2si() instead of str2sl()
 5:  d5ab3b8a =  5:  c3a07d1d lib/limits.c: set_umask(): Simplify, by calling str2i(mode_t, ) instead of str2ul()
 6:  4e89e524 =  6:  b1fdb943 lib/limits.c: setup_limits(): Simplify, by calling a2si() instead of str2sl()
 7:  426ac24e =  7:  c6f18eb5 lib/limits.c: setup_limits(): Simplify, by calling str2si() instead of str2sl()
 8:  2ef41f0d =  8:  da7f4e92 lib/limits.c: setup_limits(): Simplify, by calling str2i(mode_t, ) instead of str2ul()
 9:  2b25ce91 =  9:  7b70657e lib/sgetspent.c: sgetspent(): Simplify, by calling a2sl() instead of str2sl()
10:  bca0f25c = 10:  cc56e9b2 lib/shadow.c: my_sgetspent(): Merge 'else {if}' into 'else if'
11:  482ce215 = 11:  4eefc753 lib/shadow.c: my_sgetspent(): Remove dead code
12:  f3dc9755 = 12:  2082f0a1 lib/shadow.c: my_sgetspent(): Simplify error handling
13:  68ee8b54 = 13:  5bcad664 src/check_subid_range.c: Call get_uid() instead of str2sl()
14:  e6cf1be0 = 14:  3761dfb9 src/useradd.c: Simplify, by calling a2sl() instead of str2sl()
15:  dc887b5f = 15:  ffc14251 src/passwd.c: Simplify, by calling a2sl() instead of str2sl()
16:  2f08f7e4 = 16:  2bf7b0a3 src/usermod.c: Simplify, by calling a2sl() instead of str2sl()
17:  2fb41cd8 = 17:  d59a7d1d src/faillog.c: Simplify, by calling str2sh() instead of str2sl()
18:  07497fbf = 18:  5111c23c src/chage.c: Simplify, by calling a2sl() instead of str2sl()
```
</details>

<details>
<summary>v4e</summary>

-  Rebase

```
$ git range-diff b6dd34d7^..gh/getuh shadow/master..getuh 
 1:  b6dd34d7 =  1:  06e74c19 lib/getdef.c: getdef_num(): Simplify, by calling a2si() instead of str2sl()
 2:  e156e34c =  2:  4677ff18 lib/getdef.c: getdef_unum(): Fix wrong limit check
 3:  954c403a =  3:  d0d9b77f lib/getdef.c: getdef_long(): Simplify, by calling a2sl() instead of str2sl()
 4:  ecefbdb0 =  4:  6373a23b lib/limits.c: set_prio(): Simplify, by calling str2si() instead of str2sl()
 5:  c3a07d1d =  5:  075528ff lib/limits.c: set_umask(): Simplify, by calling str2i(mode_t, ) instead of str2ul()
 6:  b1fdb943 =  6:  936b9e63 lib/limits.c: setup_limits(): Simplify, by calling a2si() instead of str2sl()
 7:  c6f18eb5 =  7:  97bdf04a lib/limits.c: setup_limits(): Simplify, by calling str2si() instead of str2sl()
 8:  da7f4e92 =  8:  993b873b lib/limits.c: setup_limits(): Simplify, by calling str2i(mode_t, ) instead of str2ul()
 9:  7b70657e =  9:  c6f841b3 lib/sgetspent.c: sgetspent(): Simplify, by calling a2sl() instead of str2sl()
10:  cc56e9b2 = 10:  8e63fe8e lib/shadow.c: my_sgetspent(): Merge 'else {if}' into 'else if'
11:  4eefc753 = 11:  9b5c844d lib/shadow.c: my_sgetspent(): Remove dead code
12:  2082f0a1 = 12:  0f0e2146 lib/shadow.c: my_sgetspent(): Simplify error handling
13:  5bcad664 = 13:  30e7e757 src/check_subid_range.c: Call get_uid() instead of str2sl()
14:  3761dfb9 = 14:  164d3ded src/useradd.c: Simplify, by calling a2sl() instead of str2sl()
15:  ffc14251 = 15:  24beb14a src/passwd.c: Simplify, by calling a2sl() instead of str2sl()
16:  2bf7b0a3 = 16:  c7ca65b4 src/usermod.c: Simplify, by calling a2sl() instead of str2sl()
17:  d59a7d1d = 17:  02d810c5 src/faillog.c: Simplify, by calling str2sh() instead of str2sl()
18:  5111c23c = 18:  5a6e763c src/chage.c: Simplify, by calling a2sl() instead of str2sl()
```
</details>

<details>
<summary>v5</summary>

-  Use get_[ug]id() in a few more places.

```
$ git range-diff shadow/master gh/getuh getuh 
 1:  06e74c19 =  1:  06e74c19 lib/getdef.c: getdef_num(): Simplify, by calling a2si() instead of str2sl()
 2:  4677ff18 =  2:  4677ff18 lib/getdef.c: getdef_unum(): Fix wrong limit check
 3:  d0d9b77f =  3:  d0d9b77f lib/getdef.c: getdef_long(): Simplify, by calling a2sl() instead of str2sl()
 4:  6373a23b =  4:  6373a23b lib/limits.c: set_prio(): Simplify, by calling str2si() instead of str2sl()
 5:  075528ff =  5:  075528ff lib/limits.c: set_umask(): Simplify, by calling str2i(mode_t, ) instead of str2ul()
 6:  936b9e63 =  6:  936b9e63 lib/limits.c: setup_limits(): Simplify, by calling a2si() instead of str2sl()
 7:  97bdf04a =  7:  97bdf04a lib/limits.c: setup_limits(): Simplify, by calling str2si() instead of str2sl()
 8:  993b873b =  8:  993b873b lib/limits.c: setup_limits(): Simplify, by calling str2i(mode_t, ) instead of str2ul()
 9:  c6f841b3 =  9:  c6f841b3 lib/sgetspent.c: sgetspent(): Simplify, by calling a2sl() instead of str2sl()
10:  8e63fe8e = 10:  8e63fe8e lib/shadow.c: my_sgetspent(): Merge 'else {if}' into 'else if'
11:  9b5c844d = 11:  9b5c844d lib/shadow.c: my_sgetspent(): Remove dead code
12:  0f0e2146 = 12:  0f0e2146 lib/shadow.c: my_sgetspent(): Simplify error handling
13:  30e7e757 ! 13:  e5a1defd src/check_subid_range.c: Call get_uid() instead of str2sl()
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    src/check_subid_range.c: Call get_uid() instead of str2sl()
    -
    -    This value represents a uid.
    +    src/: Use get_[ug]id() where appropriate
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    @@ src/check_subid_range.c: int main(int argc, char **argv)
                exit(1);
        if (str2ul(&count, argv[4]) == -1)
                exit(1);
    +
    + ## src/get_subid_owners.c ##
    +@@
    + 
    + #include <stdio.h>
    + 
    +-#include "atoi/str2i.h"
    ++#include "atoi/getnum.h"
    + #include "subid.h"
    + #include "stdlib.h"
    + #include "prototypes.h"
    +@@ src/get_subid_owners.c: int main(int argc, char *argv[])
    +           usage();
    +   }
    +   if (argc == 3 && strcmp(argv[1], "-g") == 0) {
    +-          str2i(uid_t, &u, argv[2]);
    ++          get_uid(argv[2], &u);
    +           n = subid_get_gid_owners(u, &uids);
    +   } else if (argc == 2 && strcmp(argv[1], "-h") == 0) {
    +           usage();
    +   } else {
    +-          str2i(uid_t, &u, argv[1]);
    ++          get_gid(argv[1], &u);
    +           n = subid_get_uid_owners(u, &uids);
    +   }
    +   if (n < 0) {
14:  164d3ded = 14:  299c84a1 src/useradd.c: Simplify, by calling a2sl() instead of str2sl()
15:  24beb14a = 15:  781fd1a6 src/passwd.c: Simplify, by calling a2sl() instead of str2sl()
16:  c7ca65b4 = 16:  3d26dc5a src/usermod.c: Simplify, by calling a2sl() instead of str2sl()
17:  02d810c5 = 17:  a49bfd18 src/faillog.c: Simplify, by calling str2sh() instead of str2sl()
18:  5a6e763c = 18:  fb0f3ecb src/chage.c: Simplify, by calling a2sl() instead of str2sl()
```
</details>

<details>
<summary>v5b</summary>

-  Rebase

```
$ git range-diff master..gh/getuh shadow/master..getuh 
 1:  06e74c19 !  1:  ffca6d40 lib/getdef.c: getdef_num(): Simplify, by calling a2si() instead of str2sl()
    @@ Commit message
     
      ## lib/getdef.c ##
     @@
    + #include <libeconf.h>
      #endif
      
    - #include "alloc.h"
     +#include "atoi/a2i.h"
      #include "atoi/str2i.h"
    + #include "defines.h"
      #include "getdef.h"
    - #include "shadowlog_internal.h"
     @@ lib/getdef.c: bool getdef_bool (const char *item)
       * values are handled.
       */
 2:  4677ff18 =  2:  f568010e lib/getdef.c: getdef_unum(): Fix wrong limit check
 3:  d0d9b77f =  3:  f872fb97 lib/getdef.c: getdef_long(): Simplify, by calling a2sl() instead of str2sl()
 4:  6373a23b =  4:  6ec310ee lib/limits.c: set_prio(): Simplify, by calling str2si() instead of str2sl()
 5:  075528ff =  5:  1654022c lib/limits.c: set_umask(): Simplify, by calling str2i(mode_t, ) instead of str2ul()
 6:  936b9e63 =  6:  b5c15c64 lib/limits.c: setup_limits(): Simplify, by calling a2si() instead of str2sl()
 7:  97bdf04a =  7:  2a14ebf4 lib/limits.c: setup_limits(): Simplify, by calling str2si() instead of str2sl()
 8:  993b873b =  8:  d2315991 lib/limits.c: setup_limits(): Simplify, by calling str2i(mode_t, ) instead of str2ul()
 9:  c6f841b3 =  9:  0b3e6c8b lib/sgetspent.c: sgetspent(): Simplify, by calling a2sl() instead of str2sl()
10:  8e63fe8e = 10:  c29af369 lib/shadow.c: my_sgetspent(): Merge 'else {if}' into 'else if'
11:  9b5c844d = 11:  5f497e9e lib/shadow.c: my_sgetspent(): Remove dead code
12:  0f0e2146 ! 12:  e7dcdb4c lib/shadow.c: my_sgetspent(): Simplify error handling
    @@ Commit message
     
      ## lib/shadow.c ##
     @@
    - #include "defines.h"
    - #include <stdio.h>
    + #include <string.h>
    + #include <sys/types.h>
      
     +#include "atoi/a2i.h"
      #include "atoi/str2i.h"
    - 
    - 
    + #include "defines.h"
    + #include "prototypes.h"
     @@ lib/shadow.c: static struct spwd *my_sgetspent (const char *string)
      
        if (fields[2][0] == '\0')
13:  e5a1defd = 13:  aea35eb6 src/: Use get_[ug]id() where appropriate
14:  299c84a1 ! 14:  1be8cd81 src/useradd.c: Simplify, by calling a2sl() instead of str2sl()
    @@ src/useradd.c
     @@
      #include <unistd.h>
      
    - #include "alloc.h"
    + #include "alloc/x/xmalloc.h"
     -#include "atoi/str2i.h"
     +#include "atoi/a2i.h"
      #include "atoi/getnum.h"
15:  781fd1a6 ! 15:  6a61fefd src/passwd.c: Simplify, by calling a2sl() instead of str2sl()
    @@ Commit message
     
      ## src/passwd.c ##
     @@
    + #include <time.h>
      
      #include "agetpass.h"
    - #include "alloc.h"
     -#include "atoi/str2i.h"
     +#include "atoi/a2i.h"
      #include "defines.h"
16:  3d26dc5a ! 16:  bca3a624 src/usermod.c: Simplify, by calling a2sl() instead of str2sl()
    @@ Commit message
     
      ## src/usermod.c ##
     @@
    - #include "alloc.h"
    + #include "alloc/x/xmalloc.h"
      #include "atoi/a2i.h"
      #include "atoi/getnum.h"
     -#include "atoi/str2i.h"
17:  a49bfd18 = 17:  def0a300 src/faillog.c: Simplify, by calling str2sh() instead of str2sl()
18:  fb0f3ecb ! 18:  6b176d86 src/chage.c: Simplify, by calling a2sl() instead of str2sl()
    @@ Commit message
     
      ## src/chage.c ##
     @@
    + #endif                            /* ACCT_TOOLS_SETUID */
      #include <pwd.h>
      
    - #include "alloc.h"
     -#include "atoi/str2i.h"
     +#include "atoi/a2i.h"
      #include "defines.h"
```
</details>