### PR TITLE
src/useradd.c: get_groups(): Fix memory leak

### DIFF
--- a/src/useradd.c
+++ b/src/useradd.c
@@ -760,6 +760,15 @@ static int get_groups (char *list)
 	int errors = 0;
 	int ngroups = 0;
 
+	/*
+	 * Free previous group list before creating a new one.
+	 */
+	int i = 0;
+	while (NULL != user_groups[i]) {
+		free(user_groups[i]);
+		user_groups[i++] = NULL;
+	}
+
 	if ('\0' == *list) {
 		return 0;
 	}


### PR DESCRIPTION
After https://github.com/shadow-maint/shadow/pull/586, there is a memory leak now for `user_groups` (although probably uncritical).

Since the `get_groups` function can be called twice, the first time for default (the `GROUPS` config parameter) and the second time through the `-G` flag. 

In fact, the second call to the `get_groups` function writes groups to `user_groups` from zero, without freeing up occupied memory.

In this change, `uset_groups` is explicitly cleared before filling.

<details><summary>valgrind leak example</summary>

```
// GROUPS from file, flag -G is not set

==59280== 22 bytes in 2 blocks are still reachable in loss record 15 of 36
==59280==    at 0x483E751: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==59280==    by 0x40E320: xmalloc (in /usr/sbin/useradd)
==59280==    by 0x40E394: xstrdup (in /usr/sbin/useradd)
==59280==    by 0x4073ED: get_groups (in /usr/sbin/useradd)
==59280==    by 0x40760D: get_defaults (in /usr/sbin/useradd)
==59280==    by 0x40A3DF: main (in /usr/sbin/useradd)

// GROUPS from file, flag -G is set

==59315== 22 bytes in 2 blocks are definitely lost in loss record 20 of 37
==59315==    at 0x483E751: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==59315==    by 0x40E320: xmalloc (in /usr/sbin/useradd)
==59315==    by 0x40E394: xstrdup (in /usr/sbin/useradd)
==59315==    by 0x4073ED: get_groups (in /usr/sbin/useradd)
==59315==    by 0x40760D: get_defaults (in /usr/sbin/useradd)
==59315==    by 0x40A3DF: main (in /usr/sbin/useradd)
```

</details>

