### PR TITLE
lib/, src/: Rename unused macro as MAYBE_UNUSED

### DIFF
--- a/lib/attr.h
+++ b/lib/attr.h
@@ -6,12 +6,12 @@
 
 
 #if defined(__GNUC__)
-# define unused                      __attribute__((unused))
+# define MAYBE_UNUSED                __attribute__((unused))
 # define NORETURN                    __attribute__((__noreturn__))
 # define format_attr(type, fmt, va)  __attribute__((format(type, fmt, va)))
 # define ATTR_ACCESS(...)            __attribute__((access(__VA_ARGS__)))
 #else
-# define unused
+# define MAYBE_UNUSED
 # define NORETURN
 # define format_attr(type, fmt, va)
 # define ATTR_ACCESS(...)

--- a/lib/audit_help.c
+++ b/lib/audit_help.c
@@ -56,7 +56,7 @@ void audit_help_open (void)
  * id  -  uid or gid that the operation is being performed on. This is used
  *	  only when user is NULL.
  */
-void audit_logger (int type, unused const char *pgname, const char *op,
+void audit_logger (int type, MAYBE_UNUSED const char *pgname, const char *op,
                    const char *name, unsigned int id,
                    shadow_audit_result result)
 {

--- a/lib/cleanup_group.c
+++ b/lib/cleanup_group.c
@@ -179,7 +179,7 @@ void cleanup_report_del_group_gshadow (void *group_name)
  *
  * It should be registered after the group file is successfully locked.
  */
-void cleanup_unlock_group (unused void *arg)
+void cleanup_unlock_group (MAYBE_UNUSED void *arg)
 {
 	if (gr_unlock () == 0) {
 		fprintf (log_get_logfd(),
@@ -199,7 +199,7 @@ void cleanup_unlock_group (unused void *arg)
  *
  * It should be registered after the gshadow file is successfully locked.
  */
-void cleanup_unlock_gshadow (unused void *arg)
+void cleanup_unlock_gshadow (MAYBE_UNUSED void *arg)
 {
 	if (sgr_unlock () == 0) {
 		fprintf (log_get_logfd(),

--- a/lib/cleanup_user.c
+++ b/lib/cleanup_user.c
@@ -96,7 +96,7 @@ void cleanup_report_add_user_shadow (void *user_name)
  *
  * It should be registered after the passwd database is successfully locked.
  */
-void cleanup_unlock_passwd (unused void *arg)
+void cleanup_unlock_passwd (MAYBE_UNUSED void *arg)
 {
 	if (pw_unlock () == 0) {
 		fprintf (log_get_logfd(),
@@ -115,7 +115,7 @@ void cleanup_unlock_passwd (unused void *arg)
  *
  * It should be registered after the shadow database is successfully locked.
  */
-void cleanup_unlock_shadow (unused void *arg)
+void cleanup_unlock_shadow (MAYBE_UNUSED void *arg)
 {
 	if (spw_unlock () == 0) {
 		fprintf (log_get_logfd(),

--- a/lib/copydir.c
+++ b/lib/copydir.c
@@ -68,12 +68,12 @@ static int copy_dir (const struct path_info *src, const struct path_info *dst,
                      gid_t old_gid, gid_t new_gid);
 static /*@null@*/char *readlink_malloc (const char *filename);
 static int copy_symlink (const struct path_info *src, const struct path_info *dst,
-                         unused bool reset_selinux,
+                         MAYBE_UNUSED bool reset_selinux,
                          const struct stat *statp, const struct timespec mt[],
                          uid_t old_uid, uid_t new_uid,
                          gid_t old_gid, gid_t new_gid);
 static int copy_hardlink (const struct path_info *dst,
-                          unused bool reset_selinux,
+                          MAYBE_UNUSED bool reset_selinux,
                           struct link_name *lp);
 static int copy_special (const struct path_info *src, const struct path_info *dst,
                          bool reset_selinux,
@@ -97,7 +97,7 @@ static int fchown_if_needed (int fdst, const struct stat *statp,
  * error_acl - format the error messages for the ACL and EQ libraries.
  */
 format_attr(printf, 2, 3)
-static void error_acl (unused struct error_context *ctx, const char *fmt, ...)
+static void error_acl (MAYBE_UNUSED struct error_context *ctx, const char *fmt, ...)
 {
 	va_list ap;
 	FILE *shadow_logfd = log_get_logfd();
@@ -582,7 +582,7 @@ static /*@null@*/char *readlink_malloc (const char *filename)
  *	Return 0 on success, -1 on error.
  */
 static int copy_symlink (const struct path_info *src, const struct path_info *dst,
-                         unused bool reset_selinux,
+                         MAYBE_UNUSED bool reset_selinux,
                          const struct stat *statp, const struct timespec mt[],
                          uid_t old_uid, uid_t new_uid,
                          gid_t old_gid, gid_t new_gid)
@@ -654,7 +654,7 @@ static int copy_symlink (const struct path_info *src, const struct path_info *ds
  *	Return 0 on success, -1 on error.
  */
 static int copy_hardlink (const struct path_info *dst,
-                          unused bool reset_selinux,
+                          MAYBE_UNUSED bool reset_selinux,
                           struct link_name *lp)
 {
 	/* FIXME: selinux, ACL, Extended Attributes needed? */

--- a/lib/getdate.y
+++ b/lib/getdate.y
@@ -570,7 +570,7 @@ static TABLE const MilitaryTable[] = {
 
 
 
-static int yyerror (unused const char *s)
+static int yyerror (MAYBE_UNUSED const char *s)
 {
   return 0;
 }

--- a/lib/logind.c
+++ b/lib/logind.c
@@ -36,7 +36,7 @@ done:
     return ret;
 }
 
-unsigned long active_sessions_count(const char *name, unsigned long unused)
+unsigned long active_sessions_count(const char *name, unsigned long unused(limit))
 {
     struct passwd *pw;
     unsigned long count = 0;

--- a/lib/logind.c
+++ b/lib/logind.c
@@ -36,7 +36,7 @@ done:
     return ret;
 }
 
-unsigned long active_sessions_count(const char *name, unsigned long unused(limit))
+unsigned long active_sessions_count(const char *name, unsigned long MAYBE_UNUSED(limit))
 {
     struct passwd *pw;
     unsigned long count = 0;

--- a/lib/logind.c
+++ b/lib/logind.c
@@ -36,7 +36,7 @@ done:
     return ret;
 }
 
-unsigned long active_sessions_count(const char *name, unsigned long MAYBE_UNUSED(limit))
+unsigned long active_sessions_count(const char *name, MAYBE_UNUSED unsigned long limit)
 {
     struct passwd *pw;
     unsigned long count = 0;

--- a/lib/loginprompt.c
+++ b/lib/loginprompt.c
@@ -22,7 +22,7 @@
 #include "defines.h"
 #include "getdef.h"
 
-static void login_exit (unused int sig)
+static void login_exit (MAYBE_UNUSED int sig)
 {
 	_exit (EXIT_FAILURE);
 }

--- a/lib/obscure.c
+++ b/lib/obscure.c
@@ -29,7 +29,7 @@
 /*
  * can't be a palindrome - like `R A D A R' or `M A D A M'
  */
-static bool palindrome (unused const char *old, const char *new)
+static bool palindrome (MAYBE_UNUSED const char *old, const char *new)
 {
 	size_t i, j;
 
@@ -88,7 +88,7 @@ static char *str_lower (/*@returned@*/char *string)
 static /*@observer@*//*@null@*/const char *password_check (
 	/*@notnull@*/const char *old,
 	/*@notnull@*/const char *new,
-	/*@notnull@*/unused const struct passwd *pwdp)
+	/*@notnull@*/MAYBE_UNUSED const struct passwd *pwdp)
 {
 	const char *msg = NULL;
 	char *oldmono, *newmono, *wrapped;

--- a/lib/pam_pass_non_interactive.c
+++ b/lib/pam_pass_non_interactive.c
@@ -26,7 +26,7 @@
 static int ni_conv (int num_msg,
                     const struct pam_message **msg,
                     struct pam_response **resp,
-                    unused void *appdata_ptr);
+                    MAYBE_UNUSED void *appdata_ptr);
 static const struct pam_conv non_interactive_pam_conv = {
 	ni_conv,
 	NULL
@@ -37,7 +37,7 @@ static const struct pam_conv non_interactive_pam_conv = {
 static int ni_conv (int num_msg,
                     const struct pam_message **msg,
                     struct pam_response **resp,
-                    unused void *appdata_ptr)
+                    MAYBE_UNUSED void *appdata_ptr)
 {
 	struct pam_response *responses;
 	int count;

--- a/lib/prototypes.h
+++ b/lib/prototypes.h
@@ -92,11 +92,11 @@ void cleanup_report_del_group_gshadow (void *group_name);
 void cleanup_report_mod_passwd (void *cleanup_info);
 void cleanup_report_mod_group (void *cleanup_info);
 void cleanup_report_mod_gshadow (void *cleanup_info);
-void cleanup_unlock_group (/*@null@*/void *unused);
+void cleanup_unlock_group (/*@null@*/void *MAYBE_UNUSED);
 #ifdef SHADOWGRP
-void cleanup_unlock_gshadow (/*@null@*/void *unused);
+void cleanup_unlock_gshadow (/*@null@*/void *MAYBE_UNUSED);
 #endif
-void cleanup_unlock_passwd (/*@null@*/void *unused);
+void cleanup_unlock_passwd (/*@null@*/void *MAYBE_UNUSED);
 
 /* console.c */
 extern bool console (const char *);

--- a/lib/pwdcheck.c
+++ b/lib/pwdcheck.c
@@ -20,7 +20,7 @@
 #include "pwauth.h"
 #include "shadowlog.h"
 
-void passwd_check (const char *user, const char *passwd, unused const char *progname)
+void passwd_check (const char *user, const char *passwd, MAYBE_UNUSED const char *progname)
 {
 	struct spwd *sp;
 

--- a/lib/semanage.c
+++ b/lib/semanage.c
@@ -28,7 +28,7 @@
 
 
 format_attr(printf, 3, 4)
-static void semanage_error_callback (unused void *varg,
+static void semanage_error_callback (MAYBE_UNUSED void *varg,
                                      semanage_handle_t *handle,
                                      const char *fmt, ...)
 {

--- a/src/expiry.c
+++ b/src/expiry.c
@@ -29,14 +29,14 @@ const char *Prog;
 static bool cflg = false;
 
 /* local function prototypes */
-static void catch_signals (unused int sig);
+static void catch_signals (MAYBE_UNUSED int sig);
 NORETURN static void usage (int status);
 static void process_flags (int argc, char **argv);
 
 /*
  * catch_signals - signal catcher
  */
-static void catch_signals (unused int sig)
+static void catch_signals (MAYBE_UNUSED int sig)
 {
 	_exit (10);
 }

--- a/src/gpasswd.c
+++ b/src/gpasswd.c
@@ -101,14 +101,14 @@ static void update_group (struct group *gr);
 static void change_passwd (struct group *gr);
 #endif
 static void log_gpasswd_failure (const char *suffix);
-static void log_gpasswd_failure_system (/*@null@*/unused void *arg);
-static void log_gpasswd_failure_group (/*@null@*/unused void *arg);
+static void log_gpasswd_failure_system (/*@null@*/MAYBE_UNUSED void *arg);
+static void log_gpasswd_failure_group (/*@null@*/MAYBE_UNUSED void *arg);
 #ifdef SHADOWGRP
-static void log_gpasswd_failure_gshadow (/*@null@*/unused void *arg);
+static void log_gpasswd_failure_gshadow (/*@null@*/MAYBE_UNUSED void *arg);
 #endif
 static void log_gpasswd_success (const char *suffix);
-static void log_gpasswd_success_system (/*@null@*/unused void *arg);
-static void log_gpasswd_success_group (/*@null@*/unused void *arg);
+static void log_gpasswd_success_system (/*@null@*/MAYBE_UNUSED void *arg);
+static void log_gpasswd_success_group (/*@null@*/MAYBE_UNUSED void *arg);
 
 /*
  * usage - display usage message
@@ -480,12 +480,12 @@ static void log_gpasswd_failure (const char *suffix)
 	}
 }
 
-static void log_gpasswd_failure_system (unused void *arg)
+static void log_gpasswd_failure_system (MAYBE_UNUSED void *arg)
 {
 	log_gpasswd_failure ("");
 }
 
-static void log_gpasswd_failure_group (unused void *arg)
+static void log_gpasswd_failure_group (MAYBE_UNUSED void *arg)
 {
 	char  buf[1024];
 
@@ -494,7 +494,7 @@ static void log_gpasswd_failure_group (unused void *arg)
 }
 
 #ifdef SHADOWGRP
-static void log_gpasswd_failure_gshadow (unused void *arg)
+static void log_gpasswd_failure_gshadow (MAYBE_UNUSED void *arg)
 {
 	char  buf[1024];
 
@@ -601,12 +601,12 @@ static void log_gpasswd_success (const char *suffix)
 	}
 }
 
-static void log_gpasswd_success_system (unused void *arg)
+static void log_gpasswd_success_system (MAYBE_UNUSED void *arg)
 {
 	log_gpasswd_success ("");
 }
 
-static void log_gpasswd_success_group (unused void *arg)
+static void log_gpasswd_success_group (MAYBE_UNUSED void *arg)
 {
 	char  buf[1024];
 

--- a/src/grpconv.c
+++ b/src/grpconv.c
@@ -262,7 +262,7 @@ int main (int argc, char **argv)
 	return 0;
 }
 #else				/* !SHADOWGRP */
-int main (int unused(argc), char **argv)
+int main (int MAYBE_UNUSED(argc), char **argv)
 {
 	fprintf (stderr,
 		 "%s: not configured for shadow group support.\n", argv[0]);

--- a/src/grpconv.c
+++ b/src/grpconv.c
@@ -262,7 +262,7 @@ int main (int argc, char **argv)
 	return 0;
 }
 #else				/* !SHADOWGRP */
-int main (int MAYBE_UNUSED(argc), char **argv)
+int main (MAYBE_UNUSED int argc, char **argv)
 {
 	fprintf (stderr,
 		 "%s: not configured for shadow group support.\n", argv[0]);

--- a/src/grpunconv.c
+++ b/src/grpunconv.c
@@ -224,7 +224,7 @@ int main (int argc, char **argv)
 	return 0;
 }
 #else				/* !SHADOWGRP */
-int main (int unused(argc), char **argv)
+int main (int MAYBE_UNUSED(argc), char **argv)
 {
 	fprintf (stderr,
 		 "%s: not configured for shadow group support.\n", argv[0]);

--- a/src/grpunconv.c
+++ b/src/grpunconv.c
@@ -224,7 +224,7 @@ int main (int argc, char **argv)
 	return 0;
 }
 #else				/* !SHADOWGRP */
-int main (int MAYBE_UNUSED(argc), char **argv)
+int main (MAYBE_UNUSED int argc, char **argv)
 {
 	fprintf (stderr,
 		 "%s: not configured for shadow group support.\n", argv[0]);

--- a/src/login.c
+++ b/src/login.c
@@ -397,12 +397,12 @@ static void init_env (void)
 #endif				/* !USE_PAM */
 }
 
-static void exit_handler (unused int sig)
+static void exit_handler (MAYBE_UNUSED int sig)
 {
 	_exit (0);
 }
 
-static void alarm_handler (unused int sig)
+static void alarm_handler (MAYBE_UNUSED int sig)
 {
 	write_full(STDERR_FILENO, tmsg, strlen(tmsg));
 	signal(SIGALRM, exit_handler);

--- a/src/su.c
+++ b/src/su.c
@@ -110,7 +110,7 @@ static void execve_shell (const char *shellname,
                           char *args[],
                           char *const envp[]);
 #ifdef USE_PAM
-static void kill_child (int unused(s));
+static void kill_child (int MAYBE_UNUSED(s));
 static void prepare_pam_close_session (void);
 #else				/* !USE_PAM */
 static void die (int);
@@ -164,7 +164,7 @@ static bool iswheel (const char *username)
 	return is_on_list (grp->gr_mem, username);
 }
 #else				/* USE_PAM */
-static void kill_child (int unused(s))
+static void kill_child (int MAYBE_UNUSED(s))
 {
 	if (0 != pid_child) {
 		(void) kill (-pid_child, SIGKILL);

--- a/src/su.c
+++ b/src/su.c
@@ -110,7 +110,7 @@ static void execve_shell (const char *shellname,
                           char *args[],
                           char *const envp[]);
 #ifdef USE_PAM
-static void kill_child (int MAYBE_UNUSED(s));
+static void kill_child (MAYBE_UNUSED int s);
 static void prepare_pam_close_session (void);
 #else				/* !USE_PAM */
 static void die (int);
@@ -164,7 +164,7 @@ static bool iswheel (const char *username)
 	return is_on_list (grp->gr_mem, username);
 }
 #else				/* USE_PAM */
-static void kill_child (int MAYBE_UNUSED(s))
+static void kill_child (MAYBE_UNUSED int s)
 {
 	if (0 != pid_child) {
 		(void) kill (-pid_child, SIGKILL);

--- a/src/sulogin.c
+++ b/src/sulogin.c
@@ -50,7 +50,7 @@ static void catch_signals (int);
 static void pw_entry(const char *name, struct passwd *pwent);
 
 
-static void catch_signals (unused int sig)
+static void catch_signals (MAYBE_UNUSED int sig)
 {
 	_exit (1);
 }


### PR DESCRIPTION
Also fixes #918 by adding the omitted parameter name in active_sessions_count.

Suggested-by: Alejandro Colomar <alx@kernel.org>