### PR TITLE
src/groupmod.c: delete gr_free_members(&grp) to avoid double free

### DIFF
--- a/src/groupmod.c
+++ b/src/groupmod.c
@@ -250,8 +250,6 @@ static void grp_update (void)
 
 		if (!aflg) {
 			// requested to replace the existing groups
-			if (NULL != grp.gr_mem[0])
-				gr_free_members(&grp);
 			grp.gr_mem = XMALLOC(1, char *);
 			grp.gr_mem[0] = NULL;
 		} else {


### PR DESCRIPTION
When ori_group have more than 3 users, try "groupmod -n new_group -U user1,user2 ori_group",core dump occured.

Reading the source code and discovering in grp_update, "grp = *ogrp;" makes grp.gr_mem = *ogrp.gr_mem, so if -U without -a, gr_free_members(&grp) would free *ogrp.gr_mem, which makes original group_db original entry.gr_mem become a wild pointer.

If no -n, gr_update (&grp) would replace *ogrp with grp, nothing would happen; but if with -n, gr_update (&grp) would creat new entry so while write_all write *ogrp.gr_mem ,core dump occurs.

Add !nflg to avoid this situation.