### PR TITLE
Abstract counting commas/characters in a string

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -190,6 +190,8 @@ libshadow_la_SOURCES = \
 	string/strchr/strnul.h \
 	string/strchr/strrspn.c \
 	string/strchr/strrspn.h \
+	string/strcmp/streq.c \
+	string/strcmp/streq.h \
 	string/strcpy/stpecpy.c \
 	string/strcpy/stpecpy.h \
 	string/strcpy/strncat.c \

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -184,6 +184,8 @@ libshadow_la_SOURCES = \
 	string/sprintf/stpeprintf.h \
 	string/sprintf/xasprintf.c \
 	string/sprintf/xasprintf.h \
+	string/strchr/strchrcnt.c \
+	string/strchr/strchrcnt.h \
 	string/strchr/stpspn.c \
 	string/strchr/stpspn.h \
 	string/strchr/strnul.c \

--- a/lib/list.c
+++ b/lib/list.c
@@ -15,6 +15,7 @@
 #include "alloc/x/xmalloc.h"
 #include "prototypes.h"
 #include "defines.h"
+#include "string/strchr/strchrcnt.h"
 #include "string/strdup/xstrdup.h"
 
 
@@ -179,7 +180,8 @@ bool is_on_list (char *const *list, const char *member)
  * comma_to_list - convert comma-separated list to (char *) array
  */
 
-/*@only@*/char **comma_to_list (const char *comma)
+/*@only@*/char **
+comma_to_list(const char *comma)
 {
 	char *members;
 	char **array;
@@ -196,29 +198,11 @@ bool is_on_list (char *const *list, const char *member)
 	members = xstrdup (comma);
 
 	/*
-	 * Count the number of commas in the list
-	 */
-
-	for (cp = members, i = 0;; i++) {
-		cp2 = strchr (cp, ',');
-		if (NULL != cp2) {
-			cp = cp2 + 1;
-		} else {
-			break;
-		}
-	}
-
-	/*
-	 * Add 2 - one for the ending NULL, the other for the last item
-	 */
-
-	i += 2;
-
-	/*
 	 * Allocate the array we're going to store the pointers into.
+	 * n: number of delimiters + last element + NULL
 	 */
 
-	array = XMALLOC(i, char *);
+	array = XMALLOC(strchrcnt(members, ',') + 2, char *);
 
 	/*
 	 * Empty list is special - 0 members, not 1 empty member.  --marekm

--- a/lib/string/strchr/strchrcnt.c
+++ b/lib/string/strchr/strchrcnt.c
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#include <config.h>
+
+#include "string/strchr/strchrcnt.h"
+
+#include <stddef.h>
+
+
+extern inline size_t strchrcnt(const char *s, char c);

--- a/lib/string/strchr/strchrcnt.h
+++ b/lib/string/strchr/strchrcnt.h
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#ifndef SHADOW_INCLUDE_LIB_STRING_STRCHR_STRCHRCNT_H_
+#define SHADOW_INCLUDE_LIB_STRING_STRCHR_STRCHRCNT_H_
+
+
+#include <config.h>
+
+#include <stddef.h>
+
+#include "attr.h"
+#include "string/strcmp/streq.h"
+
+
+ATTR_STRING(1)
+inline size_t strchrcnt(const char *s, char c);
+
+
+inline size_t
+strchrcnt(const char *s, char c)
+{
+	size_t  n = 0;
+
+	for (; !streq(s, ""); s++) {
+		if (*s == c)
+			n++;
+	}
+
+	return n;
+}
+
+
+#endif  // include guard

--- a/lib/string/strcmp/streq.c
+++ b/lib/string/strcmp/streq.c
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#include <config.h>
+
+#include <stdbool.h>
+
+#include "string/strcmp/streq.h"
+
+
+extern inline bool streq(const char *s1, const char *s2);

--- a/lib/string/strcmp/streq.h
+++ b/lib/string/strcmp/streq.h
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#ifndef SHADOW_INCLUDE_LIB_STRING_STRCMP_STREQ_H_
+#define SHADOW_INCLUDE_LIB_STRING_STRCMP_STREQ_H_
+
+
+#include <config.h>
+
+#include <stdbool.h>
+#include <string.h>
+
+#include "attr.h"
+
+
+ATTR_STRING(1)
+ATTR_STRING(2)
+inline bool streq(const char *s1, const char *s2);
+
+
+/* Return true if s1 and s2 compare equal.  */
+inline bool
+streq(const char *s1, const char *s2)
+{
+	return strcmp(s1, s2) == 0;
+}
+
+
+#endif  // include guard


### PR DESCRIPTION
---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git range-diff master..gh/strchrcnt shadow/master..strchrcnt 
1:  e2897fc6 = 1:  75c3a972 lib/string/strchr/strchrcnt.[ch]: strchrcnt(): Add function
2:  4b6ff861 = 2:  9ae5b104 lib/list.c: comma_to_list(): Use strchrcnt() instead of its pattern
```
</details>

<details>
<summary>v1c</summary>

-  Simplify commit message

```
$ git range-diff master gh/strchrcnt strchrcnt 
1:  75c3a972 ! 1:  2d1571a2 lib/string/strchr/strchrcnt.[ch]: strchrcnt(): Add function
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/string/strchr/strchrcnt.[ch]: strchrcnt(): Add function
    +    lib/string/strchr/: strchrcnt(): Add function
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
2:  9ae5b104 = 2:  fa711665 lib/list.c: comma_to_list(): Use strchrcnt() instead of its pattern
```
</details>

<details>
<summary>v2</summary>

-  Several rebases

```
$ git range-diff 2d1571a2^..fa711665 shadow/master..gh/strchrcnt 
1:  2d1571a2 = 1:  c5d79ce1 lib/string/strchr/: strchrcnt(): Add function
2:  fa711665 = 2:  d49a79ea lib/list.c: comma_to_list(): Use strchrcnt() instead of its pattern
```
</details>

<details>
<summary>v3</summary>

-  Move n=0 out of the for loop (I find it confusing if the 3 parts of the for use different variables).
-  Use strcmp(3) instead of direct byte comparisons.  (This will be transformed soon to use a new streq(), which will be simpler).

```
$ git range-diff master gh/strchrcnt strchrcnt 
1:  c5d79ce1 ! 1:  940b06ec lib/string/strchr/: strchrcnt(): Add function
    @@ lib/string/strchr/strchrcnt.h (new)
     +#include <config.h>
     +
     +#include <stddef.h>
    ++#include <string.h>
     +
     +#include "attr.h"
     +#include "string/strchr/strchrcnt.h"
    @@ lib/string/strchr/strchrcnt.h (new)
     +inline size_t
     +strchrcnt(const char *s, char c)
     +{
    -+  size_t  n;
    ++  size_t  n = 0;
     +
    -+  for (n = 0; *s != '\0'; s++) {
    ++  for (; strcmp(s, "") != 0; s++) {
     +          if (*s == c)
     +                  n++;
     +  }
2:  d49a79ea = 2:  625e2be0 lib/list.c: comma_to_list(): Use strchrcnt() instead of its pattern
```
</details>

<details>
<summary>v3b</summary>

-  Remove bogus (recursive) include

```
$ git range-diff master gh/strchrcnt strchrcnt 
1:  940b06ec ! 1:  c53c9fc7 lib/string/strchr/: strchrcnt(): Add function
    @@ lib/string/strchr/strchrcnt.h (new)
     +#include <string.h>
     +
     +#include "attr.h"
    -+#include "string/strchr/strchrcnt.h"
     +
     +
     +ATTR_STRING(1)
2:  625e2be0 = 2:  46f95edd lib/list.c: comma_to_list(): Use strchrcnt() instead of its pattern
```
</details>

<details>
<summary>v4</summary>

-  Add streq(), and use it for implementing strchrcnt().

```$ git range-diff alx/master gh/strchrcnt strchrcnt 
-:  -------- > 1:  eed4ce42 lib/string/strcmp/: streq(): Add function
1:  c53c9fc7 ! 2:  37cc2b89 lib/string/strchr/: strchrcnt(): Add function
    @@ lib/string/strchr/strchrcnt.h (new)
     +#include <config.h>
     +
     +#include <stddef.h>
    -+#include <string.h>
     +
     +#include "attr.h"
    ++#include "string/strcmp/streq.h"
     +
     +
     +ATTR_STRING(1)
    @@ lib/string/strchr/strchrcnt.h (new)
     +{
     +  size_t  n = 0;
     +
    -+  for (; strcmp(s, "") != 0; s++) {
    ++  for (; !streq(s, ""); s++) {
     +          if (*s == c)
     +                  n++;
     +  }
2:  46f95edd = 3:  4c5b916f lib/list.c: comma_to_list(): Use strchrcnt() instead of its pattern
```
</details>