### PR TITLE
Fix lib/port.c issues

### DIFF
--- a/lib/port.c
+++ b/lib/port.c
@@ -130,7 +130,7 @@ static struct port *getportent (void)
 	 *      - parse off a list of days and times
 	 */
 
-again:
+next:
 
 	/*
 	 * Get the next line and remove optional trailing '\n'.
@@ -142,7 +142,7 @@ again:
 		return 0;
 	}
 	if ('#' == buf[0]) {
-		goto again;
+		goto next;
 	}
 
 	/*
@@ -159,7 +159,7 @@ again:
 		port.pt_names[j] = cp;
 		cp = strpbrk(cp, ":,");
 		if (cp == NULL)
-			goto again;	/* line format error */
+			goto next;	/* line format error */
 
 		if (':' == *cp) {	/* end of tty name list */
 			break;
@@ -195,7 +195,7 @@ again:
 	}
 
 	if (':' != *cp) {
-		goto again;
+		goto next;
 	}
 
 	stpcpy(cp++, "");
@@ -292,7 +292,7 @@ again:
 		}
 
 		if (('-' != cp[i]) || (dtime > 2400) || ((dtime % 100) > 59)) {
-			goto again;
+			goto next;
 		}
 		port.pt_times[j].t_start = dtime;
 		cp = cp + i + 1;
@@ -304,7 +304,7 @@ again:
 		if (   ((',' != cp[i]) && ('\0' != cp[i]))
 		    || (dtime > 2400)
 		    || ((dtime % 100) > 59)) {
-			goto again;
+			goto next;
 		}
 
 		port.pt_times[j].t_end = dtime;

--- a/lib/port.c
+++ b/lib/port.c
@@ -147,17 +147,15 @@ next:
 	 * TTY devices.
 	 */
 
+	if (strchr(buf, ':') == NULL)
+		goto next;
+
 	port.pt_names = ttys;
 	for (cp = buf, j = 0; j < PORT_TTY; j++) {
 		port.pt_names[j] = cp;
 		cp = strpbrk(cp, ":,");
-		if (cp == NULL)
-			goto next;	/* line format error */
-
-		if (':' == *cp) {	/* end of tty name list */
+		if (':' == *cp)		/* end of tty name list */
 			break;
-		}
-
 		if (',' == *cp)		/* end of current tty name */
 			stpcpy(cp++, "");
 	}
@@ -170,6 +168,9 @@ next:
 	 * names.  The entry '*' is used to specify all usernames.
 	 * The last entry in the list is a NULL pointer.
 	 */
+
+	if (strchr(cp, ':') == NULL)
+		goto next;
 
 	if (':' != *cp) {
 		port.pt_users = users;

--- a/lib/port.c
+++ b/lib/port.c
@@ -338,10 +338,8 @@ static struct port *getttyuser (const char *tty, const char *user)
 	setportent ();
 
 	while ((port = getportent ()) != NULL) {
-		if (   (0 == port->pt_names)
-		    || (0 == port->pt_users)) {
+		if (NULL == port->pt_users)
 			continue;
-		}
 
 		for (i = 0; NULL != port->pt_names[i]; i++) {
 			if (portcmp (port->pt_names[i], tty) == 0) {

--- a/lib/port.c
+++ b/lib/port.c
@@ -320,33 +320,33 @@ next:
  *	entries are treated as an ordered list.
  */
 
-static struct port *getttyuser (const char *tty, const char *user)
+static struct port *
+getttyuser(const char *tty, const char *user)
 {
-	int i, j;
-	struct port *port;
+	struct port  *port;
 
-	setportent ();
+	setportent();
 
-	while ((port = getportent ()) != NULL) {
-		for (i = 0; NULL != port->pt_names[i]; i++) {
-			if (portcmp (port->pt_names[i], tty) == 0) {
+	while ((port = getportent()) != NULL) {
+		char  **ptn;
+		char  **ptu;
+
+		for (ptn = port->pt_names; *ptn != NULL; ptn++) {
+			if (portcmp(*ptn, tty) == 0)
 				break;
-			}
 		}
-		if (port->pt_names[i] == 0) {
+		if (*ptn == NULL)
 			continue;
-		}
 
-		for (j = 0; NULL != port->pt_users[j]; j++) {
-			if (   (strcmp (user, port->pt_users[j]) == 0)
-			    || (strcmp (port->pt_users[j], "*") == 0))
-			{
+		for (ptu = port->pt_users; *ptu != NULL; ptu++) {
+			if (strcmp(*ptu, user) == 0)
 				goto end;
-			}
+			if (strcmp(*ptu, "*") == 0)
+				goto end;
 		}
 	}
 end:
-	endportent ();
+	endportent();
 	return port;
 }
 

--- a/lib/port.c
+++ b/lib/port.c
@@ -353,15 +353,13 @@ static struct port *getttyuser (const char *tty, const char *user)
 
 		for (j = 0; NULL != port->pt_users[j]; j++) {
 			if (   (strcmp (user, port->pt_users[j]) == 0)
-			    || (strcmp (port->pt_users[j], "*") == 0)) {
-				break;
+			    || (strcmp (port->pt_users[j], "*") == 0))
+			{
+				goto end;
 			}
 		}
-
-		if (port->pt_users[j] != 0) {
-			break;
-		}
 	}
+end:
 	endportent ();
 	return port;
 }

--- a/lib/port.c
+++ b/lib/port.c
@@ -154,16 +154,16 @@ next:
 	for (cp = buf, j = 0; j < PORT_TTY; j++) {
 		port.pt_names[j] = cp;
 		cp = strpbrk(cp, ":,");
-		if (':' == *cp)		/* end of tty name list */
+		if (':' == *cp)
 			break;
-		if (',' == *cp)		/* end of current tty name */
+		if (',' == *cp)
 			stpcpy(cp++, "");
 	}
+	port.pt_names[j] = NULL;
 	if (':' != *cp)
 		goto next;
 
 	stpcpy(cp++, "");
-	port.pt_names[j] = NULL;
 
 	/*
 	 * Get the list of user names.  It is the second colon
@@ -175,21 +175,16 @@ next:
 	if (strchr(cp, ':') == NULL)
 		goto next;
 
-	if (':' != *cp) {
-		port.pt_users = users;
-		port.pt_users[0] = cp;
-
-		for (j = 1; ':' != *cp; cp++) {
-			if ((',' == *cp) && (j < PORT_IDS)) {
-				stpcpy(cp++, "");
-				port.pt_users[j] = cp;
-				j++;
-			}
-		}
-		port.pt_users[j] = 0;
-	} else {
-		port.pt_users = 0;
+	port.pt_users = users;
+	for (j = 0; j < PORT_IDS; j++) {
+		port.pt_users[j] = cp;
+		cp = strpbrk(cp, ":,");
+		if (':' == *cp)
+			break;
+		if (',' == *cp)
+			stpcpy(cp++, "");
 	}
+	port.pt_users[j] = NULL;
 	if (':' != *cp)
 		goto next;
 
@@ -333,15 +328,11 @@ static struct port *getttyuser (const char *tty, const char *user)
 	setportent ();
 
 	while ((port = getportent ()) != NULL) {
-		if (NULL == port->pt_users)
-			continue;
-
 		for (i = 0; NULL != port->pt_names[i]; i++) {
 			if (portcmp (port->pt_names[i], tty) == 0) {
 				break;
 			}
 		}
-
 		if (port->pt_names[i] == 0) {
 			continue;
 		}

--- a/lib/port.c
+++ b/lib/port.c
@@ -131,19 +131,14 @@ static struct port *getportent (void)
 	 */
 
 next:
-
-	/*
-	 * Get the next line and remove optional trailing '\n'.
-	 * Lines which begin with '#' are all ignored.
-	 */
-
-	if (fgets (buf, sizeof buf, ports) == 0) {
+	if (fgets(buf, sizeof(buf), ports) == NULL) {
 		errno = saveerr;
-		return 0;
+		return NULL;
 	}
-	if ('#' == buf[0]) {
+	if ('#' == buf[0])
 		goto next;
-	}
+
+	stpcpy(strchrnul(buf, '\n'), "");
 
 	/*
 	 * Get the name of the TTY device.  It is the first colon
@@ -151,8 +146,6 @@ next:
 	 * leading "/dev".  The entry '*' is used to specify all
 	 * TTY devices.
 	 */
-
-	stpcpy(strchrnul(buf, '\n'), "");
 
 	port.pt_names = ttys;
 	for (cp = buf, j = 0; j < PORT_TTY; j++) {

--- a/lib/port.c
+++ b/lib/port.c
@@ -159,6 +159,9 @@ next:
 		if (',' == *cp)		/* end of current tty name */
 			stpcpy(cp++, "");
 	}
+	if (':' != *cp)
+		goto next;
+
 	stpcpy(cp++, "");
 	port.pt_names[j] = NULL;
 
@@ -187,10 +190,8 @@ next:
 	} else {
 		port.pt_users = 0;
 	}
-
-	if (':' != *cp) {
+	if (':' != *cp)
 		goto next;
-	}
 
 	stpcpy(cp++, "");
 

--- a/lib/port.c
+++ b/lib/port.c
@@ -94,17 +94,21 @@ static void endportent (void)
  *	set to EINVAL on error to distinguish the two conditions.
  */
 
-static struct port *getportent (void)
+static struct port *
+getportent(void)
 {
-	static struct port port;	/* static struct to point to         */
-	static char buf[BUFSIZ];	/* some space for stuff              */
-	static char *ttys[PORT_TTY + 1];	/* some pointers to tty names     */
-	static char *users[PORT_IDS + 1];	/* some pointers to user ids     */
-	static struct pt_time ptimes[PORT_TIMES + 1];	/* time ranges         */
-	char *cp;		/* pointer into line                 */
-	int dtime;		/* scratch time of day               */
-	int i, j;
-	int saveerr = errno;	/* errno value on entry              */
+	int   dtime;
+	int   i, j;
+	int   saveerr;
+	char  *cp;
+
+	static char            buf[BUFSIZ];
+	static char            *ttys[PORT_TTY + 1];
+	static char            *users[PORT_IDS + 1];
+	static struct port     port;
+	static struct pt_time  ptimes[PORT_TIMES + 1];
+
+	saveerr = errno;
 
 	/*
 	 * If the ports file is not open, open the file.  Do not rewind


### PR DESCRIPTION
Closes: <https://github.com/shadow-maint/shadow/issues/1036>

---

Revisions:

<details>
<summary>v1b</summary>

-  tfix

```
$ git range-diff string gh/port port 
1:  9c18ae98 = 1:  9c18ae98 lib/port.c: getttyuser(): Remove dead code
2:  eee9766c = 2:  eee9766c lib/port.c: getttyuser(): Use goto to break out of nested loops
3:  7494e4bc = 3:  7494e4bc lib/port.c: getportent(): Rename goto label
4:  4d43f0bf = 4:  4d43f0bf lib/port.c: getportent(): Remove obvious comments
5:  c47a94e5 ! 5:  08bbebb3 lib/port.c: getportent(): Make sure there are at least 2 ':' in the line
    @@ lib/port.c: next:
         * TTY devices.
         */
      
    -+  if (strchr(cp, ":") == NULL)
    ++  if (strchr(cp, ':') == NULL)
     +          goto next;
     +
        port.pt_names = ttys;
    @@ lib/port.c: next:
         * The last entry in the list is a NULL pointer.
         */
      
    -+  if (strchr(cp, ":") == NULL)
    ++  if (strchr(cp, ':') == NULL)
     +          goto next;
     +
        if (':' != *cp) {
6:  730b12e7 = 6:  5f76b80a lib/port.c: getportent(): Make sure the aren't too many fields in the CSV
7:  d89b96c0 ! 7:  c85f44de lib/port.c: getportent(): Use equivalent code to parse equally-formatted fields
    @@ lib/port.c: next:
        /*
         * Get the list of user names.  It is the second colon
     @@ lib/port.c: next:
    -   if (strchr(cp, ":") == NULL)
    +   if (strchr(cp, ':') == NULL)
                goto next;
      
     -  if (':' != *cp) {
8:  424423b7 = 8:  156d21b5 lib/port.c: getttyuser(): Use pointer arithmetic to simplify
```
</details>

<details>
<summary>v1c</summary>

-  Rebase

```
$ git range-diff 9c18ae98^..gh/port string..port 
1:  9c18ae98 = 1:  259fa993 lib/port.c: getttyuser(): Remove dead code
2:  eee9766c = 2:  7cf7edb6 lib/port.c: getttyuser(): Use goto to break out of nested loops
3:  7494e4bc = 3:  e2658dd4 lib/port.c: getportent(): Rename goto label
4:  4d43f0bf ! 4:  d40831e8 lib/port.c: getportent(): Remove obvious comments
    @@ lib/port.c: static struct port *getportent (void)
                goto next;
     -  }
     +
    -+  *strchrnul(buf, '\n') = '\0';
    ++  stpcpy(strchrnul(buf, '\n'), "");
      
        /*
         * Get the name of the TTY device.  It is the first colon
    @@ lib/port.c: next:
         * TTY devices.
         */
      
    --  *strchrnul(buf, '\n') = '\0';
    +-  stpcpy(strchrnul(buf, '\n'), "");
     -
        port.pt_names = ttys;
        for (cp = buf, j = 0; j < PORT_TTY; j++) {
5:  08bbebb3 = 5:  0e695174 lib/port.c: getportent(): Make sure there are at least 2 ':' in the line
6:  5f76b80a = 6:  8c24a030 lib/port.c: getportent(): Make sure the aren't too many fields in the CSV
7:  c85f44de = 7:  6cc67d2c lib/port.c: getportent(): Use equivalent code to parse equally-formatted fields
8:  156d21b5 = 8:  24ed30e1 lib/port.c: getttyuser(): Use pointer arithmetic to simplify
```
</details>

<details>
<summary>v1d</summary>

-  Rebase

```
$ git range-diff gh/string..gh/port string..port 
1:  259fa993 = 1:  8777e91e lib/port.c: getttyuser(): Remove dead code
2:  7cf7edb6 = 2:  c071c9ca lib/port.c: getttyuser(): Use goto to break out of nested loops
3:  e2658dd4 = 3:  f043203f lib/port.c: getportent(): Rename goto label
4:  d40831e8 = 4:  265a42ad lib/port.c: getportent(): Remove obvious comments
5:  0e695174 = 5:  f5e4be59 lib/port.c: getportent(): Make sure there are at least 2 ':' in the line
6:  8c24a030 = 6:  2fd4d747 lib/port.c: getportent(): Make sure the aren't too many fields in the CSV
7:  6cc67d2c = 7:  76023010 lib/port.c: getportent(): Use equivalent code to parse equally-formatted fields
8:  24ed30e1 = 8:  7446c282 lib/port.c: getttyuser(): Use pointer arithmetic to simplify
```
</details>

<details>
<summary>v2</summary>

-  Fix typo.
-  Use strsep(3) to simplify

```
$ git range-diff string gh/port port 
 1:  8777e91e =  1:  8777e91e lib/port.c: getttyuser(): Remove dead code
 2:  c071c9ca =  2:  c071c9ca lib/port.c: getttyuser(): Use goto to break out of nested loops
 3:  f043203f =  3:  f043203f lib/port.c: getportent(): Rename goto label
 4:  265a42ad =  4:  265a42ad lib/port.c: getportent(): Remove obvious comments
 5:  f5e4be59 !  5:  61fe7a00 lib/port.c: getportent(): Make sure there are at least 2 ':' in the line
    @@ lib/port.c: next:
         * TTY devices.
         */
      
    -+  if (strchr(cp, ':') == NULL)
    ++  if (strchr(buf, ':') == NULL)
     +          goto next;
     +
        port.pt_names = ttys;
 6:  2fd4d747 =  6:  92ab5c47 lib/port.c: getportent(): Make sure the aren't too many fields in the CSV
 7:  76023010 =  7:  2358cba9 lib/port.c: getportent(): Use equivalent code to parse equally-formatted fields
 8:  7446c282 =  8:  4e18ed4c lib/port.c: getttyuser(): Use pointer arithmetic to simplify
 -:  -------- >  9:  ed43e774 lib/port.c: getportent(): Align variables
 -:  -------- > 10:  f38e7d58 lib/port.c: getportent(): Use strsep(3) instead of its pattern
```
</details>

<details>
<summary>v2b</summary>

-  Rebase

```
$ git range-diff gh/string..gh/port string..port 
 1:  8777e91e =  1:  4272a71d lib/port.c: getttyuser(): Remove dead code
 2:  c071c9ca =  2:  af0d7aa3 lib/port.c: getttyuser(): Use goto to break out of nested loops
 3:  f043203f =  3:  d955ed89 lib/port.c: getportent(): Rename goto label
 4:  265a42ad =  4:  8a583189 lib/port.c: getportent(): Remove obvious comments
 5:  61fe7a00 =  5:  a49c9193 lib/port.c: getportent(): Make sure there are at least 2 ':' in the line
 6:  92ab5c47 =  6:  c9d0ba17 lib/port.c: getportent(): Make sure the aren't too many fields in the CSV
 7:  2358cba9 =  7:  602b6363 lib/port.c: getportent(): Use equivalent code to parse equally-formatted fields
 8:  4e18ed4c =  8:  287722d5 lib/port.c: getttyuser(): Use pointer arithmetic to simplify
 9:  ed43e774 =  9:  bdb44469 lib/port.c: getportent(): Align variables
10:  f38e7d58 = 10:  b555c046 lib/port.c: getportent(): Use strsep(3) instead of its pattern
```
</details>

<details>
<summary>v2c</summary>

-  Rebase

```
$ git range-diff 4272a71d^..gh/port string..port 
 1:  4272a71d =  1:  77221a0b lib/port.c: getttyuser(): Remove dead code
 2:  af0d7aa3 =  2:  a8d4a0be lib/port.c: getttyuser(): Use goto to break out of nested loops
 3:  d955ed89 =  3:  3fc399e9 lib/port.c: getportent(): Rename goto label
 4:  8a583189 =  4:  7b88f533 lib/port.c: getportent(): Remove obvious comments
 5:  a49c9193 =  5:  ce972d67 lib/port.c: getportent(): Make sure there are at least 2 ':' in the line
 6:  c9d0ba17 =  6:  ae60c105 lib/port.c: getportent(): Make sure the aren't too many fields in the CSV
 7:  602b6363 =  7:  75d52d74 lib/port.c: getportent(): Use equivalent code to parse equally-formatted fields
 8:  287722d5 =  8:  28142c1c lib/port.c: getttyuser(): Use pointer arithmetic to simplify
 9:  bdb44469 =  9:  8e0daccd lib/port.c: getportent(): Align variables
10:  b555c046 = 10:  a7ba79e4 lib/port.c: getportent(): Use strsep(3) instead of its pattern
```
</details>

<details>
<summary>v2d</summary>

-  Rebase

```
$ git range-diff 77221a0b^..gh/port shadow/master..port 
 1:  77221a0b =  1:  04229ae8 lib/port.c: getttyuser(): Remove dead code
 2:  a8d4a0be =  2:  08d9c883 lib/port.c: getttyuser(): Use goto to break out of nested loops
 3:  3fc399e9 =  3:  34386a8f lib/port.c: getportent(): Rename goto label
 4:  7b88f533 =  4:  c1800b35 lib/port.c: getportent(): Remove obvious comments
 5:  ce972d67 =  5:  6d509bc0 lib/port.c: getportent(): Make sure there are at least 2 ':' in the line
 6:  ae60c105 =  6:  b72e4440 lib/port.c: getportent(): Make sure the aren't too many fields in the CSV
 7:  75d52d74 =  7:  7cdf4542 lib/port.c: getportent(): Use equivalent code to parse equally-formatted fields
 8:  28142c1c =  8:  57a7d3a0 lib/port.c: getttyuser(): Use pointer arithmetic to simplify
 9:  8e0daccd =  9:  dc935c48 lib/port.c: getportent(): Align variables
10:  a7ba79e4 = 10:  a9045016 lib/port.c: getportent(): Use strsep(3) instead of its pattern
```
</details>

<details>
<summary>v2e</summary>

-  Detail commit message

```
$ git range-diff master gh/port port 
 1:  04229ae8 =  1:  04229ae8 lib/port.c: getttyuser(): Remove dead code
 2:  08d9c883 =  2:  08d9c883 lib/port.c: getttyuser(): Use goto to break out of nested loops
 3:  34386a8f =  3:  34386a8f lib/port.c: getportent(): Rename goto label
 4:  c1800b35 =  4:  c1800b35 lib/port.c: getportent(): Remove obvious comments
 5:  6d509bc0 =  5:  6d509bc0 lib/port.c: getportent(): Make sure there are at least 2 ':' in the line
 6:  b72e4440 !  6:  9eb6c496 lib/port.c: getportent(): Make sure the aren't too many fields in the CSV
    @@ Commit message
     
         Otherwise, the line is invalidly formatted, and we ignore it.
     
    +    Detailed explanation:
    +
    +    There are two conditions on which we break out of the loops that precede
    +    these added checks:
    +
    +    -  j is too big (we've exhausted the space in the static arrays)
    +
    +            $ grep -r -e PORT_TTY -e PORT_IDS lib/port.*
    +            lib/port.c:     static char *ttys[PORT_TTY + 1];        /* some pointers to tty names     */
    +            lib/port.c:     static char *users[PORT_IDS + 1];       /* some pointers to user ids     */
    +            lib/port.c:     for (cp = buf, j = 0; j < PORT_TTY; j++) {
    +            lib/port.c:                     if ((',' == *cp) && (j < PORT_IDS)) {
    +            lib/port.h: * PORT_IDS - Allowable number of IDs per entry.
    +            lib/port.h: * PORT_TTY - Allowable number of TTYs per entry.
    +            lib/port.h:#define      PORT_IDS        64
    +            lib/port.h:#define      PORT_TTY        64
    +
    +    -  strpbrk(3) found a ':', which signals the end of the outer
    +       colon-separated list.
    +
    +    If the first character in the remainder of the string is not a ':', it
    +    means we've exhausted the array size, but the CSV string was longer, so
    +    we'd be truncating it.  Consider the entire line invalid, and skip it.
    +
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/port.c ##
 7:  7cdf4542 =  7:  c65299f1 lib/port.c: getportent(): Use equivalent code to parse equally-formatted fields
 8:  57a7d3a0 =  8:  058beb58 lib/port.c: getttyuser(): Use pointer arithmetic to simplify
 9:  dc935c48 =  9:  a9582a8a lib/port.c: getportent(): Align variables
10:  a9045016 = 10:  9f88eb69 lib/port.c: getportent(): Use strsep(3) instead of its pattern
```
</details>

<details>
<summary>v2f</summary>

-  wfix

```
$ git range-diff master gh/port port 
 1:  04229ae8 =  1:  04229ae8 lib/port.c: getttyuser(): Remove dead code
 2:  08d9c883 =  2:  08d9c883 lib/port.c: getttyuser(): Use goto to break out of nested loops
 3:  34386a8f =  3:  34386a8f lib/port.c: getportent(): Rename goto label
 4:  c1800b35 =  4:  c1800b35 lib/port.c: getportent(): Remove obvious comments
 5:  6d509bc0 =  5:  6d509bc0 lib/port.c: getportent(): Make sure there are at least 2 ':' in the line
 6:  9eb6c496 !  6:  53602f8b lib/port.c: getportent(): Make sure the aren't too many fields in the CSV
    @@ Commit message
                 lib/port.h:#define      PORT_IDS        64
                 lib/port.h:#define      PORT_TTY        64
     
    -    -  strpbrk(3) found a ':', which signals the end of the outer
    -       colon-separated list.
    +    -  strpbrk(3) found a ':', which signals the end of the comma-sepatated
    +       list, and the start of the next colon-separated field.
     
         If the first character in the remainder of the string is not a ':', it
    -    means we've exhausted the array size, but the CSV string was longer, so
    +    means we've exhausted the array size, but the CSV list was longer, so
         we'd be truncating it.  Consider the entire line invalid, and skip it.
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
 7:  c65299f1 =  7:  d6073f28 lib/port.c: getportent(): Use equivalent code to parse equally-formatted fields
 8:  058beb58 =  8:  fa2b3ac2 lib/port.c: getttyuser(): Use pointer arithmetic to simplify
 9:  a9582a8a =  9:  fe878354 lib/port.c: getportent(): Align variables
10:  9f88eb69 = 10:  7d721a07 lib/port.c: getportent(): Use strsep(3) instead of its pattern
```
</details>