### PR TITLE
Passwd length

### DIFF
--- a/lib/agetpass.c
+++ b/lib/agetpass.c
@@ -11,7 +11,6 @@
 
 #include <limits.h>
 #include <readpassphrase.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -22,11 +21,6 @@
 #if WITH_LIBBSD == 0
 #include "freezero.h"
 #endif /* WITH_LIBBSD */
-
-
-#if !defined(PASS_MAX)
-#define PASS_MAX  BUFSIZ - 1
-#endif
 
 
 /*

--- a/lib/defines.h
+++ b/lib/defines.h
@@ -25,6 +25,7 @@
     ((N) == 1 ? (const char *) (Msgid1) : (const char *) (Msgid2))
 #endif
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -200,6 +201,16 @@
 #  define shadow_getenv(name) secure_getenv(name)
 # else
 #  define shadow_getenv(name) getenv(name)
+#endif
+
+/*
+ * Maximum password length
+ *
+ * Consider that there is also limit in PAM (PAM_MAX_RESP_SIZE)
+ * currently set to 512.
+ */
+#if !defined(PASS_MAX)
+#define PASS_MAX  BUFSIZ - 1
 #endif
 
 #endif				/* _DEFINES_H_ */

--- a/src/passwd.c
+++ b/src/passwd.c
@@ -175,8 +175,8 @@ static int new_password (const struct passwd *pw)
 	char *cipher;		/* Pointer to cipher text */
 	const char *salt;	/* Pointer to new salt */
 	char *cp;		/* Pointer to agetpass() response */
-	char orig[200];		/* Original password */
-	char pass[200];		/* New password */
+	char orig[PASS_MAX + 1];	/* Original password */
+	char pass[PASS_MAX + 1];	/* New password */
 	int i;			/* Counter for retries */
 	bool warned;
 	int pass_max_len = -1;


### PR DESCRIPTION
This PR addresses two issues:

* The passwd utility has limit 200 characters. Some admins wants uses longer passwords for technical accounts
* The passwd utility cuts the provided password silently

First commit unifies the password length limit between `agetpass.c` and `passwd.c`.

The second one introduces checking the length of provided password.
