### PR TITLE
src/login_nopam.c: resolve_hostname(): Use NI_MAXHOST instead of MAXHOSTNAMELEN with getnameinfo(3)

### DIFF
--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -262,7 +262,7 @@ static const char *resolve_hostname (const char *string)
 	const char       *addr_str;
 	struct addrinfo  *addrs;
 
-	static char      host[MAXHOSTNAMELEN];
+	static char      host[NI_MAXHOST];
 
 	gai_err = getaddrinfo(string, NULL, NULL, &addrs);
 	if (gai_err != 0) {


### PR DESCRIPTION
That's what the getnameinfo(3) manual page recommends.

---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git range-diff master..gh/ni_maxhost shadow/master..ni_maxhost 
1:  10cd2649 = 1:  c88c4408 src/login_nopam.c: resolve_hostname(): Use NI_MAXHOST instead of MAXHOSTNAMELEN with getnameinfo(3)
```
</details>

<details>
<summary>v2</summary>

-  Several rebases

```
$ git range-diff c88c4408^..c88c4408 shadow/master..gh/ni_maxhost 
1:  c88c4408 = 1:  092982c3 src/login_nopam.c: resolve_hostname(): Use NI_MAXHOST instead of MAXHOSTNAMELEN with getnameinfo(3)
```
</details>

<details>
<summary>v2b</summary>

-  Rebase

```
$ git range-diff alx/master..gh/ni_maxhost shadow/master..ni_maxhost 
1:  092982c3 = 1:  b5e0b46b src/login_nopam.c: resolve_hostname(): Use NI_MAXHOST instead of MAXHOSTNAMELEN with getnameinfo(3)
```
</details>

<details>
<summary>v2c</summary>

-  Rebase

```
$ git range-diff gh/master..gh/ni_maxhost shadow/master..ni_maxhost 
1:  b5e0b46b = 1:  4d2f5b6a src/login_nopam.c: resolve_hostname(): Use NI_MAXHOST instead of MAXHOSTNAMELEN with getnameinfo(3)
```
</details>