### PR TITLE
Fix escape sequence injection in /var/log/auth.log

### DIFF
--- a/src/chage.c
+++ b/src/chage.c
@@ -45,7 +45,7 @@
 /*
  * Global variables
  */
-const char *Prog;
+static const char Prog[] = "chage";
 
 static bool
     dflg = false,		/* set last password change date */
@@ -517,7 +517,7 @@ static void check_perms (void)
 		exit (E_NOPERM);
 	}
 
-	retval = pam_start ("chage", pampw->pw_name, &conv, &pamh);
+	retval = pam_start (Prog, pampw->pw_name, &conv, &pamh);
 
 	if (PAM_SUCCESS == retval) {
 		retval = pam_authenticate (pamh, 0);
@@ -771,7 +771,6 @@ int main (int argc, char **argv)
 	/*
 	 * Get the program name so that error messages can use it.
 	 */
-	Prog = Basename (argv[0]);
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
 
@@ -786,7 +785,7 @@ int main (int argc, char **argv)
 #ifdef WITH_AUDIT
 	audit_help_open ();
 #endif
-	OPENLOG ("chage");
+	OPENLOG (Prog);
 
 	ruid = getuid ();
 	rgid = getgid ();

--- a/src/check_subid_range.c
+++ b/src/check_subid_range.c
@@ -20,14 +20,13 @@
 #include "idmapping.h"
 #include "shadowlog.h"
 
-const char *Prog;
+static const char Prog[] = "check_subid_range";
 
 int main(int argc, char **argv)
 {
 	char *owner;
 	unsigned long start, count;
 	bool check_uids;
-	Prog = Basename (argv[0]);
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
 

--- a/src/chfn.c
+++ b/src/chfn.c
@@ -39,7 +39,7 @@
 /*
  * Global variables.
  */
-const char *Prog;
+static const char Prog[] = "chfn";
 static char fullnm[BUFSIZ];
 static char roomno[BUFSIZ];
 static char workph[BUFSIZ];
@@ -365,7 +365,7 @@ static void check_perms (const struct passwd *pw)
 	 * check if the change is allowed by SELinux policy.
 	 */
 	if ((pw->pw_uid != getuid ())
-	    && (check_selinux_permit ("chfn") != 0)) {
+	    && (check_selinux_permit (Prog) != 0)) {
 		fprintf (stderr, _("%s: Permission denied.\n"), Prog);
 		closelog ();
 		exit (E_NOPERM);
@@ -380,7 +380,7 @@ static void check_perms (const struct passwd *pw)
 	 * --marekm
 	 */
 	if (!amroot && getdef_bool ("CHFN_AUTH")) {
-		passwd_check (pw->pw_name, pw->pw_passwd, "chfn");
+		passwd_check (pw->pw_name, pw->pw_passwd, Prog);
 	}
 
 #else				/* !USE_PAM */
@@ -392,7 +392,7 @@ static void check_perms (const struct passwd *pw)
 		exit (E_NOPERM);
 	}
 
-	retval = pam_start ("chfn", pampw->pw_name, &conv, &pamh);
+	retval = pam_start (Prog, pampw->pw_name, &conv, &pamh);
 
 	if (PAM_SUCCESS == retval) {
 		retval = pam_authenticate (pamh, 0);
@@ -620,11 +620,6 @@ int main (int argc, char **argv)
 	char                 *user;
 	const struct passwd  *pw;
 
-	/*
-	 * Get the program name. The program name is used as a
-	 * prefix to most error messages.
-	 */
-	Prog = Basename (argv[0]);
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
 
@@ -641,7 +636,7 @@ int main (int argc, char **argv)
 	 */
 	amroot = (getuid () == 0);
 
-	OPENLOG ("chfn");
+	OPENLOG (Prog);
 
 	/* parse the command line options */
 	process_flags (argc, argv);

--- a/src/chgpasswd.c
+++ b/src/chgpasswd.c
@@ -36,7 +36,7 @@
 /*
  * Global variables
  */
-const char *Prog;
+static const char Prog[] = "chgpasswd";
 static bool eflg   = false;
 static bool md5flg = false;
 #if defined(USE_SHA_CRYPT) || defined(USE_BCRYPT) || defined(USE_YESCRYPT)
@@ -303,7 +303,7 @@ static void check_perms (void)
 		exit (1);
 	}
 
-	retval = pam_start ("chgpasswd", pampw->pw_name, &conv, &pamh);
+	retval = pam_start (Prog, pampw->pw_name, &conv, &pamh);
 
 	if (PAM_SUCCESS == retval) {
 		retval = pam_authenticate (pamh, 0);
@@ -423,7 +423,6 @@ int main (int argc, char **argv)
 	int errors = 0;
 	int line = 0;
 
-	Prog = Basename (argv[0]);
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
 
@@ -441,7 +440,7 @@ int main (int argc, char **argv)
 
 	process_flags (argc, argv);
 
-	OPENLOG ("chgpasswd");
+	OPENLOG (Prog);
 
 	check_perms ();
 

--- a/src/chpasswd.c
+++ b/src/chpasswd.c
@@ -35,7 +35,7 @@
 /*
  * Global variables
  */
-const char *Prog;
+static const char Prog[] = "chpasswd";
 static bool eflg   = false;
 static bool md5flg = false;
 #if defined(USE_SHA_CRYPT) || defined(USE_BCRYPT) || defined(USE_YESCRYPT)
@@ -302,7 +302,7 @@ static void check_perms (void)
 		exit (1);
 	}
 
-	retval = pam_start ("chpasswd", pampw->pw_name, &conv, &pamh);
+	retval = pam_start (Prog, pampw->pw_name, &conv, &pamh);
 
 	if (PAM_SUCCESS == retval) {
 		retval = pam_authenticate (pamh, 0);
@@ -450,7 +450,6 @@ int main (int argc, char **argv)
 	int errors = 0;
 	int line = 0;
 
-	Prog = Basename (argv[0]);
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
 
@@ -476,7 +475,7 @@ int main (int argc, char **argv)
 	}
 #endif				/* USE_PAM */
 
-	OPENLOG ("chpasswd");
+	OPENLOG (Prog);
 
 	check_perms ();
 
@@ -546,7 +545,7 @@ int main (int argc, char **argv)
 
 #ifdef USE_PAM
 		if (use_pam) {
-			if (do_pam_passwd_non_interactive ("chpasswd", name, newpwd) != 0) {
+			if (do_pam_passwd_non_interactive (Prog, name, newpwd) != 0) {
 				fprintf (stderr,
 				         _("%s: (line %d, user %s) password not changed\n"),
 				         Prog, line, name);

--- a/src/chsh.c
+++ b/src/chsh.c
@@ -46,7 +46,7 @@
 /*
  * Global variables
  */
-const char *Prog;		/* Program name */
+static const char Prog[] = "chsh";	/* Program name */
 static bool amroot;		/* Real UID is root */
 static char loginsh[BUFSIZ];	/* Name of new login shell */
 /* command line options */
@@ -319,7 +319,7 @@ static void check_perms (const struct passwd *pw)
 	 * check if the change is allowed by SELinux policy.
 	 */
 	if ((pw->pw_uid != getuid ())
-	    && (check_selinux_permit("chsh") != 0)) {
+	    && (check_selinux_permit(Prog) != 0)) {
 		SYSLOG ((LOG_WARN, "can't change shell for '%s'", pw->pw_name));
 		fprintf (stderr,
 		         _("You may not change the shell for '%s'.\n"),
@@ -336,7 +336,7 @@ static void check_perms (const struct passwd *pw)
 	 * chfn/chsh.  --marekm
 	 */
 	if (!amroot && getdef_bool ("CHSH_AUTH")) {
-		passwd_check (pw->pw_name, pw->pw_passwd, "chsh");
+		passwd_check (pw->pw_name, pw->pw_passwd, Prog);
         }
 
 #else				/* !USE_PAM */
@@ -348,7 +348,7 @@ static void check_perms (const struct passwd *pw)
 		exit (E_NOPERM);
 	}
 
-	retval = pam_start ("chsh", pampw->pw_name, &conv, &pamh);
+	retval = pam_start (Prog, pampw->pw_name, &conv, &pamh);
 
 	if (PAM_SUCCESS == retval) {
 		retval = pam_authenticate (pamh, 0);
@@ -473,11 +473,6 @@ int main (int argc, char **argv)
 
 	sanitize_env ();
 
-	/*
-	 * Get the program name. The program name is used as a prefix to
-	 * most error messages.
-	 */
-	Prog = Basename (argv[0]);
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
 
@@ -492,7 +487,7 @@ int main (int argc, char **argv)
 	 */
 	amroot = (getuid () == 0);
 
-	OPENLOG ("chsh");
+	OPENLOG (Prog);
 
 	/* parse the command line options */
 	process_flags (argc, argv);

--- a/src/expiry.c
+++ b/src/expiry.c
@@ -25,7 +25,7 @@
 #include "shadowlog.h"
 
 /* Global variables */
-const char *Prog;
+static const char Prog[] = "expiry";
 static bool cflg = false;
 
 /* local function prototypes */
@@ -125,7 +125,6 @@ int main (int argc, char **argv)
 	struct passwd *pwd;
 	struct spwd *spwd;
 
-	Prog = Basename (argv[0]);
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
 
@@ -147,7 +146,7 @@ int main (int argc, char **argv)
 	(void) bindtextdomain (PACKAGE, LOCALEDIR);
 	(void) textdomain (PACKAGE);
 
-	OPENLOG ("expiry");
+	OPENLOG (Prog);
 
 	process_flags (argc, argv);
 

--- a/src/faillog.c
+++ b/src/faillog.c
@@ -40,7 +40,7 @@ static void reset (void);
 /*
  * Global variables
  */
-const char *Prog;		/* Program name */
+static const char Prog[] = "faillog";	/* Program name */
 static FILE *fail;		/* failure file stream */
 static time_t seconds;		/* that number of days in seconds */
 static unsigned long umin;	/* if uflg and has_umin, only display users with uid >= umin */
@@ -510,11 +510,6 @@ int main (int argc, char **argv)
 	short fail_max = 0; // initialize to silence compiler warning
 	long days = 0;
 
-	/*
-	 * Get the program name. The program name is used as a prefix to
-	 * most error messages.
-	 */
-	Prog = Basename (argv[0]);
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
 

--- a/src/free_subid_range.c
+++ b/src/free_subid_range.c
@@ -9,7 +9,7 @@
 
 /* Test program for the subid freeing routine */
 
-const char *Prog;
+static const char Prog[] = "free_subid_range";
 
 static void usage(void)
 {
@@ -25,7 +25,6 @@ int main(int argc, char *argv[])
 	struct subordinate_range range;
 	bool group = false;   // get subuids by default
 
-	Prog = Basename (argv[0]);
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
 	while ((c = getopt(argc, argv, "g")) != EOF) {

--- a/src/get_subid_owners.c
+++ b/src/get_subid_owners.c
@@ -6,7 +6,7 @@
 #include "prototypes.h"
 #include "shadowlog.h"
 
-const char *Prog;
+static const char Prog[] = "get_subid_owners";
 
 static void usage(void)
 {
@@ -21,7 +21,6 @@ int main(int argc, char *argv[])
 	int i, n;
 	uid_t *uids;
 
-	Prog = Basename (argv[0]);
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
 	if (argc < 2) {

--- a/src/getsubids.c
+++ b/src/getsubids.c
@@ -7,7 +7,7 @@
 #include "prototypes.h"
 #include "shadowlog.h"
 
-const char *Prog;
+static const char Prog[] = "getsubids";
 
 static void usage(void)
 {
@@ -23,7 +23,6 @@ int main(int argc, char *argv[])
 	struct subid_range *ranges;
 	const char *owner;
 
-	Prog = Basename (argv[0]);
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
 	if (argc < 2)

--- a/src/gpasswd.c
+++ b/src/gpasswd.c
@@ -43,7 +43,7 @@
  * Global variables
  */
 /* The name of this command, as it is invoked */
-const char *Prog;
+static const char Prog[] = "gpasswd";
 
 #ifdef SHADOWGRP
 /* Indicate if shadow groups are enabled on the system
@@ -942,11 +942,10 @@ int main (int argc, char **argv)
 	 * with this command.
 	 */
 	bywho = getuid ();
-	Prog = Basename (argv[0]);
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
 
-	OPENLOG ("gpasswd");
+	OPENLOG (Prog);
 	setbuf (stdout, NULL);
 	setbuf (stderr, NULL);
 

--- a/src/groupadd.c
+++ b/src/groupadd.c
@@ -51,7 +51,7 @@
 /*
  * Global variables
  */
-const char *Prog;
+static const char Prog[] = "groupadd";
 
 static /*@null@*/char *group_name;
 static gid_t group_id;
@@ -543,7 +543,7 @@ static void check_perms (void)
 		exit (1);
 	}
 
-	retval = pam_start ("groupadd", pampw->pw_name, &conv, &pamh);
+	retval = pam_start (Prog, pampw->pw_name, &conv, &pamh);
 
 	if (PAM_SUCCESS == retval) {
 		retval = pam_authenticate (pamh, 0);
@@ -572,10 +572,6 @@ static void check_perms (void)
  */
 int main (int argc, char **argv)
 {
-	/*
-	 * Get my name so that I can use it to report errors.
-	 */
-	Prog = Basename (argv[0]);
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
 
@@ -586,7 +582,7 @@ int main (int argc, char **argv)
 	process_root_flag ("-R", argc, argv);
 	prefix = process_prefix_flag ("-P", argc, argv);
 
-	OPENLOG ("groupadd");
+	OPENLOG (Prog);
 #ifdef WITH_AUDIT
 	audit_help_open ();
 #endif
@@ -606,7 +602,7 @@ int main (int argc, char **argv)
 	check_perms ();
 
 	if (run_parts ("/etc/shadow-maint/groupadd-pre.d", group_name,
-			"groupadd")) {
+			Prog)) {
 		exit(1);
 	}
 
@@ -629,7 +625,7 @@ int main (int argc, char **argv)
 	grp_update ();
 	close_files ();
 	if (run_parts ("/etc/shadow-maint/groupadd-post.d", group_name,
-			"groupadd")) {
+			Prog)) {
 		exit(1);
 	}
 

--- a/src/groupdel.c
+++ b/src/groupdel.c
@@ -36,7 +36,7 @@
 /*
  * Global variables
  */
-const char *Prog;
+static const char Prog[] = "groupdel";
 
 static char *group_name;
 static gid_t group_id = -1;
@@ -349,10 +349,6 @@ int main (int argc, char **argv)
 #endif				/* USE_PAM */
 #endif				/* ACCT_TOOLS_SETUID */
 
-	/*
-	 * Get my name so that I can use it to report errors.
-	 */
-	Prog = Basename (argv[0]);
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
 
@@ -363,7 +359,7 @@ int main (int argc, char **argv)
 	process_root_flag ("-R", argc, argv);
 	prefix = process_prefix_flag ("-P", argc, argv);
 
-	OPENLOG ("groupdel");
+	OPENLOG (Prog);
 #ifdef WITH_AUDIT
 	audit_help_open ();
 #endif
@@ -389,7 +385,7 @@ int main (int argc, char **argv)
 			exit (1);
 		}
 
-		retval = pam_start ("groupdel", pampw->pw_name, &conv, &pamh);
+		retval = pam_start (Prog, pampw->pw_name, &conv, &pamh);
 	}
 
 	if (PAM_SUCCESS == retval) {
@@ -463,7 +459,7 @@ int main (int argc, char **argv)
 	}
 
 	if (run_parts ("/etc/shadow-maint/groupdel-pre.d", group_name,
-			"groupdel")) {
+			Prog)) {
 		exit(1);
 	}
 
@@ -478,7 +474,7 @@ int main (int argc, char **argv)
 	close_files ();
 
 	if (run_parts ("/etc/shadow-maint/groupdel-post.d", group_name,
-			"groupdel")) {
+			Prog)) {
 		exit(1);
 	}
 

--- a/src/groupmems.c
+++ b/src/groupmems.c
@@ -44,7 +44,7 @@
 /*
  * Global variables
  */
-const char *Prog;
+static const char Prog[] = "groupmems";
 
 static char *adduser = NULL;
 static char *deluser = NULL;
@@ -443,7 +443,7 @@ static void check_perms (void)
 			fail_exit (1);
 		}
 
-		retval = pam_start ("groupmems", pampw->pw_name, &conv, &pamh);
+		retval = pam_start (Prog, pampw->pw_name, &conv, &pamh);
 
 		if (PAM_SUCCESS == retval) {
 			retval = pam_authenticate (pamh, 0);
@@ -573,10 +573,6 @@ int main (int argc, char **argv)
 	char *name;
 	const struct group *grp;
 
-	/*
-	 * Get my name so that I can use it to report errors.
-	 */
-	Prog = Basename (argv[0]);
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
 
@@ -586,7 +582,7 @@ int main (int argc, char **argv)
 
 	process_root_flag ("-R", argc, argv);
 
-	OPENLOG ("groupmems");
+	OPENLOG (Prog);
 
 #ifdef SHADOWGRP
 	is_shadowgrp = sgr_file_present ();

--- a/src/groupmod.c
+++ b/src/groupmod.c
@@ -59,7 +59,7 @@
 /*
  * Global variables
  */
-const char *Prog;
+static const char Prog[] = "groupmod";
 
 #ifdef	SHADOWGRP
 static bool is_shadow_grp;
@@ -751,10 +751,6 @@ int main (int argc, char **argv)
 #endif				/* USE_PAM */
 #endif				/* ACCT_TOOLS_SETUID */
 
-	/*
-	 * Get my name so that I can use it to report errors.
-	 */
-	Prog = Basename (argv[0]);
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
 
@@ -765,7 +761,7 @@ int main (int argc, char **argv)
 	process_root_flag ("-R", argc, argv);
 	prefix = process_prefix_flag ("-P", argc, argv);
 
-	OPENLOG ("groupmod");
+	OPENLOG (Prog);
 #ifdef WITH_AUDIT
 	audit_help_open ();
 #endif
@@ -791,7 +787,7 @@ int main (int argc, char **argv)
 			exit (E_PAM_USERNAME);
 		}
 
-		retval = pam_start ("groupmod", pampw->pw_name, &conv, &pamh);
+		retval = pam_start (Prog, pampw->pw_name, &conv, &pamh);
 	}
 
 	if (PAM_SUCCESS == retval) {

--- a/src/groups.c
+++ b/src/groups.c
@@ -23,7 +23,7 @@
 /*
  * Global variables
  */
-const char *Prog;
+static const char Prog[] = "groups";
 
 /* local function prototypes */
 static void print_groups (const char *member);
@@ -97,10 +97,6 @@ int main (int argc, char **argv)
 	(void) bindtextdomain (PACKAGE, LOCALEDIR);
 	(void) textdomain (PACKAGE);
 
-	/*
-	 * Get the program name so that error messages can use it.
-	 */
-	Prog = Basename (argv[0]);
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
 

--- a/src/grpck.c
+++ b/src/grpck.c
@@ -43,7 +43,7 @@
 /*
  * Global variables
  */
-const char *Prog;
+static const char Prog[] = "grpck";
 
 static const char *grp_file = GROUP_FILE;
 static bool use_system_grp_file = true;
@@ -816,10 +816,6 @@ int main (int argc, char **argv)
 	int errors = 0;
 	bool changed = false;
 
-	/*
-	 * Get my name so that I can use it to report errors.
-	 */
-	Prog = Basename (argv[0]);
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
 
@@ -829,7 +825,7 @@ int main (int argc, char **argv)
 
 	process_root_flag ("-R", argc, argv);
 
-	OPENLOG ("grpck");
+	OPENLOG (Prog);
 
 	/* Parse the command line arguments */
 	process_flags (argc, argv);

--- a/src/grpconv.c
+++ b/src/grpconv.c
@@ -39,7 +39,7 @@
 /*
  * Global variables
  */
-const char *Prog;
+static const char Prog[] = "grpconv";
 
 static bool gr_locked  = false;
 static bool sgr_locked = false;
@@ -126,7 +126,6 @@ int main (int argc, char **argv)
 	const struct sgrp *sg;
 	struct sgrp sgent;
 
-	Prog = Basename (argv[0]);
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
 
@@ -136,7 +135,7 @@ int main (int argc, char **argv)
 
 	process_root_flag ("-R", argc, argv);
 
-	OPENLOG ("grpconv");
+	OPENLOG (Prog);
 
 	process_flags (argc, argv);
 

--- a/src/grpunconv.c
+++ b/src/grpunconv.c
@@ -38,7 +38,7 @@
 /*
  * Global variables
  */
-const char *Prog;
+static const char Prog[] = "grpunconv";
 
 static bool gr_locked  = false;
 static bool sgr_locked = false;
@@ -124,7 +124,6 @@ int main (int argc, char **argv)
 	struct group grent;
 	const struct sgrp *sg;
 
-	Prog = Basename (argv[0]);
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
 
@@ -134,7 +133,7 @@ int main (int argc, char **argv)
 
 	process_root_flag ("-R", argc, argv);
 
-	OPENLOG ("grpunconv");
+	OPENLOG (Prog);
 
 	process_flags (argc, argv);
 

--- a/src/lastlog.c
+++ b/src/lastlog.c
@@ -40,7 +40,7 @@
 /*
  * Global variables
  */
-const char *Prog;		/* Program name */
+static const char Prog[] = "lastlog";	/* Program name */
 static FILE *lastlogfile;	/* lastlog file stream */
 static unsigned long umin;	/* if uflg and has_umin, only display users with uid >= umin */
 static bool has_umin = false;
@@ -291,7 +291,6 @@ int main (int argc, char **argv)
 	 * Get the program name. The program name is used as a prefix to
 	 * most error messages.
 	 */
-	Prog = Basename (argv[0]);
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
 

--- a/src/login.c
+++ b/src/login.c
@@ -68,7 +68,7 @@ static pam_handle_t *pamh = NULL;
 /*
  * Global variables
  */
-const char *Prog;
+static const char Prog[] = "login";
 
 static const char *hostname = "";
 static /*@null@*/ /*@only@*/char *username = NULL;
@@ -520,7 +520,6 @@ int main (int argc, char **argv)
 	initenv ();
 
 	amroot = (getuid () == 0);
-	Prog = Basename (argv[0]);
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
 
@@ -587,7 +586,7 @@ int main (int argc, char **argv)
 	}
 #endif				/* RLOGIN */
 
-	OPENLOG ("login");
+	OPENLOG (Prog);
 
 	setup_tty ();
 
@@ -670,7 +669,7 @@ int main (int argc, char **argv)
 	retries = getdef_unum ("LOGIN_RETRIES", RETRIES);
 
 #ifdef USE_PAM
-	retcode = pam_start ("login", username, &conv, &pamh);
+	retcode = pam_start (Prog, username, &conv, &pamh);
 	if (retcode != PAM_SUCCESS) {
 		fprintf (stderr,
 		         _("login: PAM Failure, aborting: %s\n"),

--- a/src/logoutd.c
+++ b/src/logoutd.c
@@ -24,7 +24,7 @@
 /*
  * Global variables
  */
-const char *Prog;
+static const char Prog[] = "logoutd";
 
 #ifndef DEFAULT_HUP_MESG
 #define DEFAULT_HUP_MESG _("login time exceeded\n\n")
@@ -157,11 +157,10 @@ main(int argc, char **argv)
 	/*
 	 * Start syslogging everything
 	 */
-	Prog = Basename (argv[0]);
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
 
-	OPENLOG ("logoutd");
+	OPENLOG (Prog);
 
 	/*
 	 * Scan the utmp file once per minute looking for users that

--- a/src/new_subid_range.c
+++ b/src/new_subid_range.c
@@ -9,7 +9,7 @@
 
 /* Test program for the subid creation routine */
 
-const char *Prog;
+static const char Prog[] = "new_subid_range";
 
 static void usage(void)
 {
@@ -28,7 +28,6 @@ int main(int argc, char *argv[])
 	bool group = false;   // get subuids by default
 	bool ok;
 
-	Prog = Basename (argv[0]);
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
 	while ((c = getopt(argc, argv, "gn")) != EOF) {

--- a/src/newgidmap.c
+++ b/src/newgidmap.c
@@ -23,7 +23,7 @@
 /*
  * Global variables
  */
-const char *Prog;
+static const char Prog[] = "newgidmap";
 
 
 static bool verify_range(struct passwd *pw, struct map_range *range, bool *allow_setgroups)
@@ -151,7 +151,6 @@ int main(int argc, char **argv)
 	struct passwd *pw;
 	bool allow_setgroups = false;
 
-	Prog = Basename (argv[0]);
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
 

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -31,7 +31,7 @@
 /*
  * Global variables
  */
-const char *Prog;
+static const char *Prog;
 
 extern char **newenvp;
 

--- a/src/newuidmap.c
+++ b/src/newuidmap.c
@@ -23,7 +23,7 @@
 /*
  * Global variables
  */
-const char *Prog;
+static const char Prog[] = "newuidmap";
 
 static bool verify_range(struct passwd *pw, struct map_range *range)
 {
@@ -80,7 +80,6 @@ int main(int argc, char **argv)
 	struct stat st;
 	struct passwd *pw;
 
-	Prog = Basename (argv[0]);
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
 

--- a/src/newusers.c
+++ b/src/newusers.c
@@ -56,7 +56,7 @@
 /*
  * Global variables
  */
-const char *Prog;
+static const char Prog[] = "newusers";
 
 static bool rflg = false;	/* create a system account */
 #ifndef USE_PAM
@@ -1059,7 +1059,6 @@ int main (int argc, char **argv)
 	unsigned int nusers = 0;
 #endif				/* USE_PAM */
 
-	Prog = Basename (argv[0]);
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
 

--- a/src/passwd.c
+++ b/src/passwd.c
@@ -48,7 +48,7 @@
 /*
  * Global variables
  */
-const char *Prog;		/* Program name */
+static const char Prog[] = "passwd";	/* Program name */
 
 static char *name;		/* The name of user whose password is being changed */
 static char *myname;		/* The current user's name */
@@ -729,11 +729,6 @@ int main (int argc, char **argv)
 
 	sanitize_env ();
 
-	/*
-	 * Get the program name. The program name is used as a prefix to
-	 * most error messages.
-	 */
-	Prog = Basename (argv[0]);
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
 
@@ -755,7 +750,7 @@ int main (int argc, char **argv)
 	 */
 	amroot = (getuid () == 0);
 
-	OPENLOG ("passwd");
+	OPENLOG (Prog);
 
 	{
 		/*
@@ -984,7 +979,7 @@ int main (int argc, char **argv)
 #ifdef WITH_SELINUX
 	/* only do this check when getuid()==0 because it's a pre-condition for
 	   changing a password without entering the old one */
-	if (amroot && (check_selinux_permit ("passwd") != 0)) {
+	if (amroot && (check_selinux_permit (Prog) != 0)) {
 		SYSLOG ((LOG_ALERT,
 		         "root is not authorized by SELinux to change the password of %s",
 		         name));

--- a/src/pwck.c
+++ b/src/pwck.c
@@ -47,7 +47,7 @@
 /*
  * Global variables
  */
-const char *Prog;
+static const char Prog[] = "pwck";
 
 static bool use_system_pw_file = true;
 static bool use_system_spw_file = true;
@@ -833,10 +833,6 @@ int main (int argc, char **argv)
 	int errors = 0;
 	bool changed = false;
 
-	/*
-	 * Get my name so that I can use it to report errors.
-	 */
-	Prog = Basename (argv[0]);
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
 
@@ -846,7 +842,7 @@ int main (int argc, char **argv)
 
 	process_root_flag ("-R", argc, argv);
 
-	OPENLOG ("pwck");
+	OPENLOG (Prog);
 
 	/* Parse the command line arguments */
 	process_flags (argc, argv);

--- a/src/pwconv.c
+++ b/src/pwconv.c
@@ -68,7 +68,7 @@
 /*
  * Global variables
  */
-const char *Prog;
+static const char Prog[] = "pwconv";
 
 static bool spw_locked = false;
 static bool pw_locked = false;
@@ -155,7 +155,6 @@ int main (int argc, char **argv)
 	const struct spwd *sp;
 	struct spwd spent;
 
-	Prog = Basename (argv[0]);
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
 
@@ -165,7 +164,7 @@ int main (int argc, char **argv)
 
 	process_root_flag ("-R", argc, argv);
 
-	OPENLOG ("pwconv");
+	OPENLOG (Prog);
 
 	process_flags (argc, argv);
 

--- a/src/pwunconv.c
+++ b/src/pwunconv.c
@@ -31,7 +31,7 @@
 /*
  * Global variables
  */
-const char *Prog;
+static const char Prog[] = "pwunconv";
 
 static bool spw_locked = false;
 static bool pw_locked = false;
@@ -115,7 +115,6 @@ int main (int argc, char **argv)
 	struct passwd pwent;
 	const struct spwd *spwd;
 
-	Prog = Basename (argv[0]);
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
 
@@ -125,7 +124,7 @@ int main (int argc, char **argv)
 
 	process_root_flag ("-R", argc, argv);
 
-	OPENLOG ("pwunconv");
+	OPENLOG (Prog);
 
 	process_flags (argc, argv);
 

--- a/src/su.c
+++ b/src/su.c
@@ -66,7 +66,7 @@
 /*
  * Global variables
  */
-const char *Prog;
+static const char Prog[] = "su";
 static /*@observer@*/const char *caller_tty = NULL;	/* Name of tty SU is run from */
 static bool caller_is_root = false;
 static uid_t caller_uid;
@@ -738,11 +738,6 @@ static void save_caller_context (char **argv)
 	const char *password = NULL;
 #endif				/* SU_ACCESS */
 #endif				/* !USE_PAM */
-	/*
-	 * Get the program name. The program name is used as a prefix to
-	 * most error messages.
-	 */
-	Prog = Basename (argv[0]);
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
 
@@ -1018,14 +1013,14 @@ int main (int argc, char **argv)
 
 	save_caller_context (argv);
 
-	OPENLOG ("su");
+	OPENLOG (Prog);
 
 	process_flags (argc, argv);
 
 	initenv ();
 
 #ifdef USE_PAM
-	ret = pam_start ("su", name, &conv, &pamh);
+	ret = pam_start (Prog, name, &conv, &pamh);
 	if (PAM_SUCCESS != ret) {
 		SYSLOG ((LOG_ERR, "pam_start: error %d", ret);
 		fprintf (stderr,

--- a/src/sulogin.c
+++ b/src/sulogin.c
@@ -33,7 +33,7 @@
 /*
  * Global variables
  */
-const char *Prog;
+static const char Prog[] = "sulogin";
 
 
 extern char **newenvp;
@@ -72,7 +72,6 @@ main(int argc, char **argv)
 	termio.c_lflag |= (ECHO | ECHOE | ECHOK | ICANON | ISIG);
 	tcsetattr (0, TCSANOW, &termio);
 
-	Prog = Basename (argv[0]);
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
 	(void) setlocale (LC_ALL, "");

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -85,7 +85,7 @@
 /*
  * Global variables
  */
-const char *Prog;
+static const char Prog[] = "useradd";
 
 /*
  * These defaults are used if there is no defaults file.
@@ -2485,10 +2485,6 @@ int main (int argc, char **argv)
 	unsigned long subuid_count = 0;
 	unsigned long subgid_count = 0;
 
-	/*
-	 * Get my name so that I can use it to report errors.
-	 */
-	Prog = Basename (argv[0]);
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
 
@@ -2500,7 +2496,7 @@ int main (int argc, char **argv)
 
 	prefix = process_prefix_flag("-P", argc, argv);
 
-	OPENLOG ("useradd");
+	OPENLOG (Prog);
 #ifdef WITH_AUDIT
 	audit_help_open ();
 #endif
@@ -2552,7 +2548,7 @@ int main (int argc, char **argv)
 			fail_exit (1);
 		}
 
-		retval = pam_start ("useradd", pampw?pampw->pw_name:"root", &conv, &pamh);
+		retval = pam_start (Prog, pampw?pampw->pw_name:"root", &conv, &pamh);
 	}
 
 	if (PAM_SUCCESS == retval) {

--- a/src/userdel.c
+++ b/src/userdel.c
@@ -72,7 +72,7 @@
 /*
  * Global variables
  */
-const char *Prog;
+static const char Prog[] = "userdel";
 
 static char *user_name;
 static uid_t user_id;
@@ -959,10 +959,6 @@ int main (int argc, char **argv)
 #endif				/* USE_PAM */
 #endif				/* ACCT_TOOLS_SETUID */
 
-	/*
-	 * Get my name so that I can use it to report errors.
-	 */
-	Prog = Basename (argv[0]);
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
 	(void) setlocale (LC_ALL, "");
@@ -972,7 +968,7 @@ int main (int argc, char **argv)
 	process_root_flag ("-R", argc, argv);
 	prefix = process_prefix_flag ("-P", argc, argv);
 
-	OPENLOG ("userdel");
+	OPENLOG (Prog);
 #ifdef WITH_AUDIT
 	audit_help_open ();
 #endif				/* WITH_AUDIT */
@@ -1056,7 +1052,7 @@ int main (int argc, char **argv)
 			exit (E_PW_UPDATE);
 		}
 
-		retval = pam_start ("userdel", pampw->pw_name, &conv, &pamh);
+		retval = pam_start (Prog, pampw->pw_name, &conv, &pamh);
 	}
 
 	if (PAM_SUCCESS == retval) {

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -90,7 +90,7 @@
 /*
  * Global variables
  */
-const char *Prog;
+static const char Prog[] = "usermod";
 
 static char *user_name;
 static char *user_newname;
@@ -2158,10 +2158,6 @@ int main (int argc, char **argv)
 #endif				/* USE_PAM */
 #endif				/* ACCT_TOOLS_SETUID */
 
-	/*
-	 * Get my name so that I can use it to report errors.
-	 */
-	Prog = Basename (argv[0]);
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
 
@@ -2172,7 +2168,7 @@ int main (int argc, char **argv)
 	process_root_flag ("-R", argc, argv);
 	prefix = process_prefix_flag ("-P", argc, argv);
 
-	OPENLOG ("usermod");
+	OPENLOG (Prog);
 #ifdef WITH_AUDIT
 	audit_help_open ();
 #endif
@@ -2218,7 +2214,7 @@ int main (int argc, char **argv)
 			exit (1);
 		}
 
-		retval = pam_start ("usermod", pampw->pw_name, &conv, &pamh);
+		retval = pam_start (Prog, pampw->pw_name, &conv, &pamh);
 	}
 
 	if (PAM_SUCCESS == retval) {


### PR DESCRIPTION
See issue #959. su was sending argv[0] to auth.log, which can contain newlines or escape sequences, which can be used to hide messages.