### PR TITLE
share/containers/, .github/workflows/: Don't make(1) twice

### DIFF
--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -32,10 +32,7 @@ jobs:
     - name: Build shadow-utils
       run: |
         PROCESSORS=$(/usr/bin/getconf _NPROCESSORS_ONLN)
-        make -kj$PROCESSORS || true
-
-    - name: Check build errors
-      run: make
+        make -Orecurse -j$PROCESSORS
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/share/containers/alpine.dockerfile
+++ b/share/containers/alpine.dockerfile
@@ -26,8 +26,7 @@ RUN ./autogen.sh \
 	--disable-man \
 	--disable-nls \
 	--with-yescrypt
-RUN make -kj4 || true
-RUN make
+RUN make -Orecurse -j4
 RUN bash -c "trap 'cat <tests/unit/test-suite.log >&2' ERR; make check;"
 RUN make install
 

--- a/share/containers/debian.dockerfile
+++ b/share/containers/debian.dockerfile
@@ -23,8 +23,7 @@ RUN ./autogen.sh \
 	--without-selinux \
 	--enable-man \
 	--with-yescrypt
-RUN make -kj4 || true
-RUN make
+RUN make -Orecurse -j4
 RUN bash -c "trap 'cat <tests/unit/test-suite.log >&2' ERR; make check;"
 RUN make install
 

--- a/share/containers/fedora.dockerfile
+++ b/share/containers/fedora.dockerfile
@@ -25,8 +25,7 @@ RUN ./autogen.sh \
         --with-group-name-max-length=32 \
 	--enable-lastlog \
 	--enable-logind=no
-RUN make -kj4 || true
-RUN make
+RUN make -Orecurse -j4
 RUN bash -c "trap 'cat <tests/unit/test-suite.log >&2' ERR; make check;"
 RUN make install
 


### PR DESCRIPTION
It was being done so that the second one prints errors without races. However, the same thing can be done by passing -Orecurse to make(1).

And this makes the logs even more readable, since there's no racy output at all.

Fixes: 97f79e3b2715 ("CI: Make build logs more readable")
Link: <https://github.com/shadow-maint/shadow/pull/702>
Link: <https://github.com/nginx/unit/pull/1123>
Acked-by: @ikerexxe 
Cc: @ac000
Cc: @thresheek
Cc: @arbourd