### PR TITLE
Simplify string handling, and add some new APIs for that

### DIFF
--- a/contrib/adduser.c
+++ b/contrib/adduser.c
@@ -118,6 +118,7 @@
 #include <sys/stat.h>
 #include <syslog.h>
 
+
 #define IMMEDIATE_CHANGE	/* Expire newly created password, must be changed
 				 * immediately upon next login */
 #define HAVE_QUOTAS		/* Obvious */
@@ -291,12 +292,10 @@ main (void)
 	  printf ("Home Directory [%s/%s]: ", DEFAULT_HOME, usrname);
 	  fflush (stdout);
 	  safeget (dir, sizeof (dir));
-	  if (!strlen (dir))
-	    {			/* hit return */
-	      sprintf (dir, "%s/%s", DEFAULT_HOME, usrname);
-	    }
+	  if (!strlen(dir))  /* hit return */
+	    sprintf(dir, "%s/%s", DEFAULT_HOME, usrname);
 	  else if (dir[strlen (dir) - 1] == '/')
-	    sprintf (dir+strlen(dir), "%s", usrname);
+	    strcat(dir, usrname);
 	}
       else
 	{
@@ -308,7 +307,7 @@ main (void)
       fflush (stdout);
       safeget (shell, sizeof (shell));
       if (!strlen (shell))
-	sprintf (shell, "%s", DEFAULT_SHELL);
+	strcpy(shell, DEFAULT_SHELL);
       else
 	{
 	  char *sh;
@@ -327,7 +326,7 @@ main (void)
 	      else
 		{
 		  printf ("Shell NOT in /etc/shells, DEFAULT used\n");
-		  sprintf (shell, "%s", DEFAULT_SHELL);
+		  strcpy(shell, DEFAULT_SHELL);
 		}
 	    }
 	}

--- a/contrib/adduser.c
+++ b/contrib/adduser.c
@@ -491,12 +491,12 @@ safeget (char *buf, int maxlen)
       bad = (!isalnum (c) && (c != '_') && (c != ' '));
       *(buf++) = c;
     }
-  *buf = '\0';
+  stpcpy(buf, "");
 
   if (bad)
     {
       printf ("\nString contained banned character. Please stick to alphanumerics.\n");
-      *bstart = '\0';
+      stpcpy(bstart, "");
     }
 }
 

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -162,6 +162,14 @@ libshadow_la_SOURCES = \
 	string/sprintf/stpeprintf.h \
 	string/sprintf/xasprintf.c \
 	string/sprintf/xasprintf.h \
+	string/strchr/stpcspn.c \
+	string/strchr/stpcspn.h \
+	string/strchr/stpspn.c \
+	string/strchr/stpspn.h \
+	string/strchr/strnul.c \
+	string/strchr/strnul.h \
+	string/strchr/strrspn.c \
+	string/strchr/strrspn.h \
 	string/strcpy/stpecpy.c \
 	string/strcpy/stpecpy.h \
 	string/strcpy/strncat.c \

--- a/lib/commonio.c
+++ b/lib/commonio.c
@@ -197,7 +197,7 @@ static int do_lock_file (const char *file, const char *lock, bool log)
 		errno = EINVAL;
 		return 0;
 	}
-	buf[len] = '\0';
+	stpcpy(&buf[len], "");
 	if (get_pid(buf, &pid) == -1) {
 		if (log) {
 			(void) fprintf (shadow_logfd,
@@ -659,7 +659,7 @@ int commonio_open (struct commonio_db *db, int mode)
 				goto cleanup_buf;
 			}
 		}
-		*strchrnul(buf, '\n') = '\0';
+		stpcpy(strchrnul(buf, '\n'), "");
 
 		line = strdup (buf);
 		if (NULL == line) {

--- a/lib/console.c
+++ b/lib/console.c
@@ -76,7 +76,7 @@ static bool is_listed (const char *cfgin, const char *tty, bool def)
 	 */
 
 	while (fgets (buf, sizeof (buf), fp) != NULL) {
-		*strchrnul(buf, '\n') = '\0';
+		stpcpy(strchrnul(buf, '\n'), "");
 		if (strcmp (buf, tty) == 0) {
 			(void) fclose (fp);
 			return true;

--- a/lib/copydir.c
+++ b/lib/copydir.c
@@ -17,6 +17,7 @@
 #include <sys/time.h>
 #include <fcntl.h>
 #include <stdio.h>
+#include <string.h>
 
 #include "alloc/malloc.h"
 #include "alloc/x/xmalloc.h"
@@ -563,7 +564,7 @@ static /*@null@*/char *readlink_malloc (const char *filename)
 
 		if ((size_t) nchars < size) { /* The buffer was large enough */
 			/* readlink does not nul-terminate */
-			buffer[nchars] = '\0';
+			stpcpy(&buffer[nchars], "");
 			return buffer;
 		}
 

--- a/lib/fields.c
+++ b/lib/fields.c
@@ -14,7 +14,10 @@
 #include <ctype.h>
 #include <string.h>
 #include <stdio.h>
+
 #include "prototypes.h"
+#include "string/strchr/strrspn.h"
+
 
 /*
  * valid_field - insure that a field contains all legal characters
@@ -89,11 +92,7 @@ void change_field (char *buf, size_t maxsize, const char *prompt)
 		 * makes it possible to change the field to empty, by
 		 * entering a space.  --marekm
 		 */
-
-		while (newf < cp && isspace (cp[-1])) {
-			cp--;
-		}
-		*cp = '\0';
+		*strrspn(newf, " \t\n") = '\0';
 
 		cp = newf;
 		while (isspace (*cp)) {

--- a/lib/fields.c
+++ b/lib/fields.c
@@ -84,7 +84,7 @@ void change_field (char *buf, size_t maxsize, const char *prompt)
 	if (NULL == cp) {
 		return;
 	}
-	*cp = '\0';
+	stpcpy(cp, "");
 
 	if ('\0' != newf[0]) {
 		/*
@@ -92,7 +92,7 @@ void change_field (char *buf, size_t maxsize, const char *prompt)
 		 * makes it possible to change the field to empty, by
 		 * entering a space.  --marekm
 		 */
-		*strrspn(newf, " \t\n") = '\0';
+		stpcpy(strrspn(newf, " \t\n"), "");
 
 		cp = newf;
 		while (isspace (*cp)) {

--- a/lib/fputsx.c
+++ b/lib/fputsx.c
@@ -10,6 +10,8 @@
 #include <config.h>
 
 #include <stdio.h>
+#include <string.h>
+
 #include "defines.h"
 #include "prototypes.h"
 
@@ -33,10 +35,8 @@ fgetsx(/*@returned@*/char *restrict buf, int cnt, FILE *restrict f)
 		ep = strrchr (cp, '\\');
 		if ((NULL != ep) && (*(ep + 1) == '\n')) {
 			cnt -= ep - cp;
-			if (cnt > 0) {
-				cp = ep;
-				*cp = '\0';
-			}
+			if (cnt > 0)
+				cp = stpcpy(ep, "");
 		} else {
 			break;
 		}

--- a/lib/getdate.y
+++ b/lib/getdate.y
@@ -646,7 +646,7 @@ static int LookupWord (char *buff)
   else if (strlen (buff) == 4 && buff[3] == '.')
     {
       abbrev = true;
-      buff[3] = '\0';
+      stpcpy(&buff[3], "");
     }
   else
     abbrev = false;
@@ -689,7 +689,7 @@ static int LookupWord (char *buff)
   i = strlen (buff) - 1;
   if (buff[i] == 's')
     {
-      buff[i] = '\0';
+      stpcpy(&buff[i], "");
       for (tp = UnitsTable; tp->name; tp++)
 	if (strcmp (buff, tp->name) == 0)
 	  {
@@ -723,7 +723,7 @@ static int LookupWord (char *buff)
       *p++ = *q;
     else
       i++;
-  *p = '\0';
+  stpcpy(p, "");
   if (0 != i)
     for (tp = TimezoneTable; NULL != tp->name; tp++)
       if (strcmp (buff, tp->name) == 0)
@@ -772,7 +772,7 @@ yylex (void)
 	  for (p = buff; (c = *yyInput++, isalpha (c)) || c == '.';)
 	    if (p < &buff[sizeof buff - 1])
 	      *p++ = c;
-	  *p = '\0';
+          stpcpy(p, "");
 	  yyInput--;
 	  return LookupWord (buff);
 	}

--- a/lib/getdef.c
+++ b/lib/getdef.c
@@ -31,6 +31,7 @@
 #include "string/sprintf/xasprintf.h"
 #include "string/strchr/stpcspn.h"
 #include "string/strchr/stpspn.h"
+#include "string/strchr/strrspn.h"
 
 
 /*
@@ -528,7 +529,6 @@ static void def_load (void)
 #else /* USE_ECONF */
 static void def_load (void)
 {
-	int i;
 	FILE *fp;
 	char buf[1024], *name, *value, *s;
 
@@ -560,13 +560,7 @@ static void def_load (void)
 		/*
 		 * Trim trailing whitespace.
 		 */
-		for (i = (ptrdiff_t) strlen (buf) - 1; i >= 0; --i) {
-			if (!isspace (buf[i])) {
-				break;
-			}
-		}
-		i++;
-		buf[i] = '\0';
+		*strrspn(buf, " \t\n") = '\0';
 
 		/*
 		 * Break the line into two fields.

--- a/lib/getdef.c
+++ b/lib/getdef.c
@@ -29,6 +29,8 @@
 #include "prototypes.h"
 #include "shadowlog_internal.h"
 #include "string/sprintf/xasprintf.h"
+#include "string/strchr/stpcspn.h"
+#include "string/strchr/stpspn.h"
 
 
 /*
@@ -569,16 +571,16 @@ static void def_load (void)
 		/*
 		 * Break the line into two fields.
 		 */
-		name = buf + strspn (buf, " \t");	/* first nonwhite */
+		name = stpspn(buf, " \t");	/* first nonwhite */
 		if (*name == '\0' || *name == '#')
 			continue;	/* comment or empty */
 
-		s = name + strcspn (name, " \t");	/* end of field */
+		s = stpcspn(name, " \t");	/* end of field */
 		if (*s == '\0')
 			continue;	/* only 1 field?? */
 
 		*s++ = '\0';
-		value = s + strspn (s, " \"\t");	/* next nonwhite */
+		value = stpspn(s, " \"\t");	/* next nonwhite */
 		*strchrnul(value, '"') = '\0';
 
 		/*

--- a/lib/getdef.c
+++ b/lib/getdef.c
@@ -560,7 +560,7 @@ static void def_load (void)
 		/*
 		 * Trim trailing whitespace.
 		 */
-		*strrspn(buf, " \t\n") = '\0';
+		stpcpy(strrspn(buf, " \t\n"), "");
 
 		/*
 		 * Break the line into two fields.
@@ -573,9 +573,9 @@ static void def_load (void)
 		if (*s == '\0')
 			continue;	/* only 1 field?? */
 
-		*s++ = '\0';
+		stpcpy(s++, "");
 		value = stpspn(s, " \"\t");	/* next nonwhite */
-		*strchrnul(value, '"') = '\0';
+		stpcpy(strchrnul(value, '"'), "");
 
 		/*
 		 * Store the value in def_table.

--- a/lib/gshadow.c
+++ b/lib/gshadow.c
@@ -91,7 +91,7 @@ void endsgent (void)
 	}
 
 	strcpy (sgrbuf, string);
-	*strchrnul(sgrbuf, '\n') = '\0';
+	stpcpy(strchrnul(sgrbuf, '\n'), "");
 
 	/*
 	 * There should be exactly 4 colon separated fields.  Find
@@ -172,7 +172,7 @@ void endsgent (void)
 				return NULL;
 			}
 		}
-		*strchrnul(buf, '\n') = '\0';
+		stpcpy(strchrnul(buf, '\n'), "");
 		return (sgetsgent (buf));
 	}
 	return NULL;
@@ -244,53 +244,36 @@ int putsgent (const struct sgrp *sgrp, FILE * fp)
 	/*
 	 * Copy the group name and passwd.
 	 */
-
-	strcpy (cp, sgrp->sg_name);
-	cp += strlen (cp);
-	*cp++ = ':';
-
-	strcpy (cp, sgrp->sg_passwd);
-	cp += strlen (cp);
-	*cp++ = ':';
+	cp = stpcpy(stpcpy(cp, sgrp->sg_name), ":");
+	cp = stpcpy(stpcpy(cp, sgrp->sg_passwd), ":");
 
 	/*
 	 * Copy the administrators, separating each from the other
 	 * with a ",".
 	 */
-
 	for (i = 0; NULL != sgrp->sg_adm[i]; i++) {
-		if (i > 0) {
-			*cp++ = ',';
-		}
+		if (i > 0)
+			cp = stpcpy(cp, ",");
 
-		strcpy (cp, sgrp->sg_adm[i]);
-		cp += strlen (cp);
+		cp = stpcpy(cp, sgrp->sg_adm[i]);
 	}
-	*cp = ':';
-	cp++;
+	cp = stpcpy(cp, ":");
 
 	/*
 	 * Now do likewise with the group members.
 	 */
-
 	for (i = 0; NULL != sgrp->sg_mem[i]; i++) {
-		if (i > 0) {
-			*cp = ',';
-			cp++;
-		}
+		if (i > 0)
+			cp = stpcpy(cp, ",");
 
-		strcpy (cp, sgrp->sg_mem[i]);
-		cp += strlen (cp);
+		cp = stpcpy(cp, sgrp->sg_mem[i]);
 	}
-	*cp = '\n';
-	cp++;
-	*cp = '\0';
+	stpcpy(cp, "\n");
 
 	/*
 	 * Output using the function which understands the line
 	 * continuation conventions.
 	 */
-
 	if (fputsx (buf, fp) == EOF) {
 		free (buf);
 		return -1;

--- a/lib/hushed.c
+++ b/lib/hushed.c
@@ -72,7 +72,7 @@ bool hushed (const char *username)
 		return false;
 	}
 	for (found = false; !found && (fgets (buf, sizeof buf, fp) == buf);) {
-		*strchrnul(buf, '\n') = '\0';
+		stpcpy(strchrnul(buf, '\n'), "");
 		found = (strcmp (buf, pw->pw_shell) == 0) ||
 		        (strcmp (buf, pw->pw_name) == 0);
 	}

--- a/lib/loginprompt.c
+++ b/lib/loginprompt.c
@@ -87,7 +87,7 @@ void login_prompt (char *name, int namesize)
 	if (NULL == cp) {
 		exit (EXIT_FAILURE);
 	}
-	*cp = '\0';		/* remove \n [ must be there ] */
+	stpcpy(cp, "");		/* remove \n [ must be there ] */
 
 	/*
 	 * Skip leading whitespace.  This makes "  username" work right.
@@ -98,7 +98,7 @@ void login_prompt (char *name, int namesize)
 
 	for (i = 0; i < namesize - 1 && *cp != '\0'; name[i++] = *cp++);
 
-	name[i] = '\0';
+	stpcpy(&name[i], "");
 
 	/*
 	 * Set the SIGQUIT handler back to its original value

--- a/lib/obscure.c
+++ b/lib/obscure.c
@@ -189,12 +189,10 @@ static /*@observer@*//*@null@*/const char *obscure_msg (
 
 	new1 = xstrdup (new);
 	old1 = xstrdup (old);
-	if (newlen > maxlen) {
-		new1[maxlen] = '\0';
-	}
-	if (oldlen > maxlen) {
-		old1[maxlen] = '\0';
-	}
+	if (newlen > maxlen)
+		stpcpy(&new1[maxlen], "");
+	if (oldlen > maxlen)
+		stpcpy(&old1[maxlen], "");
 
 	msg = password_check (old1, new1, pwdp);
 

--- a/lib/port.c
+++ b/lib/port.c
@@ -152,7 +152,7 @@ again:
 	 * TTY devices.
 	 */
 
-	*strchrnul(buf, '\n') = '\0';
+	stpcpy(strchrnul(buf, '\n'), "");
 
 	port.pt_names = ttys;
 	for (cp = buf, j = 0; j < PORT_TTY; j++) {
@@ -165,12 +165,10 @@ again:
 			break;
 		}
 
-		if (',' == *cp) {	/* end of current tty name */
-			*cp++ = '\0';
-		}
+		if (',' == *cp)		/* end of current tty name */
+			stpcpy(cp++, "");
 	}
-	*cp = '\0';
-	cp++;
+	stpcpy(cp++, "");
 	port.pt_names[j] = NULL;
 
 	/*
@@ -186,8 +184,7 @@ again:
 
 		for (j = 1; ':' != *cp; cp++) {
 			if ((',' == *cp) && (j < PORT_IDS)) {
-				*cp = '\0';
-				cp++;
+				stpcpy(cp++, "");
 				port.pt_users[j] = cp;
 				j++;
 			}
@@ -201,8 +198,7 @@ again:
 		goto again;
 	}
 
-	*cp = '\0';
-	cp++;
+	stpcpy(cp++, "");
 
 	/*
 	 * Get the list of valid times.  The times field is the third

--- a/lib/readpassphrase.c
+++ b/lib/readpassphrase.c
@@ -141,7 +141,7 @@ restart:
 			*p++ = ch;
 		}
 	}
-	*p = '\0';
+	stpcpy(p, "");
 	save_errno = errno;
 	if (!(term.c_lflag & ECHO))
 		(void)write(output, "\n", 1);

--- a/lib/salt.c
+++ b/lib/salt.c
@@ -291,6 +291,7 @@ static /*@observer@*/unsigned long YESCRYPT_get_salt_cost (/*@null@*/const int *
 static /*@observer@*/void YESCRYPT_salt_cost_to_buf (char *buf, unsigned long cost)
 {
 	const size_t buf_begin = strlen (buf);
+	char  *p;
 
 	/*
 	 * Check if the result buffer is long enough.
@@ -302,17 +303,17 @@ static /*@observer@*/void YESCRYPT_salt_cost_to_buf (char *buf, unsigned long co
 	 */
 	assert (GENSALT_SETTING_SIZE > buf_begin + 4);
 
-	buf[buf_begin + 0] = 'j';
+	p = &buf[buf_begin];
+	p = stpcpy(p, "j");
 	if (cost < 3) {
-		buf[buf_begin + 1] = 0x36 + cost;
+		*p++ = 0x36 + cost;
 	} else if (cost < 6) {
-		buf[buf_begin + 1] = 0x34 + cost;
+		*p++ = 0x34 + cost;
 	} else {
-		buf[buf_begin + 1] = 0x3b + cost;
+		*p++ = 0x3b + cost;
 	}
-	buf[buf_begin + 2] = cost >= 3 ? 'T' : '5';
-	buf[buf_begin + 3] = '$';
-	buf[buf_begin + 4] = '\0';
+	p = stpcpy(p, (cost >= 3) ? "T" : "5");
+	stpcpy(p, "$");
 }
 #endif /* USE_YESCRYPT */
 
@@ -330,7 +331,7 @@ static /*@observer@*/const char *gensalt (size_t salt_size)
 		strcat (salt, l64a (csrand ()));
 	} while (strlen (salt) < salt_size);
 
-	salt[salt_size] = '\0';
+	stpcpy(&salt[salt_size], "");
 
 	return salt;
 }
@@ -421,7 +422,7 @@ static /*@observer@*/const char *gensalt (size_t salt_size)
 		salt_len = GENSALT_SETTING_SIZE - 1;
 		rounds = 0;
 		memset(result, '.', salt_len);
-		result[salt_len] = '\0';
+		stpcpy(&result[salt_len], "");
 	}
 
 	char *retval = crypt_gensalt (result, rounds, NULL, 0);

--- a/lib/setupenv.c
+++ b/lib/setupenv.c
@@ -56,7 +56,7 @@ static void read_env_file (const char *filename)
 		if (NULL == cp) {
 			break;
 		}
-		*cp = '\0';
+		stpcpy(cp, "");
 
 		cp = buf;
 		/* ignore whitespace and comments */
@@ -78,8 +78,7 @@ static void read_env_file (const char *filename)
 			continue;
 		}
 		/* NUL-terminate the name */
-		*cp = '\0';
-		cp++;
+		stpcpy(cp++, "");
 		val = cp;
 #if 0				/* XXX untested, and needs rewrite with fewer goto's :-) */
 /*
@@ -112,7 +111,7 @@ static void read_env_file (const char *filename)
 			goto finished;
 		} else if (isspace (*cp)) {
 			/* unescaped whitespace - end of string */
-			*cp = '\0';
+			stpcpy(cp, "");
 			goto finished;
 		} else {
 			cp++;

--- a/lib/sgetgrent.c
+++ b/lib/sgetgrent.c
@@ -83,7 +83,7 @@ struct group *sgetgrent (const char *buf)
 		}
 	}
 	strcpy (grpbuf, buf);
-	*strchrnul(grpbuf, '\n') = '\0';
+	stpcpy(strchrnul(grpbuf, '\n'), "");
 
 	for (cp = grpbuf, i = 0; (i < NFIELDS) && (NULL != cp); i++)
 		grpfields[i] = strsep(&cp, ":");

--- a/lib/sgetspent.c
+++ b/lib/sgetspent.c
@@ -54,7 +54,7 @@ sgetspent(const char *string)
 		return NULL;	/* fail if too long */
 	}
 	strcpy (spwbuf, string);
-	*strchrnul(spwbuf, '\n') = '\0';
+	stpcpy(strchrnul(spwbuf, '\n'), "");
 
 	/*
 	 * Tokenize the string into colon separated fields.  Allow up to

--- a/lib/shadow.c
+++ b/lib/shadow.c
@@ -77,7 +77,7 @@ static struct spwd *my_sgetspent (const char *string)
 	if (strlen (string) >= sizeof spwbuf)
 		return 0;
 	strcpy (spwbuf, string);
-	*strchrnul(spwbuf, '\n') = '\0';
+	stpcpy(strchrnul(spwbuf, '\n'), "");
 
 	/*
 	 * Tokenize the string into colon separated fields.  Allow up to
@@ -202,7 +202,7 @@ struct spwd *fgetspent (FILE * fp)
 
 	if (fgets (buf, sizeof buf, fp) != NULL)
 	{
-		*strchrnul(buf, '\n') = '\0';
+		stpcpy(strchrnul(buf, '\n'), "");
 		return my_sgetspent (buf);
 	}
 	return 0;

--- a/lib/sssd.c
+++ b/lib/sssd.c
@@ -24,7 +24,7 @@ int
 sssd_flush_cache(int dbflags)
 {
 	int          status, code, rv;
-	int          i = 0;
+	char         *p;
 	char         *sss_cache_args = NULL;
 	const char   *cmd = "/usr/sbin/sss_cache";
 	const char   *spawnedArgs[] = {"sss_cache", NULL, NULL};
@@ -40,15 +40,13 @@ sssd_flush_cache(int dbflags)
 	    return -1;
 	}
 
-	sss_cache_args[i++] = '-';
-	if (dbflags & SSSD_DB_PASSWD) {
-		sss_cache_args[i++] = 'U';
-	}
-	if (dbflags & SSSD_DB_GROUP) {
-		sss_cache_args[i++] = 'G';
-	}
-	sss_cache_args[i++] = '\0';
-	if (i == 2) {
+	p = stpcpy(sss_cache_args, "-");
+	if (dbflags & SSSD_DB_PASSWD)
+		stpcpy(p, "U");
+	if (dbflags & SSSD_DB_GROUP)
+		stpcpy(p, "G");
+
+	if (*p == '\0') {
 		/* Neither passwd nor group, nothing to do */
 		free(sss_cache_args);
 		return 0;

--- a/lib/sssd.c
+++ b/lib/sssd.c
@@ -16,17 +16,20 @@
 
 #include "shadowlog_internal.h"
 
+
 #define MSG_SSSD_FLUSH_CACHE_FAILED "%s: Failed to flush the sssd cache."
 
-int sssd_flush_cache (int dbflags)
+
+int
+sssd_flush_cache(int dbflags)
 {
-	int status, code, rv;
-	const char *cmd = "/usr/sbin/sss_cache";
-	struct stat sb;
-	char *sss_cache_args = NULL;
-	const char *spawnedArgs[] = {"sss_cache", NULL, NULL};
-	const char *spawnedEnv[] = {NULL};
-	int i = 0;
+	int          status, code, rv;
+	int          i = 0;
+	char         *sss_cache_args = NULL;
+	const char   *cmd = "/usr/sbin/sss_cache";
+	const char   *spawnedArgs[] = {"sss_cache", NULL, NULL};
+	const char   *spawnedEnv[] = {NULL};
+	struct stat  sb;
 
 	rv = stat(cmd, &sb);
 	if (rv == -1 && errno == ENOENT)

--- a/lib/string/strchr/stpcspn.c
+++ b/lib/string/strchr/stpcspn.c
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#include <config.h>
+
+#include "string/strchr/stpcspn.h"

--- a/lib/string/strchr/stpcspn.h
+++ b/lib/string/strchr/stpcspn.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#ifndef SHADOW_INCLUDE_LIB_STRING_STRCHR_STPCSPN_H_
+#define SHADOW_INCLUDE_LIB_STRING_STRCHR_STPCSPN_H_
+
+
+#include <config.h>
+
+#include <string.h>
+
+#include "attr.h"
+
+
+// Similar to strcspn(3), but return a pointer instead of an offset.
+// Similar to strchrnul(3), but search for several delimiters.
+// Similar to strpbrk(3), but return 's + strlen(s)' if not found.
+#define stpcspn(s, reject)                                                    \
+({                                                                            \
+	__auto_type  s_ = s;                                                  \
+                                                                              \
+	s_ + strcspn(s_, reject);                                             \
+})
+
+
+#endif  // include guard

--- a/lib/string/strchr/stpspn.c
+++ b/lib/string/strchr/stpspn.c
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#include <config.h>
+
+#include "string/strchr/stpspn.h"

--- a/lib/string/strchr/stpspn.h
+++ b/lib/string/strchr/stpspn.h
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#ifndef SHADOW_INCLUDE_LIB_STRING_STRCHR_STPSPN_H_
+#define SHADOW_INCLUDE_LIB_STRING_STRCHR_STPSPN_H_
+
+
+#include <config.h>
+
+#include <string.h>
+
+#include "attr.h"
+
+
+// Similar to strspn(3), but return a pointer instead of an offset.
+// Similar to strchrnul(3), but search for any bytes not in 'accept'.
+#define stpspn(s, accept)                                                     \
+({                                                                            \
+	__auto_type  s_ = s;                                                  \
+                                                                              \
+	s_ + strspn(s_, accept);                                              \
+})
+
+
+#endif  // include guard

--- a/lib/string/strchr/strnul.c
+++ b/lib/string/strchr/strnul.c
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#include <config.h>
+
+#include "string/strchr/strnul.h"

--- a/lib/string/strchr/strnul.h
+++ b/lib/string/strchr/strnul.h
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#ifndef SHADOW_INCLUDE_LIB_STRING_STRCHR_STRNUL_H_
+#define SHADOW_INCLUDE_LIB_STRING_STRCHR_STRNUL_H_
+
+
+#include <config.h>
+
+#include <string.h>
+
+#include "attr.h"
+
+
+// Similar to strlen(3), but return a pointer instead of an offset.
+#define strnul(s)                                                             \
+({                                                                            \
+	__auto_type  s_ = s;                                                  \
+                                                                              \
+	s_ + strlen(s_);                                                      \
+})
+
+
+#endif  // include guard

--- a/lib/string/strchr/strrspn.c
+++ b/lib/string/strchr/strrspn.c
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#include <config.h>
+
+#include "string/strchr/strrspn.h"
+
+
+extern inline char *strrspn(char *restrict s, const char *restrict accept);

--- a/lib/string/strchr/strrspn.h
+++ b/lib/string/strchr/strrspn.h
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#ifndef SHADOW_INCLUDE_LIB_STRING_STRCHR_STRRSPN_H_
+#define SHADOW_INCLUDE_LIB_STRING_STRCHR_STRRSPN_H_
+
+
+#include <config.h>
+
+#include <string.h>
+
+#include "attr.h"
+#include "string/strchr/strnul.h"
+
+
+ATTR_STRING(2)
+inline char *strrspn(char *restrict s, const char *restrict accept);
+
+
+// Available in Oracle Solaris: strrspn(3GEN).
+// <https://docs.oracle.com/cd/E36784_01/html/E36877/strrspn-3gen.html>
+inline char *
+strrspn(char *restrict s, const char *restrict accept)
+{
+	char  *p;
+
+	p = strnul(s);
+	while (p > s) {
+		p--;
+		if (strchr(accept, *p) == NULL)
+			return p + 1;
+	}
+	return s;
+}
+
+
+#endif  // include guard

--- a/lib/tcbfuncs.c
+++ b/lib/tcbfuncs.c
@@ -135,13 +135,13 @@ static /*@null@*/ char *shadowtcb_path_rel_existing (const char *name)
 	}
 	free (path);
 	if ((size_t)ret >= sizeof(link) - 1) {
-		link[sizeof(link) - 1] = '\0';
+		stpcpy(&link[sizeof(link) - 1], "");
 		fprintf (shadow_logfd,
 		         _("%s: Suspiciously long symlink: %s\n"),
 		         shadow_progname, link);
 		return NULL;
 	}
-	link[ret] = '\0';
+	stpcpy(&link[ret], "");
 	rval = strdup (link);
 	if (NULL == rval) {
 		OUT_OF_MEMORY;
@@ -200,7 +200,7 @@ static shadowtcb_status mkdir_leading (const char *name, uid_t uid)
 		goto out_free_path;
 	}
 	while ((ind = strchr (ptr, '/'))) {
-		*ind = '\0';
+		stpcpy(ind, "");
 		if (asprintf (&dir, TCB_DIR "/%s", path) == -1) {
 			OUT_OF_MEMORY;
 			return SHADOWTCB_FAILURE;
@@ -266,7 +266,7 @@ static shadowtcb_status rmdir_leading (char *path)
 	char *ind, *dir;
 	shadowtcb_status ret = SHADOWTCB_SUCCESS;
 	while ((ind = strrchr (path, '/'))) {
-		*ind = '\0';
+		stpcpy(ind, "");
 		if (asprintf (&dir, TCB_DIR "/%s", path) == -1) {
 			OUT_OF_MEMORY;
 			return SHADOWTCB_FAILURE;

--- a/lib/ttytype.c
+++ b/lib/ttytype.c
@@ -49,7 +49,7 @@ void ttytype (const char *line)
 			continue;
 		}
 
-		*strchrnul(buf, '\n') = '\0';
+		stpcpy(strchrnul(buf, '\n'), "");
 
 		if (   (sscanf (buf, "%1023s %1023s", type, port) == 2)
 		    && (strcmp (line, port) == 0)) {

--- a/lib/tz.c
+++ b/lib/tz.c
@@ -42,7 +42,7 @@
 
 		strcpy (tzbuf, def_tz);
 	} else {
-		*strchrnul(tzbuf, '\n') = '\0';
+		stpcpy(strchrnul(tzbuf, '\n'), "");
 	}
 
 	if (NULL != fp) {

--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -20,6 +20,7 @@
 #include <sys/socket.h>
 #include <netdb.h>
 #include <stdio.h>
+#include <string.h>
 #include <fcntl.h>
 
 #include "alloc/x/xcalloc.h"
@@ -46,7 +47,7 @@ is_my_tty(const char tty[UTX_LINESIZE])
 	/* tmptty shall be bigger than full_tty */
 	static char  tmptty[sizeof(full_tty) + 1];
 
-	full_tty[0] = '\0';
+	stpcpy(full_tty, "");
 	if (tty[0] != '/')
 		strcpy (full_tty, "/dev/");
 	strncat(full_tty, tty, UTX_LINESIZE);

--- a/src/chgpasswd.c
+++ b/src/chgpasswd.c
@@ -462,7 +462,7 @@ int main (int argc, char **argv)
 		line++;
 		cp = strrchr (buf, '\n');
 		if (NULL != cp) {
-			*cp = '\0';
+			stpcpy(cp, "");
 		} else {
 			fprintf (stderr, _("%s: line %d: line too long\n"),
 			         Prog, line);
@@ -482,7 +482,7 @@ int main (int argc, char **argv)
 		name = buf;
 		cp = strchr (name, ':');
 		if (NULL != cp) {
-			*cp = '\0';
+			stpcpy(cp, "");
 			cp++;
 		} else {
 			fprintf (stderr,

--- a/src/chpasswd.c
+++ b/src/chpasswd.c
@@ -503,7 +503,7 @@ int main (int argc, char **argv)
 		line++;
 		cp = strrchr (buf, '\n');
 		if (NULL != cp) {
-			*cp = '\0';
+			stpcpy(cp, "");
 		} else {
 			if (feof (stdin) == 0) {
 
@@ -535,8 +535,7 @@ int main (int argc, char **argv)
 		name = buf;
 		cp = strchr (name, ':');
 		if (NULL != cp) {
-			*cp = '\0';
-			cp++;
+			stpcpy(cp++, "");
 		} else {
 			fprintf (stderr,
 			         _("%s: line %d: missing new password\n"),

--- a/src/groupadd.c
+++ b/src/groupadd.c
@@ -431,7 +431,7 @@ static void process_flags (int argc, char **argv)
 				exit (E_BAD_ARG);
 			}
 			/* terminate name, point to value */
-			*cp++ = '\0';
+			stpcpy(cp++, "");
 			if (putdef_str (optarg, cp, NULL) < 0) {
 				exit (E_BAD_ARG);
 			}

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -57,6 +57,7 @@
 #include <arpa/inet.h>		/* for inet_ntoa() */
 
 #include "sizeof.h"
+#include "string/strchr/strrspn.h"
 
 #if !defined(MAXHOSTNAMELEN) || (MAXHOSTNAMELEN < 64)
 #undef MAXHOSTNAMELEN
@@ -110,10 +111,7 @@ int login_access (const char *user, const char *from)
 			if (line[0] == '#') {
 				continue;	/* comment line */
 			}
-			while (end > 0 && isspace (line[end - 1])) {
-				end--;
-			}
-			line[end] = '\0';	/* strip trailing whitespace */
+			*strrspn(line, " \t\n") = '\0';
 			if (line[0] == '\0') {	/* skip blank lines */
 				continue;
 			}

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -100,10 +100,8 @@ int login_access (const char *user, const char *from)
 		int lineno = 0;	/* for diagnostics */
 		while (   !match
 		       && (fgets (line, sizeof (line), fp) == line)) {
-			ptrdiff_t  end;
 			lineno++;
-			end = strlen (line) - 1;
-			if (line[0] == '\0' || line[end] != '\n') {
+			if (line[0] == '\0' || strchr(line, '\n') == NULL) {
 				SYSLOG ((LOG_ERR,
 					 "%s: line %d: missing newline or line too long",
 					 TABLE, lineno));

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -111,7 +111,7 @@ int login_access (const char *user, const char *from)
 			if (line[0] == '#') {
 				continue;	/* comment line */
 			}
-			*strrspn(line, " \t\n") = '\0';
+			stpcpy(strrspn(line, " \t\n"), "");
 			if (line[0] == '\0') {	/* skip blank lines */
 				continue;
 			}
@@ -182,7 +182,7 @@ static char *myhostname (void)
 
 	if (name[0] == '\0') {
 		gethostname (name, sizeof (name));
-		name[MAXHOSTNAMELEN] = '\0';
+		stpcpy(&name[MAXHOSTNAMELEN], "");
 	}
 	return (name);
 }
@@ -222,7 +222,7 @@ static bool user_match (const char *tok, const char *string)
 	 */
 	at = strchr (tok + 1, '@');
 	if (NULL != at) {	/* split user@host pattern */
-		*at = '\0';
+		stpcpy(at, "");
 		return (   user_match (tok, string)
 		        && from_match (at + 1, myhostname ()));
 #if HAVE_INNETGR

--- a/src/logoutd.c
+++ b/src/logoutd.c
@@ -200,11 +200,10 @@ main(int argc, char **argv)
 			}
 			/* child */
 
-			if (strncmp (ut->ut_line, "/dev/", 5) != 0) {
-				strcpy (tty_name, "/dev/");
-			} else {
-				tty_name[0] = '\0';
-			}
+			if (strncmp(ut->ut_line, "/dev/", 5) != 0)
+				strcpy(tty_name, "/dev/");
+			else
+				strcpy(tty_name, "");
 
 			STRNCAT(tty_name, ut->ut_line);
 #ifndef O_NOCTTY

--- a/src/newusers.c
+++ b/src/newusers.c
@@ -1107,9 +1107,8 @@ int main (int argc, char **argv)
 				 Prog, line);
 			fail_exit (EXIT_FAILURE);
 		}
-		if (cp != NULL) {
-			*cp = '\0';
-		}
+		if (cp != NULL)
+			stpcpy(cp, "");
 
 		/*
 		 * Break the string into fields and screw around with them.

--- a/src/passwd.c
+++ b/src/passwd.c
@@ -226,7 +226,7 @@ static int new_password (const struct passwd *pw)
 		erase_pass (clear);
 		strzero (cipher);
 	} else {
-		orig[0] = '\0';
+		strcpy(orig, "");
 	}
 
 	/*
@@ -514,9 +514,8 @@ static char *update_crypt_pw (char *cp)
 		}
 	}
 
-	if (dflg) {
-		*cp = '\0';
-	}
+	if (dflg)
+		strcpy(cp, "");
 
 	if (uflg && *cp == '!') {
 		if (cp[1] == '\0') {

--- a/src/suauth.c
+++ b/src/suauth.c
@@ -81,7 +81,7 @@ int check_su_auth (const char *actual_id,
 			continue;
 		}
 
-		*strrspn(temp, " \t\n") = '\0';
+		stpcpy(strrspn(temp, " \t\n"), "");
 
 		posn = 0;
 		while (temp[posn] == ' ' || temp[posn] == '\t')

--- a/src/suauth.c
+++ b/src/suauth.c
@@ -8,13 +8,17 @@
  */
 
 #include <config.h>
+
 #include <errno.h>
 #include <grp.h>
 #include <pwd.h>
 #include <stdio.h>
 #include <sys/types.h>
+
 #include "defines.h"
 #include "prototypes.h"
+#include "string/strchr/strrspn.h"
+
 
 #ifndef SUAUTHFILE
 #define SUAUTHFILE "/etc/suauth"
@@ -77,11 +81,7 @@ int check_su_auth (const char *actual_id,
 			continue;
 		}
 
-		while (endline > 0 && (temp[endline - 1] == ' '
-				       || temp[endline - 1] == '\t'
-				       || temp[endline - 1] == '\n'))
-			endline--;
-		temp[endline] = '\0';
+		*strrspn(temp, " \t\n") = '\0';
 
 		posn = 0;
 		while (temp[posn] == ' ' || temp[posn] == '\t')

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -361,7 +361,7 @@ static void get_defaults (void)
 	 * values are used, everything else can be ignored.
 	 */
 	while (fgets (buf, sizeof buf, fp) == buf) {
-		*strchrnul(buf, '\n') = '\0';
+		stpcpy(strchrnul(buf, '\n'), "");
 
 		cp = strchr (buf, '=');
 		if (NULL == cp) {
@@ -605,7 +605,7 @@ static int set_defaults (void)
 	while (fgets (buf, sizeof buf, ifp) == buf) {
 		cp = strrchr (buf, '\n');
 		if (NULL != cp) {
-			*cp = '\0';
+			stpcpy(cp, "");
 		} else {
 			/* A line which does not end with \n is only valid
 			 * at the end of the file.
@@ -1358,8 +1358,7 @@ static void process_flags (int argc, char **argv)
 					exit (E_BAD_ARG);
 				}
 				/* terminate name, point to value */
-				*cp = '\0';
-				cp++;
+				stpcpy(cp++, "");
 				if (putdef_str (optarg, cp, NULL) < 0) {
 					exit (E_BAD_ARG);
 				}
@@ -2223,7 +2222,7 @@ static void create_home (void)
 	if (access (prefix_user_home, F_OK) == 0)
 		return;
 
-	path[0] = '\0';
+	strcpy(path, "");
 	bhome = strdup(prefix_user_home);
 	if (!bhome) {
 		fprintf(stderr,
@@ -2269,7 +2268,7 @@ static void create_home (void)
 					Prog, path);
 				fail_exit(E_HOMEDIR);
 			}
-			btrfs_check[strlen(path) - strlen(cp) - 1] = '\0';
+			stpcpy(&btrfs_check[strlen(path) - strlen(cp) - 1], "");
 			if (is_btrfs(btrfs_check) <= 0) {
 				fprintf(stderr,
 					_("%s: home directory \"%s\" must be mounted on BTRFS\n"),

--- a/tests/unit/test_chkname.c
+++ b/tests/unit/test_chkname.c
@@ -139,10 +139,10 @@ test_is_valid_user_name_long(void **state)
 
 	memset(name, '_', max);
 
-	name[max] = '\0';
+	stpcpy(&name[max], "");
 	assert_true(false == is_valid_user_name(name));
 
-	name[max - 1] = '\0';
+	stpcpy(&name[max - 1], "");
 	assert_true(is_valid_user_name(name));
 
 	free(name);


### PR DESCRIPTION
---

Revisions:

<details>
<summary>v1b</summary>

-  Fix includes

```
$ git range-diff shadow/master gh/string string 
1:  3adb0ad0 = 1:  3adb0ad0 lib/string/strchr/: stp[rc]spn(), strnul(): Add macros and functions
2:  d91463be = 2:  d91463be lib/getdef.c: def_load(): Use stp[c]spn() instead of their patterns
3:  5670297a = 3:  5670297a src/login_nopam.c: login_access(): Simplify, calling strchr(3)
4:  9627b8e5 = 4:  9627b8e5 lib/sssd.c: Style fixes
5:  3e5fde30 ! 5:  66c757bb lib/, src/: Use stprspn() instead of its pattern
    @@ lib/fields.c
      #include <stdio.h>
     +
      #include "prototypes.h"
    -+#include "string/stpspn.h"
    ++#include "string/strchr/stprspn.h"
     +
      
      /*
    @@ lib/fields.c: void change_field (char *buf, size_t maxsize, const char *prompt)
                while (isspace (*cp)) {
     
      ## lib/getdef.c ##
    +@@
    + #include "string/sprintf/xasprintf.h"
    + #include "string/strchr/stpcspn.h"
    + #include "string/strchr/stpspn.h"
    ++#include "string/strchr/stprspn.h"
    + 
    + 
    + /*
     @@ lib/getdef.c: static void def_load (void)
      #else /* USE_ECONF */
      static void def_load (void)
    @@ src/login_nopam.c
      #include <arpa/inet.h>            /* for inet_ntoa() */
      
      #include "sizeof.h"
    -+#include "string/stpspn.h"
    ++#include "string/string/stprspn.h"
      
      #if !defined(MAXHOSTNAMELEN) || (MAXHOSTNAMELEN < 64)
      #undef MAXHOSTNAMELEN
    @@ src/suauth.c
     +
      #include "defines.h"
      #include "prototypes.h"
    -+#include "string/stpspn.h"
    ++#include "string/strchr/stprspn.h"
     +
      
      #ifndef SUAUTHFILE
6:  49fc8f79 = 6:  837f6557 contrib, lib/, src/, tests/: Use stpcpy(3) instead of its pattern
7:  9695c71b = 7:  13c5a064 contrib/adduser.c: main(): Use strcpy/cat(3) instead of their pattern
```
</details>

<details>
<summary>v1c</summary>

-  Add missing include

```
$ git range-diff shadow/master gh/string string 
1:  3adb0ad0 ! 1:  9b33f7d0 lib/string/strchr/: stp[rc]spn(), strnul(): Add macros and functions
    @@ lib/string/strchr/stprspn.h (new)
     +#include <string.h>
     +
     +#include "attr.h"
    ++#include "string/strchr/strnul.h"
     +
     +
     +// Similar to strspn(3), but start from the end, and return a pointer.
2:  d91463be = 2:  e9b74af9 lib/getdef.c: def_load(): Use stp[c]spn() instead of their patterns
3:  5670297a = 3:  ecc4ba88 src/login_nopam.c: login_access(): Simplify, calling strchr(3)
4:  9627b8e5 = 4:  1a7abdcf lib/sssd.c: Style fixes
5:  66c757bb = 5:  7b7baa54 lib/, src/: Use stprspn() instead of its pattern
6:  837f6557 = 6:  c2642082 contrib, lib/, src/, tests/: Use stpcpy(3) instead of its pattern
7:  13c5a064 = 7:  a90be944 contrib/adduser.c: main(): Use strcpy/cat(3) instead of their pattern
```
</details>

<details>
<summary>v1d</summary>

-  Fix include

```
$ git range-diff shadow/master gh/string string 
1:  9b33f7d0 = 1:  9b33f7d0 lib/string/strchr/: stp[rc]spn(), strnul(): Add macros and functions
2:  e9b74af9 = 2:  e9b74af9 lib/getdef.c: def_load(): Use stp[c]spn() instead of their patterns
3:  ecc4ba88 = 3:  ecc4ba88 src/login_nopam.c: login_access(): Simplify, calling strchr(3)
4:  1a7abdcf = 4:  1a7abdcf lib/sssd.c: Style fixes
5:  7b7baa54 ! 5:  9b00f777 lib/, src/: Use stprspn() instead of its pattern
    @@ src/login_nopam.c
      #include <arpa/inet.h>            /* for inet_ntoa() */
      
      #include "sizeof.h"
    -+#include "string/string/stprspn.h"
    ++#include "string/strchr/stprspn.h"
      
      #if !defined(MAXHOSTNAMELEN) || (MAXHOSTNAMELEN < 64)
      #undef MAXHOSTNAMELEN
6:  c2642082 = 6:  743030f7 contrib, lib/, src/, tests/: Use stpcpy(3) instead of its pattern
7:  a90be944 = 7:  00e6458f contrib/adduser.c: main(): Use strcpy/cat(3) instead of their pattern
```
</details>

<details>
<summary>v2</summary>

-  Add missing parameters (I had accidentally removed them while transforming some APIs from functions to macros),

```
$ git range-diff shadow/master gh/string string 
1:  9b33f7d0 ! 1:  f3b843ca lib/string/strchr/: stp[rc]spn(), strnul(): Add macros and functions
    @@ lib/string/strchr/stpcspn.h (new)
     +
     +
     +// Similar to strcspn(3), but return a pointer.
    -+#define stpcspn(s)                                                            \
    ++#define stpcspn(s, reject)                                                    \
     +({                                                                            \
     +  __auto_type  s_ = s;                                                  \
     +                                                                              \
    -+  s_ + strcspn(s_);                                                     \
    ++  s_ + strcspn(s_, reject);                                             \
     +})
     +
     +
    @@ lib/string/strchr/stpspn.h (new)
     +({                                                                            \
     +  __auto_type  s_ = s;                                                  \
     +                                                                              \
    -+  s_ + strspn(s_);                                                      \
    ++  s_ + strspn(s_, accept);                                              \
     +})
     +
     +
2:  e9b74af9 = 2:  b7eee949 lib/getdef.c: def_load(): Use stp[c]spn() instead of their patterns
3:  ecc4ba88 = 3:  0a5349d6 src/login_nopam.c: login_access(): Simplify, calling strchr(3)
4:  1a7abdcf = 4:  2801e87f lib/sssd.c: Style fixes
5:  9b00f777 = 5:  c033ab93 lib/, src/: Use stprspn() instead of its pattern
6:  743030f7 = 6:  1f1afc35 contrib, lib/, src/, tests/: Use stpcpy(3) instead of its pattern
7:  00e6458f = 7:  88c6cf98 contrib/adduser.c: main(): Use strcpy/cat(3) instead of their pattern
```
</details>

<details>
<summary>v2b</summary>

-  Add a few more cases

```
$ git range-diff shadow/master gh/string string 
1:  f3b843ca = 1:  f3b843ca lib/string/strchr/: stp[rc]spn(), strnul(): Add macros and functions
2:  b7eee949 = 2:  b7eee949 lib/getdef.c: def_load(): Use stp[c]spn() instead of their patterns
3:  0a5349d6 = 3:  0a5349d6 src/login_nopam.c: login_access(): Simplify, calling strchr(3)
4:  2801e87f = 4:  2801e87f lib/sssd.c: Style fixes
5:  c033ab93 = 5:  c033ab93 lib/, src/: Use stprspn() instead of its pattern
6:  1f1afc35 ! 6:  dcca5be5 contrib, lib/, src/, tests/: Use stpcpy(3) instead of its pattern
    @@ lib/getdate.y: static int LookupWord (char *buff)
          }
        else
          abbrev = false;
    +@@ lib/getdate.y: static int LookupWord (char *buff)
    +   i = strlen (buff) - 1;
    +   if (buff[i] == 's')
    +     {
    +-      buff[i] = '\0';
    ++      stpcpy(&buf[i], "");
    +       for (tp = UnitsTable; tp->name; tp++)
    +   if (strcmp (buff, tp->name) == 0)
    +     {
     @@ lib/getdate.y: static int LookupWord (char *buff)
            *p++ = *q;
          else
    @@ lib/obscure.c: static /*@observer@*//*@null@*/const char *obscure_msg (
      
     
      ## lib/port.c ##
    +@@ lib/port.c: again:
    +    * TTY devices.
    +    */
    + 
    +-  *strchrnul(buf, '\n') = '\0';
    ++  stpcpy(strchrnul(buf, '\n'), "");
    + 
    +   port.pt_names = ttys;
    +   for (cp = buf, j = 0; j < PORT_TTY; j++) {
     @@ lib/port.c: again:
                        break;
                }
    @@ lib/tcbfuncs.c: static /*@null@*/ char *shadowtcb_path_rel_existing (const char
        rval = strdup (link);
        if (NULL == rval) {
                OUT_OF_MEMORY;
    +@@ lib/tcbfuncs.c: static shadowtcb_status mkdir_leading (const char *name, uid_t uid)
    +           goto out_free_path;
    +   }
    +   while ((ind = strchr (ptr, '/'))) {
    +-          *ind = '\0';
    ++          stpcpy(ind, "");
    +           if (asprintf (&dir, TCB_DIR "/%s", path) == -1) {
    +                   OUT_OF_MEMORY;
    +                   return SHADOWTCB_FAILURE;
     @@ lib/tcbfuncs.c: static shadowtcb_status rmdir_leading (char *path)
        char *ind, *dir;
        shadowtcb_status ret = SHADOWTCB_SUCCESS;
7:  88c6cf98 = 7:  28c2e770 contrib/adduser.c: main(): Use strcpy/cat(3) instead of their pattern
```
</details>

<details>
<summary>v2c</summary>

- Fix typo introduced in v2b.

```
$ git range-diff shadow/master gh/string string 
1:  f3b843ca = 1:  f3b843ca lib/string/strchr/: stp[rc]spn(), strnul(): Add macros and functions
2:  b7eee949 = 2:  b7eee949 lib/getdef.c: def_load(): Use stp[c]spn() instead of their patterns
3:  0a5349d6 = 3:  0a5349d6 src/login_nopam.c: login_access(): Simplify, calling strchr(3)
4:  2801e87f = 4:  2801e87f lib/sssd.c: Style fixes
5:  c033ab93 = 5:  c033ab93 lib/, src/: Use stprspn() instead of its pattern
6:  dcca5be5 ! 6:  1b2e08d0 contrib, lib/, src/, tests/: Use stpcpy(3) instead of its pattern
    @@ lib/getdate.y: static int LookupWord (char *buff)
        if (buff[i] == 's')
          {
     -      buff[i] = '\0';
    -+      stpcpy(&buf[i], "");
    ++      stpcpy(&buff[i], "");
            for (tp = UnitsTable; tp->name; tp++)
        if (strcmp (buff, tp->name) == 0)
          {
7:  28c2e770 = 7:  470a9de3 contrib/adduser.c: main(): Use strcpy/cat(3) instead of their pattern
```
</details>

<details>
<summary>v2d</summary>

-  Rebase

```
$ git range-diff master..gh/string shadow/master..string 
1:  f3b843ca = 1:  eeff3e63 lib/string/strchr/: stp[rc]spn(), strnul(): Add macros and functions
2:  b7eee949 = 2:  460cae37 lib/getdef.c: def_load(): Use stp[c]spn() instead of their patterns
3:  0a5349d6 = 3:  33f5eed8 src/login_nopam.c: login_access(): Simplify, calling strchr(3)
4:  2801e87f = 4:  0866dd74 lib/sssd.c: Style fixes
5:  c033ab93 = 5:  f5930587 lib/, src/: Use stprspn() instead of its pattern
6:  1b2e08d0 = 6:  896d8843 contrib, lib/, src/, tests/: Use stpcpy(3) instead of its pattern
7:  470a9de3 = 7:  d6bfd265 contrib/adduser.c: main(): Use strcpy/cat(3) instead of their pattern
```
</details>

<details>
<summary>v2e</summary>

-  Describe the added functions and macros further by comparing them to well-known functions.

```
$ git range-diff master gh/string string 
1:  eeff3e63 ! 1:  d7cd8b88 lib/string/strchr/: stp[rc]spn(), strnul(): Add macros and functions
    @@ lib/string/strchr/stpcspn.h (new)
     +
     +
     +// Similar to strcspn(3), but return a pointer.
    ++// Similar to strchrnul(3), but search for several delimiters.
    ++// Similar to strpbrk(3), but return 's + strlen(s)' if not found.
     +#define stpcspn(s, reject)                                                    \
     +({                                                                            \
     +  __auto_type  s_ = s;                                                  \
    @@ lib/string/strchr/stprspn.h (new)
     +#include "string/strchr/strnul.h"
     +
     +
    -+// Similar to strspn(3), but start from the end, and return a pointer.
    ++// Similar to strspn(3),
    ++//  but start from the end, and return a pointer.
    ++// Similar to strrchr(3),
    ++//  but search for several delimiters, and return 's' if not found.
    ++// Identical to Solaris strrspn(3GEN),
    ++//  but I didn't like their choice of a name.
     +ATTR_STRING(2)
     +inline char *stprspn(char *restrict s, const char *restrict accept);
     +
    @@ lib/string/strchr/stpspn.h (new)
     +
     +
     +// Similar to strspn(3), but return a pointer.
    ++// Similar to strchrnul(3), but search for all bytes not in 'accept'.
     +#define stpspn(s, accept)                                                     \
     +({                                                                            \
     +  __auto_type  s_ = s;                                                  \
2:  460cae37 = 2:  36a95b16 lib/getdef.c: def_load(): Use stp[c]spn() instead of their patterns
3:  33f5eed8 = 3:  f9c7504f src/login_nopam.c: login_access(): Simplify, calling strchr(3)
4:  0866dd74 = 4:  3294c812 lib/sssd.c: Style fixes
5:  f5930587 = 5:  025353a6 lib/, src/: Use stprspn() instead of its pattern
6:  896d8843 = 6:  1963586f contrib, lib/, src/, tests/: Use stpcpy(3) instead of its pattern
7:  d6bfd265 = 7:  c39d3337 contrib/adduser.c: main(): Use strcpy/cat(3) instead of their pattern
```
</details>

<details>
<summary>v2f</summary>

-  Add link to Oracle Solaris documentation for strrspn(3GEN) in commit message.
-  wfix.

```
$ git range-diff master gh/string string 
1:  d7cd8b88 ! 1:  b0adba05 lib/string/strchr/: stp[rc]spn(), strnul(): Add macros and functions
    @@ Commit message
     
         Ofter, a pointer is more useful than a length when calling these.
     
    +    Link: <https://docs.oracle.com/cd/E86824_01/html/E54769/strrspn-3gen.html>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/Makefile.am ##
    @@ lib/string/strchr/stpspn.h (new)
     +
     +
     +// Similar to strspn(3), but return a pointer.
    -+// Similar to strchrnul(3), but search for all bytes not in 'accept'.
    ++// Similar to strchrnul(3), but search for any bytes not in 'accept'.
     +#define stpspn(s, accept)                                                     \
     +({                                                                            \
     +  __auto_type  s_ = s;                                                  \
2:  36a95b16 = 2:  732aa367 lib/getdef.c: def_load(): Use stp[c]spn() instead of their patterns
3:  f9c7504f = 3:  31a538e4 src/login_nopam.c: login_access(): Simplify, calling strchr(3)
4:  3294c812 = 4:  434a08aa lib/sssd.c: Style fixes
5:  025353a6 = 5:  36b9d865 lib/, src/: Use stprspn() instead of its pattern
6:  1963586f = 6:  bc99c740 contrib, lib/, src/, tests/: Use stpcpy(3) instead of its pattern
7:  c39d3337 = 7:  e15fd51a contrib/adduser.c: main(): Use strcpy/cat(3) instead of their pattern
```
</details>

<details>
<summary>v2g</summary>

-  s/Ofter/Often/  @hallyn 

```
$ git range-diff master gh/string string 
1:  b0adba05 ! 1:  2683f6c2 lib/string/strchr/: stp[rc]spn(), strnul(): Add macros and functions
    @@ Metadata
      ## Commit message ##
         lib/string/strchr/: stp[rc]spn(), strnul(): Add macros and functions
     
    -    Ofter, a pointer is more useful than a length when calling these.
    +    Often, a pointer is more useful than a length when calling these.
     
         Link: <https://docs.oracle.com/cd/E86824_01/html/E54769/strrspn-3gen.html>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
2:  732aa367 = 2:  77174000 lib/getdef.c: def_load(): Use stp[c]spn() instead of their patterns
3:  31a538e4 = 3:  ce484b83 src/login_nopam.c: login_access(): Simplify, calling strchr(3)
4:  434a08aa = 4:  3c6330b4 lib/sssd.c: Style fixes
5:  36b9d865 = 5:  8fb49c71 lib/, src/: Use stprspn() instead of its pattern
6:  bc99c740 = 6:  be17255e contrib, lib/, src/, tests/: Use stpcpy(3) instead of its pattern
7:  e15fd51a = 7:  d019faf8 contrib/adduser.c: main(): Use strcpy/cat(3) instead of their pattern
```
</details>

<details>
<summary>v2h</summary>

-  Move comments to function definition.

```
$ git range-diff master gh/string string 
1:  2683f6c2 ! 1:  96cffb93 lib/string/strchr/: stp[rc]spn(), strnul(): Add macros and functions
    @@ lib/string/strchr/stprspn.h (new)
     +#include "string/strchr/strnul.h"
     +
     +
    ++ATTR_STRING(2)
    ++inline char *stprspn(char *restrict s, const char *restrict accept);
    ++
    ++
     +// Similar to strspn(3),
     +//  but start from the end, and return a pointer.
     +// Similar to strrchr(3),
     +//  but search for several delimiters, and return 's' if not found.
     +// Identical to Solaris strrspn(3GEN),
     +//  but I didn't like their choice of a name.
    -+ATTR_STRING(2)
    -+inline char *stprspn(char *restrict s, const char *restrict accept);
    -+
    -+
     +inline char *
     +stprspn(char *restrict s, const char *restrict accept)
     +{
2:  77174000 = 2:  a8ef68a0 lib/getdef.c: def_load(): Use stp[c]spn() instead of their patterns
3:  ce484b83 = 3:  032bbbcb src/login_nopam.c: login_access(): Simplify, calling strchr(3)
4:  3c6330b4 = 4:  387d7330 lib/sssd.c: Style fixes
5:  8fb49c71 = 5:  7e97fc64 lib/, src/: Use stprspn() instead of its pattern
6:  be17255e = 6:  e25437bd contrib, lib/, src/, tests/: Use stpcpy(3) instead of its pattern
7:  d019faf8 = 7:  26867ae4 contrib/adduser.c: main(): Use strcpy/cat(3) instead of their pattern
```
</details>

<details>
<summary>v2i</summary>

-  wfix

```
$ git range-diff master gh/string string 
1:  96cffb93 ! 1:  bf20ab2e lib/string/strchr/: stp[rc]spn(), strnul(): Add macros and functions
    @@ lib/string/strchr/stprspn.h (new)
     +
     +
     +// Similar to strspn(3),
    -+//  but start from the end, and return a pointer.
    ++//  but start from the end and search backwards,
    ++//  and return a pointer.
     +// Similar to strrchr(3),
    -+//  but search for several delimiters, and return 's' if not found.
    ++//  but search for any bytes not in 'accept',
    ++//  and return a pointer to one after that, or 's' if not found.
     +// Identical to Solaris strrspn(3GEN),
     +//  but I didn't like their choice of a name.
     +inline char *
2:  a8ef68a0 = 2:  3c86bfca lib/getdef.c: def_load(): Use stp[c]spn() instead of their patterns
3:  032bbbcb = 3:  bb73e951 src/login_nopam.c: login_access(): Simplify, calling strchr(3)
4:  387d7330 = 4:  ca39eacd lib/sssd.c: Style fixes
5:  7e97fc64 = 5:  f9bc7177 lib/, src/: Use stprspn() instead of its pattern
6:  e25437bd = 6:  2bca8c14 contrib, lib/, src/, tests/: Use stpcpy(3) instead of its pattern
7:  26867ae4 = 7:  5e6666af contrib/adduser.c: main(): Use strcpy/cat(3) instead of their pattern
```
</details>

<details>
<summary>v3</summary>

-  Use Oracle Solaris name: strrspn(3GEN).  It's actually how these *spn() functions should have been designed from the start, since a length is useless.  That makes it easier to refer to them for documentation.

```
$ git range-diff master gh/string string 
1:  bf20ab2e ! 1:  303300ad lib/string/strchr/: stp[rc]spn(), strnul(): Add macros and functions
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/string/strchr/: stp[rc]spn(), strnul(): Add macros and functions
    +    lib/string/strchr/: stp[c]spn(), strrspn(), strnul(): Add macros and functions
     
         Often, a pointer is more useful than a length when calling these.
     
    @@ lib/Makefile.am: libshadow_la_SOURCES = \
        string/sprintf/xasprintf.h \
     +  string/strchr/stpcspn.c \
     +  string/strchr/stpcspn.h \
    -+  string/strchr/stprspn.c \
    -+  string/strchr/stprspn.h \
     +  string/strchr/stpspn.c \
     +  string/strchr/stpspn.h \
     +  string/strchr/strnul.c \
     +  string/strchr/strnul.h \
    ++  string/strchr/strrspn.c \
    ++  string/strchr/strrspn.h \
        string/strcpy/stpecpy.c \
        string/strcpy/stpecpy.h \
        string/strcpy/strncat.c \
    @@ lib/string/strchr/stpcspn.h (new)
     +})
     +
     +
    -+#endif  // include guard
    -
    - ## lib/string/strchr/stprspn.c (new) ##
    -@@
    -+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
    -+// SPDX-License-Identifier: BSD-3-Clause
    -+
    -+
    -+#include <config.h>
    -+
    -+#include "string/strchr/stpspn.h"
    -+
    -+
    -+extern inline char *stprspn(char *restrict s, const char *restrict accept);
    -
    - ## lib/string/strchr/stprspn.h (new) ##
    -@@
    -+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
    -+// SPDX-License-Identifier: BSD-3-Clause
    -+
    -+
    -+#ifndef SHADOW_INCLUDE_LIB_STRING_STRCHR_STPRSPN_H_
    -+#define SHADOW_INCLUDE_LIB_STRING_STRCHR_STPRSPN_H_
    -+
    -+
    -+#include <config.h>
    -+
    -+#include <string.h>
    -+
    -+#include "attr.h"
    -+#include "string/strchr/strnul.h"
    -+
    -+
    -+ATTR_STRING(2)
    -+inline char *stprspn(char *restrict s, const char *restrict accept);
    -+
    -+
    -+// Similar to strspn(3),
    -+//  but start from the end and search backwards,
    -+//  and return a pointer.
    -+// Similar to strrchr(3),
    -+//  but search for any bytes not in 'accept',
    -+//  and return a pointer to one after that, or 's' if not found.
    -+// Identical to Solaris strrspn(3GEN),
    -+//  but I didn't like their choice of a name.
    -+inline char *
    -+stprspn(char *restrict s, const char *restrict accept)
    -+{
    -+  char  *p;
    -+
    -+  p = strnul(s);
    -+  while (p > s) {
    -+          p--;
    -+          if (strchr(accept, *p) == NULL)
    -+                  return p + 1;
    -+  }
    -+  return s;
    -+}
    -+
    -+
     +#endif  // include guard
     
      ## lib/string/strchr/stpspn.c (new) ##
    @@ lib/string/strchr/strnul.h (new)
     +
     +
     +#endif  // include guard
    +
    + ## lib/string/strchr/strrspn.c (new) ##
    +@@
    ++// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
    ++// SPDX-License-Identifier: BSD-3-Clause
    ++
    ++
    ++#include <config.h>
    ++
    ++#include "string/strchr/strrspn.h"
    ++
    ++
    ++extern inline char *strrspn(char *restrict s, const char *restrict accept);
    +
    + ## lib/string/strchr/strrspn.h (new) ##
    +@@
    ++// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
    ++// SPDX-License-Identifier: BSD-3-Clause
    ++
    ++
    ++#ifndef SHADOW_INCLUDE_LIB_STRING_STRCHR_STRRSPN_H_
    ++#define SHADOW_INCLUDE_LIB_STRING_STRCHR_STRRSPN_H_
    ++
    ++
    ++#include <config.h>
    ++
    ++#include <string.h>
    ++
    ++#include "attr.h"
    ++#include "string/strchr/strnul.h"
    ++
    ++
    ++ATTR_STRING(2)
    ++inline char *strrspn(char *restrict s, const char *restrict accept);
    ++
    ++
    ++// Available in Oracle Solaris: strrspn(3GEN).
    ++// <https://docs.oracle.com/cd/E36784_01/html/E36877/strrspn-3gen.html>
    ++inline char *
    ++strrspn(char *restrict s, const char *restrict accept)
    ++{
    ++  char  *p;
    ++
    ++  p = strnul(s);
    ++  while (p > s) {
    ++          p--;
    ++          if (strchr(accept, *p) == NULL)
    ++                  return p + 1;
    ++  }
    ++  return s;
    ++}
    ++
    ++
    ++#endif  // include guard
2:  3c86bfca = 2:  b83b6904 lib/getdef.c: def_load(): Use stp[c]spn() instead of their patterns
3:  bb73e951 = 3:  88bf401a src/login_nopam.c: login_access(): Simplify, calling strchr(3)
4:  ca39eacd = 4:  97506539 lib/sssd.c: Style fixes
5:  f9bc7177 ! 5:  a30a2609 lib/, src/: Use stprspn() instead of its pattern
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/, src/: Use stprspn() instead of its pattern
    +    lib/, src/: Use strrspn() instead of its pattern
     
         This requires changing isspace(3) calls to an explicit accept string,
         and I chose " \t\n" for it (as is done in other parts of this project),
    @@ lib/fields.c
      #include <stdio.h>
     +
      #include "prototypes.h"
    -+#include "string/strchr/stprspn.h"
    ++#include "string/strchr/strrspn.h"
     +
      
      /*
    @@ lib/fields.c: void change_field (char *buf, size_t maxsize, const char *prompt)
     -                  cp--;
     -          }
     -          *cp = '\0';
    -+          *stprspn(newf, " \t\n") = '\0';
    ++          *strrspn(newf, " \t\n") = '\0';
      
                cp = newf;
                while (isspace (*cp)) {
    @@ lib/getdef.c
      #include "string/sprintf/xasprintf.h"
      #include "string/strchr/stpcspn.h"
      #include "string/strchr/stpspn.h"
    -+#include "string/strchr/stprspn.h"
    ++#include "string/strchr/strrspn.h"
      
      
      /*
    @@ lib/getdef.c: static void def_load (void)
     -          }
     -          i++;
     -          buf[i] = '\0';
    -+          *stprspn(buf, " \t\n") = '\0';
    ++          *strrspn(buf, " \t\n") = '\0';
      
                /*
                 * Break the line into two fields.
    @@ src/login_nopam.c
      #include <arpa/inet.h>            /* for inet_ntoa() */
      
      #include "sizeof.h"
    -+#include "string/strchr/stprspn.h"
    ++#include "string/strchr/strrspn.h"
      
      #if !defined(MAXHOSTNAMELEN) || (MAXHOSTNAMELEN < 64)
      #undef MAXHOSTNAMELEN
    @@ src/login_nopam.c: int login_access (const char *user, const char *from)
     -                          end--;
     -                  }
     -                  line[end] = '\0';       /* strip trailing whitespace */
    -+                  *stprspn(line, " \t\n") = '\0';
    ++                  *strrspn(line, " \t\n") = '\0';
                        if (line[0] == '\0') {  /* skip blank lines */
                                continue;
                        }
    @@ src/suauth.c
     +
      #include "defines.h"
      #include "prototypes.h"
    -+#include "string/strchr/stprspn.h"
    ++#include "string/strchr/strrspn.h"
     +
      
      #ifndef SUAUTHFILE
    @@ src/suauth.c: int check_su_auth (const char *actual_id,
     -                                 || temp[endline - 1] == '\n'))
     -                  endline--;
     -          temp[endline] = '\0';
    -+          *stprspn(temp, " \t\n") = '\0';
    ++          *strrspn(temp, " \t\n") = '\0';
      
                posn = 0;
                while (temp[posn] == ' ' || temp[posn] == '\t')
6:  2bca8c14 ! 6:  6831dbdf contrib, lib/, src/, tests/: Use stpcpy(3) instead of its pattern
    @@ lib/fields.c: void change_field (char *buf, size_t maxsize, const char *prompt)
                 * makes it possible to change the field to empty, by
                 * entering a space.  --marekm
                 */
    --          *stprspn(newf, " \t\n") = '\0';
    -+          stpcpy(stprspn(newf, " \t\n"), "");
    +-          *strrspn(newf, " \t\n") = '\0';
    ++          stpcpy(strrspn(newf, " \t\n"), "");
      
                cp = newf;
                while (isspace (*cp)) {
    @@ lib/getdef.c: static void def_load (void)
                /*
                 * Trim trailing whitespace.
                 */
    --          *stprspn(buf, " \t\n") = '\0';
    -+          stpcpy(stprspn(buf, " \t\n"), "");
    +-          *strrspn(buf, " \t\n") = '\0';
    ++          stpcpy(strrspn(buf, " \t\n"), "");
      
                /*
                 * Break the line into two fields.
    @@ src/login_nopam.c: int login_access (const char *user, const char *from)
                        if (line[0] == '#') {
                                continue;       /* comment line */
                        }
    --                  *stprspn(line, " \t\n") = '\0';
    -+                  stpcpy(stprspn(line, " \t\n"), "");
    +-                  *strrspn(line, " \t\n") = '\0';
    ++                  stpcpy(strrspn(line, " \t\n"), "");
                        if (line[0] == '\0') {  /* skip blank lines */
                                continue;
                        }
    @@ src/suauth.c: int check_su_auth (const char *actual_id,
                        continue;
                }
      
    --          *stprspn(temp, " \t\n") = '\0';
    -+          stpcpy(stprspn(temp, " \t\n"), "");
    +-          *strrspn(temp, " \t\n") = '\0';
    ++          stpcpy(strrspn(temp, " \t\n"), "");
      
                posn = 0;
                while (temp[posn] == ' ' || temp[posn] == '\t')
7:  5e6666af = 7:  bcc04a5d contrib/adduser.c: main(): Use strcpy/cat(3) instead of their pattern
```
</details>

<details>
<summary>v3b</summary>

-  wfix

```
$ git range-diff master gh/string string 
1:  303300ad ! 1:  53780f68 lib/string/strchr/: stp[c]spn(), strrspn(), strnul(): Add macros and functions
    @@ lib/string/strchr/stpcspn.h (new)
     +#include "attr.h"
     +
     +
    -+// Similar to strcspn(3), but return a pointer.
    ++// Similar to strcspn(3), but return a pointer instead of an offset.
     +// Similar to strchrnul(3), but search for several delimiters.
     +// Similar to strpbrk(3), but return 's + strlen(s)' if not found.
     +#define stpcspn(s, reject)                                                    \
    @@ lib/string/strchr/stpspn.h (new)
     +#include "attr.h"
     +
     +
    -+// Similar to strspn(3), but return a pointer.
    ++// Similar to strspn(3), but return a pointer instead of an offset.
     +// Similar to strchrnul(3), but search for any bytes not in 'accept'.
     +#define stpspn(s, accept)                                                     \
     +({                                                                            \
    @@ lib/string/strchr/strnul.h (new)
     +#include "attr.h"
     +
     +
    -+// Similar to strlen(3), but return a pointer.
    ++// Similar to strlen(3), but return a pointer instead of an offset.
     +#define strnul(s)                                                             \
     +({                                                                            \
     +  __auto_type  s_ = s;                                                  \
2:  b83b6904 = 2:  30951171 lib/getdef.c: def_load(): Use stp[c]spn() instead of their patterns
3:  88bf401a = 3:  2c6c6b32 src/login_nopam.c: login_access(): Simplify, calling strchr(3)
4:  97506539 = 4:  9f107526 lib/sssd.c: Style fixes
5:  a30a2609 = 5:  d65d9b98 lib/, src/: Use strrspn() instead of its pattern
6:  6831dbdf = 6:  5fe33f9e contrib, lib/, src/, tests/: Use stpcpy(3) instead of its pattern
7:  bcc04a5d = 7:  d35731a4 contrib/adduser.c: main(): Use strcpy/cat(3) instead of their pattern
```
</details>