### PR TITLE
Some getrange() simplification

### DIFF
--- a/lib/get_gid.c
+++ b/lib/get_gid.c
@@ -16,13 +16,13 @@
 int
 get_gid(const char *gidstr, gid_t *gid)
 {
+	char       *end;
 	long long  val;
-	char *endptr;
 
 	errno = 0;
-	val = strtoll(gidstr, &endptr, 10);
+	val = strtoll(gidstr, &end, 10);
 	if (   ('\0' == *gidstr)
-	    || ('\0' != *endptr)
+	    || ('\0' != *end)
 	    || (0 != errno)
 	    || (/*@+longintegral@*/val != (gid_t)val)/*@=longintegral@*/) {
 		return -1;

--- a/lib/get_pid.c
+++ b/lib/get_pid.c
@@ -17,15 +17,16 @@
 #include "string/sprintf.h"
 
 
-int get_pid (const char *pidstr, pid_t *pid)
+int
+get_pid(const char *pidstr, pid_t *pid)
 {
+	char       *end;
 	long long  val;
-	char *endptr;
 
 	errno = 0;
-	val = strtoll(pidstr, &endptr, 10);
+	val = strtoll(pidstr, &end, 10);
 	if (   ('\0' == *pidstr)
-	    || ('\0' != *endptr)
+	    || ('\0' != *end)
 	    || (0 != errno)
 	    || (val < 1)
 	    || (/*@+longintegral@*/val != (pid_t)val)/*@=longintegral@*/) {
@@ -43,15 +44,15 @@ int get_pid (const char *pidstr, pid_t *pid)
  */
 int get_pidfd_from_fd(const char *pidfdstr)
 {
-	long long  val;
-	char *endptr;
-	struct stat st;
+	char         *end;
+	long long    val;
+	struct stat  st;
 	dev_t proc_st_dev, proc_st_rdev;
 
 	errno = 0;
-	val = strtoll(pidfdstr, &endptr, 10);
+	val = strtoll(pidfdstr, &end, 10);
 	if (   ('\0' == *pidfdstr)
-	    || ('\0' != *endptr)
+	    || ('\0' != *end)
 	    || (0 != errno)
 	    || (val < 0)
 	    || (/*@+longintegral@*/val != (int)val)/*@=longintegral@*/) {

--- a/lib/get_uid.c
+++ b/lib/get_uid.c
@@ -16,13 +16,13 @@
 int
 get_uid(const char *uidstr, uid_t *uid)
 {
+	char       *end;
 	long long  val;
-	char *endptr;
 
 	errno = 0;
-	val = strtoll(uidstr, &endptr, 10);
+	val = strtoll(uidstr, &end, 10);
 	if (   ('\0' == *uidstr)
-	    || ('\0' != *endptr)
+	    || ('\0' != *end)
 	    || (0 != errno)
 	    || (/*@+longintegral@*/val != (uid_t)val)/*@=longintegral@*/) {
 		return -1;

--- a/lib/getgr_nam_gid.c
+++ b/lib/getgr_nam_gid.c
@@ -23,17 +23,17 @@
  */
 extern /*@only@*//*@null@*/struct group *getgr_nam_gid (/*@null@*/const char *grname)
 {
+	char       *end;
 	long long  gid;
-	char *endptr;
 
 	if (NULL == grname) {
 		return NULL;
 	}
 
 	errno = 0;
-	gid = strtoll(grname, &endptr, 10);
+	gid = strtoll(grname, &end, 10);
 	if (   ('\0' != *grname)
-	    && ('\0' == *endptr)
+	    && ('\0' == *end)
 	    && (0 == errno)
 	    && (/*@+longintegral@*/gid == (gid_t)gid)/*@=longintegral@*/) {
 		return xgetgrgid (gid);

--- a/lib/getrange.c
+++ b/lib/getrange.c
@@ -30,8 +30,7 @@ getrange(const char *range,
          unsigned long *min, bool *has_min,
          unsigned long *max, bool *has_max)
 {
-	char *endptr;
-	unsigned long n;
+	char  *endptr;
 
 	if (NULL == range)
 		return -1;
@@ -44,16 +43,15 @@ getrange(const char *range,
 			return -1;
 
 		errno = 0;
-		n = strtoul_noneg(&range[1], &endptr, 10);
+		*max = strtoul_noneg(&range[1], &endptr, 10);
 		if (('\0' != *endptr) || (0 != errno))
 			return -1;
 		*has_max = true;
 
 		/* -<long> */
-		*max = n;
 	} else {
 		errno = 0;
-		n = strtoul_noneg(range, &endptr, 10);
+		*min = strtoul_noneg(range, &endptr, 10);
 		if (endptr == range || 0 != errno)
 			return -1;
 		*has_min = true;
@@ -62,26 +60,22 @@ getrange(const char *range,
 		case '\0':
 			/* <long> */
 			*has_max = true;
-			*min = n;
-			*max = n;
+			*max = *min;
 			break;
 		case '-':
 			endptr++;
 			if ('\0' == *endptr) {
 				/* <long>- */
-				*min = n;
 			} else if (!isdigit (*endptr)) {
 				return -1;
 			} else {
-				*min = n;
 				errno = 0;
-				n = strtoul_noneg(endptr, &endptr, 10);
+				*max = strtoul_noneg(endptr, &endptr, 10);
 				if ('\0' != *endptr || 0 != errno)
 					return -1;
 				*has_max = true;
 
 				/* <long>-<long> */
-				*max = n;
 			}
 			break;
 		default:

--- a/lib/getrange.c
+++ b/lib/getrange.c
@@ -30,7 +30,7 @@ getrange(const char *range,
          unsigned long *min, bool *has_min,
          unsigned long *max, bool *has_max)
 {
-	char  *endptr;
+	char  *end;
 
 	if (NULL == range)
 		return -1;
@@ -39,32 +39,32 @@ getrange(const char *range,
 	*has_max = false;
 
 	if ('-' == range[0]) {
-		endptr = range + 1;
+		end = range + 1;
 		goto parse_max;
 	}
 
 	errno = 0;
-	*min = strtoul_noneg(range, &endptr, 10);
-	if (endptr == range || 0 != errno)
+	*min = strtoul_noneg(range, &end, 10);
+	if (end == range || 0 != errno)
 		return -1;
 	*has_min = true;
 
-	switch (*endptr++) {
+	switch (*end++) {
 	case '\0':
 		*has_max = true;
 		*max = *min;
 		return 0;  /* <long> */
 
 	case '-':
-		if ('\0' == *endptr)
+		if ('\0' == *end)
 			return 0;  /* <long>- */
 parse_max:
-		if (!isdigit(*endptr))
+		if (!isdigit(*end))
 			return -1;
 
 		errno = 0;
-		*max = strtoul_noneg(endptr, &endptr, 10);
-		if ('\0' != *endptr || 0 != errno)
+		*max = strtoul_noneg(end, &end, 10);
+		if ('\0' != *end || 0 != errno)
 			return -1;
 		*has_max = true;
 

--- a/lib/getrange.c
+++ b/lib/getrange.c
@@ -64,9 +64,9 @@ getrange(const char *range,
 			break;
 		case '-':
 			endptr++;
-			if ('\0' == *endptr) {
-				/* <long>- */
-			} else if (!isdigit (*endptr)) {
+			if ('\0' == *endptr)
+				return 0;  /* <long>- */
+			if (!isdigit (*endptr)) {
 				return -1;
 			} else {
 				errno = 0;

--- a/lib/getrange.c
+++ b/lib/getrange.c
@@ -39,16 +39,8 @@ getrange(const char *range,
 	*has_max = false;
 
 	if ('-' == range[0]) {
-		if (!isdigit(range[1]))
-			return -1;
-
-		errno = 0;
-		*max = strtoul_noneg(&range[1], &endptr, 10);
-		if (('\0' != *endptr) || (0 != errno))
-			return -1;
-		*has_max = true;
-
-		return 0;  /* -<long> */
+		endptr = range + 1;
+		goto parse_max;
 	}
 
 	errno = 0;
@@ -57,16 +49,16 @@ getrange(const char *range,
 		return -1;
 	*has_min = true;
 
-	switch (*endptr) {
+	switch (*endptr++) {
 	case '\0':
 		*has_max = true;
 		*max = *min;
 		return 0;  /* <long> */
 
 	case '-':
-		endptr++;
 		if ('\0' == *endptr)
 			return 0;  /* <long>- */
+parse_max:
 		if (!isdigit(*endptr))
 			return -1;
 
@@ -76,7 +68,7 @@ getrange(const char *range,
 			return -1;
 		*has_max = true;
 
-		return 0;  /* <long>-<long> */
+		return 0;  /* <long>-<long>, or -<long> */
 
 	default:
 		return -1;

--- a/lib/getrange.c
+++ b/lib/getrange.c
@@ -48,38 +48,38 @@ getrange(const char *range,
 			return -1;
 		*has_max = true;
 
-		/* -<long> */
-	} else {
+		return 0;  /* -<long> */
+	}
+
+	errno = 0;
+	*min = strtoul_noneg(range, &endptr, 10);
+	if (endptr == range || 0 != errno)
+		return -1;
+	*has_min = true;
+
+	switch (*endptr) {
+	case '\0':
+		/* <long> */
+		*has_max = true;
+		*max = *min;
+		break;
+	case '-':
+		endptr++;
+		if ('\0' == *endptr)
+			return 0;  /* <long>- */
+		if (!isdigit(*endptr))
+			return -1;
+
 		errno = 0;
-		*min = strtoul_noneg(range, &endptr, 10);
-		if (endptr == range || 0 != errno)
+		*max = strtoul_noneg(endptr, &endptr, 10);
+		if ('\0' != *endptr || 0 != errno)
 			return -1;
-		*has_min = true;
+		*has_max = true;
 
-		switch (*endptr) {
-		case '\0':
-			/* <long> */
-			*has_max = true;
-			*max = *min;
-			break;
-		case '-':
-			endptr++;
-			if ('\0' == *endptr)
-				return 0;  /* <long>- */
-			if (!isdigit(*endptr))
-				return -1;
-
-			errno = 0;
-			*max = strtoul_noneg(endptr, &endptr, 10);
-			if ('\0' != *endptr || 0 != errno)
-				return -1;
-			*has_max = true;
-
-			/* <long>-<long> */
-			break;
-		default:
-			return -1;
-		}
+		/* <long>-<long> */
+		break;
+	default:
+		return -1;
 	}
 
 	return 0;

--- a/lib/getrange.c
+++ b/lib/getrange.c
@@ -66,17 +66,16 @@ getrange(const char *range,
 			endptr++;
 			if ('\0' == *endptr)
 				return 0;  /* <long>- */
-			if (!isdigit (*endptr)) {
+			if (!isdigit(*endptr))
 				return -1;
-			} else {
-				errno = 0;
-				*max = strtoul_noneg(endptr, &endptr, 10);
-				if ('\0' != *endptr || 0 != errno)
-					return -1;
-				*has_max = true;
 
-				/* <long>-<long> */
-			}
+			errno = 0;
+			*max = strtoul_noneg(endptr, &endptr, 10);
+			if ('\0' != *endptr || 0 != errno)
+				return -1;
+			*has_max = true;
+
+			/* <long>-<long> */
 			break;
 		default:
 			return -1;

--- a/lib/getrange.c
+++ b/lib/getrange.c
@@ -59,10 +59,10 @@ getrange(const char *range,
 
 	switch (*endptr) {
 	case '\0':
-		/* <long> */
 		*has_max = true;
 		*max = *min;
-		break;
+		return 0;  /* <long> */
+
 	case '-':
 		endptr++;
 		if ('\0' == *endptr)
@@ -76,11 +76,9 @@ getrange(const char *range,
 			return -1;
 		*has_max = true;
 
-		/* <long>-<long> */
-		break;
+		return 0;  /* <long>-<long> */
+
 	default:
 		return -1;
 	}
-
-	return 0;
 }

--- a/lib/getrange.c
+++ b/lib/getrange.c
@@ -47,20 +47,20 @@ getrange(const char *range,
 		n = strtoul_noneg(&range[1], &endptr, 10);
 		if (('\0' != *endptr) || (0 != errno))
 			return -1;
+		*has_max = true;
 
 		/* -<long> */
-		*has_max = true;
 		*max = n;
 	} else {
 		errno = 0;
 		n = strtoul_noneg(range, &endptr, 10);
 		if (endptr == range || 0 != errno)
 			return -1;
+		*has_min = true;
 
 		switch (*endptr) {
 		case '\0':
 			/* <long> */
-			*has_min = true;
 			*has_max = true;
 			*min = n;
 			*max = n;
@@ -69,20 +69,18 @@ getrange(const char *range,
 			endptr++;
 			if ('\0' == *endptr) {
 				/* <long>- */
-				*has_min = true;
 				*min = n;
 			} else if (!isdigit (*endptr)) {
 				return -1;
 			} else {
-				*has_min = true;
 				*min = n;
 				errno = 0;
 				n = strtoul_noneg(endptr, &endptr, 10);
 				if ('\0' != *endptr || 0 != errno)
 					return -1;
+				*has_max = true;
 
 				/* <long>-<long> */
-				*has_max = true;
 				*max = n;
 			}
 			break;

--- a/lib/getrange.c
+++ b/lib/getrange.c
@@ -36,6 +36,9 @@ getrange(const char *range,
 	if (NULL == range)
 		return -1;
 
+	*has_min = false;
+	*has_max = false;
+
 	if ('-' == range[0]) {
 		if (!isdigit(range[1]))
 			return -1;
@@ -46,7 +49,6 @@ getrange(const char *range,
 			return -1;
 
 		/* -<long> */
-		*has_min = false;
 		*has_max = true;
 		*max = n;
 	} else {
@@ -68,7 +70,6 @@ getrange(const char *range,
 			if ('\0' == *endptr) {
 				/* <long>- */
 				*has_min = true;
-				*has_max = false;
 				*min = n;
 			} else if (!isdigit (*endptr)) {
 				return -1;

--- a/lib/gettime.c
+++ b/lib/gettime.c
@@ -26,7 +26,7 @@
  */
 /*@observer@*/time_t gettime (void)
 {
-	char *endptr;
+	char  *end;
 	char *source_date_epoch;
 	time_t fallback;
 	unsigned long long epoch;
@@ -39,19 +39,19 @@
 		return fallback;
 
 	errno = 0;
-	epoch = strtoull_noneg(source_date_epoch, &endptr, 10);
+	epoch = strtoull_noneg(source_date_epoch, &end, 10);
 	if (errno != 0) {
 		fprintf (shadow_logfd,
 			 _("Environment variable $SOURCE_DATE_EPOCH: strtoull: %s\n"),
 			 strerror(errno));
-	} else if (endptr == source_date_epoch) {
+	} else if (end == source_date_epoch) {
 		fprintf (shadow_logfd,
 			 _("Environment variable $SOURCE_DATE_EPOCH: No digits were found: %s\n"),
-			 endptr);
-	} else if (*endptr != '\0') {
+			 end);
+	} else if (*end != '\0') {
 		fprintf (shadow_logfd,
 			 _("Environment variable $SOURCE_DATE_EPOCH: Trailing garbage: %s\n"),
-			 endptr);
+			 end);
 	} else if (epoch > ULONG_MAX) {
 		fprintf (shadow_logfd,
 			 _("Environment variable $SOURCE_DATE_EPOCH: value must be smaller than or equal to %lu but was found to be: %llu\n"),

--- a/lib/limits.c
+++ b/lib/limits.c
@@ -49,7 +49,7 @@ static int setrlimit_value (unsigned int resource,
                             const char *value,
                             unsigned int multiplier)
 {
-	char           *endptr;
+	char           *end;
 	long           l;
 	rlim_t         limit;
 	struct rlimit  rlim;
@@ -67,9 +67,9 @@ static int setrlimit_value (unsigned int resource,
 		 * work with the limit string parser as is anyway)
 		 */
 		errno = 0;
-		l = strtol(value, &endptr, 10);
+		l = strtol(value, &end, 10);
 
-		if (value == endptr || errno != 0)
+		if (value == end || errno != 0)
 			return 0;  // FIXME: We could instead throw an error, though.
 
 		if (__builtin_mul_overflow(l, multiplier, &limit)) {

--- a/lib/prefix_flag.c
+++ b/lib/prefix_flag.c
@@ -334,9 +334,9 @@ extern void prefix_endgrent(void)
 
 extern struct group *prefix_getgr_nam_gid(const char *grname)
 {
-	long long  gid;
-	char *endptr;
-	struct group *g;
+	char          *end;
+	long long     gid;
+	struct group  *g;
 
 	if (NULL == grname) {
 		return NULL;
@@ -346,9 +346,9 @@ extern struct group *prefix_getgr_nam_gid(const char *grname)
 		return getgr_nam_gid(grname);
 
 	errno = 0;
-	gid = strtoll(grname, &endptr, 10);
+	gid = strtoll(grname, &end, 10);
 	if (   ('\0' != *grname)
-	    && ('\0' == *endptr)
+	    && ('\0' == *end)
 	    && (0 == errno)
 	    && (gid == (gid_t)gid))
 	{

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -857,14 +857,14 @@ static int get_groups (char *list)
  */
 static struct group * get_local_group(char * grp_name)
 {
+	char  *end;
 	const struct group *grp;
 	struct group *result_grp = NULL;
 	long long  gid;
-	char *endptr;
 
-	gid = strtoll (grp_name, &endptr, 10);
+	gid = strtoll(grp_name, &end, 10);
 	if (   ('\0' != *grp_name)
-		&& ('\0' == *endptr)
+		&& ('\0' == *end)
 		&& (ERANGE != errno)
 		&& (gid == (gid_t)gid)) {
 		grp = gr_locate_gid (gid);


### PR DESCRIPTION
This is part of the changes from <https://github.com/shadow-maint/shadow/pull/892> (at v5).

I've decided to leave the last commits in that PR for later, since I have some ideas to do it differently.  The first commits are refactors that are easier to apply separately.

Here's the range-diff vs that PR at v5:

```
$ git range-diff master gh/getrange gh/gr2
 1:  cb16a79a =  1:  cb16a79a lib/getrange.c: getrange(): Small refactor
 2:  06a3c8fa =  2:  06a3c8fa lib/getrange.c: getrange(): Small refactor
 3:  d25fedb2 =  3:  d25fedb2 lib/getrange.c: getrange(): Remove temporary variable
 4:  e40985b1 =  4:  e40985b1 lib/getrange.c: getrange(): Return early to remove an else
 5:  e76e4722 =  5:  e76e4722 lib/getrange.c: getrange(): Don't else after return
 6:  6fa83922 =  6:  6fa83922 lib/getrange.c: getrange(): Return early to reduce indentation
 7:  4ff016be =  7:  4ff016be lib/getrange.c: getrange(): Return early
 8:  60ed6697 =  8:  60ed6697 lib/getrange.c: getrange(): Use goto to deduplicate code
 9:  7b4fee1d =  9:  7b4fee1d lib/, src/: Rename some local variables
10:  e432eeec <  -:  -------- lib/getrange.c: getrange(): Reduce uses of non-const pointer
11:  6555aa2b <  -:  -------- lib/getrange.c: getrange(): Rename local variable
12:  2dd2c645 <  -:  -------- lib/getrange.c: getrange(): Use a2ul() instead of strtoul_noneg()
13:  baba0f11 <  -:  -------- lib/getrange.c: getrange(): Add missing cast
14:  57437f13 <  -:  -------- lib/getrange.c: getrange(): Report an ERANGE error when min>max
```