### PR TITLE
Noting copy_symlink behaviour

### DIFF
--- a/man/useradd.8.xml
+++ b/man/useradd.8.xml
@@ -296,6 +296,11 @@
 	    <filename>/etc/skel</filename>.
 	  </para>
 	  <para>
+	    Absolute symlinks that link back to the skel directory will have
+	    the <filename>/etc/skel</filename> prefix replaced with the user's
+	    home directory.
+	  </para>
+	  <para>
 	    If possible, the ACLs and extended attributes are copied.
 	  </para>
 	</listitem>


### PR DESCRIPTION
Mention that symlinks are modified when they prefix the skel directory.

Closes #933