### PR TITLE
Always using 644 for /etc/default/useradd

### DIFF
--- a/src/useradd.c
+++ b/src/useradd.c
@@ -590,6 +590,17 @@ set_defaults(void)
 	}
 
 	/*
+	 * Change the permissions of the new file to 644
+	 */
+	if (chmod(new_file, 0644) != 0) {
+		fprintf(stderr,
+				_("%s: failed to change permissions for %s\n"),
+				Prog,
+				new_file);
+		goto err_free_def;
+	}
+
+	/*
 	 * Open the existing defaults file and copy the lines to the
 	 * temporary file, using any new values. Each line is checked
 	 * to insure that it is not output more than once.


### PR DESCRIPTION
The original perms for `/etc/default/useradd` is `644`.

```
-rw-r--r-- 1 root root 1.5K Sep 23 15:10 /etc/default/useradd
```

But when I run `useradd -D -s /bin/bash`, it will change the perms to `600`

```
-rw------- 1 root root 1.5K Sep 23 15:16 /etc/default/useradd
```

The reason is `mkstemp` will always set the perms to `600`. Would it be better to always set its perms to `644`? Could you please review my code? I have already tested it on Ubuntu, and it works fine. Thank you.