### PR TITLE
lib/, src/: Use consistent style using strchr(3) in conditionals

### DIFF
--- a/lib/env.c
+++ b/lib/env.c
@@ -226,9 +226,9 @@ void sanitize_env (void)
 			if (!strprefix(*cur, *bad)) {
 				continue;
 			}
-			if (strchr (*cur, '/') == NULL) {
+			if (!strchr(*cur, '/'))
 				continue;	/* OK */
-			}
+
 			for (move = cur; NULL != *move; move++) {
 				*move = *(move + 1);
 			}

--- a/lib/obscure.c
+++ b/lib/obscure.c
@@ -13,6 +13,7 @@
 
 #include <ctype.h>
 #include <stdio.h>
+#include <string.h>
 
 #include "attr.h"
 #include "prototypes.h"
@@ -66,9 +67,8 @@ static bool similar (/*@notnull@*/const char *old, /*@notnull@*/const char *new)
 	}
 
 	for (i = j = 0; ('\0' != new[i]) && ('\0' != old[i]); i++) {
-		if (strchr (new, old[i]) != NULL) {
+		if (strchr(new, old[i]))
 			j++;
-		}
 	}
 
 	if (i >= j * 2) {

--- a/lib/setupenv.c
+++ b/lib/setupenv.c
@@ -235,7 +235,7 @@ void setup_env (struct passwd *info)
 	if (NULL == cp) {
 		/* not specified, use a minimal default */
 		addenv ((info->pw_uid == 0) ? "PATH=/sbin:/bin:/usr/sbin:/usr/bin" : "PATH=/bin:/usr/bin", NULL);
-	} else if (strchr (cp, '=')) {
+	} else if (strchr(cp, '=')) {
 		/* specified as name=value (PATH=...) */
 		addenv (cp, NULL);
 	} else {

--- a/lib/tcbfuncs.c
+++ b/lib/tcbfuncs.c
@@ -189,7 +189,7 @@ static shadowtcb_status mkdir_leading (const char *name, uid_t uid)
 		         shadow_progname, TCB_DIR, strerror (errno));
 		goto out_free_path;
 	}
-	while ((ind = strchr (ptr, '/'))) {
+	while (NULL != (ind = strchr(ptr, '/'))) {
 		stpcpy(ind, "");
 		dir = aprintf(TCB_DIR "/%s", path);
 		if (dir == NULL) {

--- a/src/chfn.c
+++ b/src/chfn.c
@@ -15,6 +15,7 @@
 #include <pwd.h>
 #include <signal.h>
 #include <stdio.h>
+#include <string.h>
 #include <sys/types.h>
 #include <getopt.h>
 
@@ -159,9 +160,8 @@ static bool may_change_field (int field)
 		cp = "frwh";
 	}
 
-	if (strchr (cp, field) != NULL) {
+	if (strchr(cp, field))
 		return true;
-	}
 
 	return false;
 }

--- a/src/chpasswd.c
+++ b/src/chpasswd.c
@@ -17,6 +17,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #ifdef USE_PAM
 #include "pam_defs.h"
@@ -510,10 +511,8 @@ int main (int argc, char **argv)
 			if (feof (stdin) == 0) {
 				// Drop all remaining characters on this line.
 				while (fgets (buf, sizeof buf, stdin) != NULL) {
-					cp = strchr (buf, '\n');
-					if (cp != NULL) {
+					if (strchr(buf, '\n'))
 						break;
-					}
 				}
 
 				fprintf (stderr,

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -315,9 +315,8 @@ static bool from_match (char *tok, const char *string)
 			return true;
 		}
 	} else if (strcaseeq(tok, "LOCAL")) {	/* LOCAL: no dots */
-		if (strchr (string, '.') == NULL) {
+		if (!strchr(string, '.'))
 			return true;
-		}
 	} else if (   (!streq(tok, "") && tok[strlen(tok) - 1] == '.') /* network */
 		   && strprefix(resolve_hostname(string), tok)) {
 		return true;

--- a/src/su.c
+++ b/src/su.c
@@ -951,7 +951,7 @@ static void set_environment (struct passwd *pw)
 	cp = getdef_str ((pw->pw_uid == 0) ? "ENV_SUPATH" : "ENV_PATH");
 	if (NULL == cp) {
 		addenv ((pw->pw_uid == 0) ? "PATH=/sbin:/bin:/usr/sbin:/usr/bin" : "PATH=/bin:/usr/bin", NULL);
-	} else if (strchr (cp, '=') != NULL) {
+	} else if (strchr(cp, '=')) {
 		addenv (cp, NULL);
 	} else {
 		addenv ("PATH", cp);


### PR DESCRIPTION
Among other things, remove most uses of strtok(3).  Replace its calls by strsep(3), which is stateless.

This probably silently fixes some bugs, where two separators were being merged as the same one.

Also, that's the reason why I didn't replace all strtok(3) calls.  In some cases (paths), it makes sense to merge adjacent `//`.

----

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git range-diff master..gh/string shadow/master..string 
 1:  5ba4cfca !  1:  e825c03e lib/, src/: Use stpspn() instead of its pattern
    @@ lib/getdate.y: yylex (void)
     
      ## lib/limits.c ##
     @@
    - #include "atoi/a2i.h"
    - #include "atoi/str2i.h"
    + #include "atoi/str2i/str2s.h"
    + #include "atoi/str2i/str2u.h"
      #include "memzero.h"
     +#include "string/strchr/stpspn.h"
      #include "typetraits.h"
    @@ lib/strtoday.c
     @@
      #ident "$Id$"
      
    - #include "atoi/str2i.h"
    + #include "atoi/str2i/str2s.h"
     -#include "prototypes.h"
      #include "getdate.h"
     +#include "prototypes.h"
 2:  f5cde8a7 =  2:  e7710fda lib/port.c: portcmp(): Use strcmp(3) instead of its pattern
 3:  009a6aaa =  3:  13ff7c5a lib/gshadow.c: endsgent(): Remove dead assignment
 4:  49317790 =  4:  f090d6c3 src/suauth.c: check_su_auth(): Use strspn(3) instead of its pattern
 5:  1e064044 =  5:  526c8f72 src/suauth.c: check_su_auth(): Use pointers to simplify
 6:  faae7f68 =  6:  30835d33 lib/, src/: Use strsep(3) instead of strtok(3)
 7:  edd0e442 =  7:  e4213fdf lib/loginprompt.c: login_prompt(): Use strtcpy() instead of its pattern
 8:  0cd40e34 =  8:  446541e1 contrib/, lib/, src/: Use strchr(3) to compact comparisons
 9:  c960c5f9 !  9:  946d07ca lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
    @@ lib/getrange.c
      #include <stdlib.h>
     +#include <string.h>
      
    - #include "atoi/a2i.h"
    + #include "atoi/a2i/a2u.h"
      #include "defines.h"
     @@ lib/getrange.c: getrange(const char *range,
                return 0;  /* <long> */
    @@ lib/strtoday.c
     -#ident "$Id$"
     +#include <string.h>
      
    - #include "atoi/str2i.h"
    + #include "atoi/str2i/str2s.h"
      #include "getdate.h"
     @@
       *        24-sep-72
10:  fbbbd797 = 10:  da0b2f80 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
11:  812cbae4 = 11:  4d80b61b lib/fields.c: Remove dead code
```
</details>

<details>
<summary>v1c</summary>

-  Rebase

```
$ git range-diff master..gh/string shadow/master..string 
 1:  e825c03e =  1:  9688e694 lib/, src/: Use stpspn() instead of its pattern
 2:  e7710fda =  2:  3ad3a4fc lib/port.c: portcmp(): Use strcmp(3) instead of its pattern
 3:  13ff7c5a =  3:  35252105 lib/gshadow.c: endsgent(): Remove dead assignment
 4:  f090d6c3 =  4:  70bd2134 src/suauth.c: check_su_auth(): Use strspn(3) instead of its pattern
 5:  526c8f72 =  5:  b1d22c99 src/suauth.c: check_su_auth(): Use pointers to simplify
 6:  30835d33 =  6:  f78b0844 lib/, src/: Use strsep(3) instead of strtok(3)
 7:  e4213fdf =  7:  13b28353 lib/loginprompt.c: login_prompt(): Use strtcpy() instead of its pattern
 8:  446541e1 =  8:  4df5efb7 contrib/, lib/, src/: Use strchr(3) to compact comparisons
 9:  946d07ca !  9:  ff3588d5 lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
    @@ Commit message
     
      ## lib/chkname.c ##
     @@
    - #include <limits.h>
      #include <stdbool.h>
      #include <stddef.h>
    + #include <stdint.h>
     +#include <string.h>
    + #include <sys/param.h>
      #include <unistd.h>
      
    - #include "defines.h"
     @@ lib/chkname.c: login_name_max_size(void)
      }
      
10:  da0b2f80 = 10:  fa44b22f contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
11:  4d80b61b = 11:  1eb75b33 lib/fields.c: Remove dead code
```
</details>

<details>
<summary>v1d</summary>

-  Rebase

```
$ git range-diff alx/master..gh/string shadow/master..string 
 1:  9688e694 =  1:  7442a127 lib/, src/: Use stpspn() instead of its pattern
 2:  3ad3a4fc =  2:  5a46723a lib/port.c: portcmp(): Use strcmp(3) instead of its pattern
 3:  35252105 =  3:  93362cc3 lib/gshadow.c: endsgent(): Remove dead assignment
 4:  70bd2134 =  4:  ae1c284e src/suauth.c: check_su_auth(): Use strspn(3) instead of its pattern
 5:  b1d22c99 =  5:  376e4166 src/suauth.c: check_su_auth(): Use pointers to simplify
 6:  f78b0844 =  6:  db93a222 lib/, src/: Use strsep(3) instead of strtok(3)
 7:  13b28353 =  7:  9a6e3284 lib/loginprompt.c: login_prompt(): Use strtcpy() instead of its pattern
 8:  4df5efb7 =  8:  d3350b67 contrib/, lib/, src/: Use strchr(3) to compact comparisons
 9:  ff3588d5 =  9:  44df1083 lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
10:  fa44b22f = 10:  b71d2236 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
11:  1eb75b33 = 11:  a719bc39 lib/fields.c: Remove dead code
```
</details>

<details>
<summary>v2</summary>

-  Drop bogus commit.

```
$ git range-diff master gh/string string 
 1:  7442a127 =  1:  7442a127 lib/, src/: Use stpspn() instead of its pattern
 2:  5a46723a =  2:  5a46723a lib/port.c: portcmp(): Use strcmp(3) instead of its pattern
 3:  93362cc3 =  3:  93362cc3 lib/gshadow.c: endsgent(): Remove dead assignment
 4:  ae1c284e =  4:  ae1c284e src/suauth.c: check_su_auth(): Use strspn(3) instead of its pattern
 5:  376e4166 =  5:  376e4166 src/suauth.c: check_su_auth(): Use pointers to simplify
 6:  db93a222 =  6:  db93a222 lib/, src/: Use strsep(3) instead of strtok(3)
 7:  9a6e3284 =  7:  9a6e3284 lib/loginprompt.c: login_prompt(): Use strtcpy() instead of its pattern
 8:  d3350b67 <  -:  -------- contrib/, lib/, src/: Use strchr(3) to compact comparisons
 9:  44df1083 !  8:  34737968 lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
    @@ lib/valid.c: bool valid (const char *password, const struct passwd *ent)
         * Now, perform the encryption using the salt from before on
     
      ## src/grpck.c ##
    -@@ src/grpck.c: check_grp_file(int *errors, bool *changed)
    +@@ src/grpck.c: static void check_grp_file (int *errors, bool *changed)
                 */
                if (   (NULL != grp->gr_mem[0])
                    && (NULL == grp->gr_mem[1])
    @@ src/grpck.c: check_grp_file(int *errors, bool *changed)
      
     
      ## src/login.c ##
    -@@ src/login.c: main(int argc, char **argv)
    +@@ src/login.c: int main (int argc, char **argv)
                /* if we didn't get a user on the command line,
                   set it to NULL */
                get_pam_user (&pam_user);
    @@ src/login.c: main(int argc, char **argv)
                        retcode = pam_set_item (pamh, PAM_USER, NULL);
                        PAM_FAIL_CHECK;
                }
    -@@ src/login.c: main(int argc, char **argv)
    +@@ src/login.c: int main (int argc, char **argv)
                        username = XMALLOC(max_size, char);
                        login_prompt(username, max_size);
      
    @@ src/login.c: main(int argc, char **argv)
                                /* Prompt for a new login */
                                free (username);
                                username = NULL;
    -@@ src/login.c: main(int argc, char **argv)
    +@@ src/login.c: int main (int argc, char **argv)
                 * guys won't see that the passwordless account exists at
                 * all).  --marekm
                 */
10:  b71d2236 !  9:  5f0b6d47 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
    @@ Commit message
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## contrib/adduser.c ##
    -@@ contrib/adduser.c: main(void)
    +@@ contrib/adduser.c: main (void)
              printf ("That name is in use, choose another.\n");
              done = 0;
            }
11:  a719bc39 = 10:  ad52f5f5 lib/fields.c: Remove dead code
```
</details>

<details>
<summary>v2b</summary>

-  Rebase

```
$ git range-diff alx/master..gh/string shadow/master..string 
 1:  7442a127 =  1:  6f5c3680 lib/, src/: Use stpspn() instead of its pattern
 2:  5a46723a =  2:  7ce03828 lib/port.c: portcmp(): Use strcmp(3) instead of its pattern
 3:  93362cc3 =  3:  0fcb014b lib/gshadow.c: endsgent(): Remove dead assignment
 4:  ae1c284e =  4:  fb3d9fe0 src/suauth.c: check_su_auth(): Use strspn(3) instead of its pattern
 5:  376e4166 =  5:  db8c4239 src/suauth.c: check_su_auth(): Use pointers to simplify
 6:  db93a222 =  6:  79b5a0c4 lib/, src/: Use strsep(3) instead of strtok(3)
 7:  9a6e3284 =  7:  af97262f lib/loginprompt.c: login_prompt(): Use strtcpy() instead of its pattern
 8:  34737968 =  8:  357e5e63 lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
 9:  5f0b6d47 =  9:  dad01af5 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
10:  ad52f5f5 = 10:  5b35729d lib/fields.c: Remove dead code
```
</details>

<details>
<summary>v2c</summary>

-  Rebase

```
$ git range-diff master..gh/string shadow/master..string 
 1:  6f5c3680 =  1:  66270bd9 lib/, src/: Use stpspn() instead of its pattern
 2:  7ce03828 =  2:  46e8763b lib/port.c: portcmp(): Use strcmp(3) instead of its pattern
 3:  0fcb014b =  3:  ab2551eb lib/gshadow.c: endsgent(): Remove dead assignment
 4:  fb3d9fe0 =  4:  de8f691d src/suauth.c: check_su_auth(): Use strspn(3) instead of its pattern
 5:  db8c4239 =  5:  68792229 src/suauth.c: check_su_auth(): Use pointers to simplify
 6:  79b5a0c4 =  6:  ab0b9884 lib/, src/: Use strsep(3) instead of strtok(3)
 7:  af97262f =  7:  1a943f2c lib/loginprompt.c: login_prompt(): Use strtcpy() instead of its pattern
 8:  357e5e63 =  8:  4e1c5add lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
 9:  dad01af5 =  9:  d2c77cf9 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
10:  5b35729d = 10:  d70eb4d2 lib/fields.c: Remove dead code
```
</details>

<details>
<summary>v2d</summary>

-  Rebase

```
$ git range-diff master..gh/string shadow/master..string 
 1:  66270bd9 !  1:  93711361 lib/, src/: Use stpspn() instead of its pattern
    @@ lib/limits.c
     @@
      #include "atoi/str2i/str2s.h"
      #include "atoi/str2i/str2u.h"
    - #include "memzero.h"
    + #include "string/memset/memzero.h"
     +#include "string/strchr/stpspn.h"
      #include "typetraits.h"
      
    @@ lib/limits.c: static int do_user_limits (const char *buf, const char *name)
      ## lib/loginprompt.c ##
     @@
      #include "getdef.h"
    - #include "memzero.h"
      #include "prototypes.h"
    + #include "string/memset/memzero.h"
     +#include "string/strchr/stpspn.h"
      #include "string/strtok/stpsep.h"
      
 2:  46e8763b =  2:  b2476283 lib/port.c: portcmp(): Use strcmp(3) instead of its pattern
 3:  ab2551eb =  3:  887a7e26 lib/gshadow.c: endsgent(): Remove dead assignment
 4:  de8f691d =  4:  e466fa72 src/suauth.c: check_su_auth(): Use strspn(3) instead of its pattern
 5:  68792229 =  5:  f8e2a2d0 src/suauth.c: check_su_auth(): Use pointers to simplify
 6:  ab0b9884 =  6:  3429f64f lib/, src/: Use strsep(3) instead of strtok(3)
 7:  1a943f2c !  7:  1a92729e lib/loginprompt.c: login_prompt(): Use strtcpy() instead of its pattern
    @@ Commit message
     
      ## lib/loginprompt.c ##
     @@
    - #include "memzero.h"
      #include "prototypes.h"
    + #include "string/memset/memzero.h"
      #include "string/strchr/stpspn.h"
     +#include "string/strcpy/strtcpy.h"
      #include "string/strtok/stpsep.h"
 8:  4e1c5add =  8:  334095fd lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
 9:  d2c77cf9 !  9:  e1180ed3 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
    @@ lib/obscure.c
     +#include <string.h>
      
      #include "attr.h"
    - #include "memzero.h"
    + #include "prototypes.h"
     @@ lib/obscure.c: static bool palindrome (MAYBE_UNUSED const char *old, const char *new)
       * more than half of the characters are different ones.
       */
10:  d70eb4d2 = 10:  ffdf778d lib/fields.c: Remove dead code
```
</details>

<details>
<summary>v2e</summary>

-  Rebase

```
$ git range-diff gh/master..gh/string shadow/master..string 
 1:  93711361 =  1:  75c094da lib/, src/: Use stpspn() instead of its pattern
 2:  b2476283 =  2:  0a599855 lib/port.c: portcmp(): Use strcmp(3) instead of its pattern
 3:  887a7e26 =  3:  8cbfdc6f lib/gshadow.c: endsgent(): Remove dead assignment
 4:  e466fa72 =  4:  76045e06 src/suauth.c: check_su_auth(): Use strspn(3) instead of its pattern
 5:  f8e2a2d0 =  5:  5e0c907a src/suauth.c: check_su_auth(): Use pointers to simplify
 6:  3429f64f =  6:  e7be1ce8 lib/, src/: Use strsep(3) instead of strtok(3)
 7:  1a92729e =  7:  e7dc5f26 lib/loginprompt.c: login_prompt(): Use strtcpy() instead of its pattern
 8:  334095fd !  8:  a2c70df5 lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
    @@ lib/chkname.c
      #include <sys/param.h>
      #include <unistd.h>
      
    -@@ lib/chkname.c: login_name_max_size(void)
    - }
    - 
    - 
    --static bool is_valid_name (const char *name)
    -+static bool
    -+is_valid_name(const char *name)
    - {
    -   if (allow_bad_names) {
    -           return true;
    -@@ lib/chkname.c: static bool is_valid_name (const char *name)
    +@@ lib/chkname.c: is_valid_name(const char *name)
               */
        int numeric;
      
    @@ lib/chkname.c: static bool is_valid_name (const char *name)
            !((*name >= 'a' && *name <= 'z') ||
              (*name >= 'A' && *name <= 'Z') ||
              (*name >= '0' && *name <= '9') ||
    -@@ lib/chkname.c: static bool is_valid_name (const char *name)
    +@@ lib/chkname.c: is_valid_name(const char *name)
                      *name == '_' ||
                      *name == '.' ||
                      *name == '-' ||
     -                (*name == '$' && name[1] == '\0')
     +                strcmp(name, "$") == 0
    -                )) {
    -                   return false;
    -           }
    +                ))
    +           {
    +                   errno = EINVAL;
     
      ## lib/getrange.c ##
     @@
 9:  e1180ed3 =  9:  9af0b281 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
10:  ffdf778d = 10:  afd0b323 lib/fields.c: Remove dead code
```
</details>

<details>
<summary>v3</summary>

-  Fix mistake.

```
$ git range-diff str gh/string string 
1:  e7be1ce8 = 1:  e7be1ce8 lib/, src/: Use strsep(3) instead of strtok(3)
2:  e7dc5f26 = 2:  e7dc5f26 lib/loginprompt.c: login_prompt(): Use strtcpy() instead of its pattern
3:  a2c70df5 ! 3:  25059777 lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
    @@ lib/port.c: next:
         */
      
     -  for (j = 0; ('\0' != *cp) && (j < PORT_TIMES); j++) {
    -+  for (j = 0; strcmp(cp, "") == 0 && (j < PORT_TIMES); j++) {
    ++  for (j = 0; strcmp(cp, "") != 0 && (j < PORT_TIMES); j++) {
      
                /*
                 * Start off with no days of the week
4:  9af0b281 = 4:  8412e015 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
5:  afd0b323 = 5:  b6191b16 lib/fields.c: Remove dead code
```
</details>

<details>
<summary>v3b</summary>

-  Rebase

```
$ git range-diff gh/str..gh/string master..string 
1:  e7be1ce8 = 1:  60d9fa84 lib/, src/: Use strsep(3) instead of strtok(3)
2:  e7dc5f26 = 2:  4562e89d lib/loginprompt.c: login_prompt(): Use strtcpy() instead of its pattern
3:  25059777 = 3:  9fcea456 lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
4:  8412e015 = 4:  8e2a3591 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
5:  b6191b16 = 5:  be7b3022 lib/fields.c: Remove dead code
```
</details>

<details>
<summary>v3c</summary>

-  Reorder commits

```
$ git range-diff master gh/string string 
2:  4562e89d = 1:  3a253dc1 lib/loginprompt.c: login_prompt(): Use strtcpy() instead of its pattern
1:  60d9fa84 = 2:  1ada0038 lib/, src/: Use strsep(3) instead of strtok(3)
3:  9fcea456 = 3:  874c025e lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
4:  8e2a3591 = 4:  0f3baf67 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
5:  be7b3022 = 5:  a4838e69 lib/fields.c: Remove dead code
```
</details>

<details>
<summary>v3d</summary>

-  Rebase (after the 2 PRs that contain some of the commits in this one).

```
$ git range-diff master..gh/string strsep..string 
1:  3a253dc1 < -:  -------- lib/loginprompt.c: login_prompt(): Use strtcpy() instead of its pattern
2:  1ada0038 < -:  -------- lib/, src/: Use strsep(3) instead of strtok(3)
3:  874c025e = 1:  ec607650 lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
4:  0f3baf67 = 2:  c81a9322 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
5:  a4838e69 = 3:  5f396feb lib/fields.c: Remove dead code
```
</details>

<details>
<summary>v3e</summary>

-  Rebase

```
$ git range-diff gh/strsep..gh/string strsep..string 
1:  ec607650 = 1:  ee5bceb6 lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
2:  c81a9322 = 2:  2f753cf6 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
3:  5f396feb = 3:  aa3f0f9d lib/fields.c: Remove dead code
```
</details>

<details>
<summary>v3f</summary>

-  Rebase

```
$ git range-diff ee5bceb6^..gh/string strsep..string 
1:  ee5bceb6 = 1:  d7de5bb1 lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
2:  2f753cf6 = 2:  ef95139f contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
3:  aa3f0f9d = 3:  b2ffdd6c lib/fields.c: Remove dead code
```
</details>

<details>
<summary>v4</summary>

-  Several rebases

```
$ git range-diff strsep..string gh/strsep..gh/string 
1:  d7de5bb1 ! 1:  5b142222 lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
    @@ src/useradd.c: err_free_new:
      {
        struct group *grp;
        int errors = 0;
    -   int ngroups = 0;
    +@@ src/useradd.c: static int get_groups (char *list)
    +           user_groups[i++] = NULL;
    +   }
      
     -  if ('\0' == *list) {
     +  if (strcmp(list, "") == 0)
2:  ef95139f = 2:  20e903b9 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
3:  b2ffdd6c < -:  -------- lib/fields.c: Remove dead code
```
</details>

<details>
<summary>v4b</summary>

-  Rebase

```
$ git range-diff gh/strsep..gh/string strsep..string 
1:  5b142222 ! 1:  e1b87c9a lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
    @@ lib/list.c
      #include <assert.h>
      
      #include "alloc/x/xmalloc.h"
    -@@ lib/list.c: bool is_on_list (char *const *list, const char *member)
    +@@ lib/list.c: comma_to_list(const char *comma)
         * Empty list is special - 0 members, not 1 empty member.  --marekm
         */
      
2:  20e903b9 = 2:  d60d0794 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
```
</details>

<details>
<summary>v4c</summary>

-  Rebase

```
$ git range-diff gh/strsep..gh/string strsep..string 
1:  e1b87c9a ! 1:  941f2556 lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
    @@ lib/port.c: next:
      
     -  if ('\0' == *cp) {
     +  if (strcmp(field, "") == 0) {
    -           port.pt_times = 0;
    +           port.pt_times = NULL;
                return &port;
        }
     @@ lib/port.c: next:
    @@ lib/sgetspent.c: sgetspent(const char *string)
        else if (str2ul(&spwd.sp_flag, fields[8]) == -1)
                return NULL;
     
    - ## lib/shadow.c ##
    -@@ lib/shadow.c: void endspent (void)
    -  * my_sgetspent - convert string in shadow file format to (struct spwd *)
    -  */
    - 
    --static struct spwd *my_sgetspent (const char *string)
    -+static struct spwd *
    -+my_sgetspent(const char *string)
    - {
    -   int                 i;
    -   char                *fields[FIELDS];
    -@@ lib/shadow.c: static struct spwd *my_sgetspent (const char *string)
    -    * incorrectly formatted number, unless we are using NIS.
    -    */
    - 
    --  if (fields[2][0] == '\0')
    -+  if (strcmp(fields[2], "") == 0)
    -           spwd.sp_lstchg = -1;
    -   else if (a2sl(&spwd.sp_lstchg, fields[2], NULL, 0, 0, LONG_MAX) == -1)
    -           return 0;
    -@@ lib/shadow.c: static struct spwd *my_sgetspent (const char *string)
    -    * Get the minimum period between password changes.
    -    */
    - 
    --  if (fields[3][0] == '\0')
    -+  if (strcmp(fields[3], "") == 0)
    -           spwd.sp_min = -1;
    -   else if (a2sl(&spwd.sp_min, fields[3], NULL, 0, 0, LONG_MAX) == -1)
    -           return 0;
    -@@ lib/shadow.c: static struct spwd *my_sgetspent (const char *string)
    -    * Get the maximum number of days a password is valid.
    -    */
    - 
    --  if (fields[4][0] == '\0')
    -+  if (strcmp(fields[4], "") == 0)
    -           spwd.sp_max = -1;
    -   else if (a2sl(&spwd.sp_max, fields[4], NULL, 0, 0, LONG_MAX) == -1)
    -           return 0;
    -@@ lib/shadow.c: static struct spwd *my_sgetspent (const char *string)
    -    * Get the number of days of password expiry warning.
    -    */
    - 
    --  if (fields[5][0] == '\0')
    -+  if (strcmp(fields[5], "") == 0)
    -           spwd.sp_warn = -1;
    -   else if (a2sl(&spwd.sp_warn, fields[5], NULL, 0, 0, LONG_MAX) == -1)
    -           return 0;
    -@@ lib/shadow.c: static struct spwd *my_sgetspent (const char *string)
    -    * disabled.
    -    */
    - 
    --  if (fields[6][0] == '\0')
    -+  if (strcmp(fields[6], "") == 0)
    -           spwd.sp_inact = -1;
    -   else if (a2sl(&spwd.sp_inact, fields[6], NULL, 0, 0, LONG_MAX) == -1)
    -           return 0;
    -@@ lib/shadow.c: static struct spwd *my_sgetspent (const char *string)
    -    * set to expire.
    -    */
    - 
    --  if (fields[7][0] == '\0')
    -+  if (strcmp(fields[7], "") == 0)
    -           spwd.sp_expire = -1;
    -   else if (a2sl(&spwd.sp_expire, fields[7], NULL, 0, 0, LONG_MAX) == -1)
    -           return 0;
    -@@ lib/shadow.c: static struct spwd *my_sgetspent (const char *string)
    -    * to have anything other than a valid integer in it.
    -    */
    - 
    --  if (fields[8][0] == '\0')
    -+  if (strcmp(fields[8], "") == 0)
    -           spwd.sp_flag = SHADOW_SP_FLAG_UNSET;
    -   else if (str2ul(&spwd.sp_flag, fields[8]) == -1)
    -           return 0;
    -
      ## lib/sssd.c ##
     @@ lib/sssd.c: sssd_flush_cache(int dbflags)
        if (dbflags & SSSD_DB_GROUP)
2:  d60d0794 = 2:  4443b615 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
```
</details>

<details>
<summary>v4d</summary>

-  Rebase

```
$ git range-diff gh/strsep..gh/string strsep..string 
1:  941f2556 ! 1:  74e87516 lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
    @@ lib/port.c: static int portcmp (const char *pattern, const char *port)
     -  if (('\0' == *pattern) && ('\0' == *port)) {
     +  if (strcmp(pattern, "") == 0 && strcmp(port, "") == 0)
                return 0;
    --  }
    -+
    -   if (strcmp(orig, "SU") == 0)
    -           return 1;
    - 
    +   }
    +   if (streq(orig, "SU"))
     @@ lib/port.c: next:
      
        cp = field;
    @@ lib/prefix_flag.c: extern const char* process_prefix_flag (const char* short_opt
                        exit (EXIT_FAILURE);
                }
      
    --          if ( prefix[0] == '\0' || !strcmp(prefix, "/"))
    -+          if (strcmp(prefix, "") == 0 || strcmp(prefix, "/") == 0)
    +-          if (prefix[0] == '\0' || streq(prefix, "/"))
    ++          if (strcmp(prefix, "") == 0 || streq(prefix, "/"))
                        return ""; /* if prefix is "/" then we ignore the flag option */
                /* should we prevent symbolic link from being used as a prefix? */
      
    @@ lib/pwauth.c: int pw_auth (const char *cipher,
     
      ## lib/salt.c ##
     @@
    - #include "getdef.h"
    - #include "shadowlog.h"
    + #include "string/strcmp/streq.h"
    + 
      
     +
      #if (defined CRYPT_GENSALT_IMPLEMENTS_AUTO_ENTROPY && \
    @@ lib/utmp.c: active_sessions_count(const char *name, unsigned long limit)
      ## lib/valid.c ##
     @@
      
    - #include <config.h>
    - 
    --#ident "$Id$"
    --
    -+#include <pwd.h>
    - #include <sys/types.h>
    + #include <pwd.h>
      #include <stdio.h>
     +#include <string.h>
    -+
    - #include "prototypes.h"
    + #include <sys/types.h>
    + 
      #include "defines.h"
    --#include <pwd.h>
    -+
    -+
    - /*
    -  * valid - compare encrypted passwords
    -  *
     @@
       *        is used to indicate that a dummy salt must be used to encrypt the
       *        password anyway.
    @@ src/newgrp.c: static void check_perms (const struct group *grp,
                }
      
     -          if (grp->gr_passwd[0] == '\0' ||
    --              strcmp (cpasswd, grp->gr_passwd) != 0) {
    +-              !streq(cpasswd, grp->gr_passwd)) {
     +          if (strcmp(grp->gr_passwd, "") == 0 ||
    -+              strcmp(grp->gr_passwd, cpasswd) != 0)
    ++              !streq(grp->gr_passwd, cpasswd))
     +          {
      #ifdef WITH_AUDIT
                        SNPRINTF(audit_buf, "authentication new-gid=%lu",
    @@ src/useradd.c
     @@ src/useradd.c: get_defaults(void)
                 * Default Skeleton information
                 */
    -           else if (strcmp(buf, DSKEL) == 0) {
    +           else if (streq(buf, DSKEL)) {
     -                  if ('\0' == *ccp)
     +                  if (strcmp(ccp, "") == 0)
                                ccp = SKEL_DIR;
    @@ src/useradd.c: get_defaults(void)
     @@ src/useradd.c: get_defaults(void)
                 * Default Usr Skeleton information
                 */
    -           else if (strcmp(buf, DUSRSKEL) == 0) {
    +           else if (streq(buf, DUSRSKEL)) {
     -                  if ('\0' == *ccp)
     +                  if (strcmp(ccp, "") == 0)
                                ccp = USRSKELDIR;
    @@ src/useradd.c: get_defaults(void)
     @@ src/useradd.c: get_defaults(void)
                 * Create by default user mail spool or not ?
                 */
    -           else if (strcmp(buf, DCREATE_MAIL_SPOOL) == 0) {
    +           else if (streq(buf, DCREATE_MAIL_SPOOL)) {
     -                  if (*ccp == '\0')
     +                  if (strcmp(ccp, "") == 0)
                                ccp = "no";
    @@ src/useradd.c: get_defaults(void)
     @@ src/useradd.c: get_defaults(void)
                 * By default do we add the user to the lastlog and faillog databases ?
                 */
    -           else if (strcmp(buf, DLOG_INIT) == 0) {
    +           else if (streq(buf, DLOG_INIT)) {
     -                  if (*ccp == '\0')
     +                  if (strcmp(ccp, "") == 0)
                                ccp = def_log_init;
2:  4443b615 = 2:  e3aa2a53 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
```
</details>

<details>
<summary>v4e</summary>

-  Rebase

```
$ git range-diff e1bad69d..gh/string strsep..string 
1:  74e87516 = 1:  d25baeb4 lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
2:  e3aa2a53 = 2:  c9cdabee contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
```
</details>

<details>
<summary>v4f</summary>

-  Rebase

```
$ git range-diff d25baeb43672^..c9cdabee2760 strsep..string 
1:  d25baeb4 = 1:  3aa7932b lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
2:  c9cdabee = 2:  f338e63b contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
```
</details>

<details>
<summary>v4g</summary>

-  tfix

```
$ git range-diff strsep gh/string string 
1:  3aa7932b = 1:  3aa7932b lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
2:  f338e63b ! 2:  1428790a contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
    @@ lib/obscure.c: static bool similar (/*@notnull@*/const char *old, /*@notnull@*/c
      
        if (i >= j * 2) {
     
    + ## lib/port.c ##
    +@@ lib/port.c: static int portcmp (const char *pattern, const char *port)
    +           port++;
    +   }
    + 
    +-  if (strcmp(pattern, "") == 0 && strcmp(port, "") == 0)
    ++  if (strcmp(pattern, "") == 0 && strcmp(port, "") == 0) {
    +           return 0;
    +   }
    +   if (streq(orig, "SU"))
    +
      ## lib/setupenv.c ##
     @@ lib/setupenv.c: setup_env(struct passwd *info)
        if (NULL == cp) {
```
</details>

<details>
<summary>v4h</summary>

-  Rebase

```
$ git range-diff strsep..gh/string shadow/master..string 
1:  3aa7932b = 1:  50a8cf6e lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
2:  1428790a = 2:  1a0068c3 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
```
</details>

<details>
<summary>v5</summary>

-  Rebase after <https://github.com/shadow-maint/shadow/pull/1142>.

```
$ git range-diff master..gh/string streq_empty..string
1:  50a8cf6e ! 1:  701d6a95 lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
    @@ lib/getrange.c
      
      #include "atoi/a2i/a2u.h"
      #include "defines.h"
    -@@ lib/getrange.c: getrange(const char *range,
    -           return 0;  /* <long> */
    - 
    -   case '-':
    --          if ('\0' == *end)
    -+          if (strcmp(end, "") == 0)
    -                   return 0;  /* <long>- */
    - parse_max:
    -           if (!isdigit((unsigned char) *end))
     
      ## lib/limits.c ##
     @@
    @@ lib/limits.c: static bool user_in_group (const char *uname, const char *gname)
      {
        FILE *fil;
        char buf[1024];
    -@@ lib/limits.c: static int setup_user_limits (const char *uname)
    -           }
    -   }
    -   (void) fclose (fil);
    --  if (limits[0] == '\0') {
    -+  if (strcmp(limits, "") == 0) {
    -           /* no user specific limits */
    --          if (deflimits[0] == '\0') {     /* no default limits */
    -+          if (strcmp(deflimits, "") == 0)  /* no defaults limits */
    -                   return 0;
    --          }
    -+
    -           strcpy (limits, deflimits);     /* use the default limits */
    -   }
    -   return do_user_limits (limits, uname);
     
      ## lib/list.c ##
     @@
    @@ lib/list.c
      #include <assert.h>
      
      #include "alloc/x/xmalloc.h"
    -@@ lib/list.c: comma_to_list(const char *comma)
    -    * Empty list is special - 0 members, not 1 empty member.  --marekm
    -    */
    - 
    --  if ('\0' == *members) {
    -+  if (strcmp(members, "") == 0) {
    -           *array = NULL;
    -           free (members);
    -           return array;
     
      ## lib/port.c ##
    -@@ lib/port.c: static int portcmp (const char *pattern, const char *port)
    -           port++;
    -   }
    - 
    --  if (('\0' == *pattern) && ('\0' == *port)) {
    -+  if (strcmp(pattern, "") == 0 && strcmp(port, "") == 0)
    -           return 0;
    -   }
    -   if (streq(orig, "SU"))
    -@@ lib/port.c: next:
    - 
    -   cp = field;
    - 
    --  if ('\0' == *cp) {
    -+  if (strcmp(field, "") == 0) {
    -           port.pt_times = NULL;
    -           return &port;
    -   }
     @@ lib/port.c: next:
         * Get the next comma separated entry
         */
    @@ lib/prefix_flag.c: static FILE* fp_grent = NULL;
      {
        /*
         * Parse the command line options.
    -@@ lib/prefix_flag.c: extern const char* process_prefix_flag (const char* short_opt, int argc, char **
    -                   exit (EXIT_FAILURE);
    -           }
    - 
    --          if (prefix[0] == '\0' || streq(prefix, "/"))
    -+          if (strcmp(prefix, "") == 0 || streq(prefix, "/"))
    -                   return ""; /* if prefix is "/" then we ignore the flag option */
    -           /* should we prevent symbolic link from being used as a prefix? */
    - 
     
      ## lib/pwauth.c ##
     @@
    @@ lib/pwauth.c: static const char *PROMPT = gettext_noop ("%s's Password: ");
      {
        int          retval;
        char         prompt[1024];
    -@@ lib/pwauth.c: int pw_auth (const char *cipher,
    -    * the user could just hit <ENTER>, so it doesn't really
    -    * matter.
    -    */
    --
    --  if ((NULL == cipher) || ('\0' == *cipher)) {
    -+  if (NULL == cipher || strcmp(cipher, "") == 0)
    -           return 0;
    --  }
    - 
    - #ifdef    SKEY
    -   /*
    -@@ lib/pwauth.c: int pw_auth (const char *cipher,
    -    * ...Re-prompt, with echo on.
    -    * -- AR 8/22/1999
    -    */
    --  if ((0 != retval) && ('\0' == input[0]) && use_skey) {
    -+  if (0 != retval && strcmp(input, "") == 0 && use_skey) {
    -           erase_pass(clear);
    -           clear = agetpass(prompt);
    -           input = (clear == NULL) ? "" : clear;
     
      ## lib/salt.c ##
     @@
    @@ lib/salt.c: static /*@observer@*/const char *gensalt (size_t salt_size)
      {
        static char result[GENSALT_SETTING_SIZE];
        size_t salt_len = MAX_SALT_SIZE;
    -@@ lib/salt.c: static /*@observer@*/const char *gensalt (size_t salt_size)
    -    * Prepare DES setting for crypt_gensalt(), if result
    -    * has not been filled with anything previously.
    -    */
    --  if ('\0' == result[0]) {
    -+  if (strcmp(result, "") == 0) {
    -           /* Avoid -Wunused-but-set-variable. */
    -           salt_len = GENSALT_SETTING_SIZE - 1;
    -           rounds = 0;
     
      ## lib/setupenv.c ##
     @@
    @@ lib/setupenv.c: static void read_env_file (const char *filename)
      {
      #ifndef USE_PAM
        const char *envf;
    -@@ lib/setupenv.c: void setup_env (struct passwd *info)
    -    * Create the SHELL environmental variable and export it.
    -    */
    - 
    --  if ((NULL == info->pw_shell) || ('\0' == *info->pw_shell)) {
    -+  if (NULL == info->pw_shell || strcmp(info->pw_shell, "") == 0) {
    -           free (info->pw_shell);
    -           info->pw_shell = xstrdup (SHELL);
    -   }
     
      ## lib/sgetgrent.c ##
    -@@ lib/sgetgrent.c: list(char *s)
    -                           return NULL;
    -                   }
    -           }
    --          if (!s || s[0] == '\0')
    -+          if (!s || strcmp(s, "") == 0)
    -                   break;
    -           members[i++] = strsep(&s, ",");
    -   }
     @@ lib/sgetgrent.c: list(char *s)
      }
      
    @@ lib/sgetgrent.c: list(char *s)
      {
        static char *grpbuf = NULL;
        static size_t size = 0;
    -@@ lib/sgetgrent.c: struct group *sgetgrent (const char *buf)
    -   for (cp = grpbuf, i = 0; (i < NFIELDS) && (NULL != cp); i++)
    -           grpfields[i] = strsep(&cp, ":");
    - 
    --  if (i < (NFIELDS - 1) || *grpfields[2] == '\0' || cp != NULL) {
    -+  if (i < (NFIELDS - 1) || strcmp(grpfields[2], "") == 0 || cp != NULL) {
    -           return NULL;
    -   }
    -   grent.gr_name = grpfields[0];
    -
    - ## lib/sgetpwent.c ##
    -@@ lib/sgetpwent.c: sgetpwent(const char *buf)
    -    * There must be exactly NFIELDS colon separated fields or
    -    * the entry is invalid.  Also, the UID and GID must be non-blank.
    -    */
    --
    --  if (i != NFIELDS || *fields[2] == '\0' || *fields[3] == '\0')
    -+  if (i != NFIELDS)
    -+          return NULL;
    -+  if (strcmp(fields[2], "") == 0)
    -+          return NULL;
    -+  if (strcmp(fields[3], "") == 0)
    -           return NULL;
    - 
    -   /*
    -
    - ## lib/sgetspent.c ##
    -@@ lib/sgetspent.c: sgetspent(const char *string)
    -    * incorrectly formatted number.
    -    */
    - 
    --  if (fields[2][0] == '\0')
    -+  if (strcmp(fields[2], "") == 0)
    -           spwd.sp_lstchg = -1;
    -   else if (a2sl(&spwd.sp_lstchg, fields[2], NULL, 0, 0, LONG_MAX) == -1)
    -           return NULL;
    -@@ lib/sgetspent.c: sgetspent(const char *string)
    -    * Get the minimum period between password changes.
    -    */
    - 
    --  if (fields[3][0] == '\0')
    -+  if (strcmp(fields[3], "") == 0)
    -           spwd.sp_min = -1;
    -   else if (a2sl(&spwd.sp_min, fields[3], NULL, 0, 0, LONG_MAX) == -1)
    -           return NULL;
    -@@ lib/sgetspent.c: sgetspent(const char *string)
    -    * Get the maximum number of days a password is valid.
    -    */
    - 
    --  if (fields[4][0] == '\0')
    -+  if (strcmp(fields[4], "") == 0)
    -           spwd.sp_max = -1;
    -   else if (a2sl(&spwd.sp_max, fields[4], NULL, 0, 0, LONG_MAX) == -1)
    -           return NULL;
    -@@ lib/sgetspent.c: sgetspent(const char *string)
    -    * Get the number of days of password expiry warning.
    -    */
    - 
    --  if (fields[5][0] == '\0')
    -+  if (strcmp(fields[5], "") == 0)
    -           spwd.sp_warn = -1;
    -   else if (a2sl(&spwd.sp_warn, fields[5], NULL, 0, 0, LONG_MAX) == -1)
    -           return NULL;
    -@@ lib/sgetspent.c: sgetspent(const char *string)
    -    * disabled.
    -    */
    - 
    --  if (fields[6][0] == '\0')
    -+  if (strcmp(fields[6], "") == 0)
    -           spwd.sp_inact = -1;
    -   else if (a2sl(&spwd.sp_inact, fields[6], NULL, 0, 0, LONG_MAX) == -1)
    -           return NULL;
    -@@ lib/sgetspent.c: sgetspent(const char *string)
    -    * set to expire.
    -    */
    - 
    --  if (fields[7][0] == '\0')
    -+  if (strcmp(fields[7], "") == 0)
    -           spwd.sp_expire = -1;
    -   else if (a2sl(&spwd.sp_expire, fields[7], NULL, 0, 0, LONG_MAX) == -1)
    -           return NULL;
    -@@ lib/sgetspent.c: sgetspent(const char *string)
    -    * to have anything other than a valid integer in it.
    -    */
    - 
    --  if (fields[8][0] == '\0')
    -+  if (strcmp(fields[8], "") == 0)
    -           spwd.sp_flag = SHADOW_SP_FLAG_UNSET;
    -   else if (str2ul(&spwd.sp_flag, fields[8]) == -1)
    -           return NULL;
    -
    - ## lib/sssd.c ##
    -@@ lib/sssd.c: sssd_flush_cache(int dbflags)
    -   if (dbflags & SSSD_DB_GROUP)
    -           stpcpy(p, "G");
    - 
    --  if (*p == '\0') {
    -+  if (strcmp(p, "") == 0) {
    -           /* Neither passwd nor group, nothing to do */
    -           free(sss_cache_args);
    -           return 0;
     
      ## lib/strtoday.c ##
    -@@
    - #include <config.h>
    - 
    - #include <ctype.h>
    --
    --#ident "$Id$"
    -+#include <string.h>
    - 
    - #include "atoi/str2i/str2s.h"
    - #include "getdate.h"
     @@
       *        24-sep-72
       *        24sep72
    @@ lib/strtoday.c
      {
        time_t t;
        bool isnum = true;
    -@@ lib/strtoday.c: long strtoday (const char *str)
    -    * which is not what we expect, unless you're a BOFH :-).
    -    * (useradd sets sp_expire = current date for new lusers)
    -    */
    --  if ((NULL == str) || ('\0' == *str)) {
    -+  if (NULL == str || strcmp(str, "") == 0)
    -           return -1;
    --  }
    - 
    -   /* If a numerical value is provided, this is already a number of
    -    * days since EPOCH.
    -
    - ## lib/subordinateio.c ##
    -@@ lib/subordinateio.c: subordinate_parse(const char *line)
    -    * There must be exactly SUBID_NFIELDS colon separated fields or
    -    * the entry is invalid.  Also, fields must be non-blank.
    -    */
    --  if (i != SUBID_NFIELDS || *fields[0] == '\0' || *fields[1] == '\0' || *fields[2] == '\0')
    -+  if (i != SUBID_NFIELDS)
    -+          return NULL;
    -+  if (strcmp(fields[0], "") == 0)
    -+          return NULL;
    -+  if (strcmp(fields[1], "") == 0)
    -+          return NULL;
    -+  if (strcmp(fields[2], "") == 0)
    -           return NULL;
    -   range.owner = fields[0];
    -   if (str2ul(&range.start, fields[1]) == -1)
     
      ## lib/utmp.c ##
    -@@ lib/utmp.c: is_my_tty(const char tty[UTX_LINESIZE])
    -           strcpy (full_tty, "/dev/");
    -   strncat(full_tty, tty, UTX_LINESIZE);
    - 
    --  if ('\0' == tmptty[0]) {
    -+  if (strcmp(tmptty, "") == 0) {
    -           const char *tname = ttyname (STDIN_FILENO);
    -           if (NULL != tname)
    -                   STRTCPY(tmptty, tname);
    -   }
    - 
    --  if ('\0' == tmptty[0]) {
    -+  if (strcmp(tmptty, "") == 0) {
    -           (void) puts (_("Unable to determine your tty name."));
    -           exit (EXIT_FAILURE);
    -   }
     @@ lib/utmp.c: active_sessions_count(const char *name, unsigned long limit)
                if (USER_PROCESS != ut->ut_type) {
                        continue;
    @@ lib/valid.c
      {
        const char *encrypted;
        /*@observer@*/const char *salt;
    -@@ lib/valid.c: bool valid (const char *password, const struct passwd *ent)
    -    * the password is really empty do you return quickly.  This
    -    * routine is meant to waste CPU time.
    -    */
    --
    --  if ((NULL != ent->pw_name) && ('\0' == ent->pw_passwd[0])) {
    --          if ('\0' == password[0]) {
    -+  if (NULL != ent->pw_name && strcmp(ent->pw_passwd, "") == 0) {
    -+          if (strcmp(password, "") == 0)
    -                   return true;    /* user entered nothing */
    --          } else {
    -+          else
    -                   return false;   /* user entered something! */
    --          }
    -   }
    - 
    -   /*
    -    * If there is no entry then we need a salt to use.
    -    */
    --
    --  if ((NULL == ent->pw_name) || ('\0' == ent->pw_passwd[0])) {
    -+  if (NULL == ent->pw_name || strcmp(ent->pw_passwd, "") == 0)
    -           salt = "xx";
    --  } else {
    -+  else
    -           salt = ent->pw_passwd;
    --  }
    - 
    -   /*
    -    * Now, perform the encryption using the salt from before on
    -
    - ## src/grpck.c ##
    -@@ src/grpck.c: static void check_grp_file (int *errors, bool *changed)
    -            */
    -           if (   (NULL != grp->gr_mem[0])
    -               && (NULL == grp->gr_mem[1])
    --              && ('\0' == grp->gr_mem[0][0])) {
    -+              && strcmp(grp->gr_mem[0], "") == 0)
    -+          {
    -                   grp->gr_mem[0] = NULL;
    -           }
    - 
    -
    - ## src/login.c ##
    -@@ src/login.c: int main (int argc, char **argv)
    -           /* if we didn't get a user on the command line,
    -              set it to NULL */
    -           get_pam_user (&pam_user);
    --          if ((NULL != pam_user) && ('\0' == pam_user[0])) {
    -+          if (NULL != pam_user && strcmp(pam_user, "") == 0) {
    -                   retcode = pam_set_item (pamh, PAM_USER, NULL);
    -                   PAM_FAIL_CHECK;
    -           }
    -@@ src/login.c: int main (int argc, char **argv)
    -                   username = XMALLOC(max_size, char);
    -                   login_prompt(username, max_size);
    - 
    --                  if ('\0' == username[0]) {
    -+                  if (strcmp(username, "") == 0) {
    -                           /* Prompt for a new login */
    -                           free (username);
    -                           username = NULL;
    -@@ src/login.c: int main (int argc, char **argv)
    -            * guys won't see that the passwordless account exists at
    -            * all).  --marekm
    -            */
    --          if (user_passwd[0] == '\0') {
    -+          if (strcmp(user_passwd, "") == 0)
    -                   pw_auth ("!", username, reason, NULL);
    --          }
    - 
    -           /*
    -            * Authentication of this user failed.
     
      ## src/login_nopam.c ##
    -@@ src/login_nopam.c: login_access(const char *user, const char *from)
    -                           continue;       /* comment line */
    -                   }
    -                   stpcpy(strrspn(line, " \t"), "");
    --                  if (line[0] == '\0') {  /* skip blank lines */
    -+                  if (strcmp(line, "") == 0)  /* skip blank lines */
    -                           continue;
    --                  }
    -+
    -                   p = line;
    -                   perm = strsep(&p, ":");
    -                   users = strsep(&p, ":");
     @@ src/login_nopam.c: list_match(char *list, const char *item, bool (*match_fn)(const char *, const ch
      }
      
    @@ src/login_nopam.c: list_match(char *list, const char *item, bool (*match_fn)(con
      {
        static char name[MAXHOSTNAMELEN + 1] = "";
      
    --  if (name[0] == '\0') {
    -+  if (strcmp(name, "") == 0) {
    -           gethostname (name, sizeof (name));
    -           stpcpy(&name[MAXHOSTNAMELEN], "");
    -   }
     @@ src/login_nopam.c: static const char *resolve_hostname (const char *string)
      
      /* from_match - match a host or tty against a list of tokens */
    @@ src/newgrp.c: static void check_perms (const struct group *grp,
                spw_free (spwd);
        }
      
    --  if ((pwd->pw_passwd[0] == '\0') && (grp->gr_passwd[0] != '\0')) {
    -+  if (strcmp(pwd->pw_passwd, "") == 0 && strcmp(grp->gr_passwd, "") != 0)
    +-  if (streq(pwd->pw_passwd, "") && (grp->gr_passwd[0] != '\0')) {
    ++  if (streq(pwd->pw_passwd, "") && strcmp(grp->gr_passwd, "") != 0) {
                needspasswd = true;
    --  }
    +   }
      
    -   /*
    -    * Now I see about letting her into the group she requested. If she
    -@@ src/newgrp.c: static void check_perms (const struct group *grp,
    -                   goto failure;
    -           }
    - 
    --          if (grp->gr_passwd[0] == '\0' ||
    --              !streq(cpasswd, grp->gr_passwd)) {
    -+          if (strcmp(grp->gr_passwd, "") == 0 ||
    -+              !streq(grp->gr_passwd, cpasswd))
    -+          {
    - #ifdef WITH_AUDIT
    -                   SNPRINTF(audit_buf, "authentication new-gid=%lu",
    -                            (unsigned long) grp->gr_gid);
     
      ## src/su.c ##
     @@
    @@ src/su.c: save_caller_context(void)
      {
        int c;
        static struct option long_options[] = {
    -@@ src/su.c: static void process_flags (int argc, char **argv)
    -   if (optind < argc) {
    -           STRTCPY(name, argv[optind++]);  /* use this login id */
    -   }
    --  if ('\0' == name[0]) {          /* use default user */
    -+  if (strcmp(name, "") == 0) {            /* use default user */
    -           struct passwd *root_pw = getpwnam ("root");
    -           if ((NULL != root_pw) && (0 == root_pw->pw_uid)) {
    -                   (void) strcpy (name, "root");
     @@ src/su.c: static void set_environment (struct passwd *pw)
       *        particular, the argument "-c" will cause the next argument to be
       *        interpreted as a command by the common shell programs.
    @@ src/su.c: static void set_environment (struct passwd *pw)
      {
        const char *cp;
        struct passwd *pw = NULL;
    -@@ src/su.c: int main (int argc, char **argv)
    -           shellstr = pw->pw_shell;
    -   }
    - 
    --  /*
    --   * Set the default shell.
    --   */
    --  if ((NULL == shellstr) || ('\0' == shellstr[0])) {
    -+  /* Set the default shell.  */
    -+  if (NULL == shellstr || strcmp(shellstr, "") == 0)
    -           shellstr = SHELL;
    --  }
    - 
    -   sulog (caller_tty, true, caller_name, name);    /* save SU information */
    -   if (getdef_bool ("SYSLOG_SU_ENAB")) {
     
      ## src/sulogin.c ##
     @@
    @@ src/sulogin.c
      #include <sys/ioctl.h>
      #include <sys/types.h>
      
    -@@ src/sulogin.c: main(int argc, char *argv[])
    -            * it will work with standard getpass() (no NULL on EOF).
    -            * --marekm
    -            */
    --          if ((NULL == pass) || ('\0' == *pass)) {
    -+          if (NULL == pass || strcmp(pass, "") == 0) {
    -                   erase_pass (pass);
    -                   (void) puts ("");
    - #ifdef    TELINIT
     
      ## src/useradd.c ##
    -@@ src/useradd.c: get_defaults(void)
    -            * Default Skeleton information
    -            */
    -           else if (streq(buf, DSKEL)) {
    --                  if ('\0' == *ccp)
    -+                  if (strcmp(ccp, "") == 0)
    -                           ccp = SKEL_DIR;
    - 
    -                   if (prefix[0]) {
    -@@ src/useradd.c: get_defaults(void)
    -            * Default Usr Skeleton information
    -            */
    -           else if (streq(buf, DUSRSKEL)) {
    --                  if ('\0' == *ccp)
    -+                  if (strcmp(ccp, "") == 0)
    -                           ccp = USRSKELDIR;
    - 
    -                   if (prefix[0]) {
    -@@ src/useradd.c: get_defaults(void)
    -            * Create by default user mail spool or not ?
    -            */
    -           else if (streq(buf, DCREATE_MAIL_SPOOL)) {
    --                  if (*ccp == '\0')
    -+                  if (strcmp(ccp, "") == 0)
    -                           ccp = "no";
    - 
    -                   def_create_mail_spool = xstrdup(ccp);
    -@@ src/useradd.c: get_defaults(void)
    -            * By default do we add the user to the lastlog and faillog databases ?
    -            */
    -           else if (streq(buf, DLOG_INIT)) {
    --                  if (*ccp == '\0')
    -+                  if (strcmp(ccp, "") == 0)
    -                           ccp = def_log_init;
    - 
    -                   def_log_init = xstrdup(ccp);
     @@ src/useradd.c: err_free_new:
       *        converts it to a NULL-terminated array. Any unknown group
       *        names are reported as errors.
    @@ src/useradd.c: err_free_new:
      {
        struct group *grp;
        int errors = 0;
    -@@ src/useradd.c: static int get_groups (char *list)
    -           user_groups[i++] = NULL;
    -   }
    - 
    --  if ('\0' == *list) {
    -+  if (strcmp(list, "") == 0)
    -           return 0;
    --  }
    - 
    -   /*
    -    * Open the group files
     
      ## src/userdel.c ##
     @@
    @@ src/userdel.c: static int remove_tcbdir (const char *user_name, uid_t user_id)
      {
        int errors = 0; /* Error in the removal of the home directory */
      
    -@@ src/userdel.c: int main (int argc, char **argv)
    -    * Note: This is a best effort basis. The user may log in between,
    -    * a cron job may be started on her behalf, etc.
    -    */
    --  if ((prefix[0] == '\0') && !Rflg && user_busy (user_name, user_id) != 0) {
    --          if (!fflg) {
    -+  if (strcmp(prefix, "") == 0 && !Rflg) {
    -+          if (user_busy (user_name, user_id) != 0 && !fflg) {
    - #ifdef WITH_AUDIT
    -                   audit_logger (AUDIT_DEL_USER, Prog,
    -                                 "deleting user logged in",
    -@@ src/userdel.c: int main (int argc, char **argv)
    -    * Cancel any crontabs or at jobs. Have to do this before we remove
    -    * the entry from /etc/passwd.
    -    */
    --  if (prefix[0] == '\0')
    -+  if (strcmp(prefix, "") == 0)
    -           user_cancel (user_name);
    -   close_files ();
    - 
     
      ## src/usermod.c ##
     @@
    @@ src/usermod.c: extern int allow_bad_names;
      {
        struct group *grp;
        int errors = 0;
    -@@ src/usermod.c: static int get_groups (char *list)
    -    */
    -   user_groups[0] = NULL;
    - 
    --  if ('\0' == *list) {
    -+  if (strcmp(list, "") == 0)
    -           return 0;
    --  }
    - 
    -   /*
    -    * So long as there is some data to be converted, strip off each
     @@ src/usermod.c: static void move_mailbox (void)
      /*
       * main - usermod command
    @@ src/usermod.c: static void move_mailbox (void)
      {
      #ifdef ACCT_TOOLS_SETUID
      #ifdef USE_PAM
    -@@ src/usermod.c: int main (int argc, char **argv)
    -    * be changed while the user is logged in.
    -    * Note: no need to check if a prefix is specified...
    -    */
    --  if ( (prefix[0] == '\0') &&  (uflg || lflg || dflg
    -+  if ( strcmp(prefix, "") == 0 &&  (uflg || lflg || dflg
    - #ifdef ENABLE_SUBIDS
    -           || Vflg || Wflg
    - #endif                            /* ENABLE_SUBIDS */
2:  1a0068c3 ! 2:  e2a7b642 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
    @@ lib/obscure.c: static bool similar (/*@notnull@*/const char *old, /*@notnull@*/c
      
        if (i >= j * 2) {
     
    - ## lib/port.c ##
    -@@ lib/port.c: static int portcmp (const char *pattern, const char *port)
    -           port++;
    -   }
    - 
    --  if (strcmp(pattern, "") == 0 && strcmp(port, "") == 0)
    -+  if (strcmp(pattern, "") == 0 && strcmp(port, "") == 0) {
    -           return 0;
    -   }
    -   if (streq(orig, "SU"))
    -
      ## lib/setupenv.c ##
     @@ lib/setupenv.c: setup_env(struct passwd *info)
        if (NULL == cp) {
```
</details>

<details>
<summary>v5b</summary>

-  Remove leftovers from v5.

```
$ git range-diff --creation-factor=99 streq_empty gh/string string 
1:  701d6a95 ! 1:  4022dbc7 lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
    @@ Commit message
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    - ## lib/chkname.c ##
    -@@
    - #include <stdbool.h>
    - #include <stddef.h>
    - #include <stdint.h>
    -+#include <string.h>
    - #include <sys/param.h>
    - #include <unistd.h>
    - 
    -@@ lib/chkname.c: is_valid_name(const char *name)
    -          */
    -   int numeric;
    - 
    --  if ('\0' == *name ||
    --      ('.' == *name && (('.' == name[1] && '\0' == name[2]) ||
    --                        '\0' == name[1])) ||
    -+  if (strcmp(name, "") == 0 ||
    -+      strcmp(name, ".") == 0 ||
    -+      strcmp(name, "..") == 0 ||
    -       !((*name >= 'a' && *name <= 'z') ||
    -         (*name >= 'A' && *name <= 'Z') ||
    -         (*name >= '0' && *name <= '9') ||
    -@@ lib/chkname.c: is_valid_name(const char *name)
    -                 *name == '_' ||
    -                 *name == '.' ||
    -                 *name == '-' ||
    --                (*name == '$' && name[1] == '\0')
    -+                strcmp(name, "$") == 0
    -                ))
    -           {
    -                   errno = EINVAL;
    -
    - ## lib/getrange.c ##
    -@@
    - 
    - #include <ctype.h>
    - #include <stdlib.h>
    -+#include <string.h>
    - 
    - #include "atoi/a2i/a2u.h"
    - #include "defines.h"
    -
    - ## lib/limits.c ##
    -@@
    - 
    - #ident "$Id$"
    - 
    -+#include <string.h>
    - #include <sys/types.h>
    - #include <sys/stat.h>
    - #include <stdio.h>
    -@@ lib/limits.c: static bool user_in_group (const char *uname, const char *gname)
    -   return is_on_list (groupdata->gr_mem, uname);
    - }
    - 
    --static int setup_user_limits (const char *uname)
    -+static int
    -+setup_user_limits(const char *uname)
    - {
    -   FILE *fil;
    -   char buf[1024];
    -
    - ## lib/list.c ##
    -@@
    - 
    - #include <config.h>
    - 
    --#ident "$Id$"
    --
    -+#include <string.h>
    - #include <assert.h>
    - 
    - #include "alloc/x/xmalloc.h"
    -
      ## lib/port.c ##
     @@ lib/port.c: next:
         * Get the next comma separated entry
    @@ lib/port.c: next:
                /*
                 * Start off with no days of the week
     
    - ## lib/prefix_flag.c ##
    -@@
    - #ident "$Id$"
    - 
    - #include <stdio.h>
    -+#include <string.h>
    - #include <assert.h>
    - 
    - #include "atoi/getnum.h"
    -@@ lib/prefix_flag.c: static FILE* fp_grent = NULL;
    -  *
    -  * The audit, syslog, or locale files shall be open before
    -  */
    --extern const char* process_prefix_flag (const char* short_opt, int argc, char **argv)
    -+extern const char *
    -+process_prefix_flag(const char* short_opt, int argc, char **argv)
    - {
    -   /*
    -    * Parse the command line options.
    -
    - ## lib/pwauth.c ##
    -@@
    - #include <fcntl.h>
    - #include <signal.h>
    - #include <stdio.h>
    -+#include <string.h>
    - #include <sys/types.h>
    - #include <unistd.h>
    - 
    -@@ lib/pwauth.c: static const char *PROMPT = gettext_noop ("%s's Password: ");
    -  *        compared.
    -  */
    - 
    --int pw_auth (const char *cipher,
    --             const char *user,
    --             int reason,
    --             /*@null@*/const char *input)
    -+int
    -+pw_auth(const char *cipher, const char *user, int reason,
    -+        /*@null@*/const char *input)
    - {
    -   int          retval;
    -   char         prompt[1024];
    -
    - ## lib/salt.c ##
    -@@
    - #include "string/strcmp/streq.h"
    - 
    - 
    -+
    - #if (defined CRYPT_GENSALT_IMPLEMENTS_AUTO_ENTROPY && \
    -      CRYPT_GENSALT_IMPLEMENTS_AUTO_ENTROPY)
    - #define USE_XCRYPT_GENSALT 1
    -@@ lib/salt.c: static /*@observer@*/const char *gensalt (size_t salt_size)
    -  *    (if not NULL).
    -  *  * For the YESCRYPT method, this specifies the cost factor (if not NULL).
    -  */
    --/*@observer@*/const char *crypt_make_salt (/*@null@*//*@observer@*/const char *meth, /*@null@*/void *arg)
    -+/*@observer@*/const char *
    -+crypt_make_salt(/*@null@*//*@observer@*/const char *meth, /*@null@*/void *arg)
    - {
    -   static char result[GENSALT_SETTING_SIZE];
    -   size_t salt_len = MAX_SALT_SIZE;
    -
    - ## lib/setupenv.c ##
    -@@
    - #ident "$Id$"
    - 
    - #include <assert.h>
    -+#include <ctype.h>
    -+#include <stdio.h>
    -+#include <string.h>
    - #include <sys/types.h>
    - #include <sys/stat.h>
    --#include <stdio.h>
    --#include <ctype.h>
    - 
    - #include "prototypes.h"
    - #include "defines.h"
    -@@ lib/setupenv.c: static void read_env_file (const char *filename)
    -  *        variables.
    -  */
    - 
    --void setup_env (struct passwd *info)
    -+void
    -+setup_env(struct passwd *info)
    - {
    - #ifndef USE_PAM
    -   const char *envf;
    -
    - ## lib/sgetgrent.c ##
    -@@ lib/sgetgrent.c: list(char *s)
    - }
    - 
    - 
    --struct group *sgetgrent (const char *buf)
    -+struct group *
    -+sgetgrent(const char *buf)
    - {
    -   static char *grpbuf = NULL;
    -   static size_t size = 0;
    -
    - ## lib/strtoday.c ##
    -@@
    -  *        24-sep-72
    -  *        24sep72
    -  */
    --long strtoday (const char *str)
    -+long
    -+strtoday(const char *str)
    - {
    -   time_t t;
    -   bool isnum = true;
    -
      ## lib/utmp.c ##
     @@ lib/utmp.c: active_sessions_count(const char *name, unsigned long limit)
                if (USER_PROCESS != ut->ut_type) {
    @@ lib/utmp.c: active_sessions_count(const char *name, unsigned long limit)
                if (count > limit) {
                        break;
     
    - ## lib/valid.c ##
    -@@
    - 
    - #include <pwd.h>
    - #include <stdio.h>
    -+#include <string.h>
    - #include <sys/types.h>
    - 
    - #include "defines.h"
    -@@
    -  *        is used to indicate that a dummy salt must be used to encrypt the
    -  *        password anyway.
    -  */
    --bool valid (const char *password, const struct passwd *ent)
    -+bool
    -+valid(const char *password, const struct passwd *ent)
    - {
    -   const char *encrypted;
    -   /*@observer@*/const char *salt;
    -
      ## src/login_nopam.c ##
     @@ src/login_nopam.c: list_match(char *list, const char *item, bool (*match_fn)(const char *, const ch
      }
    @@ src/newgrp.c: static void check_perms (const struct group *grp,
                needspasswd = true;
        }
      
    -
    - ## src/su.c ##
    -@@
    - #include <pwd.h>
    - #include <signal.h>
    - #include <stdio.h>
    -+#include <string.h>
    - #include <sys/types.h>
    - #include <unistd.h>
    - #ifndef USE_PAM
    -@@ src/su.c: save_caller_context(void)
    -  *        the values that the user will be created with accordingly. The
    -  *        values are checked for sanity.
    -  */
    --static void process_flags (int argc, char **argv)
    -+static void
    -+process_flags(int argc, char **argv)
    - {
    -   int c;
    -   static struct option long_options[] = {
    -@@ src/su.c: static void set_environment (struct passwd *pw)
    -  *        particular, the argument "-c" will cause the next argument to be
    -  *        interpreted as a command by the common shell programs.
    -  */
    --int main (int argc, char **argv)
    -+int
    -+main(int argc, char **argv)
    - {
    -   const char *cp;
    -   struct passwd *pw = NULL;
    -
    - ## src/sulogin.c ##
    -@@
    - #include <pwd.h>
    - #include <signal.h>
    - #include <stdio.h>
    -+#include <string.h>
    - #include <sys/ioctl.h>
    - #include <sys/types.h>
    - 
    -
    - ## src/useradd.c ##
    -@@ src/useradd.c: err_free_new:
    -  *        converts it to a NULL-terminated array. Any unknown group
    -  *        names are reported as errors.
    -  */
    --static int get_groups (char *list)
    -+static int
    -+get_groups(char *list)
    - {
    -   struct group *grp;
    -   int errors = 0;
    -
    - ## src/userdel.c ##
    -@@
    - #include <grp.h>
    - #include <pwd.h>
    - #include <stdio.h>
    -+#include <string.h>
    - #include <sys/stat.h>
    - #include <sys/types.h>
    - #include <unistd.h>
    -@@ src/userdel.c: static int remove_tcbdir (const char *user_name, uid_t user_id)
    - /*
    -  * main - userdel command
    -  */
    --int main (int argc, char **argv)
    -+int
    -+main(int argc, char **argv)
    - {
    -   int errors = 0; /* Error in the removal of the home directory */
    - 
    -
    - ## src/usermod.c ##
    -@@
    - #endif                            /* USE_PAM */
    - #endif                            /* ACCT_TOOLS_SETUID */
    - #include <stdio.h>
    -+#include <string.h>
    - #include <strings.h>
    - #include <sys/stat.h>
    - #include <sys/types.h>
    -@@ src/usermod.c: extern int allow_bad_names;
    -  *        converts it to a NULL-terminated array. Any unknown group names are
    -  *        reported as errors.
    -  */
    --static int get_groups (char *list)
    -+static int
    -+get_groups(char *list)
    - {
    -   struct group *grp;
    -   int errors = 0;
    -@@ src/usermod.c: static void move_mailbox (void)
    - /*
    -  * main - usermod command
    -  */
    --int main (int argc, char **argv)
    -+int
    -+main(int argc, char **argv)
    - {
    - #ifdef ACCT_TOOLS_SETUID
    - #ifdef USE_PAM
2:  e2a7b642 ! 2:  3da8482d contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
    @@ lib/obscure.c: static bool similar (/*@notnull@*/const char *old, /*@notnull@*/c
        if (i >= j * 2) {
     
      ## lib/setupenv.c ##
    -@@ lib/setupenv.c: setup_env(struct passwd *info)
    +@@ lib/setupenv.c: void setup_env (struct passwd *info)
        if (NULL == cp) {
                /* not specified, use a minimal default */
                addenv ((info->pw_uid == 0) ? "PATH=/sbin:/bin:/usr/sbin:/usr/bin" : "PATH=/bin:/usr/bin", NULL);
    @@ src/login_nopam.c: from_match(const char *tok, const char *string)
                   && (strncmp (tok, resolve_hostname (string), tok_len) == 0)) {
     
      ## src/su.c ##
    -@@ src/su.c: process_flags(int argc, char **argv)
    +@@ src/su.c: static void process_flags (int argc, char **argv)
        }
      }
      
```
</details>

<details>
<summary>v6</summary>

-  Rebase

```
$ git range-diff gh/streq_empty..gh/string streq_empty..string 
1:  4022dbc7 ! 1:  39b9485c lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
    @@ lib/port.c: next:
         * Get the next comma separated entry
         */
      
    --  for (j = 0; ('\0' != *cp) && (j < PORT_TIMES); j++) {
    -+  for (j = 0; strcmp(cp, "") != 0 && (j < PORT_TIMES); j++) {
    +-  for (j = 0; !streq(cp, "") && (j < PORT_TIMES); j++) {
    ++  for (j = 0; ('\0' != *cp) && (j < PORT_TIMES); j++) {
      
                /*
                 * Start off with no days of the week
    @@ lib/utmp.c: active_sessions_count(const char *name, unsigned long limit)
                        break;
     
      ## src/login_nopam.c ##
    -@@ src/login_nopam.c: list_match(char *list, const char *item, bool (*match_fn)(const char *, const ch
    - }
    - 
    - /* myhostname - figure out local machine name */
    --static char *myhostname (void)
    -+static char *
    -+myhostname(void)
    - {
    -   static char name[MAXHOSTNAMELEN + 1] = "";
    - 
    -@@ src/login_nopam.c: static const char *resolve_hostname (const char *string)
    - 
    - /* from_match - match a host or tty against a list of tokens */
    - 
    --static bool from_match (const char *tok, const char *string)
    -+static bool
    -+from_match(const char *tok, const char *string)
    - {
    -   size_t tok_len;
    - 
     @@ src/login_nopam.c: static bool from_match (const char *tok, const char *string)
                if (strchr (string, '.') == NULL) {
                        return true;
                }
    --  } else if (   (tok[0] != '\0' && tok[(tok_len = strlen (tok)) - 1] == '.') /* network */
    -+  } else if (   (strcmp(tok, "") != 0)
    -+             && (tok[(tok_len = strlen (tok)) - 1] == '.') /* network */
    +-  } else if (   (!streq(tok != '\0') && tok[(tok_len = strlen (tok)) - 1] == '.') /* network */
    ++  } else if (   (tok[0] != '\0' && tok[(tok_len = strlen (tok)) - 1] == '.') /* network */
                   && (strncmp (tok, resolve_hostname (string), tok_len) == 0)) {
                return true;
        }
    @@ src/logoutd.c: main(int argc, char **argv)
                        }
     
      ## src/newgrp.c ##
    -@@
    - #include <grp.h>
    - #include <pwd.h>
    - #include <stdio.h>
    -+#include <string.h>
    - #include <assert.h>
    - 
    - #include "agetpass.h"
    -@@ src/newgrp.c: static /*@null@*/struct group *find_matching_group (const char *name, struct gro
    -  *
    -  *        It will not return if the user could not be authenticated.
    -  */
    --static void check_perms (const struct group *grp,
    --                         struct passwd *pwd,
    --                         const char *groupname)
    -+static void
    -+check_perms(const struct group *grp, struct passwd *pwd, const char *groupname)
    - {
    -   bool needspasswd = false;
    -   struct spwd *spwd;
     @@ src/newgrp.c: static void check_perms (const struct group *grp,
                spw_free (spwd);
        }
      
    --  if (streq(pwd->pw_passwd, "") && (grp->gr_passwd[0] != '\0')) {
    -+  if (streq(pwd->pw_passwd, "") && strcmp(grp->gr_passwd, "") != 0) {
    +-  if (streq(pwd->pw_passwd, "") && !streq(grp->gr_passwd, "")) {
    ++  if (streq(pwd->pw_passwd, "") && (grp->gr_passwd[0] != '\0')) {
                needspasswd = true;
        }
      
2:  3da8482d ! 2:  e944be4e contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
    @@ src/chpasswd.c: int main (int argc, char **argv)
                                fprintf (stderr,
     
      ## src/login_nopam.c ##
    -@@ src/login_nopam.c: from_match(const char *tok, const char *string)
    +@@ src/login_nopam.c: static bool from_match (const char *tok, const char *string)
                        return true;
                }
        } else if (strcasecmp (tok, "LOCAL") == 0) {    /* local: no dots */
    @@ src/login_nopam.c: from_match(const char *tok, const char *string)
     +          if (strchr(string, '.') == NULL)
                        return true;
     -          }
    -+
    -   } else if (   (strcmp(tok, "") != 0)
    -              && (tok[(tok_len = strlen (tok)) - 1] == '.') /* network */
    +   } else if (   (tok[0] != '\0' && tok[(tok_len = strlen (tok)) - 1] == '.') /* network */
                   && (strncmp (tok, resolve_hostname (string), tok_len) == 0)) {
    +           return true;
     
      ## src/su.c ##
     @@ src/su.c: static void process_flags (int argc, char **argv)
```
</details>

<details>
<summary>v6b</summary>

-  Fix rebase accidents from v6.

```
$ git range-diff streq_empty gh/string string 
1:  39b9485c ! 1:  d6c6ff67 lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
    @@ Commit message
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    - ## lib/port.c ##
    -@@ lib/port.c: next:
    -    * Get the next comma separated entry
    -    */
    - 
    --  for (j = 0; !streq(cp, "") && (j < PORT_TIMES); j++) {
    -+  for (j = 0; ('\0' != *cp) && (j < PORT_TIMES); j++) {
    - 
    -           /*
    -            * Start off with no days of the week
    -
      ## lib/utmp.c ##
     @@ lib/utmp.c: active_sessions_count(const char *name, unsigned long limit)
                if (USER_PROCESS != ut->ut_type) {
    @@ lib/utmp.c: active_sessions_count(const char *name, unsigned long limit)
                if (count > limit) {
                        break;
     
    - ## src/login_nopam.c ##
    -@@ src/login_nopam.c: static bool from_match (const char *tok, const char *string)
    -           if (strchr (string, '.') == NULL) {
    -                   return true;
    -           }
    --  } else if (   (!streq(tok != '\0') && tok[(tok_len = strlen (tok)) - 1] == '.') /* network */
    -+  } else if (   (tok[0] != '\0' && tok[(tok_len = strlen (tok)) - 1] == '.') /* network */
    -              && (strncmp (tok, resolve_hostname (string), tok_len) == 0)) {
    -           return true;
    -   }
    -
      ## src/logoutd.c ##
     @@
      #include <fcntl.h>
    @@ src/logoutd.c: main(int argc, char **argv)
                        if (check_login (ut)) {
                                continue;
                        }
    -
    - ## src/newgrp.c ##
    -@@ src/newgrp.c: static void check_perms (const struct group *grp,
    -           spw_free (spwd);
    -   }
    - 
    --  if (streq(pwd->pw_passwd, "") && !streq(grp->gr_passwd, "")) {
    -+  if (streq(pwd->pw_passwd, "") && (grp->gr_passwd[0] != '\0')) {
    -           needspasswd = true;
    -   }
    - 
2:  e944be4e ! 2:  e391c3ad contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
    @@ src/login_nopam.c: static bool from_match (const char *tok, const char *string)
     +          if (strchr(string, '.') == NULL)
                        return true;
     -          }
    -   } else if (   (tok[0] != '\0' && tok[(tok_len = strlen (tok)) - 1] == '.') /* network */
    +   } else if (   (!streq(tok != '\0') && tok[(tok_len = strlen (tok)) - 1] == '.') /* network */
                   && (strncmp (tok, resolve_hostname (string), tok_len) == 0)) {
                return true;
     
```
</details>

<details>
<summary>v6c</summary>

-  Rebase

```
$ git range-diff d6c6ff67^..gh/string streq_empty..string 
1:  d6c6ff67 = 1:  c15066cc lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
2:  e391c3ad ! 2:  2ed39644 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
    @@ src/login_nopam.c: static bool from_match (const char *tok, const char *string)
     +          if (strchr(string, '.') == NULL)
                        return true;
     -          }
    -   } else if (   (!streq(tok != '\0') && tok[(tok_len = strlen (tok)) - 1] == '.') /* network */
    +   } else if (   (!streq(tok, "") && tok[(tok_len = strlen(tok)) - 1] == '.') /* network */
                   && (strncmp (tok, resolve_hostname (string), tok_len) == 0)) {
                return true;
     
```
</details>

<details>
<summary>v6d</summary>

-  Rebase

```
$ git range-diff gh/streq_empty..gh/string streq_empty..string 
1:  c15066cc = 1:  6ba2e50f lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
2:  2ed39644 = 2:  05ba997c contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
```
</details>

<details>
<summary>v6e</summary>

-  Rebase

```
$ git range-diff 6ba2e50f^..gh/string sp..string 
1:  6ba2e50f = 1:  f4a7f271 lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
2:  05ba997c ! 2:  f6c84828 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
    @@ lib/env.c: void set_env (int argc, char *const *argv)
        char **envp = environ;
        const char *const *bad;
     @@ lib/env.c: void sanitize_env (void)
    -                   if (strncmp (*cur, *bad, strlen (*bad)) != 0) {
    +                   if (!strprefix(*cur, *bad)) {
                                continue;
                        }
     -                  if (strchr (*cur, '/') == NULL) {
    @@ src/login_nopam.c: static bool from_match (const char *tok, const char *string)
     +          if (strchr(string, '.') == NULL)
                        return true;
     -          }
    -   } else if (   (!streq(tok, "") && tok[(tok_len = strlen(tok)) - 1] == '.') /* network */
    -              && (strncmp (tok, resolve_hostname (string), tok_len) == 0)) {
    +   } else if (   (!streq(tok, "") && tok[strlen(tok) - 1] == '.') /* network */
    +              && strprefix(resolve_hostname(string), tok)) {
                return true;
     
      ## src/su.c ##
```
</details>

<details>
<summary>v6f</summary>

-  Rebase

```
$ git range-diff gh/sp..gh/string sp..string 
1:  f4a7f271 = 1:  03f3bf31 lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
2:  f6c84828 = 2:  d3e61a96 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
```
</details>

<details>
<summary>v6g</summary>

-  Rebase

```
$ git range-diff gh/sp..gh/string sp..string 
1:  03f3bf31 = 1:  a83eb67a lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
2:  d3e61a96 = 2:  90ea1150 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
```
</details>

<details>
<summary>v6h</summary>

-  Rebase

```
$ git range-diff gh/sp..gh/string sp..string 
1:  a83eb67a = 1:  c6395b2b lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
2:  90ea1150 = 2:  18a7c7d1 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
```
</details>

<details>
<summary>v7</summary>

-  Use implicit conversion from pointer to bool with strchr().  I think that's more readable and consistent.

```
$ git range-diff gh/sp..gh/string sp..string 
1:  c6395b2b = 1:  4ad84760 lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
2:  18a7c7d1 ! 2:  5c3f5704 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
    @@ Metadata
      ## Commit message ##
         contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
     
    -    For negative matches, use
    -            if (strchr(...) == NULL)
    +    While the return value is a pointer, it can be interpreted as a boolean
    +    value meaning "found".  In general, we use explicit comparisons of
    +    pointers to NULL, but in this specific case, let's use that
    +    interpretation, and make an exception, using an implicit conversion to
    +    boolean.
     
    -    For positive matches, use the cast-to-bool operator:
    -            if (!!strchr(...))
    +    For negative matches, use
    +            if (!strchr(...))
    +
    +    For positive matches, use
    +            if (strchr(...))
     
         For positive matches, when a variable is also set, use
                 while (NULL != (p = strchr(...)))
    @@ contrib/adduser.c: main (void)
              done = 0;
            }
     -    else if (strchr (usrname, ' ') != NULL)
    -+    else if (!!strchr(usrname, ' '))
    ++    else if (strchr(usrname, ' '))
            {
              printf ("No spaces in username!!\n");
              done = 0;
     
      ## lib/env.c ##
    -@@ lib/env.c: void set_env (int argc, char *const *argv)
    -  * but... I feel better with that silly precaution. -j.
    -  */
    - 
    --void sanitize_env (void)
    -+void
    -+sanitize_env(void)
    - {
    -   char **envp = environ;
    -   const char *const *bad;
     @@ lib/env.c: void sanitize_env (void)
                        if (!strprefix(*cur, *bad)) {
                                continue;
                        }
     -                  if (strchr (*cur, '/') == NULL) {
    -+                  if (strchr(*cur, '/') == NULL)
    ++                  if (!strchr(*cur, '/'))
                                continue;       /* OK */
     -                  }
     +
    @@ lib/obscure.c
      
      #include "attr.h"
      #include "prototypes.h"
    -@@ lib/obscure.c: static bool palindrome (MAYBE_UNUSED const char *old, const char *new)
    -  * more than half of the characters are different ones.
    -  */
    - 
    --static bool similar (/*@notnull@*/const char *old, /*@notnull@*/const char *new)
    -+static bool
    -+similar(/*@notnull@*/const char *old, /*@notnull@*/const char *new)
    - {
    -   int i, j;
    - 
     @@ lib/obscure.c: static bool similar (/*@notnull@*/const char *old, /*@notnull@*/const char *new)
        }
      
        for (i = j = 0; ('\0' != new[i]) && ('\0' != old[i]); i++) {
     -          if (strchr (new, old[i]) != NULL) {
    -+          if (!!strchr(new, old[i]))
    ++          if (strchr(new, old[i]))
                        j++;
     -          }
        }
    @@ lib/setupenv.c: void setup_env (struct passwd *info)
                /* not specified, use a minimal default */
                addenv ((info->pw_uid == 0) ? "PATH=/sbin:/bin:/usr/sbin:/usr/bin" : "PATH=/bin:/usr/bin", NULL);
     -  } else if (strchr (cp, '=')) {
    -+  } else if (!!strchr(cp, '=')) {
    ++  } else if (strchr(cp, '=')) {
                /* specified as name=value (PATH=...) */
                addenv (cp, NULL);
        } else {
     
      ## lib/tcbfuncs.c ##
    -@@ lib/tcbfuncs.c: static /*@null@*/ char *shadowtcb_path_existing (const char *name)
    -   return ret;
    - }
    - 
    --static shadowtcb_status mkdir_leading (const char *name, uid_t uid)
    -+static shadowtcb_status
    -+mkdir_leading(const char *name, uid_t uid)
    - {
    -   char *ind, *dir, *ptr, *path = shadowtcb_path_rel (name, uid);
    -   struct stat st;
     @@ lib/tcbfuncs.c: static shadowtcb_status mkdir_leading (const char *name, uid_t uid)
                         shadow_progname, TCB_DIR, strerror (errno));
                goto out_free_path;
    @@ src/chfn.c
      #include <sys/types.h>
      #include <getopt.h>
      
    -@@ src/chfn.c: usage (int status)
    -  *
    -  *        Return true if the user can change the field and false otherwise.
    -  */
    --static bool may_change_field (int field)
    -+static bool
    -+may_change_field(int field)
    - {
    -   const char *cp;
    - 
     @@ src/chfn.c: static bool may_change_field (int field)
                cp = "frwh";
        }
      
     -  if (strchr (cp, field) != NULL) {
    -+  if (!!strchr(cp, field))
    ++  if (strchr(cp, field))
                return true;
     -  }
      
    @@ src/chpasswd.c
      
      #ifdef USE_PAM
      #include "pam_defs.h"
    -@@ src/chpasswd.c: static const char *get_salt(void)
    -   return crypt_make_salt (crypt_method, arg);
    - }
    - 
    --int main (int argc, char **argv)
    -+int
    -+main(int argc, char **argv)
    - {
    -   char buf[BUFSIZ];
    -   char *name;
    -   char *newpwd;
    --  char *cp;
    -   const char *salt;
    - 
    - #ifdef USE_PAM
     @@ src/chpasswd.c: int main (int argc, char **argv)
    -    * present.
    -    */
    -   while (fgets (buf, sizeof buf, stdin) != NULL) {
    -+          char  *cp;
    -+
    -           line++;
    -           if (stpsep(buf, "\n") == NULL) {
                        if (feof (stdin) == 0) {
                                // Drop all remaining characters on this line.
                                while (fgets (buf, sizeof buf, stdin) != NULL) {
     -                                  cp = strchr (buf, '\n');
     -                                  if (cp != NULL) {
    -+                                  if (!!strchr(buf, '\n'))
    ++                                  if (strchr(buf, '\n'))
                                                break;
     -                                  }
                                }
    @@ src/login_nopam.c: static bool from_match (const char *tok, const char *string)
                }
        } else if (strcasecmp (tok, "LOCAL") == 0) {    /* local: no dots */
     -          if (strchr (string, '.') == NULL) {
    -+          if (strchr(string, '.') == NULL)
    ++          if (!strchr(string, '.'))
                        return true;
     -          }
        } else if (   (!streq(tok, "") && tok[strlen(tok) - 1] == '.') /* network */
    @@ src/login_nopam.c: static bool from_match (const char *tok, const char *string)
                return true;
     
      ## src/su.c ##
    -@@ src/su.c: static void process_flags (int argc, char **argv)
    -   }
    - }
    - 
    --static void set_environment (struct passwd *pw)
    -+static void
    -+set_environment(struct passwd *pw)
    - {
    -   const char *cp;
    -   /*
     @@ src/su.c: static void set_environment (struct passwd *pw)
        cp = getdef_str ((pw->pw_uid == 0) ? "ENV_SUPATH" : "ENV_PATH");
        if (NULL == cp) {
                addenv ((pw->pw_uid == 0) ? "PATH=/sbin:/bin:/usr/sbin:/usr/bin" : "PATH=/bin:/usr/bin", NULL);
     -  } else if (strchr (cp, '=') != NULL) {
    -+  } else if (!!strchr(cp, '=')) {
    ++  } else if (strchr(cp, '=')) {
                addenv (cp, NULL);
        } else {
                addenv ("PATH", cp);
```
</details>

<details>
<summary>v7b</summary>

-  Rebase

```
$ git range-diff gh/sp..gh/string sp..string 
1:  4ad84760 = 1:  3610f6a0 lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
2:  5c3f5704 ! 2:  6d7ddd60 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
    @@ src/chpasswd.c: int main (int argc, char **argv)
                                fprintf (stderr,
     
      ## src/login_nopam.c ##
    -@@ src/login_nopam.c: static bool from_match (const char *tok, const char *string)
    +@@ src/login_nopam.c: static bool from_match (char *tok, const char *string)
                        return true;
                }
        } else if (strcasecmp (tok, "LOCAL") == 0) {    /* local: no dots */
```
</details>

<details>
<summary>v7c</summary>

-  Rebase

```
$ git range-diff gh/sp..gh/string sp..string 
1:  3610f6a0 = 1:  a20242c7 lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
2:  6d7ddd60 ! 2:  6800e910 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
    @@ src/chfn.c: static bool may_change_field (int field)
     
      ## src/chpasswd.c ##
     @@
    - #include <pwd.h>
    + #include <stdint.h>
      #include <stdio.h>
      #include <stdlib.h>
     +#include <string.h>
```
</details>

<details>
<summary>v7d</summary>

-  Rebase

```
$ git range-diff gh/sp..gh/string sp..string 
1:  a20242c7 = 1:  34efa976 lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
2:  6800e910 = 2:  e7cd55da contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
```
</details>

<details>
<summary>v7e</summary>

-  Rebase

```
$ git range-diff gh/sp..gh/string sp..string 
1:  34efa976 = 1:  7c229c8b lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
2:  e7cd55da = 2:  d174814c contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
```
</details>

<details>
<summary>v7f</summary>

-  Rebase

```
$ git range-diff gh/sp..gh/string sp..string 
1:  7c229c8b = 1:  0735d718 lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
2:  d174814c ! 2:  919d0185 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
    @@ src/login_nopam.c
     @@ src/login_nopam.c: static bool from_match (char *tok, const char *string)
                        return true;
                }
    -   } else if (strcasecmp (tok, "LOCAL") == 0) {    /* local: no dots */
    +   } else if (strcaseeq(tok, "LOCAL")) {   /* LOCAL: no dots */
     -          if (strchr (string, '.') == NULL) {
     +          if (!strchr(string, '.'))
                        return true;
```
</details>

<details>
<summary>v7g</summary>

-  Rebase

```
$ git range-diff gh/sp..gh/string sp..string 
1:  0735d718 = 1:  086a9b08 lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
2:  919d0185 = 2:  52266725 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
```
</details>

<details>
<summary>v7h</summary>

-  Rebase

```
$ git range-diff gh/sp..gh/string sp..string 
1:  086a9b08 = 1:  8b053063 lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
2:  52266725 = 2:  e3338be1 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
```
</details>

<details>
<summary>v7i</summary>

-  Rebase

```
$ git range-diff gh/sp..gh/string sp..string 
1:  8b053063 = 1:  4aedf986 lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
2:  e3338be1 = 2:  e7b24218 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
```
</details>

<details>
<summary>v7j</summary>

-  Rebase

```
$ git range-diff gh/sp..gh/string sp..string 
1:  4aedf986 = 1:  68c3f50e lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
2:  e7b24218 = 2:  888cf1d9 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
```
</details>

<details>
<summary>v7k</summary>

-  Rebase

```
$ git range-diff gh/sp..gh/string sp..string 
1:  68c3f50e = 1:  f43ec93f lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
2:  888cf1d9 = 2:  ec047bef contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
```
</details>

<details>
<summary>v7l</summary>

-  Rebase

```
$ git range-diff gh/sp..gh/string sp..string
1:  f43ec93f = 1:  464bea6d lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
2:  ec047bef = 2:  b84f0a61 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
```
</details>

<details>
<summary>v7m</summary>

-  Rebase

```
$ git range-diff gh/sp..gh/string sp..string 
1:  464bea6d = 1:  3942443c lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
2:  b84f0a61 = 2:  f86fcfbc contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
```
</details>

<details>
<summary>v7n</summary>

-  Rebase

```
$ git range-diff gh/sp..gh/string shadow/master..string 
1:  3942443c = 1:  99cba286 lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
2:  f86fcfbc = 2:  c4f58fd3 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
```
</details>

<details>
<summary>v7o</summary>

-  Rebase

```
$ git rd
1:  99cba286 = 1:  1e4aa726 lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
2:  c4f58fd3 = 2:  40a2b1d2 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
```
</details>

<details>
<summary>v7p</summary>

-  Rebase

```
$ git rd
1:  1e4aa726 = 1:  0e5824c3 lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
2:  40a2b1d2 = 2:  caf980b1 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
```
</details>

<details>
<summary>v7q</summary>

-  Rebase

```
$ git rd
1:  0e5824c3 = 1:  48482518 lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
2:  caf980b1 = 2:  c7863c74 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
```
</details>

<details>
<summary>v7r</summary>

-  Rebase

```
$ git rd
1:  48482518 = 1:  9565c393 lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
2:  c7863c74 = 2:  86f83976 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
```
</details>

<details>
<summary>v7s</summary>

-  Rebase

```
$ git rd 
1:  9565c393 = 1:  3e0cf08f lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
2:  86f83976 = 2:  7446cc0a contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
```
</details>

<details>
<summary>v7t</summary>

-  Rebase

```
$ git rd 
1:  3e0cf08f = 1:  810601e5 lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
2:  7446cc0a ! 2:  044bfd89 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
    @@ lib/tcbfuncs.c: static shadowtcb_status mkdir_leading (const char *name, uid_t u
     -  while ((ind = strchr (ptr, '/'))) {
     +  while (NULL != (ind = strchr(ptr, '/'))) {
                stpcpy(ind, "");
    -           if (asprintf (&dir, TCB_DIR "/%s", path) == -1) {
    -                   OUT_OF_MEMORY;
    +           dir = aprintf(TCB_DIR "/%s", path);
    +           if (dir == NULL) {
     
      ## src/chfn.c ##
     @@
```
</details>

<details>
<summary>v8</summary>

-  Use countof instead of NITEMS().
-  Update commit message (after some rebase operations, it doesn't use any strcmp(3) anymore).

```
$ git rd 
1:  810601e5 ! 1:  32f13c9c lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
    +    lib/, src/: Use strncmp(3) instead of explicit byte comparisons
     
         This is simpler to read, IMO.
     
    @@ lib/utmp.c: active_sessions_count(const char *name, unsigned long limit)
                        continue;
                }
     -          if ('\0' == ut->ut_user[0]) {
    -+          if (strncmp(ut->ut_user, "", NITEMS(ut->ut_user)) == 0)
    ++          if (strncmp(ut->ut_user, "", countof(ut->ut_user)) == 0)
                        continue;
     -          }
     -          if (strncmp (name, ut->ut_user, sizeof (ut->ut_user)) != 0) {
     +
    -+          if (strncmp(ut->ut_user, name, NITEMS(ut->ut_user)) != 0)
    ++          if (strncmp(ut->ut_user, name, countof(ut->ut_user)) != 0)
                        continue;
     -          }
     +
    @@ src/logoutd.c: main(int argc, char **argv)
                                continue;
                        }
     -                  if (ut->ut_user[0] == '\0') {
    -+                  if (strncmp(ut->ut_user, "", NITEMS(ut->ut_user)) == 0)
    ++                  if (strncmp(ut->ut_user, "", countof(ut->ut_user)) == 0)
                                continue;
     -                  }
     +
2:  044bfd89 = 2:  4a514b51 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
```
</details>

<details>
<summary>v8b</summary>

-  Rebase

```
$ git rd 
1:  32f13c9c = 1:  63ba0336 lib/, src/: Use strncmp(3) instead of explicit byte comparisons
2:  4a514b51 = 2:  2dde1ab5 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
```
</details>

<details>
<summary>v8c</summary>

-  Rebase

```
$ git rd 
1:  63ba0336 = 1:  5d0cbbbd lib/, src/: Use strncmp(3) instead of explicit byte comparisons
2:  2dde1ab5 ! 2:  11d4f1c8 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
    +    lib/, src/: Use consistent style using strchr(3) in conditionals
     
         While the return value is a pointer, it can be interpreted as a boolean
         value meaning "found".  In general, we use explicit comparisons of
    @@ Commit message
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    - ## contrib/adduser.c ##
    -@@ contrib/adduser.c: main (void)
    -         printf ("That name is in use, choose another.\n");
    -         done = 0;
    -       }
    --    else if (strchr (usrname, ' ') != NULL)
    -+    else if (strchr(usrname, ' '))
    -       {
    -         printf ("No spaces in username!!\n");
    -         done = 0;
    -
      ## lib/env.c ##
     @@ lib/env.c: void sanitize_env (void)
                        if (!strprefix(*cur, *bad)) {
```
</details>

<details>
<summary>v8d</summary>

-  Rebase

```
$ git rd 
1:  5d0cbbbd = 1:  1efe0ddf lib/, src/: Use strncmp(3) instead of explicit byte comparisons
2:  11d4f1c8 = 2:  6278c60d lib/, src/: Use consistent style using strchr(3) in conditionals
```
</details>

<details>
<summary>v8e</summary>

-  Rebase

```
$ git rd 
1:  1efe0ddf = 1:  47b7f577 lib/, src/: Use strncmp(3) instead of explicit byte comparisons
2:  6278c60d = 2:  cb1161e8 lib/, src/: Use consistent style using strchr(3) in conditionals
```
</details>

<details>
<summary>v8f</summary>

-  Rebase

```
$ git rd
1:  47b7f577 = 1:  42017e63 lib/, src/: Use strncmp(3) instead of explicit byte comparisons
2:  cb1161e8 = 2:  0f6052df lib/, src/: Use consistent style using strchr(3) in conditionals
```
</details>

<details>
<summary>v9</summary>

-  Change a few more cases of strncmp(3).

```
$ git rd 
1:  42017e63 ! 1:  cc5fcce1 lib/, src/: Use strncmp(3) instead of explicit byte comparisons
    @@ Commit message
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/utmp.c ##
    +@@ lib/utmp.c: get_session_host(char **out, pid_t main_pid)
    +   ut = get_current_utmp(main_pid);
    + 
    + #if defined(HAVE_STRUCT_UTMPX_UT_HOST)
    +-  if ((ut != NULL) && (ut->ut_host[0] != '\0')) {
    ++  if ((ut != NULL) && strncmp(ut->ut_host, "", countof(ut->ut_host)) != 0) {
    +           *out = XSTRNDUP(ut->ut_host);
    +   } else {
    +           *out = NULL;
    +@@ lib/utmp.c: prepare_utmp(const char *name, const char *line, const char *host,
    +   if (NULL != host && !streq(host, ""))
    +           hostname = xstrdup(host);
    + #if defined(HAVE_STRUCT_UTMPX_UT_HOST)
    +-  else if (NULL != ut && '\0' != ut->ut_host[0])
    ++  else if (NULL != ut && strncmp(ut->ut_host, "", countof(ut->ut_host)) != 0)
    +           hostname = XSTRNDUP(ut->ut_host);
    + #endif
    + 
     @@ lib/utmp.c: active_sessions_count(const char *name, unsigned long limit)
                if (USER_PROCESS != ut->ut_type) {
                        continue;
    @@ lib/utmp.c: active_sessions_count(const char *name, unsigned long limit)
                if (count > limit) {
                        break;
     
    + ## src/login.c ##
    +@@ src/login.c: int main (int argc, char **argv)
    +                   printf (_("Last login: %s on %s"),
    +                           ptime, ll.ll_line);
    + #ifdef HAVE_LL_HOST               /* __linux__ || SUN4 */
    +-                  if ('\0' != ll.ll_host[0]) {
    ++                  if (strncmp(ll.ll_host, "", countof(ll.ll_host)) != 0) {
    +                           printf (_(" from %.*s"),
    +                                   (int) sizeof ll.ll_host, ll.ll_host);
    +                   }
    +
      ## src/logoutd.c ##
     @@
      #include <fcntl.h>
2:  0f6052df = 2:  6231ae69 lib/, src/: Use consistent style using strchr(3) in conditionals
```
</details>

<details>
<summary>v10</summary>

-  Drop one commit.  (Moved to #1336.)

```
$ git rd 
1:  cc5fcce1 < -:  -------- lib/, src/: Use strncmp(3) instead of explicit byte comparisons
2:  6231ae69 = 1:  2f432bfa lib/, src/: Use consistent style using strchr(3) in conditionals
```
</details>

<details>
<summary>v10b</summary>

-  Rebase

```
$ git rd 
1:  2f432bfa = 1:  b7efbe9c lib/, src/: Use consistent style using strchr(3) in conditionals
```
</details>