### PR TITLE
src/login_nopam.c: Rely on the system's MAXHOSTNAMELEN

### DIFF
--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -52,6 +52,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <stdlib.h>
+#include <sys/param.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>		/* for inet_ntoa() */
@@ -60,11 +61,6 @@
 #include "string/strchr/strrspn.h"
 #include "string/strtok/stpsep.h"
 
-
-#if !defined(MAXHOSTNAMELEN) || (MAXHOSTNAMELEN < 64)
-#undef MAXHOSTNAMELEN
-#define MAXHOSTNAMELEN 256
-#endif
 
  /* Path name of the access control file. */
 #ifndef	TABLE


### PR DESCRIPTION
The reason for that code seems to be some ancient AIX versions that defined a value that was too small (32).  We don't support such systems. In the link below, I found the following comment and code:

```
	 /*
	  * Some AIX versions advertise a too small MAXHOSTNAMELEN value (32).
	  * Result: long hostnames would be truncated, and connections would be
	  * dropped because of host name verification failures. Adrian van Bloois
	  * (A.vanBloois@info.nic.surfnet.nl) figured out what was the problem. */

	#if (MAXHOSTNAMELEN < 64)
	#undef MAXHOSTNAMELEN
	#endif

	/* In case not defined in <sys/param.h>. */

	#ifndef MAXHOSTNAMELEN
	#define MAXHOSTNAMELEN  256             /* storage for host name */
	#endif
```

Today's systems seem to be much better regarding this macro.  Rely on them.

Link: <https://sources.debian.org/src/tcp-wrappers/7.6.q-33/workarounds.c/?hl=36#L36>

---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git range-diff master..gh/maxhostnamelen shadow/master..maxhostnamelen 
1:  55ba5be3 = 1:  ba79bdeb src/login_nopam.c: Rely on the system's MAXHOSTNAMELEN
```
</details>

<details>
<summary>v2</summary>

-  Several rebases

```
$ git range-diff ba79bdeb^..ba79bdeb shadow/master..gh/maxhostnamelen 
1:  ba79bdeb = 1:  c0cb9655 src/login_nopam.c: Rely on the system's MAXHOSTNAMELEN
```
</details>