### PR TITLE
useradd: fix write_full() return value

### DIFF
--- a/src/useradd.c
+++ b/src/useradd.c
@@ -2042,7 +2042,7 @@ static void lastlog_reset (uid_t uid)
 		return;
 	}
 	if (   (lseek (fd, offset_uid, SEEK_SET) != offset_uid)
-	    || (write_full (fd, &ll, sizeof (ll)) != (ssize_t) sizeof (ll))
+	    || (write_full (fd, &ll, sizeof (ll)) != -1)
 	    || (fsync (fd) != 0)) {
 		fprintf (stderr,
 		         _("%s: failed to reset the lastlog entry of UID %lu: %s\n"),


### PR DESCRIPTION
write_full() returns -1 on error and useradd was checking another value.

Closes: https://github.com/shadow-maint/shadow/issues/1072
Fixes: f45498a6c286 ("libmisc/write_full.c: Improve write_full()")