### PR TITLE
configure.ac: Release 4.15.2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ m4_define([libsubid_abi_major], 4)
 m4_define([libsubid_abi_minor], 0)
 m4_define([libsubid_abi_micro], 0)
 m4_define([libsubid_abi], [libsubid_abi_major.libsubid_abi_minor.libsubid_abi_micro])
-AC_INIT([shadow], [4.15.1], [pkg-shadow-devel@lists.alioth.debian.org], [],
+AC_INIT([shadow], [4.15.2], [pkg-shadow-devel@lists.alioth.debian.org], [],
 	[https://github.com/shadow-maint/shadow])
 AM_INIT_AUTOMAKE([1.11 foreign dist-xz subdir-objects])
 AC_CONFIG_MACRO_DIRS([m4])


### PR DESCRIPTION
To be merged _after_ 4.16.0 has been released, so we benefit from the testing of its -rc pre-releases.

This forks 4.15.x from master right before the first breaking change in 4.16.0.

---

Here's the graph log:

```
* a3bf4df5 (HEAD -> rel_4152, gh/rel_4152) configure.ac: Release 4.15.2
| * 2df2c35b (tag: 4.16.0-rc1, shadow/master, gh/master, alx/master, master) release 4.16.0-rc1
| * 9b7d786b configure.ac: specify tar-pax to avoid 99 char filename limit
| * ca046af5 Remove support for rlogind in login(1), that is, remove the '-r' flag
| * df590886 libsubid: Fix code style issues
| * b620b5d0 libsubid: Fail on plugin loading if no subid_free provided
| * 29dbcfba libsubid: Apply minor fixes
| * 02175163 libsubid: Add routine to free allocated memory
|/  
* 18f113cc libsubid: Dealocate memory on exit
* 10429edc src/groupmod.c: delete gr_free_members(&grp) to avoid double free
* 8acec35d man/lastlog: remove wrong use of keyword term
* 69f74dbf lib/cast.h: const_cast(): Reimplement with _Generic(3)
* 4e2453fa configure: move cmocka library detection
* d0fef040 tests: add the tests/ subdirectory to dist tarball
* 71e28359 lib/atoi/strtou_noneg.[ch], tests/: strtoul_noneg(): Remove unused function
* f3a1e1cf src/check_subid_range.c: Call str2ul() instead of strtoul_noneg()
* fb49de61 lib/atoi/strtou_noneg.[ch], tests/: strtoull_noneg(): Remove unused function
* 895dfd77 lib/gettime.c: gettime(): Call a2i() instead of strtoull_noneg()
* 9dddcd29 STABLE.md: 4.15.x is now stable
```