### PR TITLE
lib: Eliminate dead code

### DIFF
--- a/lib/tz.c
+++ b/lib/tz.c
@@ -32,27 +32,23 @@
 /*@observer@*/const char *tz (const char *fname)
 {
 	FILE *fp = NULL;
+	const char *result;
 	static char tzbuf[BUFSIZ];
-	const char *def_tz = "TZ=CST6CDT";
 
 	fp = fopen (fname, "r");
 	if (   (NULL == fp)
 	    || (fgets (tzbuf, sizeof (tzbuf), fp) == NULL)) {
-		def_tz = getdef_str ("ENV_TZ");
-		if ((NULL == def_tz) || ('/' == def_tz[0])) {
-			def_tz = "TZ=CST6CDT";
-		}
-
-		strcpy (tzbuf, def_tz);
+		result = "TZ=CST6CDT";
 	} else {
 		stpsep(tzbuf, "\n");
+		result = tzbuf;
 	}
 
 	if (NULL != fp) {
 		(void) fclose (fp);
 	}
 
-	return tzbuf;
+	return result;
 }
 #else				/* !USE_PAM */
 extern int ISO_C_forbids_an_empty_translation_unit;


### PR DESCRIPTION
The tz function is only called if ENV_TZ starts with a slash.

If the specified file cannot be read, the code implies that ENV_TZ would be returned if it does not start with a slash.

Since we know that it DOES start with a slash, the code can be simplified to state that "TZ=CST6CDT" is returned as a default if the specified file cannot be read.

Benefit of this change is that strcpy's use case here can be easier verified.