### PR TITLE
Install chpasswd,newusers configs when built with pam but without setuid

### DIFF
--- a/etc/pam.d/Makefile.am
+++ b/etc/pam.d/Makefile.am
@@ -2,20 +2,20 @@
 # and also cooperate to make a distribution for `make dist'
 
 pamd_files = \
+	chpasswd \
 	chfn \
 	chsh \
 	groupmems \
 	login \
+	newusers \
 	passwd
 
 pamd_acct_tools_files = \
 	chage \
-	chgpasswd \
 	chpasswd \
 	groupadd \
 	groupdel \
 	groupmod \
-	newusers \
 	useradd \
 	userdel \
 	usermod


### PR DESCRIPTION
Install pam configs for chage and newusers when using ./configure --with-libpam --disable-account-tools-setuid.
Fixes https://github.com/shadow-maint/shadow/issues/810.