### PR TITLE
src/login.c, src/login_nopam.c: Remove support for remote login (telndetd; innetgr(3))

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -49,7 +49,7 @@ AC_CHECK_HEADER([shadow.h],,[AC_MSG_ERROR([You need a libc with shadow.h])])
 AC_CHECK_FUNCS(arc4random_buf futimes \
 	getentropy getrandom getspnam getusershell \
 	initgroups lckpwdf lutimes \
-	setgroups updwtmpx innetgr \
+	setgroups updwtmpx \
 	getspnam_r \
 	rpmatch \
 	memset_explicit explicit_bzero stpecpy stpeprintf)

--- a/lib/log.c
+++ b/lib/log.c
@@ -33,8 +33,7 @@
 void dolastlog (
 	struct lastlog *ll,
 	const struct passwd *pw,
-	/*@unique@*/const char *line,
-	/*@unique@*/const char *host)
+	/*@unique@*/const char *line)
 {
 	int fd;
 	off_t offset;
@@ -83,7 +82,7 @@ void dolastlog (
 	newlog.ll_time = ll_time;
 	STRTCPY(newlog.ll_line, line);
 #if HAVE_LL_HOST
-	STRNCPY(newlog.ll_host, host);
+	STRNCPY(newlog.ll_host, "");
 #endif
 	if (   (lseek (fd, offset, SEEK_SET) != offset)
 	    || (write_full(fd, &newlog, sizeof newlog) == -1)) {

--- a/lib/prototypes.h
+++ b/lib/prototypes.h
@@ -205,11 +205,10 @@ extern /*@only@*/char **comma_to_list (const char *);
 
 #ifdef ENABLE_LASTLOG
 /* log.c */
-extern void dolastlog (
+extern void dolastlog(
 	struct lastlog *ll,
 	const struct passwd *pw,
-	/*@unique@*/const char *line,
-	/*@unique@*/const char *host);
+	/*@unique@*/const char *line);
 #endif /* ENABLE_LASTLOG */
 
 /* login_nopam.c */
@@ -480,25 +479,19 @@ extern int get_session_host (char **out);
  *
  * @param[in] user username
  * @param[in] tty tty
- * @param[in] host hostname
  *
  * @return 0 if utmp was updated properly,
  *         1 on error.
  */
-extern int update_utmp (const char *user,
-                        const char *tty,
-                        const char *host);
+extern int update_utmp(const char *user, const char *tty);
 /**
  * @brief Update the cumulative failure log
  *
  * @param[in] failent_user username
  * @param[in] tty tty
- * @param[in] host hostname
  *
  */
-extern void record_failure(const char *failent_user,
-                           const char *tty,
-                           const char *hostname);
+extern void record_failure(const char *failent_user, const char *tty);
 #endif /* ENABLE_LOGIND */
 
 /**

--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -241,8 +241,7 @@ updwtmpx(const char *filename, const struct utmpx *ut)
  *	The returned structure shall be freed by the caller.
  */
 static /*@only@*/struct utmpx *
-prepare_utmp(const char *name, const char *line, const char *host,
-             /*@null@*/const struct utmpx *ut)
+prepare_utmp(const char *name, const char *line, /*@null@*/const struct utmpx *ut)
 {
 	char            *hostname = NULL;
 	struct utmpx    *utent;
@@ -253,10 +252,8 @@ prepare_utmp(const char *name, const char *line, const char *host,
 
 
 
-	if (NULL != host && '\0' != host[0])
-		hostname = xstrdup(host);
 #if defined(HAVE_STRUCT_UTMPX_UT_HOST)
-	else if (NULL != ut && '\0' != ut->ut_host[0])
+	if (NULL != ut && '\0' != ut->ut_host[0])
 		hostname = XSTRNDUP(ut->ut_host);
 #endif
 
@@ -368,12 +365,12 @@ setutmp(struct utmpx *ut)
 
 
 int
-update_utmp(const char *user, const char *tty, const char *host)
+update_utmp(const char *user, const char *tty)
 {
 	struct utmpx  *utent, *ut;
 
 	utent = get_current_utmp ();
-	ut = prepare_utmp  (user, tty, host, utent);
+	ut = prepare_utmp(user, tty, utent);
 
 	(void) setutmp  (ut);	/* make entry in the utmp & wtmp files */
 
@@ -385,13 +382,13 @@ update_utmp(const char *user, const char *tty, const char *host)
 
 
 void
-record_failure(const char *failent_user, const char *tty, const char *hostname)
+record_failure(const char *failent_user, const char *tty)
 {
 	struct utmpx  *utent, *failent;
 
 	if (getdef_str ("FTMP_FILE") != NULL) {
 		utent = get_current_utmp ();
-		failent = prepare_utmp (failent_user, tty, hostname, utent);
+		failent = prepare_utmp(failent_user, tty, utent);
 		failtmp (failent_user, failent);
 		free (utent);
 		free (failent);

--- a/src/login.c
+++ b/src/login.c
@@ -74,7 +74,6 @@ static pam_handle_t *pamh = NULL;
  */
 static const char Prog[] = "login";
 
-static const char hostname[] = "";
 static /*@null@*/ /*@only@*/char *username = NULL;
 
 #ifndef USE_PAM
@@ -612,7 +611,7 @@ int main (int argc, char **argv)
 	 * PAM_RHOST and PAM_TTY are used for authentication, only use
 	 * information coming from login or from the caller (e.g. no utmp)
 	 */
-	retcode = pam_set_item (pamh, PAM_RHOST, hostname);
+	retcode = pam_set_item (pamh, PAM_RHOST, "");
 	PAM_FAIL_CHECK;
 	retcode = pam_set_item (pamh, PAM_TTY, tty);
 	PAM_FAIL_CHECK;
@@ -703,7 +702,7 @@ int main (int argc, char **argv)
 			                        "login",
 			                        failent_user,
 			                        AUDIT_NO_ID,
-			                        hostname,
+			                        "",
 			                        NULL,    /* addr */
 			                        tty,
 			                        0);      /* result */
@@ -926,7 +925,7 @@ int main (int argc, char **argv)
 			failure (pwd->pw_uid, tty, &faillog);
 		}
 #ifndef ENABLE_LOGIND
-		record_failure(failent_user, tty, hostname);
+		record_failure(failent_user, tty);
 #endif /* ENABLE_LOGIND */
 
 		retries--;
@@ -1019,7 +1018,7 @@ int main (int argc, char **argv)
 	                        "login",
 	                        username,
 	                        AUDIT_NO_ID,
-	                        hostname,
+	                        "",
 	                        NULL,    /* addr */
 	                        tty,
 	                        1);      /* result */
@@ -1031,7 +1030,7 @@ int main (int argc, char **argv)
 	if (   getdef_bool ("LASTLOG_ENAB")
 	    && pwd->pw_uid <= (uid_t) getdef_ulong ("LASTLOG_UID_MAX", 0xFFFFFFFFUL)) {
 		/* give last login and log this one */
-		dolastlog (&ll, pwd, tty, hostname);
+		dolastlog(&ll, pwd, tty);
 	}
 #endif /* ENABLE_LASTLOG */
 #endif
@@ -1103,7 +1102,7 @@ int main (int argc, char **argv)
 	 * The utmp entry needs to be updated to indicate the new status
 	 * of the session, the new PID and SID.
 	 */
-	err = update_utmp (username, tty, hostname);
+	err = update_utmp(username, tty);
 	if (err != 0) {
 		SYSLOG ((LOG_WARN, "Unable to update utmp entry for %s", username));
 	}

--- a/src/login.c
+++ b/src/login.c
@@ -76,7 +76,6 @@ static const char Prog[] = "login";
 
 static const char hostname[] = "";
 static /*@null@*/ /*@only@*/char *username = NULL;
-static int reason = PW_LOGIN;
 
 #ifndef USE_PAM
 #ifdef ENABLE_LASTLOG
@@ -882,7 +881,7 @@ int main (int argc, char **argv)
 			goto auth_ok;
 		}
 
-		if (pw_auth (user_passwd, username, reason, NULL) == 0) {
+		if (pw_auth(user_passwd, username, PW_LOGIN, NULL) == 0) {
 			goto auth_ok;
 		}
 
@@ -944,7 +943,7 @@ int main (int argc, char **argv)
 		 * all).  --marekm
 		 */
 		if (user_passwd[0] == '\0') {
-			pw_auth ("!", username, reason, NULL);
+			pw_auth("!", username, PW_LOGIN, NULL);
 		}
 
 		/*

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -189,23 +189,6 @@ static char *myhostname (void)
 	return (name);
 }
 
-#if HAVE_INNETGR
-/* netgroup_match - match group against machine or user */
-static bool
-netgroup_match (const char *group, const char *machine, const char *user)
-{
-	static char *mydomain = NULL;
-
-	if (mydomain == NULL) {
-		static char domain[MAXHOSTNAMELEN + 1];
-
-		getdomainname (domain, MAXHOSTNAMELEN);
-		mydomain = domain;
-	}
-
-	return (innetgr (group, machine, user, mydomain) != 0);
-}
-#endif
 
 /* user_match - match a username against one token */
 static bool user_match (const char *tok, const char *string)
@@ -225,10 +208,6 @@ static bool user_match (const char *tok, const char *string)
 	host = stpsep(tok + 1, "@");	/* split user@host pattern */
 	if (host != NULL) {
 		return user_match(tok, string) && from_match(host, myhostname());
-#if HAVE_INNETGR
-	} else if (tok[0] == '@') {	/* netgroup */
-		return (netgroup_match (tok + 1, NULL, string));
-#endif
 	} else if (string_match (tok, string)) {	/* ALL or exact match */
 		return true;
 	/* local, no need for xgetgrnam */
@@ -300,11 +279,6 @@ static bool from_match (const char *tok, const char *string)
 	 * contain a "." character. If the token is a network number, return true
 	 * if it matches the head of the string.
 	 */
-#if HAVE_INNETGR
-	if (tok[0] == '@') {	/* netgroup */
-		return (netgroup_match (tok + 1, string, NULL));
-	} else
-#endif
 	if (string_match (tok, string)) {	/* ALL or exact match */
 		return true;
 	} else if (tok[0] == '.') {	/* domain: match last fields */


### PR DESCRIPTION
---

Revisions:

<details>
<summary>v1b</summary>

-  Reviewed-by: @dancrossnyc 
-  Add @dancrossnyc 's comment to the commit message.  (<https://github.com/shadow-maint/shadow/pull/1022#issuecomment-2190316864>)
-  Link to the PR.

```
$ git range-diff alx/master gh/telnetd telnetd 
1:  337ad270 ! 1:  55c5a072 src/login.c: Remove support for telnetd in login(1), that is, remove the '-h' flag
    @@ Commit message
     
         Hardcode the hostname to "".
     
    +    Dan Cross wrote:
    +    > Note that this change means that comparisons against the hostname in
    +    > login.access no longer apply for names other than whatever has been
    +    > assigned to the local system.  For the axspawn program from the AX.25
    +    > suite, this applies to the protocol as well.
    +
    +    Link: <https://github.com/shadow-maint/shadow/pull/1022>
    +    Reviewed-by: Dan Cross <crossd@gmail.com>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## src/login.c ##
2:  93c43b74 ! 2:  e3a4c1ec src/login.c: The only reason is PW_LOGIN
    @@ Metadata
      ## Commit message ##
         src/login.c: The only reason is PW_LOGIN
     
    +    Link: <https://github.com/shadow-maint/shadow/pull/1022>
    +    Reviewed-by: Dan Cross <crossd@gmail.com>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## src/login.c ##
3:  2b8e3669 ! 3:  cd4f2cfe lib/, src/login.c: hostname is always ""
    @@ Commit message
         This is true since a few commits ago we removed support for rlogind and
         telndetd in login(1), removing -r and -h.
     
    +    Link: <https://github.com/shadow-maint/shadow/pull/1022>
    +    Reviewed-by: Dan Cross <crossd@gmail.com>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/log.c ##
4:  0d28804f ! 4:  7e80f6ba src/login_nopam.c: Remove support for innetgr(3)
    @@ Metadata
      ## Commit message ##
         src/login_nopam.c: Remove support for innetgr(3)
     
    +    Link: <https://github.com/shadow-maint/shadow/pull/1022>
    +    Reviewed-by: Dan Cross <crossd@gmail.com>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## configure.ac ##
5:  17dbf39b ! 5:  595c3f3b src/login_nopam.c: Remove support for network hostnames
    @@ Commit message
         We dropped support for remote login recently, so we should reject
         network hostnames.
     
    +    Link: <https://github.com/shadow-maint/shadow/pull/1022>
    +    Reviewed-by: Dan Cross <crossd@gmail.com>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## src/login_nopam.c ##
```
</details>

<details>
<summary>v1c</summary>

-  Rebase

```
$ git range-diff alx/master..gh/telnetd shadow/master..telnetd 
1:  55c5a072 = 1:  ddabc1e0 src/login.c: Remove support for telnetd in login(1), that is, remove the '-h' flag
2:  e3a4c1ec = 2:  43b8d123 src/login.c: The only reason is PW_LOGIN
3:  cd4f2cfe = 3:  b112ffb6 lib/, src/login.c: hostname is always ""
4:  7e80f6ba = 4:  96754035 src/login_nopam.c: Remove support for innetgr(3)
5:  595c3f3b = 5:  7273d687 src/login_nopam.c: Remove support for network hostnames
```
</details>

<details>
<summary>v1d</summary>

-  Rebase

```
$ git range-diff master..gh/telnetd shadow/master..telnetd 
1:  ddabc1e0 = 1:  333092e6 src/login.c: Remove support for telnetd in login(1), that is, remove the '-h' flag
2:  43b8d123 = 2:  c734b2e2 src/login.c: The only reason is PW_LOGIN
3:  b112ffb6 ! 3:  d1dbd06b lib/, src/login.c: hostname is always ""
    @@ lib/utmp.c: prepare_utmp(const char *name, const char *line, const char *host,
      
      
      
    --  if (   (NULL != host)
    --      && ('\0' != host[0])) {
    --          hostname = XMALLOC(strlen(host) + 1, char);
    --          strcpy (hostname, host);
    +-  if (NULL != host && '\0' != host[0])
    +-          hostname = xstrdup(host);
      #if defined(HAVE_STRUCT_UTMPX_UT_HOST)
    --  } else if (   (NULL != ut)
    --             && ('\0' != ut->ut_host[0])) {
    -+  if (NULL != ut && '\0' != ut->ut_host[0]) {
    -           hostname = XMALLOC(NITEMS(ut->ut_host) + 1, char);
    -           ZUSTR2STP(hostname, ut->ut_host);
    --#endif
    -   }
    -+#endif
    +-  else if (NULL != ut && '\0' != ut->ut_host[0])
    ++  if (NULL != ut && '\0' != ut->ut_host[0])
    +           hostname = XSTRNDUP(ut->ut_host);
    + #endif
      
    -   if (strncmp(line, "/dev/", 5) == 0) {
    -           line += 5;
     @@ lib/utmp.c: setutmp(struct utmpx *ut)
      
      
4:  96754035 = 4:  8a1d3f38 src/login_nopam.c: Remove support for innetgr(3)
5:  7273d687 = 5:  01a474c2 src/login_nopam.c: Remove support for network hostnames
```
</details>

<details>
<summary>v1e</summary>

-  Rebase

```
$ git range-diff master..gh/telnetd shadow/master..telnetd 
1:  333092e6 = 1:  1dd08490 src/login.c: Remove support for telnetd in login(1), that is, remove the '-h' flag
2:  c734b2e2 = 2:  d7cfb4fe src/login.c: The only reason is PW_LOGIN
3:  d1dbd06b = 3:  8776c239 lib/, src/login.c: hostname is always ""
4:  8a1d3f38 = 4:  61ba2e8b src/login_nopam.c: Remove support for innetgr(3)
5:  01a474c2 = 5:  d1ac2677 src/login_nopam.c: Remove support for network hostnames
```
</details>

<details>
<summary>v1f</summary>

-  Rebase

```
$ git range-diff alx/master..gh/telnetd shadow/master..telnetd 
1:  1dd08490 = 1:  3e61cc62 src/login.c: Remove support for telnetd in login(1), that is, remove the '-h' flag
2:  d7cfb4fe = 2:  8f267484 src/login.c: The only reason is PW_LOGIN
3:  8776c239 = 3:  36c5b421 lib/, src/login.c: hostname is always ""
4:  61ba2e8b ! 4:  560c86c7 src/login_nopam.c: Remove support for innetgr(3)
    @@ src/login_nopam.c: static char *myhostname (void)
      /* user_match - match a username against one token */
      static bool user_match (const char *tok, const char *string)
     @@ src/login_nopam.c: static bool user_match (const char *tok, const char *string)
    -           *at = '\0';
    +           stpcpy(at, "");
                return (   user_match (tok, string)
                        && from_match (at + 1, myhostname ()));
     -#if HAVE_INNETGR
5:  d1ac2677 ! 5:  d72ab137 src/login_nopam.c: Remove support for network hostnames
    @@ src/login_nopam.c
     -#include <arpa/inet.h>            /* for inet_ntoa() */
      
      #include "sizeof.h"
    - 
    + #include "string/strchr/strrspn.h"
     @@ src/login_nopam.c: static bool list_match (char *list, const char *item, bool (*match_fn) (const ch
      static bool user_match (const char *tok, const char *string);
      static bool from_match (const char *tok, const char *string);
```
</details>

<details>
<summary>v1g</summary>

-  Rebase

```
$ git range-diff gh/master..gh/telnetd shadow/master..telnetd 
1:  3e61cc62 = 1:  f1747f09 src/login.c: Remove support for telnetd in login(1), that is, remove the '-h' flag
2:  8f267484 = 2:  5c867dc4 src/login.c: The only reason is PW_LOGIN
3:  36c5b421 = 3:  f7eed6e0 lib/, src/login.c: hostname is always ""
4:  560c86c7 = 4:  92a52cfa src/login_nopam.c: Remove support for innetgr(3)
5:  d72ab137 = 5:  8c5bb461 src/login_nopam.c: Remove support for network hostnames
```
</details>

<details>
<summary>v1h</summary>

-  Rebase

```
$ git range-diff gh/master..gh/telnetd master..telnetd 
1:  f1747f09 = 1:  82cf81db src/login.c: Remove support for telnetd in login(1), that is, remove the '-h' flag
2:  5c867dc4 = 2:  d00cdd1d src/login.c: The only reason is PW_LOGIN
3:  f7eed6e0 = 3:  04eced12 lib/, src/login.c: hostname is always ""
4:  92a52cfa ! 4:  a74714bc src/login_nopam.c: Remove support for innetgr(3)
    @@ src/login_nopam.c: static char *myhostname (void)
      /* user_match - match a username against one token */
      static bool user_match (const char *tok, const char *string)
     @@ src/login_nopam.c: static bool user_match (const char *tok, const char *string)
    -           stpcpy(at, "");
    -           return (   user_match (tok, string)
    -                   && from_match (at + 1, myhostname ()));
    +   host = stpsep(tok + 1, "@");    /* split user@host pattern */
    +   if (host != NULL) {
    +           return user_match(tok, string) && from_match(host, myhostname());
     -#if HAVE_INNETGR
     -  } else if (tok[0] == '@') {     /* netgroup */
     -          return (netgroup_match (tok + 1, NULL, string));
5:  8c5bb461 = 5:  58050db0 src/login_nopam.c: Remove support for network hostnames
```
</details>

<details>
<summary>v1i</summary>

-  Rebase

```
$ git range-diff master..gh/telnetd shadow/master..telnetd 
1:  82cf81db = 1:  afd8af13 src/login.c: Remove support for telnetd in login(1), that is, remove the '-h' flag
2:  d00cdd1d = 2:  71215b6d src/login.c: The only reason is PW_LOGIN
3:  04eced12 = 3:  629c244a lib/, src/login.c: hostname is always ""
4:  a74714bc = 4:  7a262ad8 src/login_nopam.c: Remove support for innetgr(3)
5:  58050db0 = 5:  4a9e3ce7 src/login_nopam.c: Remove support for network hostnames
```
</details>