### PR TITLE
lib/, src/: Use local time for human-readable dates

### DIFF
--- a/lib/time/day_to_str.h
+++ b/lib/time/day_to_str.h
@@ -38,7 +38,7 @@ day_to_str(size_t size, char buf[size], long day)
 		return;
 	}
 
-	if (gmtime_r(&date, &tm) == NULL) {
+	if (localtime_r(&date, &tm) == NULL) {
 		strtcpy(buf, "future", size);
 		return;
 	}

--- a/src/chage.c
+++ b/src/chage.c
@@ -242,7 +242,7 @@ print_day_as_date(long day)
 		return;
 	}
 
-	if (gmtime_r(&date, &tm) == NULL) {
+	if (localtime_r(&date, &tm) == NULL) {
 		(void) printf ("time_t: %lu\n", (unsigned long)date);
 		return;
 	}


### PR DESCRIPTION
That is, use localtime_r(3) instead of gmtime_r(3).

Closes: <https://github.com/shadow-maint/shadow/issues/1057>
Reported-by: @kenion
Cc: @hallyn 
Cc: @eggert 