### PR TITLE
Deprecate non-standard date format

### DIFF
--- a/src/chage.c
+++ b/src/chage.c
@@ -252,6 +252,11 @@ print_day_as_date(long day)
 		return;
 	}
 
+	if (!iflg) {
+		fputs(_("This date format is deprecated; use the '-i' option.\n"),
+		      stderr);
+	}
+
 	(void) puts (buf);
 }
 


### PR DESCRIPTION
---

Revisions:

<details>
<summary>v2</summary>

-  Rebase

```
$ git range-diff master..gh/t3 shadow/master..t3 
1:  68a97728 < -:  -------- lib/, src/: Use %F instead of %Y-%m-%d with strftime(3)
2:  d2bfc356 ! 1:  66cbfd63 src/chage.c: print_day_as_date(): Deprecate the non-standard date format
    @@ src/chage.c: print_day_as_date(long day)
     +                stderr);
     +  }
     +
    -   STRFTIME(buf, iflg ? "%F" : "%b %d, %Y", &tm);
        (void) puts (buf);
      }
    + 
```
</details>