### PR TITLE
lib/run_part: Minor cleanups

### DIFF
--- a/lib/run_part.c
+++ b/lib/run_part.c
@@ -15,7 +15,7 @@
 #include "shadowlog_internal.h"
 
 
-int run_part (char *script_path, const char *name, const char *action)
+static int run_part (char *script_path, const char *name, const char *action)
 {
 	pid_t pid;
 	int wait_status;

--- a/lib/run_part.c
+++ b/lib/run_part.c
@@ -17,9 +17,9 @@
 
 int run_part (char *script_path, const char *name, const char *action)
 {
-	int pid;
+	pid_t pid;
 	int wait_status;
-	int pid_status;
+	pid_t pid_status;
 	char *args[] = { script_path, NULL };
 
 	pid=fork();

--- a/lib/run_part.c
+++ b/lib/run_part.c
@@ -15,7 +15,7 @@
 #include "shadowlog_internal.h"
 
 
-static int run_part (char *script_path, const char *name, const char *action)
+static int run_part(char *script_path, const char *name, const char *action)
 {
 	pid_t pid;
 	int wait_status;
@@ -24,34 +24,34 @@ static int run_part (char *script_path, const char *name, const char *action)
 
 	pid=fork();
 	if (pid==-1) {
-		fprintf (shadow_logfd, "fork: %s\n", strerror(errno));
+		fprintf(shadow_logfd, "fork: %s\n", strerror(errno));
 		return 1;
 	}
 	if (pid==0) {
-		setenv ("ACTION",action,1);
-		setenv ("SUBJECT",name,1);
-		execv (script_path,args);
-		fprintf (shadow_logfd, "execv: %s\n", strerror(errno));
+		setenv("ACTION",action,1);
+		setenv("SUBJECT",name,1);
+		execv(script_path,args);
+		fprintf(shadow_logfd, "execv: %s\n", strerror(errno));
 		exit(1);
 	}
 
-	pid_status = wait (&wait_status);
+	pid_status = wait(&wait_status);
 	if (pid_status == pid) {
 		return (wait_status);
 	}
 
-	fprintf (shadow_logfd, "waitpid: %s\n", strerror(errno));
+	fprintf(shadow_logfd, "waitpid: %s\n", strerror(errno));
 	return (1);
 }
 
-int run_parts (const char *directory, const char *name, const char *action)
+int run_parts(const char *directory, const char *name, const char *action)
 {
 	struct dirent **namelist;
 	int scanlist;
 	int n;
 	int execute_result = 0;
 
-	scanlist = scandir (directory, &namelist, 0, alphasort);
+	scanlist = scandir(directory, &namelist, 0, alphasort);
 	if (scanlist<=0) {
 		return (0);
 	}
@@ -61,7 +61,7 @@ int run_parts (const char *directory, const char *name, const char *action)
 		struct stat  sb;
 
 		if (asprintf(&s, "%s/%s", directory, namelist[n]->d_name) == -1) {
-			fprintf (shadow_logfd, "asprintf: %s\n", strerror(errno));
+			fprintf(shadow_logfd, "asprintf: %s\n", strerror(errno));
 			for (; n<scanlist; n++) {
 				free(namelist[n]);
 			}
@@ -70,35 +70,35 @@ int run_parts (const char *directory, const char *name, const char *action)
 		}
 
 		execute_result = 0;
-		if (stat (s, &sb) == -1) {
-			fprintf (shadow_logfd, "stat: %s\n", strerror(errno));
+		if (stat(s, &sb) == -1) {
+			fprintf(shadow_logfd, "stat: %s\n", strerror(errno));
 			free(s);
 			for (; n<scanlist; n++) {
-				free (namelist[n]);
+				free(namelist[n]);
 			}
-			free (namelist);
+			free(namelist);
 			return (1);
 		}
 
-		if (S_ISREG (sb.st_mode) || S_ISLNK (sb.st_mode)) {
-			execute_result = run_part (s, name, action);
+		if (S_ISREG(sb.st_mode) || S_ISLNK(sb.st_mode)) {
+			execute_result = run_part(s, name, action);
 		}
 
 		free(s);
 
 		if (execute_result!=0) {
-			fprintf (shadow_logfd,
+			fprintf(shadow_logfd,
 				"%s: did not exit cleanly.\n",
 			    namelist[n]->d_name);
 			for (; n<scanlist; n++) {
-				free (namelist[n]);
+				free(namelist[n]);
 			}
 			break;
 		}
 
-		free (namelist[n]);
+		free(namelist[n]);
 	}
-	free (namelist);
+	free(namelist);
 
 	return (execute_result);
 }

--- a/lib/run_part.c
+++ b/lib/run_part.c
@@ -24,14 +24,14 @@ int run_part (char *script_path, const char *name, const char *action)
 
 	pid=fork();
 	if (pid==-1) {
-		perror ("Could not fork");
+		fprintf (shadow_logfd, "Could not fork: %s\n", strerror(errno));
 		return 1;
 	}
 	if (pid==0) {
 		setenv ("ACTION",action,1);
 		setenv ("SUBJECT",name,1);
 		execv (script_path,args);
-		perror ("execv");
+		fprintf (shadow_logfd, "execv: %s\n", strerror(errno));
 		exit(1);
 	}
 
@@ -40,7 +40,7 @@ int run_part (char *script_path, const char *name, const char *action)
 		return (wait_status);
 	}
 
-	perror ("waitpid");
+	fprintf (shadow_logfd, "waitpid: %s\n", strerror(errno));
 	return (1);
 }
 
@@ -61,7 +61,7 @@ int run_parts (const char *directory, const char *name, const char *action)
 		struct stat  sb;
 
 		if (asprintf(&s, "%s/%s", directory, namelist[n]->d_name) == -1) {
-			fprintf(stderr, "could not allocate memory\n");
+			fprintf (shadow_logfd, "could not allocate memory\n");
 			for (; n<scanlist; n++) {
 				free(namelist[n]);
 			}
@@ -71,7 +71,7 @@ int run_parts (const char *directory, const char *name, const char *action)
 
 		execute_result = 0;
 		if (stat (s, &sb) == -1) {
-			perror ("stat");
+			fprintf (shadow_logfd, "stat: %s\n", strerror(errno));
 			free(s);
 			for (; n<scanlist; n++) {
 				free (namelist[n]);

--- a/lib/run_part.c
+++ b/lib/run_part.c
@@ -24,7 +24,7 @@ static int run_part (char *script_path, const char *name, const char *action)
 
 	pid=fork();
 	if (pid==-1) {
-		fprintf (shadow_logfd, "Could not fork: %s\n", strerror(errno));
+		fprintf (shadow_logfd, "fork: %s\n", strerror(errno));
 		return 1;
 	}
 	if (pid==0) {
@@ -61,7 +61,7 @@ int run_parts (const char *directory, const char *name, const char *action)
 		struct stat  sb;
 
 		if (asprintf(&s, "%s/%s", directory, namelist[n]->d_name) == -1) {
-			fprintf (shadow_logfd, "could not allocate memory\n");
+			fprintf (shadow_logfd, "asprintf: %s\n", strerror(errno));
 			for (; n<scanlist; n++) {
 				free(namelist[n]);
 			}

--- a/lib/run_part.h
+++ b/lib/run_part.h
@@ -1,7 +1,6 @@
 #ifndef _RUN_PART_H
 #define _RUN_PART_H
 
-int run_part (char *script_path, const char *name, const char *action);
 int run_parts (const char *directory, const char *name, const char *action);
 
 #endif /* _RUN_PART_H */

--- a/lib/shadowlog_internal.h
+++ b/lib/shadowlog_internal.h
@@ -1,7 +1,7 @@
 #ifndef _SHADOWLOG_INTERNAL_H
 #define _SHADOWLOG_INTERNAL_H
 
-extern const char *shadow_progname; /* Program name showed in error messages */
+extern const char *shadow_progname; /* Program name shown in error messages */
 extern FILE *shadow_logfd;  /* file descriptor to which error messages are printed */
 
 #endif /* _SHADOWLOG_INTERNAL_H */


### PR DESCRIPTION
- Use correct data type
- Unify logging (at least the fprintf calls)
- Reduce visibility of locally used function