### PR TITLE
src/passwd.c: Don't print the program name twice in a log entry

### DIFF
--- a/src/passwd.c
+++ b/src/passwd.c
@@ -1000,8 +1000,8 @@ int main (int argc, char **argv)
 		                _("%s: You may not view or modify password information for %s.\n"),
 		                Prog, name);
 		SYSLOG ((LOG_WARN,
-		         "%s: can't view or modify password information for %s",
-		         Prog, name));
+		         "can't view or modify password information for %s",
+		         name));
 		closelog ();
 		exit (E_NOPERM);
 	}


### PR DESCRIPTION
OPENLOG() already sets the program name as the prefix.

This resulted in entries like:

$ journalctl 2>/dev/null | grep passwd
Mar 03 01:09:47 debian passwd[140744]: passwd: can't view or modify password information for root

Fixes: 8e167d28afd6 ("[svn-upgrade] Integrating new upstream version, shadow (4.0.8)")