### PR TITLE
Include stdint.h for UINT16_MAX/UINT32_MAX

### DIFF
--- a/lib/find_new_gid.c
+++ b/lib/find_new_gid.c
@@ -9,6 +9,7 @@
 #include <config.h>
 
 #include <assert.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <errno.h>
 

--- a/lib/find_new_uid.c
+++ b/lib/find_new_uid.c
@@ -9,6 +9,7 @@
 #include <config.h>
 
 #include <assert.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <errno.h>
 


### PR DESCRIPTION
Without this, building fails:

```
/bin/bash ../libtool  --tag=CC   --mode=compile gcc  -I. -I..    -I..   -lcrypt  -g -O2 -MT libshadow_la-find_new_gid.lo -MD -MP -MF .deps/libshadow_la-find_new_gid.Tpo -c -o libshadow_la-find_new_gid.lo `test -f 'find_new_gid.c' || echo './'`find_new_gid.c
libtool: compile:  gcc -I. -I.. -I.. -lcrypt -g -O2 -MT libshadow_la-find_new_gid.lo -MD -MP -MF .deps/libshadow_la-find_new_gid.Tpo -c find_new_gid.c  -fPIC -DPIC -o .libs/libshadow_la-find_new_gid.o
find_new_gid.c: In function 'check_gid':
find_new_gid.c:117:20: error: 'UINT16_MAX' undeclared (first use in this function)
  117 |         if (gid == UINT16_MAX || gid == UINT32_MAX) {
      |                    ^~~~~~~~~~
find_new_gid.c:20:1: note: 'UINT16_MAX' is defined in header '<stdint.h>'; did you forget to '#include <stdint.h>'?
   19 | #include "shadowlog.h"
  +++ |+#include <stdint.h>
   20 |
find_new_gid.c:117:20: note: each undeclared identifier is reported only once for each function it appears in
  117 |         if (gid == UINT16_MAX || gid == UINT32_MAX) {
      |                    ^~~~~~~~~~
find_new_gid.c:117:41: error: 'UINT32_MAX' undeclared (first use in this function)
  117 |         if (gid == UINT16_MAX || gid == UINT32_MAX) {
      |                                         ^~~~~~~~~~
find_new_gid.c:117:41: note: 'UINT32_MAX' is defined in header '<stdint.h>'; did you forget to '#include <stdint.h>'?
```

```
% gcc --version
gcc (Debian 12.2.0-14) 12.2.0

libc6:arm64    2.36-9+deb12u4
```
