### PR TITLE
Avoid zero-size reallocation calls

### DIFF
--- a/lib/alloc/realloc.h
+++ b/lib/alloc/realloc.h
@@ -13,7 +13,7 @@
 
 #define REALLOC(p, n, type)                                                   \
 (                                                                             \
-	_Generic(p, type *:  (type *) reallocarray(p, n, sizeof(type)))       \
+	_Generic(p, type *: (type *) reallocarray(p, (n) ?: 1, sizeof(type))) \
 )
 
 

--- a/lib/alloc/realloc.h
+++ b/lib/alloc/realloc.h
@@ -11,9 +11,9 @@
 #include <stdlib.h>
 
 
-#define REALLOC(ptr, n, type)                                                 \
+#define REALLOC(p, n, type)                                                   \
 (                                                                             \
-	_Generic(ptr, type *:  (type *) reallocarray(ptr, n, sizeof(type)))   \
+	_Generic(p, type *:  (type *) reallocarray(p, n, sizeof(type)))       \
 )
 
 

--- a/lib/alloc/reallocf.h
+++ b/lib/alloc/reallocf.h
@@ -14,9 +14,9 @@
 #include "attr.h"
 
 
-#define REALLOCF(ptr, n, type)                                                \
+#define REALLOCF(p, n, type)                                                  \
 (                                                                             \
-	_Generic(ptr, type *:  (type *) reallocarrayf(ptr, n, sizeof(type)))  \
+	_Generic(p, type *:  (type *) reallocarrayf(p, n, sizeof(type)))      \
 )
 
 

--- a/lib/alloc/reallocf.h
+++ b/lib/alloc/reallocf.h
@@ -16,7 +16,7 @@
 
 #define REALLOCF(p, n, type)                                                  \
 (                                                                             \
-	_Generic(p, type *:  (type *) reallocarrayf(p, n, sizeof(type)))      \
+	_Generic(p, type *: (type *) reallocarrayf(p, (n) ?: 1, sizeof(type)))\
 )
 
 
@@ -30,10 +30,9 @@ reallocarrayf(void *p, size_t nmemb, size_t size)
 {
 	void  *q;
 
-	q = reallocarray(p, nmemb, size);
+	q = reallocarray(p, nmemb ?: 1, size ?: 1);
 
-	/* realloc(p, 0) is equivalent to free(p);  avoid double free.  */
-	if (q == NULL && nmemb != 0 && size != 0)
+	if (q == NULL)
 		free(p);
 	return q;
 }


### PR DESCRIPTION
Zero-length allocation calls are non-portable, and may result in nasty
bugs when porting software to other platforms.  Let's just make sure
that we never do that.  Some algorithms need malloc(0) or realloc(p, 0)
to just succeed and give a pointer that has zero elements (but is not
NULL); let's just over-allocate 1 byte, which guarantees success, and
doesn't hurt at all.

BTW, I wonder what's the history about this issue.  If anyone knows what
was the original behavior of malloc(0) and realloc(p, 0), and can
illuminate, it would be very interesting.  Was it ANSI C that goofed it
by allowing NULL to be returned?  Was it before?

---

Revisions:

<details>
<summary>v2</summary>

-  Do not avoid malloc(0) calls.  The only broken thing is realloc(p,0).  [@nabijaczleweli]

```
$ git range-diff master gh/alloc0 alloc0 
1:  39d2b51f = 1:  39d2b51f lib/alloc/realloc*.h: Rename macro parameter
2:  57b53dfe ! 2:  4b49c0c9 lib/alloc/: Always allocate at least 1 byte
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/alloc/: Always allocate at least 1 byte
    +    lib/alloc/realloc*.h: Always reallocate at least 1 byte
     
    -    Zero-length allocation calls are non-portable, and may result in nasty
    -    bugs when porting software to other platforms.  Let's just make sure
    -    that we never do that.  Some algorithms need malloc(0) or realloc(p, 0)
    -    to just succeed and give a pointer that has zero elements (but is not
    -    NULL); let's just over-allocate 1 byte, which guarantees success, and
    -    doesn't hurt at all.
    -
    -    BTW, I wonder what's the history about this issue.  If anyone knows what
    -    was the original behavior of malloc(0) and realloc(p, 0), and can
    -    illuminate, it would be very interesting.  Was it ANSI C that goofed it
    -    by allowing NULL to be returned?  Was it before?
    +    glibc's realloc(3) is broken.  It was good until 2006/2007, when it was
    +    changed to conform to C89, which had a bogus specification that required
    +    that it returns NULL.  However, by the time glibc was changed to
    +    conform to the broken C89, the standard specification had already been
    +    fixed in C99.  Thus, the change in glibc made glibc non-conforming to
    +    C99 (it had been conforming previously).
     
    +    Link: <https://github.com/shadow-maint/shadow/pull/1095>
    +    Link: <https://nabijaczleweli.xyz/content/blogn_t/017-malloc0.html>
    +    Co-developed-by: наб <nabijaczleweli@nabijaczleweli.xyz>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    - ## lib/alloc/calloc.h ##
    -@@
    - 
    - #define CALLOC(n, type)                                                       \
    - (                                                                             \
    --  (type *) calloc(n, sizeof(type))                                      \
    -+  (type *) calloc((n) ?: 1, sizeof(type))                               \
    - )
    - 
    - 
    -
    - ## lib/alloc/malloc.h ##
    -@@
    - 
    - #define MALLOC(n, type)                                                       \
    - (                                                                             \
    --  (type *) mallocarray(n, sizeof(type))                                 \
    -+  (type *) mallocarray((n) ?: 1, sizeof(type))                          \
    - )
    - 
    - 
    -@@ lib/alloc/malloc.h: inline void *mallocarray(size_t nmemb, size_t size);
    - inline void *
    - mallocarray(size_t nmemb, size_t size)
    - {
    --  return reallocarray(NULL, nmemb, size);
    -+  return reallocarray(NULL, nmemb ?: 1, size);
    - }
    - 
    - 
    -
      ## lib/alloc/realloc.h ##
     @@
      
```
</details>

<details>
<summary>v2b</summary>

-  Signed-off-by @nabijaczleweli 

```
$ git range-diff master gh/alloc0 alloc0 
1:  39d2b51f = 1:  39d2b51f lib/alloc/realloc*.h: Rename macro parameter
2:  4b49c0c9 ! 2:  98af83c4 lib/alloc/realloc*.h: Always reallocate at least 1 byte
    @@ Commit message
         Link: <https://github.com/shadow-maint/shadow/pull/1095>
         Link: <https://nabijaczleweli.xyz/content/blogn_t/017-malloc0.html>
         Co-developed-by: наб <nabijaczleweli@nabijaczleweli.xyz>
    +    Signed-off-by: наб <nabijaczleweli@nabijaczleweli.xyz>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/alloc/realloc.h ##
```
</details>

<details>
<summary>v2c</summary>

-  Reword commit message:
   -  C17 broke the standard definition of realloc(3) again.
   -  It seems glibc moved earlier to conform to C89.

```
$ git range-diff master gh/alloc0 alloc0 
1:  39d2b51f = 1:  39d2b51f lib/alloc/realloc*.h: Rename macro parameter
2:  98af83c4 ! 2:  12a0f304 lib/alloc/realloc*.h: Always reallocate at least 1 byte
    @@ Metadata
      ## Commit message ##
         lib/alloc/realloc*.h: Always reallocate at least 1 byte
     
    -    glibc's realloc(3) is broken.  It was good until 2006/2007, when it was
    -    changed to conform to C89, which had a bogus specification that required
    -    that it returns NULL.  However, by the time glibc was changed to
    -    conform to the broken C89, the standard specification had already been
    -    fixed in C99.  Thus, the change in glibc made glibc non-conforming to
    -    C99 (it had been conforming previously).
    +    glibc's realloc(3) is broken.  It was originally good (I believe) until
    +    at some point, when it was changed to conform to C89, which had a bogus
    +    specification that required that it returns NULL.  C99 fixed the mistake
    +    from C89, and so glibc's realloc(3) is non-conforming to
    +    C99/C11/POSIX.1-2008.  C17 broke again the definition of realloc(3).
     
         Link: <https://github.com/shadow-maint/shadow/pull/1095>
         Link: <https://nabijaczleweli.xyz/content/blogn_t/017-malloc0.html>
    +    Link: <https://inbox.sourceware.org/libc-alpha/5gclfbrxfd7446gtwd2x2gfuquy7ukjdbrndphyfmfszxlft76@wwjz7spd4vd7/T/#t>
         Co-developed-by: наб <nabijaczleweli@nabijaczleweli.xyz>
         Signed-off-by: наб <nabijaczleweli@nabijaczleweli.xyz>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
```
</details>

<details>
<summary>v2d</summary>

-  Some review tags.  [@ikerexxe , @eggert ]

```
$ git range-diff master gh/alloc0 alloc0 
1:  39d2b51f = 1:  39d2b51f lib/alloc/realloc*.h: Rename macro parameter
2:  12a0f304 ! 2:  73a41048 lib/alloc/realloc*.h: Always reallocate at least 1 byte
    @@ Commit message
         Link: <https://inbox.sourceware.org/libc-alpha/5gclfbrxfd7446gtwd2x2gfuquy7ukjdbrndphyfmfszxlft76@wwjz7spd4vd7/T/#t>
         Co-developed-by: наб <nabijaczleweli@nabijaczleweli.xyz>
         Signed-off-by: наб <nabijaczleweli@nabijaczleweli.xyz>
    +    Reviewed-by: Iker Pedrosa <ipedrosa@redhat.com>
    +    Acked-by: Paul Eggert <eggert@cs.ucla.edu>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/alloc/realloc.h ##
```
</details>