### PR TITLE
lib/loginprompt.c: login_prompt(): Use strtcpy() instead of its pattern

### DIFF
--- a/lib/loginprompt.c
+++ b/lib/loginprompt.c
@@ -21,6 +21,7 @@
 #include "prototypes.h"
 #include "string/memset/memzero.h"
 #include "string/strchr/stpspn.h"
+#include "string/strcpy/strtcpy.h"
 #include "string/strtok/stpsep.h"
 
 
@@ -35,8 +36,8 @@ static void login_exit (MAYBE_UNUSED int sig)
  * login_prompt() displays the standard login prompt.  If ISSUE_FILE
  * is set in login.defs, this file is displayed before the prompt.
  */
-
-void login_prompt (char *name, int namesize)
+void
+login_prompt(char *name, int namesize)
 {
 	char buf[1024];
 
@@ -95,10 +96,7 @@ void login_prompt (char *name, int namesize)
 	 */
 
 	cp = stpspn(buf, " \t");
-
-	for (i = 0; i < namesize - 1 && *cp != '\0'; name[i++] = *cp++);
-
-	stpcpy(&name[i], "");
+	strtcpy(name, cp, namesize);
 
 	/*
 	 * Set the SIGQUIT handler back to its original value


### PR DESCRIPTION
This is one of the commits from <https://github.com/shadow-maint/shadow/pull/1048>, to simplify the review.

---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git range-diff master..gh/strtcpy shadow/master..strtcpy 
1:  3a253dc1 = 1:  61646fda lib/loginprompt.c: login_prompt(): Use strtcpy() instead of its pattern
```
</details>

<details>
<summary>v1c</summary>

-  Rebase

```
$ git range-diff master..gh/strtcpy shadow/master..strtcpy 
1:  61646fda = 1:  5d288018 lib/loginprompt.c: login_prompt(): Use strtcpy() instead of its pattern
```
</details>