### PR TITLE
lib/gshadow_.h: __STDC__ is always 1

### DIFF
--- a/lib/gshadow_.h
+++ b/lib/gshadow_.h
@@ -30,7 +30,6 @@ struct sgrp {
 
 #include <stdio.h>		/* for FILE */
 
-#if __STDC__
 /*@observer@*//*@null@*/struct sgrp *getsgent (void);
 /*@observer@*//*@null@*/struct sgrp *getsgnam (const char *);
 /*@observer@*//*@null@*/struct sgrp *sgetsgent (const char *);
@@ -38,15 +37,6 @@ struct sgrp {
 void setsgent (void);
 void endsgent (void);
 int putsgent (const struct sgrp *, FILE *);
-#else
-/*@observer@*//*@null@*/struct sgrp *getsgent ();
-/*@observer@*//*@null@*/struct sgrp *getsgnam ();
-/*@observer@*//*@null@*/struct sgrp *sgetsgent ();
-/*@observer@*//*@null@*/struct sgrp *fgetsgent ();
-void setsgent ();
-void endsgent ();
-int putsgent ();
-#endif
 
 #define	GSHADOW	"/etc/gshadow"
 #endif				/* ifndef _H_GSHADOW */


### PR DESCRIPTION
We require ISO C11 since a long time ago.

---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git range-diff alx/master..gh/stdc shadow/master..stdc 
1:  2fe225b9 = 1:  9dff5322 lib/gshadow_.h: __STDC__ is always 1
```
</details>

<details>
<summary>v1c</summary>

-  Rebase

```
$ git range-diff gh/master..gh/stdc shadow/master..stdc 
1:  9dff5322 = 1:  8d74bdeb lib/gshadow_.h: __STDC__ is always 1
```
</details>