### PR TITLE
lib/chkname.[ch]: login_name_max_size(): Add function, and add missing error handling

### DIFF
--- a/lib/chkname.c
+++ b/lib/chkname.c
@@ -5,6 +5,7 @@
 // SPDX-FileCopyrightText: 2023-2024, Alejandro Colomar <alx@kernel.org>
 // SPDX-License-Identifier: BSD-3-Clause
 
+
 /*
  * is_valid_user_name(), is_valid_group_name() - check the new user/group
  * name for validity;
@@ -13,6 +14,7 @@
  *   false - bad name
  */
 
+
 #include <config.h>
 
 #ident "$Id$"
@@ -20,10 +22,16 @@
 #include <ctype.h>
 #include <errno.h>
 #include <limits.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <unistd.h>
+
 #include "defines.h"
 #include "chkname.h"
 
+
 int allow_bad_names = false;
+
 
 static bool is_valid_name (const char *name)
 {

--- a/lib/chkname.c
+++ b/lib/chkname.c
@@ -33,6 +33,20 @@
 int allow_bad_names = false;
 
 
+size_t
+login_name_max_size(void)
+{
+	long  conf;
+
+	errno = 0;
+	conf = sysconf(_SC_LOGIN_NAME_MAX);
+	if (conf == -1 && errno != 0)
+		return LOGIN_NAME_MAX;
+
+	return conf;
+}
+
+
 static bool is_valid_name (const char *name)
 {
 	if (allow_bad_names) {
@@ -84,18 +98,7 @@ static bool is_valid_name (const char *name)
 bool
 is_valid_user_name(const char *name)
 {
-	long    conf;
-	size_t  maxsize;
-
-	errno = 0;
-	conf = sysconf(_SC_LOGIN_NAME_MAX);
-
-	if (conf == -1 && errno != 0)
-		maxsize = LOGIN_NAME_MAX;
-	else
-		maxsize = conf;
-
-	if (strlen(name) >= maxsize)
+	if (strlen(name) >= login_name_max_size())
 		return false;
 
 	return is_valid_name(name);

--- a/lib/chkname.h
+++ b/lib/chkname.h
@@ -24,8 +24,10 @@
 #include <config.h>
 
 #include <stdbool.h>
+#include <stddef.h>
 
 
+extern size_t login_name_max_size(void);
 extern bool is_valid_user_name (const char *name);
 extern bool is_valid_group_name (const char *name);
 

--- a/lib/chkname.h
+++ b/lib/chkname.h
@@ -11,6 +11,7 @@
 #ifndef _CHKNAME_H_
 #define _CHKNAME_H_
 
+
 /*
  * is_valid_user_name(), is_valid_group_name() - check the new user/group
  * name for validity;
@@ -19,7 +20,11 @@
  *   false - bad name
  */
 
-#include "defines.h"
+
+#include <config.h>
+
+#include <stdbool.h>
+
 
 extern bool is_valid_user_name (const char *name);
 extern bool is_valid_group_name (const char *name);

--- a/src/login.c
+++ b/src/login.c
@@ -27,6 +27,7 @@
 
 #include "alloc.h"
 #include "attr.h"
+#include "chkname.h"
 #include "defines.h"
 #include "faillog.h"
 #include "failure.h"
@@ -573,8 +574,9 @@ int main (int argc, char **argv)
 	}
 #ifdef RLOGIN
 	if (rflg) {
-		size_t  max_size = sysconf(_SC_LOGIN_NAME_MAX);
+		size_t  max_size;
 
+		max_size = login_name_max_size();
 		assert (NULL == username);
 		username = XMALLOC(max_size, char);
 		username[max_size - 1] = '\0';
@@ -882,8 +884,9 @@ int main (int argc, char **argv)
 
 		failed = false;	/* haven't failed authentication yet */
 		if (NULL == username) {	/* need to get a login id */
-			size_t  max_size = sysconf(_SC_LOGIN_NAME_MAX);
+			size_t  max_size;
 
+			max_size = login_name_max_size();
 			if (subroot) {
 				closelog ();
 				exit (1);


### PR DESCRIPTION
It encapsulates some logic that we may want to reuse elsewhere.

Link: <https://github.com/shadow-maint/shadow/pull/989>

Prompted by @MarcinDigitic's PR.

---

Revisions:

<details>
<summary>v2</summary>

-  Call this function in a few places to add error handling.

```
$ git range-diff gh/master gh/loginnamemax loginnamemax 
1:  53067b08 = 1:  53067b08 lib/chkname.[ch]: Fix includes
2:  5c0af110 = 2:  5c0af110 lib/chkname.[ch]: login_name_max_size(): Add function
-:  -------- > 3:  2ac009ea src/login.c: main(): Use login_name_max_size()
```
</details>

<details>
<summary>v2b</summary>

-  Add missing include

```
$ git range-diff gh/master gh/loginnamemax loginnamemax 
1:  53067b08 = 1:  53067b08 lib/chkname.[ch]: Fix includes
2:  5c0af110 = 2:  5c0af110 lib/chkname.[ch]: login_name_max_size(): Add function
3:  2ac009ea ! 3:  51709012 src/login.c: main(): Use login_name_max_size()
    @@ Commit message
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## src/login.c ##
    +@@
    + 
    + #include "alloc.h"
    + #include "attr.h"
    ++#include "chkname.h"
    + #include "defines.h"
    + #include "faillog.h"
    + #include "failure.h"
     @@ src/login.c: int main (int argc, char **argv)
        }
      #ifdef RLOGIN
```
</details>