### PR TITLE
gitignore: add a few more generated files to be ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,11 @@ lib*.a
 *.o
 *.lo
 *.la
+*.mo
 *.gmo
 .deps
 .libs
+.dirstamp
 
 *.patch
 *.rej
@@ -34,6 +36,7 @@ Makefile.in
 /m4
 /missing
 /stamp-h1
+/test-driver
 /ylwrap
 
 /po/*.header

--- a/man/.gitignore
+++ b/man/.gitignore
@@ -4,5 +4,8 @@ generate_mans.deps
 
 *.[0-9]
 
+# translation symlinks
+/*/login.defs.d
+
 /po/POTFILES
 /po/stamp-po


### PR DESCRIPTION
before this, the following untracked files showed up in `git status`:

	lib/atoi/.dirstamp
	lib/string/.dirstamp
	lib/time/.dirstamp
	man/da/login.defs.d
	man/da/messages.mo
	man/de/login.defs.d
	man/de/messages.mo
	man/fr/login.defs.d
	man/fr/messages.mo
	man/it/login.defs.d
	man/it/messages.mo
	man/pl/login.defs.d
	man/pl/messages.mo
	man/ru/login.defs.d
	man/ru/messages.mo
	man/sv/login.defs.d
	man/sv/messages.mo
	man/uk/login.defs.d
	man/uk/messages.mo
	man/zh_CN/login.defs.d
	man/zh_CN/messages.mo
	test-driver