### PR TITLE
Replace most strtok(3) calls by strsep(3)

### DIFF
--- a/lib/addgrps.c
+++ b/lib/addgrps.c
@@ -14,9 +14,10 @@
 #include "prototypes.h"
 #include "defines.h"
 
-#include <stdio.h>
-#include <grp.h>
 #include <errno.h>
+#include <grp.h>
+#include <stdio.h>
+#include <string.h>
 
 #include "alloc/malloc.h"
 #include "alloc/reallocf.h"
@@ -24,19 +25,19 @@
 
 #ident "$Id$"
 
-#define SEP ",:"
 /*
  * Add groups with names from LIST (separated by commas or colons)
  * to the supplementary group set.  Silently ignore groups which are
- * already there.  Warning: uses strtok().
+ * already there.
  */
-int add_groups (const char *list)
+int
+add_groups(const char *list)
 {
 	GETGROUPS_T *grouplist;
 	size_t i;
 	int ngroups;
 	bool added;
-	char *token;
+	char *g, *p;
 	char buf[1024];
 	int ret;
 	FILE *shadow_logfd = log_get_logfd();
@@ -71,13 +72,13 @@ int add_groups (const char *list)
 	}
 
 	added = false;
-	for (token = strtok (buf, SEP); NULL != token; token = strtok (NULL, SEP)) {
+	p = buf;
+	while (NULL != (g = strsep(&p, ",:"))) {
 		struct group *grp;
 
-		grp = getgrnam (token); /* local, no need for xgetgrnam */
+		grp = getgrnam(g); /* local, no need for xgetgrnam */
 		if (NULL == grp) {
-			fprintf (shadow_logfd, _("Warning: unknown group %s\n"),
-				 token);
+			fprintf(shadow_logfd, _("Warning: unknown group %s\n"), g);
 			continue;
 		}
 

--- a/lib/console.c
+++ b/lib/console.c
@@ -26,7 +26,8 @@
  * under "cfgin" in config (directly or indirectly). Fallback to default if
  * something is bad.
  */
-static bool is_listed (const char *cfgin, const char *tty, bool def)
+static bool
+is_listed(const char *cfgin, const char *tty, bool def)
 {
 	FILE *fp;
 	char buf[1024], *s;
@@ -49,14 +50,13 @@ static bool is_listed (const char *cfgin, const char *tty, bool def)
 
 	if (*cons != '/') {
 		char *pbuf;
+
 		STRTCPY(buf, cons);
-		pbuf = &buf[0];
-		while ((s = strtok (pbuf, ":")) != NULL) {
+		pbuf = buf;
+		while (NULL != (s = strsep(&pbuf, ":"))) {
 			if (streq(s, tty)) {
 				return true;
 			}
-
-			pbuf = NULL;
 		}
 		return false;
 	}

--- a/lib/motd.c
+++ b/lib/motd.c
@@ -12,6 +12,7 @@
 #ident "$Id$"
 
 #include <stdio.h>
+#include <string.h>
 
 #include "defines.h"
 #include "getdef.h"
@@ -26,7 +27,8 @@
  * it to the user's terminal at login time.  The MOTD_FILE configuration
  * option is a colon-delimited list of filenames.
  */
-void motd (void)
+void
+motd(void)
 {
 	FILE *fp;
 	char *motdlist;
@@ -41,12 +43,8 @@ void motd (void)
 
 	motdlist = xstrdup (motdfile);
 
-	for (mb = motdlist; ;mb = NULL) {
-		motdfile = strtok (mb, ":");
-		if (NULL == motdfile) {
-			break;
-		}
-
+	mb = motdlist;
+	while (NULL != (motdfile = strsep(&mb, ":"))) {
 		fp = fopen (motdfile, "r");
 		if (NULL != fp) {
 			while ((c = getc (fp)) != EOF) {

--- a/src/groupadd.c
+++ b/src/groupadd.c
@@ -16,6 +16,7 @@
 #include <getopt.h>
 #include <grp.h>
 #include <stdio.h>
+#include <string.h>
 #include <sys/types.h>
 #ifdef ACCT_TOOLS_SETUID
 #ifdef USE_PAM
@@ -164,7 +165,8 @@ static void new_sgent (struct sgrp *sgent)
  *
  *	grp_update() writes the new records to the group files.
  */
-static void grp_update (void)
+static void
+grp_update(void)
 {
 	struct group grp;
 
@@ -196,19 +198,20 @@ static void grp_update (void)
 #endif				/* SHADOWGRP */
 
 	if (user_list) {
-		char *token;
-		token = strtok(user_list, ",");
-		while (token) {
-			if (prefix_getpwnam (token) == NULL) {
-				fprintf (stderr, _("Invalid member username %s\n"), token);
+		char  *u, *ul;
+
+		ul = user_list;
+		while (NULL != (u = strsep(&ul, ","))) {
+			if (prefix_getpwnam(u) == NULL) {
+				fprintf(stderr, _("Invalid member username %s\n"), u);
 				exit (E_GRP_UPDATE);
 			}
-			grp.gr_mem = add_list(grp.gr_mem, token);
+
+			grp.gr_mem = add_list(grp.gr_mem, u);
 #ifdef  SHADOWGRP
 			if (is_shadow_grp)
-				sgrp.sg_mem = add_list(sgrp.sg_mem, token);
+				sgrp.sg_mem = add_list(sgrp.sg_mem, u);
 #endif
-			token = strtok(NULL, ",");
 		}
 	}
 

--- a/src/groupmod.c
+++ b/src/groupmod.c
@@ -17,6 +17,7 @@
 #include <grp.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 #include <strings.h>
 #include <sys/types.h>
 #ifdef ACCT_TOOLS_SETUID
@@ -198,7 +199,8 @@ static void new_sgent (struct sgrp *sgent)
  *
  *	grp_update() updates the new records in the memory databases.
  */
-static void grp_update (void)
+static void
+grp_update(void)
 {
 	struct group grp;
 	const struct group *ogrp;
@@ -251,7 +253,7 @@ static void grp_update (void)
 	}
 
 	if (user_list) {
-		char *token;
+		char  *u, *ul;
 
 		if (!aflg) {
 			// requested to replace the existing groups
@@ -274,18 +276,18 @@ static void grp_update (void)
 		}
 #endif				/* SHADOWGRP */
 
-		token = strtok(user_list, ",");
-		while (token) {
-			if (prefix_getpwnam (token) == NULL) {
-				fprintf (stderr, _("Invalid member username %s\n"), token);
+		ul = user_list;
+		while (NULL != (u = strsep(&ul, ","))) {
+			if (prefix_getpwnam(u) == NULL) {
+				fprintf(stderr, _("Invalid member username %s\n"), u);
 				exit (E_GRP_UPDATE);
 			}
-			grp.gr_mem = add_list(grp.gr_mem, token);
+
+			grp.gr_mem = add_list(grp.gr_mem, u);
 #ifdef	SHADOWGRP
 			if (NULL != osgrp)
-				sgrp.sg_mem = add_list(sgrp.sg_mem, token);
+				sgrp.sg_mem = add_list(sgrp.sg_mem, u);
 #endif				/* SHADOWGRP */
-			token = strtok(NULL, ",");
 		}
 	}
 

--- a/src/suauth.c
+++ b/src/suauth.c
@@ -45,11 +45,9 @@ static int isgrp (const char *, const char *);
 static int lines = 0;
 
 
-int check_su_auth (const char *actual_id,
-                   const char *wanted_id,
-                   bool su_to_root)
+int
+check_su_auth(const char *actual_id, const char *wanted_id, bool su_to_root)
 {
-	const char field[] = ":";
 	FILE *authfile_fd;
 	char temp[1024];
 	char *to_users;
@@ -91,10 +89,10 @@ int check_su_auth (const char *actual_id,
 		if (*p == '#' || *p == '\0')
 			continue;
 
-		if (!(to_users = strtok(p, field))
-		    || !(from_users = strtok (NULL, field))
-		    || !(action = strtok (NULL, field))
-		    || strtok (NULL, field)) {
+		to_users = strsep(&p, ":");
+		from_users = strsep(&p, ":");
+		action = strsep(&p, ":");
+		if (action == NULL || p != NULL) {
 			SYSLOG ((LOG_ERR,
 				 "%s, line %d. Bad number of fields.\n",
 				 SUAUTHFILE, lines));
@@ -138,15 +136,14 @@ int check_su_auth (const char *actual_id,
 	return NOACTION;
 }
 
-static int applies (const char *single, char *list)
+static int
+applies(const char *single, char *list)
 {
-	const char split[] = ", ";
 	char *tok;
 
 	int state = 0;
 
-	for (tok = strtok (list, split); tok != NULL;
-	     tok = strtok (NULL, split)) {
+	while (NULL != (tok = strsep(&list, ", "))) {
 
 		if (streq(tok, "ALL")) {
 			if (state != 0) {


### PR DESCRIPTION
This is a subset of #1048 for easier review.

---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git range-diff gh/strtcpy..gh/strsep strtcpy..strsep 
1:  1ada0038 = 1:  b806041d lib/, src/: Use strsep(3) instead of strtok(3)
```
</details>

<details>
<summary>v1c</summary>

-  Rebase

```
$ git range-diff gh/strtcpy..gh/strsep master..strsep 
1:  b806041d = 1:  b87f79c6 lib/, src/: Use strsep(3) instead of strtok(3)
```
</details>

<details>
<summary>v1d</summary>

-  Expand commit message

```
$ git range-diff master gh/strsep strsep 
1:  b87f79c6 ! 1:  75903c36 lib/, src/: Use strsep(3) instead of strtok(3)
    @@ Metadata
      ## Commit message ##
         lib/, src/: Use strsep(3) instead of strtok(3)
     
    +    strsep(3) is stateless, and so is easier to reason about.
    +
    +    It also has a slight difference: strtok(3) jumps over empty fields,
    +    while strsep(3) respects them as empty fields.  In most of the cases
    +    where we were using strtok(3), it makes more sense to respect empty
    +    fields, and this commit probably silently fixes a few bugs.
    +
    +    In other cases (most notably filesystem paths), contiguous delimiters
    +    ("//") should be collapsed, so strtok(3) still makes more sense there.
    +    This commit doesn't replace such strtok(3) calls.
    +
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/addgrps.c ##
```
</details>

<details>
<summary>v1e</summary>

-  Rebase

```
$ git range-diff master..gh/strsep shadow/master..strsep 
1:  75903c36 = 1:  fa952752 lib/, src/: Use strsep(3) instead of strtok(3)
```
</details>

<details>
<summary>v2</summary>

-  Several rebases

```
$ git range-diff fa952752^..fa952752 shadow/master..gh/strsep 
1:  fa952752 = 1:  eb9e6257 lib/, src/: Use strsep(3) instead of strtok(3)
```
</details>

<details>
<summary>v2b</summary>

-  Rebase

```
$ git range-diff alx/master..gh/strsep shadow/master..strsep 
1:  eb9e6257 = 1:  7f42b741 lib/, src/: Use strsep(3) instead of strtok(3)
```
</details>

<details>
<summary>v2c</summary>

-  Rebase

```
$ git range-diff gh/master..gh/strsep shadow/master..strsep 
1:  7f42b741 ! 1:  40a468ab lib/, src/: Use strsep(3) instead of strtok(3)
    @@ src/login_nopam.c: static bool list_match (char *list, const char *item, bool (*
     +          while (   (NULL != (tok = strsep(&list, ", \t")))
                       && (strcasecmp (tok, "EXCEPT") != 0))
                        /* VOID */ ;
    -           if (tok == 0 || !list_match (NULL, item, match_fn)) {
    +           if (tok == NULL || !list_match(NULL, item, match_fn)) {
     
      ## src/suauth.c ##
     @@ src/suauth.c: static int isgrp (const char *, const char *);
```
</details>

<details>
<summary>v2d</summary>

-  Rebase

```
$ git range-diff master..gh/strsep shadow/master..strsep 
1:  40a468ab ! 1:  e1bad69d lib/, src/: Use strsep(3) instead of strtok(3)
    @@ lib/console.c: static bool is_listed (const char *cfgin, const char *tty, bool d
     -          while ((s = strtok (pbuf, ":")) != NULL) {
     +          pbuf = buf;
     +          while (NULL != (s = strsep(&pbuf, ":"))) {
    -                   if (strcmp (s, tty) == 0) {
    +                   if (streq(s, tty)) {
                                return true;
                        }
     -
    @@ src/suauth.c: int check_su_auth (const char *actual_id,
     -       tok = strtok (NULL, split)) {
     +  while (NULL != (tok = strsep(&list, ", "))) {
      
    -           if (!strcmp (tok, "ALL")) {
    +           if (streq(tok, "ALL")) {
                        if (state != 0) {
```
</details>

<details>
<summary>v3</summary>

-  Reduce the scope of a variable instead of removing it.  [@hallyn ]

```
$ git range-diff master gh/strsep strsep 
1:  e1bad69d ! 1:  508d6143 lib/, src/: Use strsep(3) instead of strtok(3)
    @@ Commit message
         ("//") should be collapsed, so strtok(3) still makes more sense there.
         This commit doesn't replace such strtok(3) calls.
     
    +    While at this, remove some useless variables used by these calls, and
    +    reduce the scope of others.
    +
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/addgrps.c ##
    @@ src/login_nopam.c: int login_access (const char *user, const char *from)
     +static bool
     +list_match(char *list, const char *item, bool (*match_fn)(const char *, const char*))
      {
    ++  static const char  sep[] = ", \t";
    ++
        char *tok;
        bool match = false;
    + 
     @@ src/login_nopam.c: static bool list_match (char *list, const char *item, bool (*match_fn) (const ch
         * a match, look for an "EXCEPT" list and recurse to determine whether
         * the match is affected by any exceptions.
         */
     -  for (tok = strtok (list, sep); tok != NULL; tok = strtok (NULL, sep)) {
    -+  while (NULL != (tok = strsep(&list, ", \t"))) {
    ++  while (NULL != (tok = strsep(&list, sep))) {
                if (strcasecmp (tok, "EXCEPT") == 0) {  /* EXCEPT: give up */
                        break;
                }
    @@ src/login_nopam.c: static bool list_match (char *list, const char *item, bool (*
        /* Process exceptions to matches. */
        if (match) {
     -          while (   ((tok = strtok (NULL, sep)) != NULL)
    -+          while (   (NULL != (tok = strsep(&list, ", \t")))
    ++          while (   (NULL != (tok = strsep(&list, sep)))
                       && (strcasecmp (tok, "EXCEPT") != 0))
                        /* VOID */ ;
                if (tok == NULL || !list_match(NULL, item, match_fn)) {
```
</details>

<details>
<summary>v4</summary>

-  Rebase

```
$ git range-diff master..gh/strsep shadow/master..strsep 
1:  508d6143 ! 1:  8e4a0e70 lib/, src/: Use strsep(3) instead of strtok(3)
    @@ src/groupadd.c: static void grp_update (void)
                                exit (E_GRP_UPDATE);
                        }
     -                  grp.gr_mem = add_list(grp.gr_mem, token);
    --                  token = strtok(NULL, ",");
    ++
     +                  grp.gr_mem = add_list(grp.gr_mem, u);
    + #ifdef  SHADOWGRP
    +                   if (is_shadow_grp)
    +-                          sgrp.sg_mem = add_list(sgrp.sg_mem, token);
    ++                          sgrp.sg_mem = add_list(sgrp.sg_mem, u);
    + #endif
    +-                  token = strtok(NULL, ",");
                }
        }
      
    @@ src/groupmod.c: static void grp_update (void)
                if (!aflg) {
                        // requested to replace the existing groups
     @@ src/groupmod.c: static void grp_update (void)
    -                           grp.gr_mem = dup_list (grp.gr_mem);
                }
    + #endif                            /* SHADOWGRP */
      
     -          token = strtok(user_list, ",");
     -          while (token) {
    @@ src/groupmod.c: static void grp_update (void)
                                exit (E_GRP_UPDATE);
                        }
     -                  grp.gr_mem = add_list(grp.gr_mem, token);
    --                  token = strtok(NULL, ",");
    ++
     +                  grp.gr_mem = add_list(grp.gr_mem, u);
    + #ifdef    SHADOWGRP
    +                   if (NULL != osgrp)
    +-                          sgrp.sg_mem = add_list(sgrp.sg_mem, token);
    ++                          sgrp.sg_mem = add_list(sgrp.sg_mem, u);
    + #endif                            /* SHADOWGRP */
    +-                  token = strtok(NULL, ",");
                }
        }
```
</details>