### PR TITLE
lib/idmapping.c: get_map_ranges(): Merge two input checks into a simpler one

### DIFF
--- a/lib/idmapping.c
+++ b/lib/idmapping.c
@@ -34,17 +34,8 @@ struct map_range *get_map_ranges(int ranges, int argc, char **argv)
 		return NULL;
 	}
 
-	if (ranges != ((argc + 2) / 3)) {
+	if (ranges * 3 != argc) {
 		fprintf(log_get_logfd(), "%s: ranges: %u is wrong for argc: %d\n", log_get_progname(), ranges, argc);
-		return NULL;
-	}
-
-	if ((ranges * 3) > argc) {
-		fprintf(log_get_logfd(), "ranges: %u argc: %d\n",
-			ranges, argc);
-		fprintf(log_get_logfd(),
-			_( "%s: Not enough arguments to form %u mappings\n"),
-			log_get_progname(), ranges);
 		return NULL;
 	}
 


### PR DESCRIPTION
```diff
Previously, we were performing the following two checks:

-       if (ranges != ((argc + 2) / 3)) {
-       if ((ranges * 3) > argc) {

Let's draw a table of the possible input that would pass the first check:

argc:	0 1 2 3 4 5 6 7 8 9
rng:	0 1 1 1 2 2 2 3 3 3
a+2/3*3:0 3 3 3 6 6 6 9 9 9	<-- this is  roundup(argc, 3);
a+2/3:	0 1 1 1 2 2 2 3 3 3	<-- this is  roundup(argc, 3) / 3;
rng*3:	0 3 3 3 6 6 6 9 9 9

From those, let's extract those that would also pass the second check:

argc:	0     3     6     9
rng:	0     1     2     3
rng*3:	0     3     6     9

We can see that there's a simple check for this input:

+       if (ranges * 3 != argc) {

As a sanity check, let's draw a table of the acceptable input with that check:

rng:	0     1     2     3
rng*3:	0     3     6     9
argc:	0     3     6     9
```

Cc: @ebiederm, @hallyn 