### PR TITLE
tests: add the tests/ subdirectory to dist tarball

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -15,3 +15,4 @@ SUBDIRS += man
 endif
 
 CLEANFILES = man/8.out man/po/remove-potcdate.* man/*/login.defs.d man/*/*.mo
+EXTRA_DIST = tests/


### PR DESCRIPTION
This is a first step to helping distributions to use our tests in CI.