### PR TITLE
lib/chkname.c: Fix off by one validation of _SC_LOGIN_NAME_MAX

### DIFF
--- a/lib/chkname.c
+++ b/lib/chkname.c
@@ -80,7 +80,7 @@ bool is_valid_user_name (const char *name)
 	 * User names length are limited by the kernel
 	 */
 	maxlen = sysconf(_SC_LOGIN_NAME_MAX);
-	if (strlen(name) > maxlen)
+	if (strlen(name) >= maxlen)
 		return false;
 
 	return is_valid_name (name);

--- a/lib/chkname.c
+++ b/lib/chkname.c
@@ -20,6 +20,8 @@
 #ident "$Id$"
 
 #include <ctype.h>
+#include <errno.h>
+#include <limits.h>
 #include "defines.h"
 #include "chkname.h"
 
@@ -74,13 +76,16 @@ static bool is_valid_name (const char *name)
 
 bool is_valid_user_name (const char *name)
 {
-	size_t  maxlen;
+	long  maxlen;
 
 	/*
 	 * User names length are limited by the kernel
 	 */
+	errno = 0;
 	maxlen = sysconf(_SC_LOGIN_NAME_MAX);
-	if (strlen(name) >= maxlen)
+	if (maxlen == -1 && errno != 0)
+		maxlen = LOGIN_NAME_MAX;
+	if (maxlen != -1 && strlen(name) >= (size_t)maxlen)
 		return false;
 
 	return is_valid_name (name);

--- a/lib/chkname.c
+++ b/lib/chkname.c
@@ -79,7 +79,7 @@ bool is_valid_user_name (const char *name)
 	long  maxlen;
 
 	/*
-	 * User names length are limited by the kernel
+	 * User name length should be limited by the kernel
 	 */
 	errno = 0;
 	maxlen = sysconf(_SC_LOGIN_NAME_MAX);

--- a/tests/unit/test_chkname.c
+++ b/tests/unit/test_chkname.c
@@ -134,15 +134,15 @@ test_is_valid_user_name_long(void **state)
 	char    *name;
 
 	max = sysconf(_SC_LOGIN_NAME_MAX);
-	name = MALLOC(max + 2, char);
+	name = MALLOC(max + 1, char);
 	assert_true(name != NULL);
 
-	memset(name, '_', max + 1);
-
-	name[max + 1] = '\0';
-	assert_true(false == is_valid_user_name(name));
+	memset(name, '_', max);
 
 	name[max] = '\0';
+	assert_true(false == is_valid_user_name(name));
+
+	name[max - 1] = '\0';
 	assert_true(is_valid_user_name(name));
 
 	free(name);


### PR DESCRIPTION
According to sysconf manual page, _SC_LOGIN_NAME_MAX is the maximum name length, **including** the terminating null byte.
Take this into account while validating user names.

Also support systems which might have no upper limit or no _SC_LOGIN_NAME_MAX at all.