### PR TITLE
lib/chkname.c: An object cannot expand further than the universe in which it resides

### DIFF
--- a/lib/chkname.c
+++ b/lib/chkname.c
@@ -24,6 +24,8 @@
 #include <limits.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
+#include <sys/param.h>
 #include <unistd.h>
 
 #include "defines.h"
@@ -43,7 +45,7 @@ login_name_max_size(void)
 	if (conf == -1 && errno != 0)
 		return LOGIN_NAME_MAX;
 
-	return conf;
+	return MIN(conf, PTRDIFF_MAX);
 }
 
 


### PR DESCRIPTION
If you want a larger object, you'll have to wait at least until the universe expands so much.  (Or maybe not, but luckily, programming is simpler than physics.)

If an implementation doesn't recognize its own limitations, its a bug, not a feature.

Closes: <https://github.com/shadow-maint/shadow/issues/1052>
Cc: @stoeckmann 