### PR TITLE
lib/sgetgrent.c: fix null pointer dereference

### DIFF
--- a/lib/sgetgrent.c
+++ b/lib/sgetgrent.c
@@ -37,8 +37,8 @@
 static char **list (char *s)
 {
 	static char **members = NULL;
-	static int size = 0;	/* max members + 1 */
-	int i;
+	static size_t size = 0;	/* max members + 1 */
+	size_t i;
 
 	i = 0;
 	for (;;) {
@@ -47,8 +47,10 @@ static char **list (char *s)
 		if (i >= size) {
 			size = i + 100;	/* at least: i + 1 */
 			members = REALLOCF(members, size, char *);
-			if (!members)
+			if (!members) {
+				size = 0;
 				return NULL;
+			}
 		}
 		if (!s || s[0] == '\0')
 			break;


### PR DESCRIPTION
If reallocation fails in function list, then reset the size to 0 again. Without the reset, the next call assumes that `members` points to a memory location with reserved space.

Also use size_t instead of int for size to prevent signed integer overflows. The length of group lines is not limited.

Fixes 45c0003e53ab671c63dcd530fd9f3245d3b29e76 (4.14 release series)

Proof of Concept:
1. Prepare a group file (one long group line and a shorter one, both with a list of users)
```
$ echo -n "root:x:0:" > /tmp/uwu
$ yes , | tr -d '\n' | dd of=/tmp/uwu bs=10 count=3145728 seek=1 conv=notrunc iflag=fullblock
$ echo -e "\nbin:x:1:," >> /tmp/uwu
```
2. Run grpck with tight memory constraints
```
$ ulimit -d 102400
$ grpck /tmp/uwu
Segmentation fault (core dumped)
```