### PR TITLE
lib/copydir:copy_entry(): use temporary stat buffer

### DIFF
--- a/lib/copydir.c
+++ b/lib/copydir.c
@@ -400,6 +400,7 @@ static int copy_entry (const struct path_info *src, const struct path_info *dst,
 {
 	int err = 0;
 	struct stat sb;
+	struct stat tmp_sb;
 	struct link_name *lp;
 	struct timespec mt[2];
 
@@ -423,7 +424,7 @@ static int copy_entry (const struct path_info *src, const struct path_info *dst,
 	* If the destination already exists do nothing.
 	* This is after the copy_dir above to still iterate into subdirectories.
 	*/
-	if (fstatat(dst->dirfd, dst->name, &sb, AT_SYMLINK_NOFOLLOW) != -1) {
+	if (fstatat(dst->dirfd, dst->name, &tmp_sb, AT_SYMLINK_NOFOLLOW) != -1) {
 		return err;
 	}
 


### PR DESCRIPTION
There are no guarantees that fstatat() does not clobber the stat buffer on errors.

Use a temporary buffer so that the following code sees correct attributes of the source entry.

Issue #973