### PR TITLE
CI: fix fedora build problems

### DIFF
--- a/share/ansible/roles/ci_run/tasks/fedora.yml
+++ b/share/ansible/roles/ci_run/tasks/fedora.yml
@@ -1,7 +1,11 @@
 ---
 # tasks file for ci_run
+- name: Ensure python is installed
+  ansible.builtin.raw: dnf install -y python3 python3-dnf
+
 - name: Ensure dependencies are installed
   ansible.builtin.dnf:
+    use_backend: dnf4
     name:
       - dnf-plugins-core
       - libcmocka-devel


### PR DESCRIPTION
The new fedora 41 has been released and some things have changed. Make
sure to install python and python3-dnf and specify the dnf version in
the roles.