### PR TITLE
lib/defines.h: Don't wrap #undef in #ifdef

### DIFF
--- a/lib/defines.h
+++ b/lib/defines.h
@@ -186,12 +186,9 @@
 #define SHADOW_SP_FLAG_UNSET ((unsigned long)-1)
 
 #ifdef WITH_AUDIT
-#ifdef __u8			/* in case we use pam < 0.80 */
+/* in case we use pam < 0.80 */
 #undef __u8
-#endif
-#ifdef __u32
 #undef __u32
-#endif
 
 #include <libaudit.h>
 #endif


### PR DESCRIPTION
ISO C guarantees that #undef is a no-op if there is no such macro.

C11::6.10.3.5p2:
> A preprocessing directive of the form
>
>       # undef identifier new-line
>
> causes the specified identifier no longer to be defined as a macro
> name.  It is ignored if the specified identifier is not currently
> defined as a macro name.

Link: <http://port70.net/~nsz/c/c11/n1570.html#6.10.3.5p2>