### PR TITLE
man: groupmod: Minor improvements

### DIFF
--- a/man/groupadd.8.xml
+++ b/man/groupadd.8.xml
@@ -230,7 +230,7 @@
 	</term>
 	<listitem>
 	  <para>
-	    A list of usernames to add as members of the group.
+	    A comma-separated list of usernames to add as members of the group.
 	  </para>
 	  <para>
 	    The default behavior (if the <option>-g</option>,

--- a/man/groupmod.8.xml
+++ b/man/groupmod.8.xml
@@ -70,7 +70,7 @@
     <variablelist remap='IP'>
       <varlistentry>
 	<term>
-	  <option>-a</option>, <option>--append</option>&nbsp;<replaceable>GID</replaceable>
+	  <option>-a</option>, <option>--append</option>
 	</term>
 	<listitem>
       <para>If group members are specified with -U, append them to the existing

--- a/man/groupmod.8.xml
+++ b/man/groupmod.8.xml
@@ -195,7 +195,7 @@
 	</term>
 	<listitem>
 	  <para>
-	    A list of usernames to add as members of the group.
+	    A comma-separated list of usernames to add as members of the group.
 	  </para>
 	  <para>
 	    The default behavior (if the <option>-g</option>,

--- a/man/groupmod.8.xml
+++ b/man/groupmod.8.xml
@@ -198,10 +198,10 @@
 	    A comma-separated list of usernames to add as members of the group.
 	  </para>
 	  <para>
-	    The default behavior (if the <option>-g</option>,
-	    <option>-N</option>, and <option>-U</option> options are not
-	    specified) is defined by the <option>USERGROUPS_ENAB</option>
-	    variable in <filename>/etc/login.defs</filename>.
+	    The default behavior (if the <option>-g</option> and
+	    <option>-U</option> options are not specified) is defined by the
+	    <option>USERGROUPS_ENAB</option> variable in
+	    <filename>/etc/login.defs</filename>.
 	  </para>
 	</listitem>
       </varlistentry>


### PR DESCRIPTION
While looking at groupmod I was confused by `--append GID` so I omitted it and groupmod worked just fine.
So looking into the code I figured the man page was wrong - and decided to fix this.

While at it I also fixed some other minor issues, ie #848 

One might argue that this PR is not complete and maybe a large overhaul is required but on the other hand those large PRs are hard to handle so I decided to keep it simple for now and do one step at a time.