### PR TITLE
useradd: fix comparison sign for write_full() return

### DIFF
--- a/src/useradd.c
+++ b/src/useradd.c
@@ -2042,7 +2042,7 @@ static void lastlog_reset (uid_t uid)
 		return;
 	}
 	if (   (lseek (fd, offset_uid, SEEK_SET) != offset_uid)
-	    || (write_full (fd, &ll, sizeof (ll)) != -1)
+	    || (write_full (fd, &ll, sizeof (ll)) == -1)
 	    || (fsync (fd) != 0)) {
 		fprintf (stderr,
 		         _("%s: failed to reset the lastlog entry of UID %lu: %s\n"),


### PR DESCRIPTION
I forgot to change the comparison sign that checks the return value of write_full()

Closes: https://github.com/shadow-maint/shadow/issues/1072
Fixes: 8903b94c86c9 ("useradd: fix write_full() return value")
Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2313559