### PR TITLE
lib/alloc.h: Reimplement [X]REALLOC[F]() macros with _Generic(3)

### DIFF
--- a/lib/alloc.h
+++ b/lib/alloc.h
@@ -1,8 +1,5 @@
-/*
- * SPDX-FileCopyrightText:  2023, Alejandro Colomar <alx@kernel.org>
- *
- * SPDX-License-Identifier:  BSD-3-Clause
- */
+// SPDX-FileCopyrightText: 2023-2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
 
 #ifndef SHADOW_INCLUDE_LIB_MALLOC_H_
@@ -27,31 +24,19 @@
 #define XMALLOC(n, type)  ((type *) xmallocarray(n, sizeof(type)))
 
 #define REALLOC(ptr, n, type)                                                 \
-({                                                                            \
-	__auto_type  p_ = (ptr);                                              \
-                                                                              \
-	static_assert(__builtin_types_compatible_p(typeof(p_), type *), "");  \
-                                                                              \
-	(type *) reallocarray(p_, n, sizeof(type));                           \
-})
+(                                                                             \
+	_Generic(ptr, type *:  (type *) reallocarray(ptr, n, sizeof(type)))   \
+)
 
 #define REALLOCF(ptr, n, type)                                                \
-({                                                                            \
-	__auto_type  p_ = (ptr);                                              \
-                                                                              \
-	static_assert(__builtin_types_compatible_p(typeof(p_), type *), "");  \
-                                                                              \
-	(type *) reallocarrayf(p_, n, sizeof(type));                          \
-})
+(                                                                             \
+	_Generic(ptr, type *:  (type *) reallocarrayf(ptr, n, sizeof(type)))  \
+)
 
 #define XREALLOC(ptr, n, type)                                                \
-({                                                                            \
-	__auto_type  p_ = (ptr);                                              \
-                                                                              \
-	static_assert(__builtin_types_compatible_p(typeof(p_), type *), "");  \
-                                                                              \
-	(type *) xreallocarray(p_, n, sizeof(type));                          \
-})
+(                                                                             \
+	_Generic(ptr, type *:  (type *) xreallocarray(ptr, n, sizeof(type)))  \
+)
 
 
 ATTR_MALLOC(free)


### PR DESCRIPTION
Instead of GNU builtins and extensions, these macros can be implemented with C11's _Generic(3), and the result is much simpler (and safer, since it's now an error, not just a warning).


I don't remember who showed me that trick; it was some months ago, in the gcc@ or libc-alpha@ mailing lists (maybe it was @uecker).  I reimplemented these macros from scratch for neomutt(1), and did it with _Generic(3), and it was much nicer than all those GNU extensions.  Let's incorporate those improvements here.  :-)

---

Revisions:

<details>
<summary>v2</summary>

v2 changes:

-  Update copyright

```
$ git range-diff shadow/master gh/alloc alloc 
1:  18ec0d85 ! 1:  84517ec8 lib/alloc.h: Reimplement [X]REALLOC[F]() macros with _Generic(3)
    @@ Commit message
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/alloc.h ##
    +@@
    +-/*
    +- * SPDX-FileCopyrightText:  2023, Alejandro Colomar <alx@kernel.org>
    +- *
    +- * SPDX-License-Identifier:  BSD-3-Clause
    +- */
    ++// SPDX-FileCopyrightText: 2023-2024, Alejandro Colomar <alx@kernel.org>
    ++// SPDX-License-Identifier: BSD-3-Clause
    + 
    + 
    + #ifndef SHADOW_INCLUDE_LIB_MALLOC_H_
     @@
      #define XMALLOC(n, type)  ((type *) xmallocarray(n, sizeof(type)))
      
```
</details>

<details>
<summary>v2b</summary>

-  Whitespace

```
$ git range-diff gh/master gh/alloc alloc 
1:  84517ec8 ! 1:  bff08b61 lib/alloc.h: Reimplement [X]REALLOC[F]() macros with _Generic(3)
    @@ lib/alloc.h
     -  (type *) reallocarray(p_, n, sizeof(type));                           \
     -})
     +(                                                                             \
    -+  _Generic(ptr, type *: (type *) reallocarray(ptr, n, sizeof(type)))    \
    ++  _Generic(ptr, type *:  (type *) reallocarray(ptr, n, sizeof(type)))   \
     +)
      
      #define REALLOCF(ptr, n, type)                                                \
    @@ lib/alloc.h
     -  (type *) reallocarrayf(p_, n, sizeof(type));                          \
     -})
     +(                                                                             \
    -+  _Generic(ptr, type *: (type *) reallocarrayf(ptr, n, sizeof(type)))   \
    ++  _Generic(ptr, type *:  (type *) reallocarrayf(ptr, n, sizeof(type)))  \
     +)
      
      #define XREALLOC(ptr, n, type)                                                \
    @@ lib/alloc.h
     -  (type *) xreallocarray(p_, n, sizeof(type));                          \
     -})
     +(                                                                             \
    -+  _Generic(ptr, type *: (type *) xreallocarray(ptr, n, sizeof(type)))   \
    ++  _Generic(ptr, type *:  (type *) xreallocarray(ptr, n, sizeof(type)))  \
     +)
      
      
```
</details>

<details>
<summary>v2c</summary>

-  Rebase

```
$ git range-diff gh/master..gh/alloc master..alloc 
1:  bff08b61 = 1:  51a03214 lib/alloc.h: Reimplement [X]REALLOC[F]() macros with _Generic(3)
```
</details>