### PR TITLE
Set default HOME_MODE to 0700

### DIFF
--- a/etc/login.defs
+++ b/etc/login.defs
@@ -204,7 +204,7 @@ UMASK		022
 # HOME_MODE is used by useradd(8) and newusers(8) to set the mode for new
 # home directories.
 # If HOME_MODE is not set, the value of UMASK is used to create the mode.
-#HOME_MODE	0700
+HOME_MODE	0700
 
 #
 # Password aging controls:


### PR DESCRIPTION
Since the introduction of https://github.com/shadow-maint/shadow/pull/209, many distros started to set HOME_MODE by default:
 -  RedHat & RH based distro like [Fedora](https://src.fedoraproject.org/rpms/shadow-utils/blob/rawhide/f/shadow-utils.login.defs#_122), but also [Arch linux](https://gitlab.archlinux.org/archlinux/packaging/packages/shadow/-/blob/main/0003-Add-Arch-Linux-defaults-for-login.defs.patch?ref_type=heads#L40), [OpenSuse](https://build.opensuse.org/package/view_file/openSUSE:Factory/shadow/shadow-login_defs-suse.patch?expand=1) all set it to 0700
 - [Ubuntu](https://git.launchpad.net/ubuntu/+source/shadow/tree/debian/login.defs#n156) sets it to 0750
 - notable exceptions are [Debian](https://salsa.debian.org/debian/shadow/-/blob/master/debian/login.defs?ref_type=heads#L156) and Gentoo that keep the variable unset.

I propose to set it to 0700 or at least 0750 by default, since it is a security best practice and it's something often tested by security benchmarks (e.g., CIS Benchmarks).
