### PR TITLE
More fixes for resource leaks

### DIFF
--- a/src/useradd.c
+++ b/src/useradd.c
@@ -571,14 +571,13 @@ static int set_defaults (void)
 	}
 
 	ret = mkdir(dirname(new_file_dup), 0755);
+	free(new_file_dup);
 	if (-1 == ret && EEXIST != errno) {
 		fprintf (stderr,
 			_("%s: cannot create directory for defaults file\n"),
 			Prog);
-		free(new_file_dup);
 		goto err_free_def;
 	}
-	free(new_file_dup);
 
 	/*
 	 * Create a temporary file to copy the new output to.

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -745,10 +745,9 @@ static int set_defaults (void)
 	         def_create_mail_spool, def_log_init));
 	ret = 0;
     setdef_err:
-	free(new_file);
-	if (prefix[0]) {
+	if (prefix[0])
 		free(default_file);
-	}
+	free(new_file);
 
 	return ret;
 }

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -558,7 +558,7 @@ static int set_defaults (void)
 			fprintf(stderr,
 			        _("%s: cannot create new defaults file: %s\n"),
 			        Prog, strerror(errno));
-			goto setdef_err;
+			goto err_free_def;
 		}
 	}
 
@@ -567,7 +567,7 @@ static int set_defaults (void)
 		fprintf (stderr,
 			_("%s: cannot create directory for defaults file\n"),
 			Prog);
-		goto setdef_err;
+		goto err_free_def;
 	}
 
 	ret = mkdir(dirname(new_file_dup), 0755);
@@ -576,7 +576,7 @@ static int set_defaults (void)
 			_("%s: cannot create directory for defaults file\n"),
 			Prog);
 		free(new_file_dup);
-		goto setdef_err;
+		goto err_free_def;
 	}
 	free(new_file_dup);
 
@@ -588,7 +588,7 @@ static int set_defaults (void)
 		fprintf (stderr,
 		         _("%s: cannot create new defaults file\n"),
 		         Prog);
-		goto setdef_err;
+		goto err_free_def;
 	}
 
 	ofp = fdopen (ofd, "w");
@@ -596,7 +596,7 @@ static int set_defaults (void)
 		fprintf (stderr,
 		         _("%s: cannot open new defaults file\n"),
 		         Prog);
-		goto setdef_err;
+		goto err_free_def;
 	}
 
 	/*
@@ -623,7 +623,7 @@ static int set_defaults (void)
 				         _("%s: line too long in %s: %s..."),
 				         Prog, default_file, buf);
 				(void) fclose (ifp);
-				goto setdef_err;
+				goto err_free_def;
 			}
 		}
 
@@ -702,9 +702,10 @@ static int set_defaults (void)
 	(void) fflush (ofp);
 	if (   (ferror (ofp) != 0)
 	    || (fsync (fileno (ofp)) != 0)
-	    || (fclose (ofp) != 0)) {
+	    || (fclose (ofp) != 0))
+	{
 		unlink (new_file);
-		goto setdef_err;
+		goto err_free_def;
 	}
 
 	/*
@@ -718,7 +719,7 @@ static int set_defaults (void)
 		         _("%s: Cannot create backup file (%s): %s\n"),
 		         Prog, buf, strerror (err));
 		unlink (new_file);
-		goto setdef_err;
+		goto err_free_def;
 	}
 
 	/*
@@ -729,7 +730,7 @@ static int set_defaults (void)
 		fprintf (stderr,
 		         _("%s: rename: %s: %s\n"),
 		         Prog, new_file, strerror (err));
-		goto setdef_err;
+		goto err_free_def;
 	}
 #ifdef WITH_AUDIT
 	audit_logger (AUDIT_USYS_CONFIG, Prog,
@@ -744,7 +745,8 @@ static int set_defaults (void)
 	         def_inactive, def_expire, def_template,
 	         def_create_mail_spool, def_log_init));
 	ret = 0;
-    setdef_err:
+
+err_free_def:
 	if (prefix[0])
 		free(default_file);
 	free(new_file);

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -615,7 +615,8 @@ static int set_defaults (void)
 				fprintf (stderr,
 				         _("%s: line too long in %s: %s..."),
 				         Prog, default_file, buf);
-				(void) fclose (ifp);
+				fclose(ifp);
+				fclose(ofp);
 				goto err_free_def;
 			}
 		}

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -558,7 +558,7 @@ static int set_defaults (void)
 			fprintf(stderr,
 			        _("%s: cannot create new defaults file: %s\n"),
 			        Prog, strerror(errno));
-			goto err_free_def;
+			goto err_free_new;
 		}
 	}
 
@@ -749,6 +749,7 @@ static int set_defaults (void)
 err_free_def:
 	if (prefix[0])
 		free(default_file);
+err_free_new:
 	free(new_file);
 
 	return ret;

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -238,6 +238,9 @@ static void create_home (void);
 static void create_mail (void);
 static void check_uid_range(int rflg, uid_t user_id);
 
+static FILE *fmkstemp(char *template);
+
+
 /*
  * fail_exit - undo as much as possible
  */
@@ -524,7 +527,6 @@ static void show_defaults (void)
  */
 static int set_defaults (void)
 {
-	int   ofd;
 	int   ret = -1;
 	bool  out_group = false;
 	bool  out_groups = false;
@@ -582,15 +584,7 @@ static int set_defaults (void)
 	/*
 	 * Create a temporary file to copy the new output to.
 	 */
-	ofd = mkstemp (new_file);
-	if (-1 == ofd) {
-		fprintf (stderr,
-		         _("%s: cannot create new defaults file\n"),
-		         Prog);
-		goto err_free_def;
-	}
-
-	ofp = fdopen (ofd, "w");
+	ofp = fmkstemp(new_file);
 	if (NULL == ofp) {
 		fprintf (stderr,
 		         _("%s: cannot open new defaults file\n"),
@@ -2752,3 +2746,23 @@ int main (int argc, char **argv)
 	return E_SUCCESS;
 }
 
+
+static FILE *
+fmkstemp(char *template)
+{
+	int   fd;
+	FILE  *fp;
+
+	fd = mkstemp(template);
+	if (fd == -1)
+		return NULL;
+
+	fp = fdopen(fd, "w");
+	if (fp == NULL) {
+		close(fd);
+		unlink(template);
+		return NULL;
+	}
+
+	return fp;
+}


### PR DESCRIPTION
While at it, I found and fixed a file-descriptor leak too, and a free(3) of an invalid pointer.

---

Revisions:

<details>
<summary>v2</summary>

-  The only fdopen(3) mode that makes sense with mkstemp(3) is `"w"`.

```
$ git range-diff shadow/master gh/goto2 goto2 
1:  f753dbe8 = 1:  f753dbe8 src/useradd.c: set_defaults(): Fix order of clean-ups
2:  29e95616 = 2:  29e95616 src/useradd.c: set_defaults(): Rename goto label
3:  555b8b07 = 3:  555b8b07 src/useradd.c: set_defaults(): Do not free(3) the result of asprintf(3) if it failed
4:  29471eec = 4:  29471eec src/useradd.c: De-duplicate code
5:  4d125f77 ! 5:  59bb454a src/useradd.c: Add fmkstemp() to fix file-descriptor leak
    @@ src/useradd.c: static void create_home (void);
      static void create_mail (void);
      static void check_uid_range(int rflg, uid_t user_id);
      
    -+static FILE *fmkstemp(char *restrict template, const char *restrict mode);
    ++static FILE *fmkstemp(char *template);
     +
     +
      /*
    @@ src/useradd.c: static int set_defaults (void)
     -  }
     -
     -  ofp = fdopen (ofd, "w");
    -+  ofp = fmkstemp(new_file, "w");
    ++  ofp = fmkstemp(new_file);
        if (NULL == ofp) {
                fprintf (stderr,
                         _("%s: cannot open new defaults file\n"),
    @@ src/useradd.c: int main (int argc, char **argv)
      
     +
     +static FILE *
    -+fmkstemp(char *restrict template, const char *restrict mode)
    ++fmkstemp(char *template)
     +{
     +  int   fd;
     +  FILE  *fp;
    @@ src/useradd.c: int main (int argc, char **argv)
     +  if (fd == -1)
     +          return NULL;
     +
    -+  fp = fdopen(fd, mode);
    ++  fp = fdopen(fd, "w");
     +  if (fp == NULL) {
     +          close(fd);
     +          unlink(template);
6:  2a44857f = 6:  29aa3459 src/useradd.c: set_defaults(): Fix FILE* leak
```
</details>