### PR TITLE
doc/contributions/introduction.md: Fix typo in link

### DIFF
--- a/doc/contributions/introduction.md
+++ b/doc/contributions/introduction.md
@@ -72,6 +72,6 @@ understand the project's development model:
 * [Build & install](build_install.md)
 * [Coding style](coding_style.md)
 * [Tests](tests.md)
-* [Continuous Integration](CI.md)
+* [Continuous Integration](ci.md)
 * [Releases](releases.md)
 * [License](license.md)


### PR DESCRIPTION
Fixes: 981bb8f9d1ba ("doc: add contributions introduction")
Reported-by: @nabijaczleweli