### PR TITLE
lib/utmp.c: Use the appropriate autotools macros for struct utmpx

### DIFF
--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -183,7 +183,7 @@ get_session_host(char **out)
 
 	ut = get_current_utmp();
 
-#if defined(HAVE_STRUCT_UTMP_UT_HOST)
+#if defined(HAVE_STRUCT_UTMPX_UT_HOST)
 	if ((ut != NULL) && (ut->ut_host[0] != '\0')) {
 		char  *hostname;
 
@@ -258,7 +258,7 @@ prepare_utmp(const char *name, const char *line, const char *host,
 	    && ('\0' != host[0])) {
 		hostname = XMALLOC(strlen(host) + 1, char);
 		strcpy (hostname, host);
-#if defined(HAVE_STRUCT_UTMP_UT_HOST)
+#if defined(HAVE_STRUCT_UTMPX_UT_HOST)
 	} else if (   (NULL != ut)
 	           && ('\0' != ut->ut_host[0])) {
 		hostname = XMALLOC(NITEMS(ut->ut_host) + 1, char);
@@ -283,20 +283,20 @@ prepare_utmp(const char *name, const char *line, const char *host,
 		/* XXX - assumes /dev/tty?? */
 		STRNCPY(utent->ut_id, line + 3);
 	}
-#if defined(HAVE_STRUCT_UTMP_UT_NAME)
+#if defined(HAVE_STRUCT_UTMPX_UT_NAME)
 	STRNCPY(utent->ut_name, name);
 #endif
 	STRNCPY(utent->ut_user, name);
 	if (NULL != hostname) {
 		struct addrinfo *info = NULL;
-#if defined(HAVE_STRUCT_UTMP_UT_HOST)
+#if defined(HAVE_STRUCT_UTMPX_UT_HOST)
 		STRNCPY(utent->ut_host, hostname);
 #endif
-#if defined(HAVE_STRUCT_UTMP_UT_SYSLEN)
+#if defined(HAVE_STRUCT_UTMPX_UT_SYSLEN)
 		utent->ut_syslen = MIN (strlen (hostname),
 		                        sizeof (utent->ut_host));
 #endif
-#if defined(HAVE_STRUCT_UTMP_UT_ADDR) || defined(HAVE_STRUCT_UTMP_UT_ADDR_V6)
+#if defined(HAVE_STRUCT_UTMPX_UT_ADDR) || defined(HAVE_STRUCT_UTMPX_UT_ADDR_V6)
 		if (getaddrinfo (hostname, NULL, NULL, &info) == 0) {
 			/* getaddrinfo might not be reliable.
 			 * Just try to log what may be useful.
@@ -304,13 +304,13 @@ prepare_utmp(const char *name, const char *line, const char *host,
 			if (info->ai_family == AF_INET) {
 				struct sockaddr_in *sa =
 					(struct sockaddr_in *) info->ai_addr;
-# if defined(HAVE_STRUCT_UTMP_UT_ADDR)
+# if defined(HAVE_STRUCT_UTMPX_UT_ADDR)
 				memcpy (&(utent->ut_addr),
 				        &(sa->sin_addr),
 				        MIN (sizeof (utent->ut_addr),
 				             sizeof (sa->sin_addr)));
 # endif
-# if defined(HAVE_STRUCT_UTMP_UT_ADDR_V6)
+# if defined(HAVE_STRUCT_UTMPX_UT_ADDR_V6)
 				memcpy (utent->ut_addr_v6,
 				        &(sa->sin_addr),
 				        MIN (sizeof (utent->ut_addr_v6),
@@ -332,10 +332,10 @@ prepare_utmp(const char *name, const char *line, const char *host,
 	/* ut_exit is only for DEAD_PROCESS */
 	utent->ut_session = getsid (0);
 	if (gettimeofday (&tv, NULL) == 0) {
-#if defined(HAVE_STRUCT_UTMP_UT_TIME)
+#if defined(HAVE_STRUCT_UTMPX_UT_TIME)
 		utent->ut_time = tv.tv_sec;
 #endif
-#if defined(HAVE_STRUCT_UTMP_UT_XTIME)
+#if defined(HAVE_STRUCT_UTMPX_UT_XTIME)
 		utent->ut_xtime = tv.tv_usec;
 #endif
 		utent->ut_tv.tv_sec  = tv.tv_sec;

--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -198,7 +198,7 @@ get_session_host(char **out)
 #else
 	*out = NULL;
 	ret = -2;
-#endif /* HAVE_STRUCT_UTMP_UT_HOST */
+#endif
 
 	return ret;
 }
@@ -263,7 +263,7 @@ prepare_utmp(const char *name, const char *line, const char *host,
 	           && ('\0' != ut->ut_host[0])) {
 		hostname = XMALLOC(NITEMS(ut->ut_host) + 1, char);
 		ZUSTR2STP(hostname, ut->ut_host);
-#endif				/* HAVE_STRUCT_UTMP_UT_HOST */
+#endif
 	}
 
 	if (strncmp(line, "/dev/", 5) == 0) {
@@ -285,17 +285,17 @@ prepare_utmp(const char *name, const char *line, const char *host,
 	}
 #ifdef HAVE_STRUCT_UTMP_UT_NAME
 	STRNCPY(utent->ut_name, name);
-#endif				/* HAVE_STRUCT_UTMP_UT_NAME */
+#endif
 	STRNCPY(utent->ut_user, name);
 	if (NULL != hostname) {
 		struct addrinfo *info = NULL;
 #ifdef HAVE_STRUCT_UTMP_UT_HOST
 		STRNCPY(utent->ut_host, hostname);
-#endif				/* HAVE_STRUCT_UTMP_UT_HOST */
+#endif
 #ifdef HAVE_STRUCT_UTMP_UT_SYSLEN
 		utent->ut_syslen = MIN (strlen (hostname),
 		                        sizeof (utent->ut_host));
-#endif				/* HAVE_STRUCT_UTMP_UT_SYSLEN */
+#endif
 #if defined(HAVE_STRUCT_UTMP_UT_ADDR) || defined(HAVE_STRUCT_UTMP_UT_ADDR_V6)
 		if (getaddrinfo (hostname, NULL, NULL, &info) == 0) {
 			/* getaddrinfo might not be reliable.
@@ -309,7 +309,7 @@ prepare_utmp(const char *name, const char *line, const char *host,
 				        &(sa->sin_addr),
 				        MIN (sizeof (utent->ut_addr),
 				             sizeof (sa->sin_addr)));
-# endif				/* HAVE_STRUCT_UTMP_UT_ADDR */
+# endif
 # ifdef HAVE_STRUCT_UTMP_UT_ADDR_V6
 				memcpy (utent->ut_addr_v6,
 				        &(sa->sin_addr),
@@ -322,11 +322,11 @@ prepare_utmp(const char *name, const char *line, const char *host,
 				        &(sa->sin6_addr),
 				        MIN (sizeof (utent->ut_addr_v6),
 				             sizeof (sa->sin6_addr)));
-# endif				/* HAVE_STRUCT_UTMP_UT_ADDR_V6 */
+# endif
 			}
 			freeaddrinfo (info);
 		}
-#endif		/* HAVE_STRUCT_UTMP_UT_ADDR || HAVE_STRUCT_UTMP_UT_ADDR_V6 */
+#endif
 		free (hostname);
 	}
 	/* ut_exit is only for DEAD_PROCESS */
@@ -334,10 +334,10 @@ prepare_utmp(const char *name, const char *line, const char *host,
 	if (gettimeofday (&tv, NULL) == 0) {
 #ifdef HAVE_STRUCT_UTMP_UT_TIME
 		utent->ut_time = tv.tv_sec;
-#endif				/* HAVE_STRUCT_UTMP_UT_TIME */
+#endif
 #ifdef HAVE_STRUCT_UTMP_UT_XTIME
 		utent->ut_xtime = tv.tv_usec;
-#endif				/* HAVE_STRUCT_UTMP_UT_XTIME */
+#endif
 		utent->ut_tv.tv_sec  = tv.tv_sec;
 		utent->ut_tv.tv_usec = tv.tv_usec;
 	}
@@ -367,7 +367,7 @@ setutmp(struct utmpx *ut)
 #ifndef USE_PAM
 	/* This is done by pam_lastlog */
 	updwtmpx(_WTMP_FILE, ut);
-#endif				/* ! USE_PAM */
+#endif
 
 	return err;
 }

--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -183,7 +183,7 @@ get_session_host(char **out)
 
 	ut = get_current_utmp();
 
-#ifdef HAVE_STRUCT_UTMP_UT_HOST
+#if defined(HAVE_STRUCT_UTMP_UT_HOST)
 	if ((ut != NULL) && (ut->ut_host[0] != '\0')) {
 		char  *hostname;
 
@@ -258,7 +258,7 @@ prepare_utmp(const char *name, const char *line, const char *host,
 	    && ('\0' != host[0])) {
 		hostname = XMALLOC(strlen(host) + 1, char);
 		strcpy (hostname, host);
-#ifdef HAVE_STRUCT_UTMP_UT_HOST
+#if defined(HAVE_STRUCT_UTMP_UT_HOST)
 	} else if (   (NULL != ut)
 	           && ('\0' != ut->ut_host[0])) {
 		hostname = XMALLOC(NITEMS(ut->ut_host) + 1, char);
@@ -283,16 +283,16 @@ prepare_utmp(const char *name, const char *line, const char *host,
 		/* XXX - assumes /dev/tty?? */
 		STRNCPY(utent->ut_id, line + 3);
 	}
-#ifdef HAVE_STRUCT_UTMP_UT_NAME
+#if defined(HAVE_STRUCT_UTMP_UT_NAME)
 	STRNCPY(utent->ut_name, name);
 #endif
 	STRNCPY(utent->ut_user, name);
 	if (NULL != hostname) {
 		struct addrinfo *info = NULL;
-#ifdef HAVE_STRUCT_UTMP_UT_HOST
+#if defined(HAVE_STRUCT_UTMP_UT_HOST)
 		STRNCPY(utent->ut_host, hostname);
 #endif
-#ifdef HAVE_STRUCT_UTMP_UT_SYSLEN
+#if defined(HAVE_STRUCT_UTMP_UT_SYSLEN)
 		utent->ut_syslen = MIN (strlen (hostname),
 		                        sizeof (utent->ut_host));
 #endif
@@ -304,13 +304,13 @@ prepare_utmp(const char *name, const char *line, const char *host,
 			if (info->ai_family == AF_INET) {
 				struct sockaddr_in *sa =
 					(struct sockaddr_in *) info->ai_addr;
-# ifdef HAVE_STRUCT_UTMP_UT_ADDR
+# if defined(HAVE_STRUCT_UTMP_UT_ADDR)
 				memcpy (&(utent->ut_addr),
 				        &(sa->sin_addr),
 				        MIN (sizeof (utent->ut_addr),
 				             sizeof (sa->sin_addr)));
 # endif
-# ifdef HAVE_STRUCT_UTMP_UT_ADDR_V6
+# if defined(HAVE_STRUCT_UTMP_UT_ADDR_V6)
 				memcpy (utent->ut_addr_v6,
 				        &(sa->sin_addr),
 				        MIN (sizeof (utent->ut_addr_v6),
@@ -332,10 +332,10 @@ prepare_utmp(const char *name, const char *line, const char *host,
 	/* ut_exit is only for DEAD_PROCESS */
 	utent->ut_session = getsid (0);
 	if (gettimeofday (&tv, NULL) == 0) {
-#ifdef HAVE_STRUCT_UTMP_UT_TIME
+#if defined(HAVE_STRUCT_UTMP_UT_TIME)
 		utent->ut_time = tv.tv_sec;
 #endif
-#ifdef HAVE_STRUCT_UTMP_UT_XTIME
+#if defined(HAVE_STRUCT_UTMP_UT_XTIME)
 		utent->ut_xtime = tv.tv_usec;
 #endif
 		utent->ut_tv.tv_sec  = tv.tv_sec;
@@ -364,7 +364,7 @@ setutmp(struct utmpx *ut)
 	}
 	endutxent();
 
-#ifndef USE_PAM
+#if !defined(USE_PAM)
 	/* This is done by pam_lastlog */
 	updwtmpx(_WTMP_FILE, ut);
 #endif

--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -204,12 +204,11 @@ get_session_host(char **out)
 }
 
 
-#ifndef USE_PAM
+#if !defined(USE_PAM) && !defined(HAVE_UPDWTMPX)
 /*
  * Some systems already have updwtmpx().  Others
  * don't, so we re-implement these functions if necessary.
  */
-# ifndef HAVE_UPDWTMPX
 static void
 updwtmpx(const char *filename, const struct utmpx *ut)
 {
@@ -221,8 +220,7 @@ updwtmpx(const char *filename, const struct utmpx *ut)
 		close (fd);
 	}
 }
-# endif				/* ! HAVE_UPDWTMPX */
-#endif				/* ! USE_PAM */
+#endif
 
 
 /*

--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -209,7 +209,7 @@ get_session_host(char **out)
  * Some systems already have updwtmpx().  Others
  * don't, so we re-implement these functions if necessary.
  */
-#ifndef HAVE_UPDWTMPX
+# ifndef HAVE_UPDWTMPX
 static void
 updwtmpx(const char *filename, const struct utmpx *ut)
 {
@@ -221,7 +221,7 @@ updwtmpx(const char *filename, const struct utmpx *ut)
 		close (fd);
 	}
 }
-#endif				/* ! HAVE_UPDWTMPX */
+# endif				/* ! HAVE_UPDWTMPX */
 #endif				/* ! USE_PAM */
 
 
@@ -306,13 +306,13 @@ prepare_utmp(const char *name, const char *line, const char *host,
 			if (info->ai_family == AF_INET) {
 				struct sockaddr_in *sa =
 					(struct sockaddr_in *) info->ai_addr;
-#ifdef HAVE_STRUCT_UTMP_UT_ADDR
+# ifdef HAVE_STRUCT_UTMP_UT_ADDR
 				memcpy (&(utent->ut_addr),
 				        &(sa->sin_addr),
 				        MIN (sizeof (utent->ut_addr),
 				             sizeof (sa->sin_addr)));
-#endif				/* HAVE_STRUCT_UTMP_UT_ADDR */
-#ifdef HAVE_STRUCT_UTMP_UT_ADDR_V6
+# endif				/* HAVE_STRUCT_UTMP_UT_ADDR */
+# ifdef HAVE_STRUCT_UTMP_UT_ADDR_V6
 				memcpy (utent->ut_addr_v6,
 				        &(sa->sin_addr),
 				        MIN (sizeof (utent->ut_addr_v6),
@@ -324,7 +324,7 @@ prepare_utmp(const char *name, const char *line, const char *host,
 				        &(sa->sin6_addr),
 				        MIN (sizeof (utent->ut_addr_v6),
 				             sizeof (sa->sin6_addr)));
-#endif				/* HAVE_STRUCT_UTMP_UT_ADDR_V6 */
+# endif				/* HAVE_STRUCT_UTMP_UT_ADDR_V6 */
 			}
 			freeaddrinfo (info);
 		}


### PR DESCRIPTION
Oops.  I forgot to do a change.

    Recently, we started using utmpx instead of utmp, and we updated
    <./configure.ac> to do the checks for 'struct utmpx' instead of
    'struct utmp'.  However, I forgot to update the preprocessor
    conditionals accordingly.
    
Fixes: 64bcb54fa962 ("lib/, src/, configure.ac: Use utmpx instead of utmp")
Link: <https://github.com/shadow-maint/shadow/pull/954>
Cc: @firasuke
Cc: @awilfox
Cc: @ikerexxe 
