### PR TITLE
Revert #1058

### DIFF
--- a/lib/time/day_to_str.c
+++ b/lib/time/day_to_str.c
@@ -7,5 +7,8 @@
 
 #include "time/day_to_str.h"
 
+#include <stdbool.h>
+#include <stddef.h>
 
-extern inline void day_to_str(size_t size, char buf[size], long day);
+
+extern inline void day_to_str(size_t size, char buf[size], long day, bool iso);

--- a/lib/time/day_to_str.h
+++ b/lib/time/day_to_str.h
@@ -45,7 +45,7 @@ day_to_str(size_t size, char buf[size], long day, bool iso)
 		return;
 	}
 
-	if (strftime(buf, size, iso ? "%F" : "%x", &tm) == 0)
+	if (strftime(buf, size, iso ? "%FZ" : "%x UTC", &tm) == 0)
 		strtcpy(buf, "future", size);
 }
 

--- a/lib/time/day_to_str.h
+++ b/lib/time/day_to_str.h
@@ -40,7 +40,7 @@ day_to_str(size_t size, char buf[size], long day, bool iso)
 		return;
 	}
 
-	if (localtime_r(&date, &tm) == NULL) {
+	if (gmtime_r(&date, &tm) == NULL) {
 		strtcpy(buf, "future", size);
 		return;
 	}

--- a/lib/time/day_to_str.h
+++ b/lib/time/day_to_str.h
@@ -9,6 +9,8 @@
 
 #include <config.h>
 
+#include <stdbool.h>
+#include <stddef.h>
 #include <time.h>
 
 #include "defines.h"
@@ -16,14 +18,14 @@
 #include "string/strcpy/strtcpy.h"
 
 
-#define DAY_TO_STR(str, day)   day_to_str(NITEMS(str), str, day)
+#define DAY_TO_STR(str, day, iso)   day_to_str(NITEMS(str), str, day, iso)
 
 
-inline void day_to_str(size_t size, char buf[size], long day);
+inline void day_to_str(size_t size, char buf[size], long day, bool iso);
 
 
 inline void
-day_to_str(size_t size, char buf[size], long day)
+day_to_str(size_t size, char buf[size], long day, bool iso)
 {
 	time_t     date;
 	struct tm  tm;
@@ -43,7 +45,7 @@ day_to_str(size_t size, char buf[size], long day)
 		return;
 	}
 
-	if (strftime(buf, size, "%F", &tm) == 0)
+	if (strftime(buf, size, iso ? "%F" : "%x", &tm) == 0)
 		strtcpy(buf, "future", size);
 }
 

--- a/src/chage.c
+++ b/src/chage.c
@@ -182,7 +182,7 @@ static int new_fields (void)
 	if (-1 == lstchgdate || lstchgdate > LONG_MAX / DAY)
 		strcpy(buf, "-1");
 	else
-		DAY_TO_STR(buf, lstchgdate);
+		DAY_TO_STR(buf, lstchgdate, 1);
 
 	change_field (buf, sizeof buf, _("Last Password Change (YYYY-MM-DD)"));
 
@@ -208,7 +208,7 @@ static int new_fields (void)
 	if (-1 == expdate || LONG_MAX / DAY < expdate)
 		strcpy(buf, "-1");
 	else
-		DAY_TO_STR(buf, expdate);
+		DAY_TO_STR(buf, expdate, 1);
 
 	change_field (buf, sizeof buf,
 	              _("Account Expiration Date (YYYY-MM-DD)"));

--- a/src/faillog.c
+++ b/src/faillog.c
@@ -172,7 +172,7 @@ static void print_one (/*@null@*/const struct passwd *pw, bool force)
 		fprintf (stderr, "Cannot read time from faillog.\n");
 		return;
 	}
-	STRFTIME(ptime, "%D %H:%M:%S %z", tm);
+	STRFTIME(ptime, "%c", tm);
 	cp = ptime;
 
 	printf ("%-9s   %5d    %5d   ",

--- a/src/lastlog.c
+++ b/src/lastlog.c
@@ -161,7 +161,7 @@ static void print_one (/*@null@*/const struct passwd *pw)
 	if (tm == NULL) {
 		cp = "(unknown)";
 	} else {
-		STRFTIME(ptime, "%a %b %e %H:%M:%S %z %Y", tm);
+		STRFTIME(ptime, "%c", tm);
 		cp = ptime;
 	}
 	if (ll.ll_time == (time_t) 0) {

--- a/src/login.c
+++ b/src/login.c
@@ -1201,7 +1201,7 @@ int main (int argc, char **argv)
 			struct tm  tm;
 
 			localtime_r(&ll_time, &tm);
-			STRFTIME(ptime, "%a %b %e %H:%M:%S %z %Y", &tm);
+			STRFTIME(ptime, "%c", &tm);
 			printf (_("Last login: %s on %s"),
 			        ptime, ll.ll_line);
 #ifdef HAVE_LL_HOST		/* __linux__ || SUN4 */

--- a/src/passwd.c
+++ b/src/passwd.c
@@ -455,7 +455,7 @@ static void print_status (const struct passwd *pw)
 
 	sp = prefix_getspnam (pw->pw_name); /* local, no need for xprefix_getspnam */
 	if (NULL != sp) {
-		DAY_TO_STR(date, sp->sp_lstchg);
+		DAY_TO_STR(date, sp->sp_lstchg, 1);
 		(void) printf ("%s %s %s %ld %ld %ld %ld\n",
 		               pw->pw_name,
 		               pw_status (sp->sp_pwdp),

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -591,8 +591,8 @@ static void new_spent (struct spwd *spent)
 		/* log dates rather than numbers of days. */
 		char new_exp[16], old_exp[16];
 
-		DAY_TO_STR(new_exp, user_newexpire);
-		DAY_TO_STR(old_exp, user_expire);
+		DAY_TO_STR(new_exp, user_newexpire, 1);
+		DAY_TO_STR(old_exp, user_expire, 1);
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
 		              "changing expiration date",


### PR DESCRIPTION
-  This reverts #1058.

```
    Revert "lib/, src/: Use local time for human-readable dates"
    
    This reverts commit 3f5b4b56268269fefed55aa106f382037297d663.
    
    Time-zone conversion of day-precision timestamps is lossy.  Since the
    timestamps are stored as UTC, let's print them as UTC.  That allows
    users to see the actual value that is stored, and thus the value that
    would be used for comparison, for example for deciding if a login is
    valid.
    
    In the following commit, we add time-zone information to the strings,
    which should allow users understand any discrepancy between the date
    input (by default in local time), and the printed one (always in UTC).
```

```
    lib/time/day_to_str.h: day_to_str(): Print time-zone information together with dates
    
    We print dates as UTC dates, but unqualified dates are understood to be
    in local time.  Thus, we need to expressely mark them as UTC dates.
    
    In ISO mode, append a 'Z' without space.  In the current locale, since
    we don't know the format, append the ' UTC'.
```

Link: <https://en.wikipedia.org/wiki/ISO_8601#Local_time_(unqualified)>
Link: <https://lists.gnu.org/archive/html/bug-gnulib/2024-08/msg00015.html>
Cc: @hallyn 
Cc: @ikerexxe 
Cc: @bhaible
Cc: @eggert 
Cc: @kenion

---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git range-diff gh/time..gh/time2 time..time2
1:  57b44b4c = 1:  7cdca6d8 Revert "lib/, src/: Use local time for human-readable dates"
2:  ded86651 = 2:  746e9c49 lib/time/day_to_str.h: day_to_str(): Print time-zone information together with dates
3:  c05f8ae1 < -:  -------- po/es.po: wsfix
```
</details>