### PR TITLE
lib/csrand.c: Fix the lower part of the domain of csrand_uniform()

### DIFF
--- a/lib/csrand.c
+++ b/lib/csrand.c
@@ -23,6 +23,7 @@
 #include "sizeof.h"
 
 
+static uint32_t csrand32(void);
 static uint32_t csrand_uniform32(uint32_t n);
 static unsigned long csrand_uniform_slow(unsigned long n);
 
@@ -97,6 +98,13 @@ csrand_interval(unsigned long min, unsigned long max)
 }
 
 
+static uint32_t
+csrand32(void)
+{
+	return csrand();
+}
+
+
 /*
  * Fast Random Integer Generation in an Interval
  * ACM Transactions on Modeling and Computer Simulation 29 (1), 2019
@@ -109,12 +117,12 @@ csrand_uniform32(uint32_t n)
 	uint64_t  r, mult;
 
 	if (n == 0)
-		return csrand();
+		return csrand32();
 
 	bound = -n % n;  // analogous to `2^32 % n`, since `x % y == (x-y) % y`
 
 	do {
-		r = csrand();
+		r = csrand32();
 		mult = r * n;
 		rem = mult;  // analogous to `mult % 2^32`
 	} while (rem < bound);  // p = (2^32 % n) / 2^32;  W.C.: n=2^31+1, p=0.5


### PR DESCRIPTION
I accidentally broke this code during an un-optimization.  We need to
start from a random value of the width of the limit, that is, 32 bits.

Thanks to Jason for pointing to his similar code in the kernel, which
made me see my mistake.

Fixes: 2a61122b5e8f ("Unoptimize the higher part of the domain of csrand_uniform()")
Closes: <https://github.com/shadow-maint/shadow/issues/1015>
Reported-by: @michaelbrunnbauer
Link: <https://git.zx2c4.com/linux-rng/tree/drivers/char/random.c#n535>
Cc: @zx2c4
Link: <https://github.com/shadow-maint/shadow/pull/638>
Link: <https://github.com/shadow-maint/shadow/issues/634>
Link: <https://github.com/shadow-maint/shadow/pull/624>