### PR TITLE
DAY_TO_STR() localization

### DIFF
--- a/lib/time/day_to_str.c
+++ b/lib/time/day_to_str.c
@@ -7,5 +7,8 @@
 
 #include "time/day_to_str.h"
 
+#include <stdbool.h>
+#include <stddef.h>
 
-extern inline void day_to_str(size_t size, char buf[size], long day);
+
+extern inline void day_to_str(size_t size, char buf[size], long day, bool iso);

--- a/lib/time/day_to_str.h
+++ b/lib/time/day_to_str.h
@@ -9,6 +9,8 @@
 
 #include <config.h>
 
+#include <stdbool.h>
+#include <stddef.h>
 #include <time.h>
 
 #include "defines.h"
@@ -16,14 +18,14 @@
 #include "string/strcpy/strtcpy.h"
 
 
-#define DAY_TO_STR(str, day)   day_to_str(NITEMS(str), str, day)
+#define DAY_TO_STR(str, day, iso)   day_to_str(NITEMS(str), str, day, iso)
 
 
-inline void day_to_str(size_t size, char buf[size], long day);
+inline void day_to_str(size_t size, char buf[size], long day, bool iso);
 
 
 inline void
-day_to_str(size_t size, char buf[size], long day)
+day_to_str(size_t size, char buf[size], long day, bool iso)
 {
 	time_t     date;
 	struct tm  tm;
@@ -43,7 +45,7 @@ day_to_str(size_t size, char buf[size], long day)
 		return;
 	}
 
-	if (strftime(buf, size, "%F", &tm) == 0)
+	if (strftime(buf, size, iso ? "%F" : "%x", &tm) == 0)
 		strtcpy(buf, "future", size);
 }
 

--- a/src/chage.c
+++ b/src/chage.c
@@ -182,7 +182,7 @@ static int new_fields (void)
 	if (-1 == lstchgdate || lstchgdate > LONG_MAX / DAY)
 		strcpy(buf, "-1");
 	else
-		DAY_TO_STR(buf, lstchgdate);
+		DAY_TO_STR(buf, lstchgdate, 1);
 
 	change_field (buf, sizeof buf, _("Last Password Change (YYYY-MM-DD)"));
 
@@ -208,7 +208,7 @@ static int new_fields (void)
 	if (-1 == expdate || LONG_MAX / DAY < expdate)
 		strcpy(buf, "-1");
 	else
-		DAY_TO_STR(buf, expdate);
+		DAY_TO_STR(buf, expdate, 1);
 
 	change_field (buf, sizeof buf,
 	              _("Account Expiration Date (YYYY-MM-DD)"));

--- a/src/faillog.c
+++ b/src/faillog.c
@@ -172,7 +172,7 @@ static void print_one (/*@null@*/const struct passwd *pw, bool force)
 		fprintf (stderr, "Cannot read time from faillog.\n");
 		return;
 	}
-	STRFTIME(ptime, "%D %H:%M:%S %z", tm);
+	STRFTIME(ptime, "%c", tm);
 	cp = ptime;
 
 	printf ("%-9s   %5d    %5d   ",

--- a/src/lastlog.c
+++ b/src/lastlog.c
@@ -161,7 +161,7 @@ static void print_one (/*@null@*/const struct passwd *pw)
 	if (tm == NULL) {
 		cp = "(unknown)";
 	} else {
-		STRFTIME(ptime, "%a %b %e %H:%M:%S %z %Y", tm);
+		STRFTIME(ptime, "%c", tm);
 		cp = ptime;
 	}
 	if (ll.ll_time == (time_t) 0) {

--- a/src/login.c
+++ b/src/login.c
@@ -1201,7 +1201,7 @@ int main (int argc, char **argv)
 			struct tm  tm;
 
 			localtime_r(&ll_time, &tm);
-			STRFTIME(ptime, "%a %b %e %H:%M:%S %z %Y", &tm);
+			STRFTIME(ptime, "%c", &tm);
 			printf (_("Last login: %s on %s"),
 			        ptime, ll.ll_line);
 #ifdef HAVE_LL_HOST		/* __linux__ || SUN4 */

--- a/src/passwd.c
+++ b/src/passwd.c
@@ -455,7 +455,7 @@ static void print_status (const struct passwd *pw)
 
 	sp = prefix_getspnam (pw->pw_name); /* local, no need for xprefix_getspnam */
 	if (NULL != sp) {
-		DAY_TO_STR(date, sp->sp_lstchg);
+		DAY_TO_STR(date, sp->sp_lstchg, 1);
 		(void) printf ("%s %s %s %ld %ld %ld %ld\n",
 		               pw->pw_name,
 		               pw_status (sp->sp_pwdp),

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -591,8 +591,8 @@ static void new_spent (struct spwd *spent)
 		/* log dates rather than numbers of days. */
 		char new_exp[16], old_exp[16];
 
-		DAY_TO_STR(new_exp, user_newexpire);
-		DAY_TO_STR(old_exp, user_expire);
+		DAY_TO_STR(new_exp, user_newexpire, 1);
+		DAY_TO_STR(old_exp, user_expire, 1);
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
 		              "changing expiration date",


### PR DESCRIPTION
Cc: @eggert 
Cc: @timparenti
Cc: @kenion

---

Revisions:

<details>
<summary>v2</summary>

-  Print localized dates and times by default.
-  Do not use custom formats.
-  Print timezone information together with date strings, as an RFC 9557 suffix.
-  Fix STRFTIME() macro

```
$ git range-diff shadow/master gh/time time 
1:  2686a033 < -:  -------- src/chage.c: Always use ISO 8601 format (YYYY-MM-DD) for printing dates
-:  -------- > 1:  68a97728 lib/, src/: Use %F instead of %Y-%m-%d with strftime(3)
-:  -------- > 2:  56067591 src/: Use %c for printing localized date&times with strftime(3)
-:  -------- > 3:  928172c4 src/chage.c: print_day_as_date(): Use %x for printing localized dates with strftime(3)
2:  de6f93bf = 4:  e78f9782 src/chage.c: print_day_as_date(): Simplify error handling
-:  -------- > 5:  fc46d1f3 lib/time/, src/: day_to_str(): Add support for formatting localized dates
3:  bd7701fa ! 6:  b2c33c58 src/chage.c: print_day_as_date(): Call DAY_TO_STR() to de-duplicate code
    @@ src/chage.c: static int new_fields (void)
     -          return;
     -  }
     -
    --  STRFTIME(buf, "%Y-%m-%d", &tm);
    +-  STRFTIME(buf, iflg ? "%F" : "%x", &tm);
     -  (void) puts (buf);
    -+  DAY_TO_STR(buf, day);
    ++  DAY_TO_STR(buf, day, iflg);
     +  puts(buf);
      }
      
-:  -------- > 7:  9c0ee33c lib/time/day_to_str.h: day_to_str(): Print numeric timezone together with local dates
-:  -------- > 8:  41a12dfe lib/string/strftime.h: STRFTIME(): Tighten macro definition
```
</details>

<details>
<summary>v3</summary>

-  Use the time zone name/abbreviation rather than the numeric offset.  It's strongly preferred by RFC 9557.  [@eggert]

```
$ git range-diff shadow/master gh/time time 
1:  68a97728 = 1:  68a97728 lib/, src/: Use %F instead of %Y-%m-%d with strftime(3)
2:  56067591 = 2:  56067591 src/: Use %c for printing localized date&times with strftime(3)
3:  928172c4 = 3:  928172c4 src/chage.c: print_day_as_date(): Use %x for printing localized dates with strftime(3)
4:  e78f9782 = 4:  e78f9782 src/chage.c: print_day_as_date(): Simplify error handling
5:  fc46d1f3 = 5:  fc46d1f3 lib/time/, src/: day_to_str(): Add support for formatting localized dates
6:  b2c33c58 = 6:  b2c33c58 src/chage.c: print_day_as_date(): Call DAY_TO_STR() to de-duplicate code
7:  9c0ee33c ! 7:  db4f966b lib/time/day_to_str.h: day_to_str(): Print numeric timezone together with local dates
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/time/day_to_str.h: day_to_str(): Print numeric timezone together with local dates
    +    lib/time/day_to_str.h: day_to_str(): Print timezone together with local dates
     
         Print it as a RFC 9557 suffix, which doesn't add any extra whitespace.
         This reduces the damage to expectations of scripts that might parse
    @@ Commit message
         Link: <https://github.com/shadow-maint/shadow/issues/1057>
         Link: <https://lists.sr.ht/~hallyn/shadow/%3Cmzbl4gkns5nyt7otg4t7cxlds2q64wutpjnngxpnix55ocbds2@whvswk343dwl%3E>
         Link: <https://www.rfc-editor.org/rfc/rfc9557.pdf>
    +    Link: <https://lists.gnu.org/archive/html/bug-gnulib/2024-08/msg00003.html>
         Suggested-by: Alejandro Colomar <alx@kernel.org>
         Suggested-by: Paul Eggert <eggert@cs.ucla.edu>
         Cc: "Serge E. Hallyn" <serge@hallyn.com>
         Cc: Tim Parenti <tim@timtimeonline.com>
         Cc: Gus Kenion <https://github.com/kenion>
         Cc: Iker Pedrosa <ipedrosa@redhat.com>
    +    Cc: Bruno Haible <bruno@clisp.org>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/time/day_to_str.h ##
    @@ lib/time/day_to_str.h: day_to_str(size_t size, char buf[size], long day, bool is
        }
      
     -  if (strftime(buf, size, iso ? "%F" : "%x", &tm) == 0)
    -+  if (strftime(buf, size, iso ? "%F[%z]" : "%x[%z]", &tm) == 0)
    ++  if (strftime(buf, size, iso ? "%F[%Z]" : "%x[%Z]", &tm) == 0)
                strtcpy(buf, "future", size);
      }
      
8:  41a12dfe = 8:  bf3481df lib/string/strftime.h: STRFTIME(): Tighten macro definition
```
</details>

<details>
<summary>v4</summary>

-  Don't use a RFC 9557 suffix; that is, don't print timezone info.  date(1) doesn't yet support them, so let's wait until that happens.

```
$ git range-diff shadow/master gh/time time 
1:  68a97728 = 1:  68a97728 lib/, src/: Use %F instead of %Y-%m-%d with strftime(3)
2:  56067591 = 2:  56067591 src/: Use %c for printing localized date&times with strftime(3)
3:  928172c4 = 3:  928172c4 src/chage.c: print_day_as_date(): Use %x for printing localized dates with strftime(3)
4:  e78f9782 = 4:  e78f9782 src/chage.c: print_day_as_date(): Simplify error handling
5:  fc46d1f3 = 5:  fc46d1f3 lib/time/, src/: day_to_str(): Add support for formatting localized dates
6:  b2c33c58 = 6:  b2c33c58 src/chage.c: print_day_as_date(): Call DAY_TO_STR() to de-duplicate code
7:  db4f966b < -:  -------- lib/time/day_to_str.h: day_to_str(): Print timezone together with local dates
8:  bf3481df = 7:  62b553e3 lib/string/strftime.h: STRFTIME(): Tighten macro definition
```
</details>

<details>
<summary>v5</summary>

-  Rebase

```
$ git range-diff master..gh/time shadow/master..time
1:  68a97728 < -:  -------- lib/, src/: Use %F instead of %Y-%m-%d with strftime(3)
2:  56067591 = 1:  b5d8ff0e src/: Use %c for printing localized date&times with strftime(3)
3:  928172c4 < -:  -------- src/chage.c: print_day_as_date(): Use %x for printing localized dates with strftime(3)
4:  e78f9782 < -:  -------- src/chage.c: print_day_as_date(): Simplify error handling
5:  fc46d1f3 = 2:  53554dc6 lib/time/, src/: day_to_str(): Add support for formatting localized dates
6:  b2c33c58 < -:  -------- src/chage.c: print_day_as_date(): Call DAY_TO_STR() to de-duplicate code
7:  62b553e3 < -:  -------- lib/string/strftime.h: STRFTIME(): Tighten macro definition
```
</details>