### PR TITLE
Fix issues detected by static analyzer

### DIFF
--- a/lib/port.c
+++ b/lib/port.c
@@ -168,7 +168,7 @@ again:
 	}
 	*cp = '\0';
 	cp++;
-	port.pt_names[j + 1] = NULL;
+	port.pt_names[j] = NULL;
 
 	/*
 	 * Get the list of user names.  It is the second colon


### PR DESCRIPTION
```
RESOURCE_LEAK (CWE-772)
shadow-4.15.0/src/usermod.c:864:3: alloc_fn: Storage is returned from allocation function "__sgr_dup".
shadow-4.15.0/src/usermod.c:864:3: var_assign: Assigning: "nsgrp" = storage returned from "__sgr_dup(sgrp)".
shadow-4.15.0/src/usermod.c:964:1: leaked_storage: Variable "nsgrp" going out of scope leaks the storage it points to.
962|                   free (nsgrp);
963|           }
964|-> }
965|   #endif                                /* SHADOWGRP */
966|

RESOURCE_LEAK (CWE-772)
shadow-4.15.0/src/usermod.c:734:3: alloc_fn: Storage is returned from allocation function "__gr_dup".
shadow-4.15.0/src/usermod.c:734:3: var_assign: Assigning: "ngrp" = storage returned from "__gr_dup(grp)".
shadow-4.15.0/src/usermod.c:815:1: leaked_storage: Variable "ngrp" going out of scope leaks the storage it points to.
813|                   gr_free(ngrp);
814|           }
815|-> }
816|
817|   #ifdef SHADOWGRP

Error: OVERRUN (CWE-119):
shadow-4.15.0/lib/port.c:154:2: alias: Assigning: "port.pt_names" = "ttys". "port.pt_names" now points to element 0 of "ttys" (which consists of 65 8-byte elements).
shadow-4.15.0/lib/port.c:155:2: cond_const: Checking "j < 64" implies that "j" is 64 on the false branch.
shadow-4.15.0/lib/port.c:175:2: overrun-local: Overrunning array of 65 8-byte elements at element index 65 (byte offset 527) by dereferencing pointer "port.pt_names + (j + 1)".
173|           *cp = '\0';
174|           cp++;
175|->         port.pt_names[j + 1] = NULL;
176|
177|           /*

Error: RESOURCE_LEAK (CWE-772):
shadow-4.15.0/src/useradd.c:575:2: alloc_fn: Storage is returned from allocation function "fdopen".
shadow-4.15.0/src/useradd.c:575:2: var_assign: Assigning: "ofp" = storage returned from "fdopen(ofd, "w")".
shadow-4.15.0/src/useradd.c:734:2: leaked_storage: Variable "ofp" going out of scope leaks the storage it points to.
732|           }
733|
734|->         return ret;
735|   }
736|

UNINIT (CWE-457)
shadow-4.15.0/src/chpasswd.c:566:3: var_decl: Declaring variable "newsp" without initializer.
shadow-4.15.0/src/chpasswd.c:617:5: assign: Assigning: "sp" = "&newsp", which points to uninitialized data.
shadow-4.15.0/src/chpasswd.c:629:4: uninit_use: Using uninitialized value "*sp". Field "sp->sp_pwdp" is uninitialized.
627|                    */
628|                   if (NULL != sp) {
629|->                         newsp = *sp;
630|                           newsp.sp_pwdp = cp;
631|                           newsp.sp_lstchg = gettime () / DAY;
```

Resolves: https://issues.redhat.com/browse/RHEL-35383