### PR TITLE
userdel: --force: Allow the flag to be specified twice, for more granularity

### DIFF
--- a/man/userdel.8.xml
+++ b/man/userdel.8.xml
@@ -79,7 +79,16 @@
 	  <para>
 	    This option forces the removal of the user account
 	    and any other requested actions,
-	    skipping any safety checks.
+	    skipping safety checks.
+	  </para>
+	  <para>
+	    If specified once,
+	    a user is removed
+	    even if it's still logged in,
+	    and its primary group is removed
+	    even if it's the primary group of another user.
+	    If specified twice,
+	    it skips all safety checks.
 	  </para>
 	  <para>
 	    <emphasis>Note:</emphasis> This option is dangerous and may leave


### PR DESCRIPTION
Previously, with a single --force, one could only chose between not forcing, and forcing (which could destroy one's system entirely).

Now one can pass --force, with only a small danger, to skip some checks, and a double --force --force with the meaning of the previous --force, which will possibly destroy the entire system.

Closes: <https://github.com/shadow-maint/shadow/issues/1050>
Reported-by: @wolfsage
Cc: @poettering
Cc: @hallyn 

---

I have NOT tested this.  Please test.

---

Revisions:

<details>
<summary>v2</summary>

-  Reword documentation

```
$ git range-diff shadow/master gh/ff ff 
1:  5d8ddfa5 ! 1:  11c0e8b5 userdel: --force: Allow the flag to be specified twice, for more granularity
    @@ man/userdel.8.xml
     +    </para>
     +    <para>
     +      If specified once,
    -+      it doesn't check if the user is still logged in.
    ++      users are removed
    ++      even if they're still logged in,
    ++      and groups are removed
    ++      even if they are the primary group of a user.
     +      If specified twice,
     +      it skips all safety checks.
          </para>
```
</details>

<details>
<summary>v2b</summary>

-  Reword paragraph.

```
$ git range-diff shadow/master gh/ff ff 
1:  11c0e8b5 ! 1:  cb580580 userdel: --force: Allow the flag to be specified twice, for more granularity
    @@ man/userdel.8.xml
     +    </para>
     +    <para>
     +      If specified once,
    -+      users are removed
    -+      even if they're still logged in,
    -+      and groups are removed
    -+      even if they are the primary group of a user.
    ++      a user is removed
    ++      even if it's still logged in,
    ++      and its primary group is removed
    ++      even if it's the primary group of another user.
     +      If specified twice,
     +      it skips all safety checks.
          </para>
```
</details>

<details>
<summary>v2c</summary>

-  Rebase

```
$ git range-diff gh/master..gh/ff master..ff 
1:  cb580580 = 1:  72af7d32 userdel: --force: Allow the flag to be specified twice, for more granularity
```
</details>

<details>
<summary>v2d</summary>

-  Rebase

```
$ git range-diff master..gh/ff shadow/master..ff 
1:  72af7d32 = 1:  372fdbe2 userdel: --force: Allow the flag to be specified twice, for more granularity
```
</details>

<details>
<summary>v2e</summary>

-  Rebase

```
$ git range-diff alx/master..gh/ff master..ff 
1:  372fdbe2 = 1:  d6d8095d userdel: --force: Allow the flag to be specified twice, for more granularity
```
</details>

<details>
<summary>v2f</summary>

-  Rebase

```
$ git range-diff alx/master..gh/ff shadow/master..ff 
1:  d6d8095d = 1:  cd0f9edb userdel: --force: Allow the flag to be specified twice, for more granularity
```
</details>

<details>
<summary>v2g</summary>

-  Rebase

```
$ git range-diff master..gh/ff shadow/master..ff 
1:  cd0f9edb = 1:  da377a98 userdel: --force: Allow the flag to be specified twice, for more granularity
```
</details>

<details>
<summary>v2h</summary>

-  Rebase

```
$ git range-diff master..gh/ff shadow/master..ff 
1:  da377a98 = 1:  49d5a39f userdel: --force: Allow the flag to be specified twice, for more granularity
```
</details>

<details>
<summary>v2i</summary>

-  Rebase

```
$ git range-diff master..gh/ff shadow/master..ff 
1:  49d5a39f = 1:  8ed1c0cb userdel: --force: Allow the flag to be specified twice, for more granularity
```
</details>

<details>
<summary>v2j</summary>

-  Rebase

```
$ git range-diff master..gh/ff shadow/master..ff 
1:  8ed1c0cb = 1:  2ba0f96a userdel: --force: Allow the flag to be specified twice, for more granularity
```
</details>

<details>
<summary>v2k</summary>

-  Rebase

```
$ git range-diff master..gh/ff shadow/master..ff 
1:  2ba0f96a ! 1:  6d8a7a22 userdel: --force: Allow the flag to be specified twice, for more granularity
    @@ src/userdel.c: int main (int argc, char **argv)
     @@ src/userdel.c: int main (int argc, char **argv)
         * a cron job may be started on her behalf, etc.
         */
    -   if ((prefix[0] == '\0') && !Rflg && user_busy (user_name, user_id) != 0) {
    +   if (streq(prefix, "") && !Rflg && user_busy(user_name, user_id) != 0) {
     -          if (!fflg) {
     +          if (fflg < 1) {
      #ifdef WITH_AUDIT
```
</details>

<details>
<summary>v2l</summary>

-  Rebase

```
$ git range-diff alx/master..gh/ff master..ff 
1:  6d8a7a22 = 1:  76a00097 userdel: --force: Allow the flag to be specified twice, for more granularity
```
</details>