### PR TITLE
Simplify readlink(2) calls

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -103,6 +103,8 @@ libshadow_la_SOURCES = \
 	find_new_sub_gids.c \
 	find_new_sub_uids.c \
 	fputsx.c \
+	fs/readlink/areadlink.c \
+	fs/readlink/areadlink.h \
 	fs/readlink/readlinknul.c \
 	fs/readlink/readlinknul.h \
 	get_pid.c \

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -103,6 +103,8 @@ libshadow_la_SOURCES = \
 	find_new_sub_gids.c \
 	find_new_sub_uids.c \
 	fputsx.c \
+	fs/readlink/readlinknul.c \
+	fs/readlink/readlinknul.h \
 	get_pid.c \
 	getdate.h \
 	getdate.y \

--- a/lib/fs/readlink/areadlink.c
+++ b/lib/fs/readlink/areadlink.c
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#include <config.h>
+
+#include "fs/readlink/areadlink.h"
+
+
+extern inline char *areadlink(const char *path);

--- a/lib/fs/readlink/areadlink.c
+++ b/lib/fs/readlink/areadlink.c
@@ -7,4 +7,4 @@
 #include "fs/readlink/areadlink.h"
 
 
-extern inline char *areadlink(const char *path);
+extern inline char *areadlink(const char *link);

--- a/lib/fs/readlink/areadlink.h
+++ b/lib/fs/readlink/areadlink.h
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#ifndef SHADOW_INCLUDE_LIB_FS_READLINK_AREADLINK_H_
+#define SHADOW_INCLUDE_LIB_FS_READLINK_AREADLINK_H_
+
+
+#include <config.h>
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+#include "alloc/malloc.h"
+#include "attr.h"
+#include "fs/readlink/readlinknul.h"
+
+
+ATTR_STRING(1)
+inline char *areadlink(const char *path);
+
+
+// Similar to readlink(2), but allocate and terminate the string.
+inline char *
+areadlink(const char *filename)
+{
+	size_t size = 1024;
+
+	while (true) {
+		int  len;
+		char *buffer = MALLOC(size, char);
+		if (NULL == buffer) {
+			return NULL;
+		}
+
+		len = readlinknul(filename, buffer, size);
+		if (len != -1)
+			return buffer;
+
+		free(buffer);
+		if (errno != E2BIG)
+			return NULL;
+
+		size *= 2;
+	}
+}
+
+
+#endif  // include guard

--- a/lib/fs/readlink/areadlink.h
+++ b/lib/fs/readlink/areadlink.h
@@ -9,6 +9,7 @@
 #include <config.h>
 
 #include <errno.h>
+#include <limits.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdlib.h>
@@ -26,7 +27,7 @@ inline char *areadlink(const char *link);
 inline char *
 areadlink(const char *link)
 {
-	size_t size = 1024;
+	size_t  size = PATH_MAX;
 
 	while (true) {
 		int   len;

--- a/lib/fs/readlink/areadlink.h
+++ b/lib/fs/readlink/areadlink.h
@@ -19,27 +19,28 @@
 
 
 ATTR_STRING(1)
-inline char *areadlink(const char *path);
+inline char *areadlink(const char *link);
 
 
 // Similar to readlink(2), but allocate and terminate the string.
 inline char *
-areadlink(const char *filename)
+areadlink(const char *link)
 {
 	size_t size = 1024;
 
 	while (true) {
-		int  len;
-		char *buffer = MALLOC(size, char);
-		if (NULL == buffer) {
+		int   len;
+		char  *buf;
+
+		buf = MALLOC(size, char);
+		if (NULL == buf)
 			return NULL;
-		}
 
-		len = readlinknul(filename, buffer, size);
+		len = readlinknul(link, buf, size);
 		if (len != -1)
-			return buffer;
+			return buf;
 
-		free(buffer);
+		free(buf);
 		if (errno != E2BIG)
 			return NULL;
 

--- a/lib/fs/readlink/readlinknul.c
+++ b/lib/fs/readlink/readlinknul.c
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#include <config.h>
+
+#include "fs/readlink/readlinknul.h"
+
+#include <stddef.h>
+
+
+extern inline int readlinknul(const char *restrict link, char *restrict buf,
+    size_t size);

--- a/lib/fs/readlink/readlinknul.h
+++ b/lib/fs/readlink/readlinknul.h
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#ifndef SHADOW_INCLUDE_LIB_FS_READLINK_READLINKNUL_H_
+#define SHADOW_INCLUDE_LIB_FS_READLINK_READLINKNUL_H_
+
+
+#include <config.h>
+
+#include <errno.h>
+#include <stddef.h>
+#include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "attr.h"
+
+
+ATTR_STRING(1)
+inline int readlinknul(const char *restrict link, char *restrict buf,
+    size_t size);
+
+
+// Similar to readlink(2), but terminate the string.
+inline int
+readlinknul(const char *restrict link, char *restrict buf, size_t size)
+{
+	ssize_t  len;
+
+	len = readlink(link, buf, size);
+	if (len == -1)
+		return -1;
+
+	if (len == size) {
+		stpcpy(&buf[size-1], "");
+		errno = E2BIG;
+		return -1;
+	}
+
+	stpcpy(&buf[len], "");
+	return len;
+}
+
+
+#endif  // include guard

--- a/lib/fs/readlink/readlinknul.h
+++ b/lib/fs/readlink/readlinknul.h
@@ -15,6 +15,10 @@
 #include <unistd.h>
 
 #include "attr.h"
+#include "sizeof.h"
+
+
+#define READLINKNUL(link, buf)  readlinknul(link, buf, NITEMS(buf))
 
 
 ATTR_STRING(1)

--- a/lib/user_busy.c
+++ b/lib/user_busy.c
@@ -21,6 +21,7 @@
 
 #include "atoi/getnum.h"
 #include "defines.h"
+#include "fs/readlink/readlinknul.h"
 #include "prototypes.h"
 #ifdef ENABLE_SUBIDS
 #include "subordinateio.h"
@@ -93,17 +94,16 @@ static int different_namespace (const char *sname)
 	/* 41: /proc/xxxxxxxxxx/task/xxxxxxxxxx/ns/user + \0 */
 	char     path[41];
 	char     buf[512], buf2[512];
-	ssize_t  llen1, llen2;
 
 	SNPRINTF(path, "/proc/%s/ns/user", sname);
 
-	if ((llen1 = readlink (path, buf, sizeof(buf))) == -1)
+	if (READLINKNUL(path, buf) == -1)
 		return 0;
 
-	if ((llen2 = readlink ("/proc/self/ns/user", buf2, sizeof(buf2))) == -1)
+	if (READLINKNUL("/proc/self/ns/user", buf2) == -1)
 		return 0;
 
-	if (llen1 == llen2 && memcmp (buf, buf2, llen1) == 0)
+	if (strcmp(buf, buf2) == 0)
 		return 0; /* same namespace */
 
 	return 1;


### PR DESCRIPTION
readlink(2) doesn't terminate the string.  That's makes using this function unnecessarily complicated and unsafe.  This patch set adds some wrappers that produce a null-terminated string, which significantly simplifies the code at call site.

---

Revisions:

<details>
<summary>v2</summary>

-  Fix typo

```
$ git range-diff master gh/readlink readlink 
1:  7b577fb5 ! 1:  2a5d0d77 lib/fs/readlink/readlinknul.[ch]: readlinknul(): Add function
    @@ lib/fs/readlink/readlinknul.h (new)
     +          return -1;
     +
     +  if (len == size) {
    -+          stpcpy(&path[size-1], "");
    ++          stpcpy(&buf[size-1], "");
     +          errno = E2BIG;
     +          return -1;
     +  }
     +
    -+  stpcpy(&path[len], "");
    ++  stpcpy(&buf[len], "");
     +  return len;
     +}
     +
2:  1f297e5e = 2:  46b23e73 lib/fs/readlink/readlinknul.h: READLINK(): Add macro
3:  41d025c3 = 3:  e0fd2a26 lib/: Use readlinknul() instead of its pattern
4:  5d282771 = 4:  ebe2d5c9 lib/: Use READLINK() instead of its pattern
5:  85ad58b7 = 5:  eaed1afc lib/fs/readlink/areadlink.[ch], lib/: areadlink(): Move and rename function
6:  e2c108cf = 6:  19df7b4f lib/fs/readlink/areadlink.h: Cosmetic changes
```
</details>

<details>
<summary>v2b</summary>

-  Add missing include

```
$ git range-diff master gh/readlink readlink 
1:  2a5d0d77 = 1:  2a5d0d77 lib/fs/readlink/readlinknul.[ch]: readlinknul(): Add function
2:  46b23e73 = 2:  46b23e73 lib/fs/readlink/readlinknul.h: READLINK(): Add macro
3:  e0fd2a26 = 3:  e0fd2a26 lib/: Use readlinknul() instead of its pattern
4:  ebe2d5c9 = 4:  ebe2d5c9 lib/: Use READLINK() instead of its pattern
5:  eaed1afc ! 5:  00b77de5 lib/fs/readlink/areadlink.[ch], lib/: areadlink(): Move and rename function
    @@ lib/fs/readlink/areadlink.h (new)
     +#include <config.h>
     +
     +#include <errno.h>
    ++#include <stdbool.h>
     +#include <stddef.h>
     +#include <stdlib.h>
     +
6:  19df7b4f = 6:  33ad778a lib/fs/readlink/areadlink.h: Cosmetic changes
```
</details>

<details>
<summary>v2c</summary>

-  Rename parameter

```
$ git range-diff master gh/readlink readlink 
1:  2a5d0d77 ! 1:  f5b574b7 lib/fs/readlink/readlinknul.[ch]: readlinknul(): Add function
    @@ lib/fs/readlink/readlinknul.c (new)
     +#include <stddef.h>
     +
     +
    -+extern inline int readlinknul(const char *restrict path, char *restrict buf,
    ++extern inline int readlinknul(const char *restrict link, char *restrict buf,
     +    size_t n);
     
      ## lib/fs/readlink/readlinknul.h (new) ##
    @@ lib/fs/readlink/readlinknul.h (new)
     +
     +
     +ATTR_STRING(1)
    -+inline int readlinknul(const char *restrict path, char *restrict buf, size_t n);
    ++inline int readlinknul(const char *restrict link, char *restrict buf, size_t n);
     +
     +
     +// Similar to readlink(2), but terminate the string.
     +inline int
    -+readlinknul(const char *restrict path, char *restrict buf, size_t size)
    ++readlinknul(const char *restrict link, char *restrict buf, size_t size)
     +{
     +  ssize_t  len;
     +
    -+  len = readlink(path, buf, size);
    ++  len = readlink(link, buf, size);
     +  if (len == -1)
     +          return -1;
     +
2:  46b23e73 ! 2:  ac8a5121 lib/fs/readlink/readlinknul.h: READLINK(): Add macro
    @@ lib/fs/readlink/readlinknul.h
     +#include "sizeof.h"
     +
     +
    -+#define READLINK(path, buf)  readlinknul(path, buf, NITEMS(buf))
    ++#define READLINK(link, buf)  readlinknul(link, buf, NITEMS(buf))
      
      
      ATTR_STRING(1)
3:  e0fd2a26 = 3:  960f4727 lib/: Use readlinknul() instead of its pattern
4:  ebe2d5c9 = 4:  07641f1d lib/: Use READLINK() instead of its pattern
5:  00b77de5 ! 5:  caa37b6b lib/fs/readlink/areadlink.[ch], lib/: areadlink(): Move and rename function
    @@ lib/fs/readlink/areadlink.h (new)
     +
     +// Similar to readlink(2), but allocate and terminate the string.
     +inline char *
    -+areadlink(const char *path)
    ++areadlink(const char *filename)
     +{
     +  size_t size = 1024;
     +
6:  33ad778a ! 6:  ceb59c19 lib/fs/readlink/areadlink.h: Cosmetic changes
    @@ Commit message
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/fs/readlink/areadlink.h ##
    -@@ lib/fs/readlink/areadlink.h: areadlink(const char *path)
    +@@
    + 
    + 
    + ATTR_STRING(1)
    +-inline char *areadlink(const char *path);
    ++inline char *areadlink(const char *link);
    + 
    + 
    + // Similar to readlink(2), but allocate and terminate the string.
    + inline char *
    +-areadlink(const char *filename)
    ++areadlink(const char *link)
    + {
        size_t size = 1024;
      
        while (true) {
    @@ lib/fs/readlink/areadlink.h: areadlink(const char *path)
     -          }
      
     -          len = readlinknul(filename, buffer, size);
    -+          len = readlinknul(filename, buf, size);
    ++          len = readlinknul(link, buf, size);
                if (len != -1)
     -                  return buffer;
     +                  return buf;
```
</details>

<details>
<summary>v2d</summary>

-  Rename parameter

```
$ git range-diff master gh/readlink readlink 
1:  f5b574b7 = 1:  f5b574b7 lib/fs/readlink/readlinknul.[ch]: readlinknul(): Add function
2:  ac8a5121 = 2:  ac8a5121 lib/fs/readlink/readlinknul.h: READLINK(): Add macro
3:  960f4727 = 3:  960f4727 lib/: Use readlinknul() instead of its pattern
4:  07641f1d = 4:  07641f1d lib/: Use READLINK() instead of its pattern
5:  caa37b6b = 5:  caa37b6b lib/fs/readlink/areadlink.[ch], lib/: areadlink(): Move and rename function
6:  ceb59c19 ! 6:  f576ee2a lib/fs/readlink/areadlink.h: Cosmetic changes
    @@ Commit message
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    + ## lib/fs/readlink/areadlink.c ##
    +@@
    + #include "fs/readlink/areadlink.h"
    + 
    + 
    +-extern inline char *areadlink(const char *path);
    ++extern inline char *areadlink(const char *link);
    +
      ## lib/fs/readlink/areadlink.h ##
     @@
      
```
</details>

<details>
<summary>v2e</summary>

-  Add missing include

```
$ git range-diff master gh/readlink readlink 
1:  f5b574b7 ! 1:  9c9b124c lib/fs/readlink/readlinknul.[ch]: readlinknul(): Add function
    @@ lib/fs/readlink/readlinknul.h (new)
     +
     +#include <errno.h>
     +#include <stddef.h>
    ++#include <string.h>
     +#include <sys/param.h>
     +#include <sys/types.h>
     +#include <unistd.h>
2:  ac8a5121 = 2:  5be06450 lib/fs/readlink/readlinknul.h: READLINK(): Add macro
3:  960f4727 = 3:  198f320c lib/: Use readlinknul() instead of its pattern
4:  07641f1d = 4:  d1fce4cd lib/: Use READLINK() instead of its pattern
5:  caa37b6b = 5:  55478839 lib/fs/readlink/areadlink.[ch], lib/: areadlink(): Move and rename function
6:  f576ee2a = 6:  3708b3be lib/fs/readlink/areadlink.h: Cosmetic changes
```
</details>

<details>
<summary>v2f</summary>

-  Rename parameter

```
$ git range-diff master gh/readlink readlink 
1:  9c9b124c ! 1:  07469f14 lib/fs/readlink/readlinknul.[ch]: readlinknul(): Add function
    @@ lib/fs/readlink/readlinknul.c (new)
     +
     +
     +extern inline int readlinknul(const char *restrict link, char *restrict buf,
    -+    size_t n);
    ++    size_t size);
     
      ## lib/fs/readlink/readlinknul.h (new) ##
     @@
    @@ lib/fs/readlink/readlinknul.h (new)
     +
     +
     +ATTR_STRING(1)
    -+inline int readlinknul(const char *restrict link, char *restrict buf, size_t n);
    ++inline int readlinknul(const char *restrict link, char *restrict buf,
    ++    size_t size);
     +
     +
     +// Similar to readlink(2), but terminate the string.
2:  5be06450 = 2:  c99d98c3 lib/fs/readlink/readlinknul.h: READLINK(): Add macro
3:  198f320c = 3:  82a9d05c lib/: Use readlinknul() instead of its pattern
4:  d1fce4cd = 4:  1f0e9e92 lib/: Use READLINK() instead of its pattern
5:  55478839 = 5:  d6100c31 lib/fs/readlink/areadlink.[ch], lib/: areadlink(): Move and rename function
6:  3708b3be = 6:  85f67970 lib/fs/readlink/areadlink.h: Cosmetic changes
```
</details>

<details>
<summary>v2g</summary>

-  Remove unused include

```
$ git range-diff master gh/readlink readlink 
1:  07469f14 ! 1:  4f6a8dc6 lib/fs/readlink/readlinknul.[ch]: readlinknul(): Add function
    @@ lib/fs/readlink/readlinknul.h (new)
     +#include <errno.h>
     +#include <stddef.h>
     +#include <string.h>
    -+#include <sys/param.h>
     +#include <sys/types.h>
     +#include <unistd.h>
     +
2:  c99d98c3 = 2:  fad9e00d lib/fs/readlink/readlinknul.h: READLINK(): Add macro
3:  82a9d05c = 3:  e043006b lib/: Use readlinknul() instead of its pattern
4:  1f0e9e92 = 4:  bf7b37a3 lib/: Use READLINK() instead of its pattern
5:  d6100c31 = 5:  520a9cca lib/fs/readlink/areadlink.[ch], lib/: areadlink(): Move and rename function
6:  85f67970 = 6:  50b3f45c lib/fs/readlink/areadlink.h: Cosmetic changes
```
</details>

<details>
<summary>v3</summary>

-  Remove unused/superfluous local variables

```
$ git range-diff master gh/readlink readlink 
1:  4f6a8dc6 = 1:  4f6a8dc6 lib/fs/readlink/readlinknul.[ch]: readlinknul(): Add function
2:  fad9e00d = 2:  fad9e00d lib/fs/readlink/readlinknul.h: READLINK(): Add macro
3:  e043006b = 3:  e043006b lib/: Use readlinknul() instead of its pattern
4:  bf7b37a3 ! 4:  48db69cd lib/: Use READLINK() instead of its pattern
    @@ lib/tcbfuncs.c
      #define SHADOWTCB_HASH_BY 1000
      #define SHADOWTCB_LOCK_SUFFIX ".lock"
      
    +@@ lib/tcbfuncs.c: static /*@null@*/ char *shadowtcb_path_rel_existing (const char *name)
    +   char *path, *rval;
    +   struct stat st;
    +   char link[8192];
    +-  ssize_t ret;
    + 
    +   if (asprintf (&path, TCB_DIR "/%s", name) == -1) {
    +           OUT_OF_MEMORY;
     @@ lib/tcbfuncs.c: static /*@null@*/ char *shadowtcb_path_rel_existing (const char *name)
                free (path);
                return NULL;
        }
     -  ret = readlink (path, link, sizeof (link) - 1);
    -+  ret = READLINK(path, link);
    -   if (-1 == ret) {
    +-  if (-1 == ret) {
    ++  if (READLINK(path, link) == -1) {
                fprintf (shadow_logfd,
                         _("%s: Cannot read symbolic link %s: %s\n"),
    +                    shadow_progname, path, strerror (errno));
     @@ lib/tcbfuncs.c: static /*@null@*/ char *shadowtcb_path_rel_existing (const char *name)
                return NULL;
        }
    @@ lib/user_busy.c
      #ifdef ENABLE_SUBIDS
      #include "subordinateio.h"
     @@ lib/user_busy.c: static int different_namespace (const char *sname)
    +   /* 41: /proc/xxxxxxxxxx/task/xxxxxxxxxx/ns/user + \0 */
    +   char     path[41];
    +   char     buf[512], buf2[512];
    +-  ssize_t  llen1, llen2;
      
        SNPRINTF(path, "/proc/%s/ns/user", sname);
      
5:  520a9cca = 5:  22a926a2 lib/fs/readlink/areadlink.[ch], lib/: areadlink(): Move and rename function
6:  50b3f45c = 6:  ecf60bae lib/fs/readlink/areadlink.h: Cosmetic changes
```
</details>

<details>
<summary>v3b</summary>

-  Rebase

```
$ git range-diff master..gh/readlink shadow/master..readlink 
1:  4f6a8dc6 = 1:  a98ceb90 lib/fs/readlink/readlinknul.[ch]: readlinknul(): Add function
2:  fad9e00d = 2:  7ecfecb9 lib/fs/readlink/readlinknul.h: READLINK(): Add macro
3:  e043006b = 3:  e44292a0 lib/: Use readlinknul() instead of its pattern
4:  48db69cd = 4:  f6a7a726 lib/: Use READLINK() instead of its pattern
5:  22a926a2 = 5:  36fed593 lib/fs/readlink/areadlink.[ch], lib/: areadlink(): Move and rename function
6:  ecf60bae = 6:  1ffb5ac0 lib/fs/readlink/areadlink.h: Cosmetic changes
```
</details>

<details>
<summary>v3c</summary>

-  Rename macro for consistency with the function it calls.

```
$ git range-diff master gh/readlink readlink 
1:  a98ceb90 = 1:  a98ceb90 lib/fs/readlink/readlinknul.[ch]: readlinknul(): Add function
2:  7ecfecb9 ! 2:  dff05f73 lib/fs/readlink/readlinknul.h: READLINK(): Add macro
    @@ lib/fs/readlink/readlinknul.h
     +#include "sizeof.h"
     +
     +
    -+#define READLINK(link, buf)  readlinknul(link, buf, NITEMS(buf))
    ++#define READLINKNUL(link, buf)  readlinknul(link, buf, NITEMS(buf))
      
      
      ATTR_STRING(1)
3:  e44292a0 = 3:  2ab0d9b1 lib/: Use readlinknul() instead of its pattern
4:  f6a7a726 ! 4:  156c93d3 lib/: Use READLINK() instead of its pattern
    @@ lib/tcbfuncs.c: static /*@null@*/ char *shadowtcb_path_rel_existing (const char
        }
     -  ret = readlink (path, link, sizeof (link) - 1);
     -  if (-1 == ret) {
    -+  if (READLINK(path, link) == -1) {
    ++  if (READLINKNUL(path, link) == -1) {
                fprintf (shadow_logfd,
                         _("%s: Cannot read symbolic link %s: %s\n"),
                         shadow_progname, path, strerror (errno));
    @@ lib/user_busy.c: static int different_namespace (const char *sname)
        SNPRINTF(path, "/proc/%s/ns/user", sname);
      
     -  if ((llen1 = readlink (path, buf, sizeof(buf))) == -1)
    -+  if (READLINK(path, buf) == -1)
    ++  if (READLINKNUL(path, buf) == -1)
                return 0;
      
     -  if ((llen2 = readlink ("/proc/self/ns/user", buf2, sizeof(buf2))) == -1)
    -+  if (READLINK("/proc/self/ns/user", buf2) == -1)
    ++  if (READLINKNUL("/proc/self/ns/user", buf2) == -1)
                return 0;
      
     -  if (llen1 == llen2 && memcmp (buf, buf2, llen1) == 0)
5:  36fed593 = 5:  867521e7 lib/fs/readlink/areadlink.[ch], lib/: areadlink(): Move and rename function
6:  1ffb5ac0 = 6:  ebaa2322 lib/fs/readlink/areadlink.h: Cosmetic changes
```
</details>

<details>
<summary>v4</summary>

-  Use macro instead of magic number

```
$ git range-diff master gh/readlink readlink 
1:  a98ceb90 = 1:  a98ceb90 lib/fs/readlink/readlinknul.[ch]: readlinknul(): Add function
2:  dff05f73 = 2:  dff05f73 lib/fs/readlink/readlinknul.h: READLINK(): Add macro
3:  2ab0d9b1 = 3:  2ab0d9b1 lib/: Use readlinknul() instead of its pattern
4:  156c93d3 = 4:  156c93d3 lib/: Use READLINK() instead of its pattern
5:  867521e7 = 5:  867521e7 lib/fs/readlink/areadlink.[ch], lib/: areadlink(): Move and rename function
6:  ebaa2322 = 6:  ebaa2322 lib/fs/readlink/areadlink.h: Cosmetic changes
-:  -------- > 7:  2e67b41e lib/fs/readlink/areadlink.h: areadlink(): Use PATH_MAX instead of a magic value
```
</details>

<details>
<summary>v4b</summary>

-  Rebase

```
$ git range-diff master..gh/readlink shadow/master..readlink 
1:  a98ceb90 = 1:  c8d8eec6 lib/fs/readlink/readlinknul.[ch]: readlinknul(): Add function
2:  dff05f73 = 2:  e5e1790d lib/fs/readlink/readlinknul.h: READLINK(): Add macro
3:  2ab0d9b1 = 3:  5030e74b lib/: Use readlinknul() instead of its pattern
4:  156c93d3 = 4:  78f254d5 lib/: Use READLINK() instead of its pattern
5:  867521e7 = 5:  8ee9bb1e lib/fs/readlink/areadlink.[ch], lib/: areadlink(): Move and rename function
6:  ebaa2322 = 6:  52376461 lib/fs/readlink/areadlink.h: Cosmetic changes
7:  2e67b41e = 7:  bc2b914d lib/fs/readlink/areadlink.h: areadlink(): Use PATH_MAX instead of a magic value
```
</details>

<details>
<summary>v4c</summary>

-  Fix commit messages

```
$ git range-diff master gh/readlink readlink 
1:  c8d8eec6 = 1:  c8d8eec6 lib/fs/readlink/readlinknul.[ch]: readlinknul(): Add function
2:  e5e1790d ! 2:  dc54b528 lib/fs/readlink/readlinknul.h: READLINK(): Add macro
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/fs/readlink/readlinknul.h: READLINK(): Add macro
    +    lib/fs/readlink/readlinknul.h: READLINKNUL(): Add macro
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
3:  5030e74b = 3:  90da1ac0 lib/: Use readlinknul() instead of its pattern
4:  78f254d5 ! 4:  0fcbca07 lib/: Use READLINK() instead of its pattern
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/: Use READLINK() instead of its pattern
    +    lib/: Use READLINKNUL() instead of its pattern
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
5:  8ee9bb1e = 5:  95b64819 lib/fs/readlink/areadlink.[ch], lib/: areadlink(): Move and rename function
6:  52376461 = 6:  679ed65e lib/fs/readlink/areadlink.h: Cosmetic changes
7:  bc2b914d = 7:  3581a5b8 lib/fs/readlink/areadlink.h: areadlink(): Use PATH_MAX instead of a magic value
```
</details>

<details>
<summary>v4d</summary>

-  Simplify commit messages

```
$ git range-diff master gh/readlink readlink 
1:  c8d8eec6 ! 1:  7633c690 lib/fs/readlink/readlinknul.[ch]: readlinknul(): Add function
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/fs/readlink/readlinknul.[ch]: readlinknul(): Add function
    +    lib/fs/readlink/: readlinknul(): Add function
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
2:  dc54b528 = 2:  0d91f731 lib/fs/readlink/readlinknul.h: READLINKNUL(): Add macro
3:  90da1ac0 = 3:  c79e17e8 lib/: Use readlinknul() instead of its pattern
4:  0fcbca07 = 4:  6139064a lib/: Use READLINKNUL() instead of its pattern
5:  95b64819 ! 5:  b7545538 lib/fs/readlink/areadlink.[ch], lib/: areadlink(): Move and rename function
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/fs/readlink/areadlink.[ch], lib/: areadlink(): Move and rename function
    +    lib/fs/readlink/, lib/: areadlink(): Move and rename function
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
6:  679ed65e = 6:  e573953c lib/fs/readlink/areadlink.h: Cosmetic changes
7:  3581a5b8 = 7:  281aa83b lib/fs/readlink/areadlink.h: areadlink(): Use PATH_MAX instead of a magic value
```
</details>