### PR TITLE
Link correctly with libdl

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,7 @@ AC_PROG_CC
 AC_PROG_LN_S
 AC_PROG_YACC
 LT_INIT
+LT_LIB_DLLOAD
 
 dnl Checks for libraries.
 

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -20,6 +20,7 @@ endif
 
 libshadow_la_CPPFLAGS += -I$(top_srcdir)
 libshadow_la_CFLAGS = $(LIBBSD_CFLAGS) $(LIBCRYPT_PAM) $(LIBSYSTEMD)
+libshadow_la_LIBADD = $(LIBADD_DLOPEN)
 
 libshadow_la_SOURCES = \
 	addgrps.c \

--- a/share/containers/debian.dockerfile
+++ b/share/containers/debian.dockerfile
@@ -9,7 +9,7 @@ RUN export DEBIAN_PRIORITY=critical \
 RUN apt-get update -y \
     && apt-get dist-upgrade -y
 RUN apt-get build-dep shadow -y
-RUN apt-get install libbsd-dev libcmocka-dev pkgconf -y
+RUN apt-get install libltdl-dev libbsd-dev libcmocka-dev pkgconf -y
 
 COPY ./ /usr/local/src/shadow/
 WORKDIR /usr/local/src/shadow/


### PR DESCRIPTION
This fixes build with glibc-2.33 (newer glibc merged libdl and libpthread into libc):
```
libtool: link: x86_64-pc-linux-gnu-gcc -isystem /usr/include/bsd -DLIBBSD_OVERLAY -O2 -pipe -Wl,-O1 -o login login.o login_nopam.o  -Wl,--as-needed ../lib/.libs/libshadow.a -lcrypt -lsystemd -lpam -lpam_misc -lbsd
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: ../lib/.libs/libshadow.a(libshadow_la-nss.o): undefined reference to symbol 'dlclose@@GLIBC_2.2.5'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /lib64/libdl.so.2: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```