### PR TITLE
newuidmap and newgidmap manpages: fix fd description

### DIFF
--- a/man/newgidmap.1.xml
+++ b/man/newgidmap.1.xml
@@ -120,8 +120,8 @@
       Instead of an integer process id, the first argument may be
       specified as <replaceable>fd:N</replaceable>, where the integer N
       is the file descriptor number for the calling process's opened
-      file for <filename>/proc/[pid[</filename>.  In this case,
-      <command>newgidmap</command> will use
+      file descriptor for the directory <filename>/proc/[pid]</filename>.
+      In this case, <command>newgidmap</command> will use
       <refentrytitle>openat</refentrytitle><manvolnum>2</manvolnum>
       to open the <filename>gid_map</filename> file under that
       directory, avoiding a TOCTTOU in case the process exits and

--- a/man/newuidmap.1.xml
+++ b/man/newuidmap.1.xml
@@ -120,8 +120,8 @@
       Instead of an integer process id, the first argument may be
       specified as <replaceable>fd:N</replaceable>, where the integer N
       is the file descriptor number for the calling process's opened
-      file for <filename>/proc/[pid[</filename>.  In this case,
-      <command>newuidmap</command> will use
+      file descriptor for the directory <filename>/proc/[pid]</filename>.
+      In this case, <command>newuidmap</command> will use
       <refentrytitle>openat</refentrytitle><manvolnum>2</manvolnum>
       to open the <filename>uid_map</filename> file under that
       directory, avoiding a TOCTTOU in case the process exits and


### PR DESCRIPTION
The manpages for newuidmap and newgidmap had a typo "[pid[" instead of "[pid]".  They were also unclear about what the /proc/pid fd should be.  Fix both.

Closes #977

Reported-by: igo95862@yandex.ru