### PR TITLE
CI: update Ubuntu repositories configuration

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -13,5 +13,5 @@ runs:
       sudo apt-mark hold grub-efi-amd64-bin grub-efi-amd64-signed
       sudo apt-get update
       sudo apt-get -y dist-upgrade
-      sudo apt-get -y install ubuntu-dev-tools automake autopoint xsltproc gettext expect byacc libtool libbsd-dev pkgconf
+      sudo apt-get -y install ubuntu-dev-tools automake autopoint xsltproc gettext expect byacc libtool libbsd-dev libltdl-dev pkgconf
       sudo apt-get -y build-dep shadow

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -5,7 +5,7 @@ runs:
   steps:
   - shell: bash
     run: |
-      sudo cat /etc/apt/sources.list.d/ubuntu.sources
+      cat /etc/apt/sources.list.d/ubuntu.sources
       sudo sed -i 's/^Types: deb/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.sources
       export DEBIAN_PRIORITY=critical
       export DEBIAN_FRONTEND=noninteractive

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -5,8 +5,13 @@ runs:
   steps:
   - shell: bash
     run: |
-      sudo apt-get update -y
-      sudo apt-get install -y ubuntu-dev-tools libbsd-dev
-      sudo sed -Ei 's/^# deb-src /deb-src /' /etc/apt/sources.list
-      sudo apt-get update -y
+      sudo cat /etc/apt/sources.list.d/ubuntu.sources
+      sudo sed -i 's/^Types: deb/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.sources
+      export DEBIAN_PRIORITY=critical
+      export DEBIAN_FRONTEND=noninteractive
+      # let's try to work around upgrade breakage in a pkg we don't care about
+      sudo apt-mark hold grub-efi-amd64-bin grub-efi-amd64-signed
+      sudo apt-get update
+      sudo apt-get -y dist-upgrade
+      sudo apt-get -y install ubuntu-dev-tools automake autopoint xsltproc gettext expect byacc libtool libbsd-dev pkgconf
       sudo apt-get -y build-dep shadow

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -25,18 +25,8 @@ jobs:
         cat /proc/self/status
         systemd-detect-virt
     - name: Install dependencies
-      run: |
-        sudo cat /etc/apt/sources.list
-        sudo sed -i '/deb-src/d' /etc/apt/sources.list
-        sudo sed -i '/^deb /p;s/ /-src /' /etc/apt/sources.list
-        export DEBIAN_PRIORITY=critical
-        export DEBIAN_FRONTEND=noninteractive
-        # let's try to work around upgrade breakage in a pkg we don't care about
-        sudo apt-mark hold grub-efi-amd64-bin grub-efi-amd64-signed
-        sudo apt-get update
-        sudo apt-get -y dist-upgrade
-        sudo apt-get -y install ubuntu-dev-tools automake autopoint xsltproc gettext expect byacc libtool libbsd-dev pkgconf libcmocka-dev
-        sudo apt-get -y build-dep shadow
+      id: dependencies
+      uses: ./.github/actions/install-dependencies
     - name: configure
       run: |
         autoreconf -v -f --install
@@ -61,18 +51,8 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Install dependencies
-      run: |
-        sudo cat /etc/apt/sources.list
-        sudo sed -i '/deb-src/d' /etc/apt/sources.list
-        sudo sed -i '/^deb /p;s/ /-src /' /etc/apt/sources.list
-        export DEBIAN_PRIORITY=critical
-        export DEBIAN_FRONTEND=noninteractive
-        # let's try to work around upgrade breakage in a pkg we don't care about
-        sudo apt-mark hold grub-efi-amd64-bin grub-efi-amd64-signed
-        sudo apt-get update
-        sudo apt-get -y dist-upgrade
-        sudo apt-get -y install ubuntu-dev-tools automake autopoint xsltproc gettext expect byacc libtool libbsd-dev pkgconf
-        sudo apt-get -y build-dep shadow
+      id: dependencies
+      uses: ./.github/actions/install-dependencies
 
     - name: Test make dist
       run: |


### PR DESCRIPTION
CI: update Ubuntu repositories configuration

Recently Ubuntu updated its repositories configuration file from
`/etc/apt/sources.list` to `/etc/apt/sources.list.d/ubuntu.source`.
Thus, we need to update its location to be able to install all the
package dependencies.

In addition, the CI script was trying to uncomment the lines starting
with `deb-src`, but there is none in the new configuration file format.
Replace `Types: deb` by `Types: deb deb-src` at the beginning of the
line instead.

Besides that, let's centralize the installation of dependencies in a single
workflow and install `libltdl-dev`, which is a dependency in the new
Ubuntu version.
    
Link: https://linuxconfig.org/ubuntus-repository-configuration-ubuntu-sources-have-moved-to-etc-apt-sources-list-d-ubuntu-sources
Closes: https://github.com/shadow-maint/shadow/issues/1088
Reported-by: Alejandro Colomar <alx@kernel.org>