### PR TITLE
lib/, src/: Use int main(void) where appropriate

### DIFF
--- a/lib/getdate.y
+++ b/lib/getdate.y
@@ -923,11 +923,8 @@ time_t get_date (const char *p, const time_t *now)
 
 #if	defined (TEST)
 
-/* ARGSUSED */
 int
-main (ac, av)
-     int ac;
-     char *av[];
+main(void)
 {
   char buff[MAX_BUFF_LEN + 1];
   time_t d;

--- a/src/id.c
+++ b/src/id.c
@@ -36,7 +36,8 @@ static void usage (void)
 	exit (EXIT_FAILURE);
 }
 
- /*ARGSUSED*/ int main (int argc, char **argv)
+int
+main(int argc, char *argv[])
 {
 	uid_t ruid, euid;
 	gid_t rgid, egid;
@@ -74,11 +75,10 @@ static void usage (void)
 	 */
 
 	if (argc > 1) {
-		if ((argc > 2) || (strcmp (argv[1], "-a") != 0)) {
-			usage ();
-		} else {
+		if (argc > 2 || strcmp(argv[1], "-a") != 0)
+			usage();
+		else
 			aflg = true;
-		}
 	}
 
 	ruid = getuid ();

--- a/src/sulogin.c
+++ b/src/sulogin.c
@@ -53,8 +53,8 @@ static void catch_signals (MAYBE_UNUSED int sig)
 }
 
 
-/*ARGSUSED*/ int
-main(int argc, char **argv)
+int
+main(int argc, char *argv[])
 {
 	int            err = 0;
 	char           **envp = environ;
@@ -78,13 +78,13 @@ main(int argc, char **argv)
 	(void) bindtextdomain (PACKAGE, LOCALEDIR);
 	(void) textdomain (PACKAGE);
 
-	initenv ();
+	initenv();
 	if (argc > 1) {
-		close (0);
-		close (1);
-		close (2);
+		close(0);
+		close(1);
+		close(2);
 
-		if (open (argv[1], O_RDWR) >= 0) {
+		if (open(argv[1], O_RDWR) >= 0) {
 			dup (0);
 			dup (0);
 		} else {

--- a/src/sulogin.c
+++ b/src/sulogin.c
@@ -84,12 +84,10 @@ main(int argc, char *argv[])
 		close(1);
 		close(2);
 
-		if (open(argv[1], O_RDWR) >= 0) {
-			dup (0);
-			dup (0);
-		} else {
-			exit (1);
-		}
+		if (open(argv[1], O_RDWR) == -1)
+			exit(1);
+		dup(0);
+		dup(0);
 	}
 	if (access (PASSWD_FILE, F_OK) == -1) {	/* must be a password file! */
 		(void) puts (_("No password file"));


### PR DESCRIPTION
Remove `/*ARGSUSED*/` comments.  Instead, use appropriate declarators for main().  ISO C allows using int main(void) if the parameters are going to be unused.

Also, do some cosmetic changes in the uses of argc and argv, to show where they are used.