### PR TITLE
etc/pam.d/Makefile.am: Fix typo

### DIFF
--- a/etc/pam.d/Makefile.am
+++ b/etc/pam.d/Makefile.am
@@ -12,7 +12,7 @@ pamd_files = \
 
 pamd_acct_tools_files = \
 	chage \
-	chpasswd \
+	chgpasswd \
 	groupadd \
 	groupdel \
 	groupmod \


### PR DESCRIPTION
Fixes: 341d80c2c751 ("Makefile: move chpasswd and newusers to pamd target")
Link: <https://github.com/shadow-maint/shadow/pull/928#discussion_r1487687347>
Link: <https://github.com/shadow-maint/shadow/issues/926#issuecomment-1941324761>
Reported-by: @DimStar77
Reported-by: @jubalh 
Cc: @loqs
Cc: @dvzrv
Cc: @ikerexxe 


To be cherry-picked to 4.14.x.