### PR TITLE
src/check_subid_range.c: Remove dead code

### DIFF
--- a/src/check_subid_range.c
+++ b/src/check_subid_range.c
@@ -6,7 +6,6 @@
 #include <config.h>
 #include <stdio.h>
 #include <string.h>
-#include <errno.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <sys/types.h>
@@ -41,7 +40,6 @@ main(int argc, char **argv)
 
 	owner = argv[1];
 	check_uids = argv[2][0] == 'u';
-	errno = 0;
 	if (get_uid(argv[3], &start) == -1)
 		exit(1);
 	if (str2ul(&count, argv[4]) == -1)


### PR DESCRIPTION
I forgot to remove the setting of errno when I switched from strtoul_noneg() to str2ul().  strtoul(3) needs errno for determining success, but str2ul() does not.

Fixes: f3a1e1cf098d ("src/check_subid_range.c: Call str2ul() instead of strtoul_noneg()")