### PR TITLE
lib/user_busy.c: Include <utmpx.h>

### DIFF
--- a/lib/user_busy.c
+++ b/lib/user_busy.c
@@ -17,6 +17,7 @@
 #include <dirent.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <utmpx.h>
 
 #include "atoi/getnum.h"
 #include "defines.h"


### PR DESCRIPTION
Since:

- utmpx APIs are used in non-Linux code blocks
- `<utmpx.h>` is already unconditionally included in Linux parts in other files then 

unconditionally include it in this file as well.