### PR TITLE
configure.ac, lib/, src/: Presume working shadow group support in libc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -76,33 +76,6 @@ AC_CHECK_FUNC(secure_getenv, [AC_DEFINE(HAS_SECURE_GETENV,
                                         1,
                                         [Defined to 1 if you have the declaration of 'secure_getenv'])])
 
-if test "$ac_cv_header_shadow_h" = "yes"; then
-	AC_CACHE_CHECK(for working shadow group support,
-		ac_cv_libc_shadowgrp,
-		AC_RUN_IFELSE([AC_LANG_SOURCE([
-				#include <shadow.h>
-				#ifdef HAVE_GSHADOW_H
-				#include <gshadow.h>
-				#endif
-				int
-				main()
-				{
-					struct sgrp *sg = sgetsgent("test:x::");
-					/* NYS libc on Red Hat 3.0.3 has broken shadow group support */
-					return !sg || !sg->sg_adm || !sg->sg_mem;
-				}]
-			)],
-			[ac_cv_libc_shadowgrp=yes],
-			[ac_cv_libc_shadowgrp=no],
-			[ac_cv_libc_shadowgrp=no]
-		)
-	)
-
-	if test "$ac_cv_libc_shadowgrp" = "yes"; then
-		AC_DEFINE(HAVE_SHADOWGRP, 1, [Have working shadow group support in libc])
-	fi
-fi
-
 AC_CACHE_CHECK([location of shared mail directory], shadow_cv_maildir,
 [for shadow_cv_maildir in /var/mail /var/spool/mail /usr/spool/mail /usr/mail none; do
 	if test -d $shadow_cv_maildir; then

--- a/lib/defines.h
+++ b/lib/defines.h
@@ -50,13 +50,8 @@
 
 #include <dirent.h>
 
-/*
- * Possible cases:
- * - /usr/include/shadow.h exists and includes the shadow group stuff.
- * - /usr/include/shadow.h exists, but we use our own gshadow.h.
- */
 #include <shadow.h>
-#if defined(SHADOWGRP) && !defined(GSHADOW)
+#if defined(SHADOWGRP)
 #include "gshadow_.h"
 #endif
 

--- a/lib/gshadow.c
+++ b/lib/gshadow.c
@@ -9,8 +9,7 @@
 
 #include <config.h>
 
-/* Newer versions of Linux libc already have shadow support.  */
-#if defined(SHADOWGRP) && !defined(HAVE_SHADOWGRP)	/*{ */
+#if defined(SHADOWGRP) && !defined(HAVE_GSHADOW_H)
 
 #ident "$Id$"
 
@@ -276,4 +275,4 @@ int putsgent (const struct sgrp *sgrp, FILE * fp)
 }
 #else
 extern int ISO_C_forbids_an_empty_translation_unit;
-#endif				/*} SHADOWGRP */
+#endif  // !SHADOWGRP

--- a/lib/gshadow.c
+++ b/lib/gshadow.c
@@ -106,7 +106,7 @@ sgetsgent(const char *string)
 	if (NULL != cp || i != FIELDS)
 		return NULL;
 
-	sgroup.sg_name = fields[0];
+	sgroup.sg_namp = fields[0];
 	sgroup.sg_passwd = fields[1];
 
 	free(sgroup.sg_adm);
@@ -192,7 +192,7 @@ sgetsgent(const char *string)
 	setsgent ();
 
 	while ((sgrp = getsgent ()) != NULL) {
-		if (streq(name, sgrp->sg_name)) {
+		if (streq(name, sgrp->sg_namp)) {
 			break;
 		}
 	}
@@ -218,7 +218,7 @@ int putsgent (const struct sgrp *sgrp, FILE * fp)
 	}
 
 	/* calculate the required buffer size */
-	size = strlen (sgrp->sg_name) + strlen (sgrp->sg_passwd) + 10;
+	size = strlen (sgrp->sg_namp) + strlen (sgrp->sg_passwd) + 10;
 	for (i = 0; (NULL != sgrp->sg_adm) && (NULL != sgrp->sg_adm[i]); i++) {
 		size += strlen (sgrp->sg_adm[i]) + 1;
 	}
@@ -235,7 +235,7 @@ int putsgent (const struct sgrp *sgrp, FILE * fp)
 	/*
 	 * Copy the group name and passwd.
 	 */
-	cp = stpcpy(stpcpy(cp, sgrp->sg_name), ":");
+	cp = stpcpy(stpcpy(cp, sgrp->sg_namp), ":");
 	cp = stpcpy(stpcpy(cp, sgrp->sg_passwd), ":");
 
 	/*

--- a/lib/gshadow_.h
+++ b/lib/gshadow_.h
@@ -1,17 +1,17 @@
-/*
- * SPDX-FileCopyrightText: 1988 - 1994, Julianne Frances Haugh
- * SPDX-FileCopyrightText: 1996 - 1997, Marek Michałkiewicz
- * SPDX-FileCopyrightText: 2003 - 2005, Tomasz Kłoczko
- *
- * SPDX-License-Identifier: BSD-3-Clause
- */
+// SPDX-FileCopyrightText: 1988-1994, Julianne Frances Haugh
+// SPDX-FileCopyrightText: 1996-1997, Marek Michałkiewicz
+// SPDX-FileCopyrightText: 2003-2005, Tomasz Kłoczko
+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
 
-/*
- *	$Id$
- */
 
-#ifndef	_H_GSHADOW
-#define	_H_GSHADOW
+#ifndef SHADOW_INCLUDE_LIB_GSHADOW__H_
+#define SHADOW_INCLUDE_LIB_GSHADOW__H_
+
+
+#if defined(HAVE_GSHADOW_H)
+# include <gshadow.h>
+#else
 
 /*
  * Shadow group security file structure
@@ -39,4 +39,7 @@ void endsgent (void);
 int putsgent (const struct sgrp *, FILE *);
 
 #define	GSHADOW	"/etc/gshadow"
-#endif				/* ifndef _H_GSHADOW */
+
+
+#endif  // !HAVE_GSHADOW_H
+#endif  // include guard

--- a/lib/gshadow_.h
+++ b/lib/gshadow_.h
@@ -18,7 +18,7 @@
  */
 
 struct sgrp {
-	char *sg_name;		/* group name */
+	char *sg_namp;		/* group name */
 	char *sg_passwd;	/* group password */
 	char **sg_adm;		/* group administrator list */
 	char **sg_mem;		/* group membership list */

--- a/lib/sgroupio.c
+++ b/lib/sgroupio.c
@@ -36,9 +36,9 @@
 	/* Do the same as the other _dup function, even if we know the
 	 * structure. */
 	/*@-mustfreeonly@*/
-	sg->sg_name = strdup (sgent->sg_name);
+	sg->sg_namp = strdup (sgent->sg_namp);
 	/*@=mustfreeonly@*/
-	if (NULL == sg->sg_name) {
+	if (NULL == sg->sg_namp) {
 		free (sg);
 		return NULL;
 	}
@@ -46,7 +46,7 @@
 	sg->sg_passwd = strdup (sgent->sg_passwd);
 	/*@=mustfreeonly@*/
 	if (NULL == sg->sg_passwd) {
-		free (sg->sg_name);
+		free (sg->sg_namp);
 		free (sg);
 		return NULL;
 	}
@@ -57,7 +57,7 @@
 	/*@=mustfreeonly@*/
 	if (NULL == sg->sg_adm) {
 		free (sg->sg_passwd);
-		free (sg->sg_name);
+		free (sg->sg_namp);
 		free (sg);
 		return NULL;
 	}
@@ -69,7 +69,7 @@
 			}
 			free (sg->sg_adm);
 			free (sg->sg_passwd);
-			free (sg->sg_name);
+			free (sg->sg_namp);
 			free (sg);
 			return NULL;
 		}
@@ -86,7 +86,7 @@
 		}
 		free (sg->sg_adm);
 		free (sg->sg_passwd);
-		free (sg->sg_name);
+		free (sg->sg_namp);
 		free (sg);
 		return NULL;
 	}
@@ -102,7 +102,7 @@
 			}
 			free (sg->sg_adm);
 			free (sg->sg_passwd);
-			free (sg->sg_name);
+			free (sg->sg_namp);
 			free (sg);
 			return NULL;
 		}
@@ -131,7 +131,7 @@ void
 sgr_free(/*@only@*/struct sgrp *sgent)
 {
 	size_t i;
-	free (sgent->sg_name);
+	free (sgent->sg_namp);
 	if (NULL != sgent->sg_passwd)
 		free(strzero(sgent->sg_passwd));
 
@@ -150,7 +150,7 @@ static const char *gshadow_getname (const void *ent)
 {
 	const struct sgrp *gr = ent;
 
-	return gr->sg_name;
+	return gr->sg_namp;
 }
 
 static void *gshadow_parse (const char *line)
@@ -163,7 +163,7 @@ static int gshadow_put (const void *ent, FILE * file)
 	const struct sgrp *sg = ent;
 
 	if (   (NULL == sg)
-	    || (valid_field (sg->sg_name, ":\n") == -1)
+	    || (valid_field (sg->sg_namp, ":\n") == -1)
 	    || (valid_field (sg->sg_passwd, ":\n") == -1)) {
 		return -1;
 	}

--- a/src/chgpasswd.c
+++ b/src/chgpasswd.c
@@ -557,7 +557,7 @@ int main (int argc, char **argv)
 				 * group, but there are no entries in
 				 * gshadow, create one.
 				 */
-				newsg.sg_name   = name;
+				newsg.sg_namp   = name;
 				/* newsg.sg_passwd = NULL; will be set later */
 				newsg.sg_adm    = &empty;
 				newsg.sg_mem    = dup_list (gr->gr_mem);
@@ -595,7 +595,7 @@ int main (int argc, char **argv)
 			if (sgr_update (&newsg) == 0) {
 				fprintf (stderr,
 				         _("%s: line %jd: failed to prepare the new %s entry '%s'\n"),
-				         Prog, line, sgr_dbname (), newsg.sg_name);
+				         Prog, line, sgr_dbname (), newsg.sg_namp);
 				errors = true;
 				continue;
 			}

--- a/src/gpasswd.c
+++ b/src/gpasswd.c
@@ -708,7 +708,7 @@ static void update_group (struct group *gr)
 	if (is_shadowgrp && (sgr_update (sg) == 0)) {
 		fprintf (stderr,
 		         _("%s: failed to prepare the new %s entry '%s'\n"),
-		         Prog, sgr_dbname (), sg->sg_name);
+		         Prog, sgr_dbname (), sg->sg_namp);
 		exit (1);
 	}
 #endif				/* SHADOWGRP */
@@ -774,13 +774,13 @@ static void get_group (struct group *gr)
 		tmpsg = sgr_locate (group);
 		if (NULL != tmpsg) {
 			*sg = *tmpsg;
-			sg->sg_name = xstrdup (tmpsg->sg_name);
+			sg->sg_namp = xstrdup (tmpsg->sg_namp);
 			sg->sg_passwd = xstrdup (tmpsg->sg_passwd);
 
 			sg->sg_mem = dup_list (tmpsg->sg_mem);
 			sg->sg_adm = dup_list (tmpsg->sg_adm);
 		} else {
-			sg->sg_name = xstrdup (group);
+			sg->sg_namp = xstrdup (group);
 			sg->sg_passwd = gr->gr_passwd;
 			gr->gr_passwd = SHADOW_PASSWD_STRING;	/* XXX warning: const */
 

--- a/src/groupadd.c
+++ b/src/groupadd.c
@@ -149,7 +149,7 @@ static void new_grent (struct group *grent)
 static void new_sgent (struct sgrp *sgent)
 {
 	memzero (sgent, sizeof *sgent);
-	sgent->sg_name = group_name;
+	sgent->sg_namp = group_name;
 	if (pflg) {
 		sgent->sg_passwd = group_passwd;
 	} else {
@@ -231,7 +231,7 @@ grp_update(void)
 	if (is_shadow_grp && (sgr_update (&sgrp) == 0)) {
 		fprintf (stderr,
 		         _("%s: failed to prepare the new %s entry '%s'\n"),
-		         Prog, sgr_dbname (), sgrp.sg_name);
+		         Prog, sgr_dbname (), sgrp.sg_namp);
 		exit (E_GRP_UPDATE);
 	}
 #endif				/* SHADOWGRP */

--- a/src/groupmems.c
+++ b/src/groupmems.c
@@ -128,7 +128,7 @@ static void add_user (const char *user,
 		if (NULL == sg) {
 			/* Create a shadow group based on this group */
 			static struct sgrp sgrent;
-			sgrent.sg_name = xstrdup (newgrp->gr_name);
+			sgrent.sg_namp = xstrdup (newgrp->gr_name);
 			sgrent.sg_mem = dup_list (newgrp->gr_mem);
 			sgrent.sg_adm = XMALLOC(1, char *);
 			sgrent.sg_adm[0] = NULL;
@@ -154,7 +154,7 @@ static void add_user (const char *user,
 		if (sgr_update (newsg) == 0) {
 			fprintf (stderr,
 			         _("%s: failed to prepare the new %s entry '%s'\n"),
-			         Prog, sgr_dbname (), newsg->sg_name);
+			         Prog, sgr_dbname (), newsg->sg_namp);
 			fail_exit (13);
 		}
 	}
@@ -203,7 +203,7 @@ static void remove_user (const char *user,
 		if (NULL == sg) {
 			/* Create a shadow group based on this group */
 			static struct sgrp sgrent;
-			sgrent.sg_name = xstrdup (newgrp->gr_name);
+			sgrent.sg_namp = xstrdup (newgrp->gr_name);
 			sgrent.sg_mem = dup_list (newgrp->gr_mem);
 			sgrent.sg_adm = XMALLOC(1, char *);
 			sgrent.sg_adm[0] = NULL;
@@ -230,7 +230,7 @@ static void remove_user (const char *user,
 		if (sgr_update (newsg) == 0) {
 			fprintf (stderr,
 			         _("%s: failed to prepare the new %s entry '%s'\n"),
-			         Prog, sgr_dbname (), newsg->sg_name);
+			         Prog, sgr_dbname (), newsg->sg_namp);
 			fail_exit (13);
 		}
 	}
@@ -269,7 +269,7 @@ static void purge_members (const struct group *grp)
 		if (NULL == sg) {
 			/* Create a shadow group based on this group */
 			static struct sgrp sgrent;
-			sgrent.sg_name = xstrdup (newgrp->gr_name);
+			sgrent.sg_namp = xstrdup (newgrp->gr_name);
 			sgrent.sg_mem = XMALLOC(1, char *);
 			sgrent.sg_mem[0] = NULL;
 			sgrent.sg_adm = XMALLOC(1, char *);
@@ -299,7 +299,7 @@ static void purge_members (const struct group *grp)
 		if (sgr_update (newsg) == 0) {
 			fprintf (stderr,
 			         _("%s: failed to prepare the new %s entry '%s'\n"),
-			         Prog, sgr_dbname (), newsg->sg_name);
+			         Prog, sgr_dbname (), newsg->sg_namp);
 			fail_exit (13);
 		}
 	}

--- a/src/groupmod.c
+++ b/src/groupmod.c
@@ -178,7 +178,7 @@ static void new_grent (struct group *grent)
 static void new_sgent (struct sgrp *sgent)
 {
 	if (nflg) {
-		sgent->sg_name = xstrdup (group_newname);
+		sgent->sg_namp = xstrdup (group_newname);
 	}
 
 	/* Always update the shadowed password if there is a shadow entry
@@ -238,7 +238,7 @@ grp_update(void)
 			 * gshadow entry when a new password is requested.
 			 */
 			bzero(&sgrp, sizeof sgrp);
-			sgrp.sg_name   = xstrdup (grp.gr_name);
+			sgrp.sg_namp   = xstrdup (grp.gr_name);
 			sgrp.sg_passwd = xstrdup (grp.gr_passwd);
 			sgrp.sg_adm    = &empty;
 			sgrp.sg_mem    = dup_list (grp.gr_mem);
@@ -318,7 +318,7 @@ grp_update(void)
 		if (sgr_update (&sgrp) == 0) {
 			fprintf (stderr,
 			         _("%s: failed to prepare the new %s entry '%s'\n"),
-			         Prog, sgr_dbname (), sgrp.sg_name);
+			         Prog, sgr_dbname (), sgrp.sg_namp);
 			exit (E_GRP_UPDATE);
 		}
 		if (nflg && (sgr_remove (group_name) == 0)) {

--- a/src/grpck.c
+++ b/src/grpck.c
@@ -613,7 +613,7 @@ static void check_grp_file (bool *errors, bool *changed)
 					struct group gr;
 					static char *empty = NULL;
 
-					sg.sg_name = grp->gr_name;
+					sg.sg_namp = grp->gr_name;
 					sg.sg_passwd = grp->gr_passwd;
 					sg.sg_adm = &empty;
 					sg.sg_mem = grp->gr_mem;
@@ -625,7 +625,7 @@ static void check_grp_file (bool *errors, bool *changed)
 					if (sgr_update (&sg) == 0) {
 						fprintf (stderr,
 						         _("%s: failed to prepare the new %s entry '%s'\n"),
-						         Prog, sgr_dbname (), sg.sg_name);
+						         Prog, sgr_dbname (), sg.sg_namp);
 						fail_exit (E_CANT_UPDATE);
 					}
 					/* remove password from /etc/group */
@@ -740,7 +740,7 @@ static void check_sgr_file (bool *errors, bool *changed)
 				continue;
 			}
 
-			if (!streq(sgr->sg_name, ent->sg_name)) {
+			if (!streq(sgr->sg_namp, ent->sg_namp)) {
 				continue;
 			}
 
@@ -763,7 +763,7 @@ static void check_sgr_file (bool *errors, bool *changed)
 		/*
 		 * Make sure this entry exists in the /etc/group file.
 		 */
-		grp = gr_locate (sgr->sg_name);
+		grp = gr_locate (sgr->sg_namp);
 		if (grp == NULL) {
 			printf (_("no matching group file entry in %s\n"),
 			        grp_file);
@@ -777,7 +777,7 @@ static void check_sgr_file (bool *errors, bool *changed)
 			 * Verify that the all members defined in /etc/gshadow are also
 			 * present in /etc/group.
 			 */
-			compare_members_lists (sgr->sg_name,
+			compare_members_lists (sgr->sg_namp,
 			                       sgr->sg_mem, grp->gr_mem,
 			                       sgr_file, grp_file);
 		}
@@ -785,7 +785,7 @@ static void check_sgr_file (bool *errors, bool *changed)
 		/*
 		 * Make sure each administrator exists
 		 */
-		if (check_members (sgr->sg_name, sgr->sg_adm,
+		if (check_members (sgr->sg_namp, sgr->sg_adm,
 		                   _("shadow group %s: no administrative user %s\n"),
 		                   _("delete administrative member '%s'? "),
 		                   "delete admin '%s' from shadow group '%s'",
@@ -798,7 +798,7 @@ static void check_sgr_file (bool *errors, bool *changed)
 		/*
 		 * Make sure each member exists
 		 */
-		if (check_members (sgr->sg_name, sgr->sg_mem,
+		if (check_members (sgr->sg_namp, sgr->sg_mem,
 		                   _("shadow group %s: no user %s\n"),
 		                   _("delete member '%s'? "),
 		                   "delete member '%s' from shadow group '%s'",

--- a/src/grpconv.c
+++ b/src/grpconv.c
@@ -172,17 +172,17 @@ int main (int argc, char **argv)
 	 */
 	(void) sgr_rewind ();
 	while ((sg = sgr_next ()) != NULL) {
-		if (gr_locate (sg->sg_name) != NULL) {
+		if (gr_locate (sg->sg_namp) != NULL) {
 			continue;
 		}
 
-		if (sgr_remove (sg->sg_name) == 0) {
+		if (sgr_remove (sg->sg_namp) == 0) {
 			/*
 			 * This shouldn't happen (the entry exists) but...
 			 */
 			fprintf (stderr,
 			         _("%s: cannot remove entry '%s' from %s\n"),
-			         Prog, sg->sg_name, sgr_dbname ());
+			         Prog, sg->sg_namp, sgr_dbname ());
 			fail_exit (3);
 		}
 		(void) sgr_rewind ();
@@ -205,7 +205,7 @@ int main (int argc, char **argv)
 
 			/* add new shadow group entry */
 			bzero(&sgent, sizeof sgent);
-			sgent.sg_name = gr->gr_name;
+			sgent.sg_namp = gr->gr_name;
 			sgent.sg_passwd = gr->gr_passwd;
 			sgent.sg_adm = &empty;
 		}
@@ -220,7 +220,7 @@ int main (int argc, char **argv)
 		if (sgr_update (&sgent) == 0) {
 			fprintf (stderr,
 			         _("%s: failed to prepare the new %s entry '%s'\n"),
-			         Prog, sgr_dbname (), sgent.sg_name);
+			         Prog, sgr_dbname (), sgent.sg_namp);
 			fail_exit (3);
 		}
 		/* remove password from /etc/group */

--- a/src/newusers.c
+++ b/src/newusers.c
@@ -323,7 +323,7 @@ static int add_group (const char *name, const char *gid, gid_t *ngid, uid_t uid)
 	if (is_shadow_grp) {
 		struct sgrp sgrent;
 		char *admins[1];
-		sgrent.sg_name = grent.gr_name;
+		sgrent.sg_namp = grent.gr_name;
 		sgrent.sg_passwd = "*";	/* XXX warning: const */
 		grent.gr_passwd  = "x";	/* XXX warning: const */
 		admins[0] = NULL;

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -1098,11 +1098,11 @@ static void grp_update (void)
 		 *        user_groups. All these groups should be checked
 		 *        for existence with gr_locate already.
 		 */
-		if (gr_locate (sgrp->sg_name) == NULL) {
+		if (gr_locate (sgrp->sg_namp) == NULL) {
 			continue;
 		}
 
-		if (!is_on_list (user_groups, sgrp->sg_name)) {
+		if (!is_on_list (user_groups, sgrp->sg_namp)) {
 			continue;
 		}
 
@@ -1133,7 +1133,7 @@ static void grp_update (void)
 		if (sgr_update (nsgrp) == 0) {
 			fprintf (stderr,
 			         _("%s: failed to prepare the new %s entry '%s'\n"),
-			         Prog, sgr_dbname (), nsgrp->sg_name);
+			         Prog, sgr_dbname (), nsgrp->sg_namp);
 			SYSLOG ((LOG_ERR, "failed to prepare the new %s entry '%s'", sgr_dbname (), user_name));
 #ifdef WITH_AUDIT
 			audit_logger (AUDIT_ADD_USER, Prog,
@@ -1151,7 +1151,7 @@ static void grp_update (void)
 #endif
 		SYSLOG ((LOG_INFO,
 		         "add '%s' to shadow group '%s'",
-		         user_name, nsgrp->sg_name));
+		         user_name, nsgrp->sg_namp));
 	}
 #endif				/* SHADOWGRP */
 }
@@ -1913,7 +1913,7 @@ static void new_grent (struct group *grent)
 static void new_sgent (struct sgrp *sgent)
 {
 	memzero (sgent, sizeof *sgent);
-	sgent->sg_name = (char *) user_name;
+	sgent->sg_namp = (char *) user_name;
 	sgent->sg_passwd = "!";	/* XXX warning: const */
 	sgent->sg_adm = &empty_list;
 	sgent->sg_mem = &empty_list;
@@ -1965,7 +1965,7 @@ static void grp_add (void)
 	if (is_shadow_grp && (sgr_update (&sgrp) == 0)) {
 		fprintf (stderr,
 		         _("%s: failed to prepare the new %s entry '%s'\n"),
-		         Prog, sgr_dbname (), sgrp.sg_name);
+		         Prog, sgr_dbname (), sgrp.sg_namp);
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_ADD_GROUP, Prog,
 		              "adding group",

--- a/src/userdel.c
+++ b/src/userdel.c
@@ -264,7 +264,7 @@ static void update_groups (void)
 		if (sgr_update (nsgrp) == 0) {
 			fprintf (stderr,
 			         _("%s: failed to prepare the new %s entry '%s'\n"),
-			         Prog, sgr_dbname (), nsgrp->sg_name);
+			         Prog, sgr_dbname (), nsgrp->sg_namp);
 			exit (E_GRP_UPDATE);
 		}
 #ifdef WITH_AUDIT
@@ -273,7 +273,7 @@ static void update_groups (void)
 		              user_name, user_id, SHADOW_AUDIT_SUCCESS);
 #endif				/* WITH_AUDIT */
 		SYSLOG ((LOG_INFO, "delete '%s' from shadow group '%s'\n",
-		         user_name, nsgrp->sg_name));
+		         user_name, nsgrp->sg_namp));
 	}
 #endif				/* SHADOWGRP */
 }

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -850,7 +850,7 @@ update_gshadow(const struct sgrp *sgrp)
 	 * concurrent groups.
 	 */
 	is_member = Gflg && (   (was_member && aflg)
-			     || is_on_list (user_groups, sgrp->sg_name));
+			     || is_on_list (user_groups, sgrp->sg_namp));
 
 	if (!was_member && !was_admin && !is_member)
 		return;
@@ -885,7 +885,7 @@ update_gshadow(const struct sgrp *sgrp)
 #endif
 		SYSLOG ((LOG_INFO,
 			 "change admin '%s' to '%s' in shadow group '%s'",
-			 user_name, user_newname, nsgrp->sg_name));
+			 user_name, user_newname, nsgrp->sg_namp));
 	}
 
 	if (was_member) {
@@ -908,7 +908,7 @@ update_gshadow(const struct sgrp *sgrp)
 				SYSLOG ((LOG_INFO,
 					 "change '%s' to '%s' in shadow group '%s'",
 					 user_name, user_newname,
-					 nsgrp->sg_name));
+					 nsgrp->sg_namp));
 			}
 		} else {
 			/* User was a member but is no more a
@@ -923,7 +923,7 @@ update_gshadow(const struct sgrp *sgrp)
 #endif
 			SYSLOG ((LOG_INFO,
 				 "delete '%s' from shadow group '%s'",
-				 user_name, nsgrp->sg_name));
+				 user_name, nsgrp->sg_namp));
 		}
 	} else if (is_member) {
 		/* User was not a member but is now a member this
@@ -937,7 +937,7 @@ update_gshadow(const struct sgrp *sgrp)
 			      user_newname, AUDIT_NO_ID, 1);
 #endif
 		SYSLOG ((LOG_INFO, "add '%s' to shadow group '%s'",
-			 user_newname, nsgrp->sg_name));
+			 user_newname, nsgrp->sg_namp));
 	}
 	if (!changed)
 		goto free_nsgrp;
@@ -948,9 +948,9 @@ update_gshadow(const struct sgrp *sgrp)
 	if (sgr_update (nsgrp) == 0) {
 		fprintf (stderr,
 			 _("%s: failed to prepare the new %s entry '%s'\n"),
-			 Prog, sgr_dbname (), nsgrp->sg_name);
+			 Prog, sgr_dbname (), nsgrp->sg_namp);
 		SYSLOG ((LOG_WARN, "failed to prepare the new %s entry '%s'",
-			 sgr_dbname (), nsgrp->sg_name));
+			 sgr_dbname (), nsgrp->sg_namp));
 		fail_exit (E_GRP_UPDATE);
 	}
 


### PR DESCRIPTION
This check was testing a specific bug in a prehistoric libc version. Red Hat 3 is long dead, and it doesn't make sense to test for that specific bug.

---

Revisions:

<details>
<summary>v2</summary>

-  Keep `lib/shadow.c` for musl, which doesn't have these APIs.
-  Include libc's `<gshadow.h>` if available.

```
$ git range-diff master gh/shadowgrp shadowgrp 
1:  7abca5a1 < -:  -------- configure.ac, lib/, src/: Presume working shadow group support in libc
-:  -------- > 1:  992aedca lib/: Include <gshadow.h> if it's available
-:  -------- > 2:  545bd8de configure.ac, lib/gshadow.c: Presume working shadow group support in libc
```
</details>

<details>
<summary>v2b</summary>

-  Remove obsolete comment

```
$ git range-diff master gh/shadowgrp shadowgrp 
1:  992aedca = 1:  992aedca lib/: Include <gshadow.h> if it's available
2:  545bd8de ! 2:  f7071ba1 configure.ac, lib/gshadow.c: Presume working shadow group support in libc
    @@ configure.ac: AC_CHECK_FUNC(secure_getenv, [AC_DEFINE(HAS_SECURE_GETENV,
     
      ## lib/gshadow.c ##
     @@
    + 
      #include <config.h>
      
    - /* Newer versions of Linux libc already have shadow support.  */
    +-/* Newer versions of Linux libc already have shadow support.  */
     -#if defined(SHADOWGRP) && !defined(HAVE_SHADOWGRP)        /*{ */
     +#if defined(SHADOWGRP) && !defined(HAVE_GSHADOW_H)        /*{ */
      
```
</details>

<details>
<summary>v3</summary>

-  Fix compatibility with libc.  Patch 1 revealed this incompatibility with libc.

```
$ git range-diff master gh/shadowgrp shadowgrp 
1:  992aedca = 1:  992aedca lib/: Include <gshadow.h> if it's available
2:  f7071ba1 = 2:  f7071ba1 configure.ac, lib/gshadow.c: Presume working shadow group support in libc
-:  -------- > 3:  8df6b06e lib/gshadow_.h: Fix compatibility with libc's struct sgrp
```
</details>

<details>
<summary>v3b</summary>

-  Silence CodeQL warning by reformatting comment

```
$ git range-diff master gh/shadowgrp shadowgrp 
1:  992aedca = 1:  992aedca lib/: Include <gshadow.h> if it's available
2:  f7071ba1 ! 2:  e0f15b7a configure.ac, lib/gshadow.c: Presume working shadow group support in libc
    @@ lib/gshadow.c
      
     -/* Newer versions of Linux libc already have shadow support.  */
     -#if defined(SHADOWGRP) && !defined(HAVE_SHADOWGRP)        /*{ */
    -+#if defined(SHADOWGRP) && !defined(HAVE_GSHADOW_H)        /*{ */
    ++#if defined(SHADOWGRP) && !defined(HAVE_GSHADOW_H)
      
      #ident "$Id$"
      
    +@@ lib/gshadow.c: int putsgent (const struct sgrp *sgrp, FILE * fp)
    + }
    + #else
    + extern int ISO_C_forbids_an_empty_translation_unit;
    +-#endif                            /*} SHADOWGRP */
    ++#endif  // !SHADOWGRP
3:  8df6b06e = 3:  d8090da9 lib/gshadow_.h: Fix compatibility with libc's struct sgrp
```
</details>

<details>
<summary>v3c</summary>

-  Rebase

```
$ git range-diff alx/master..gh/shadowgrp shadow/master..shadowgrp 
1:  992aedca = 1:  0fb36eda lib/: Include <gshadow.h> if it's available
2:  e0f15b7a = 2:  81334580 configure.ac, lib/gshadow.c: Presume working shadow group support in libc
3:  d8090da9 = 3:  679d7552 lib/gshadow_.h: Fix compatibility with libc's struct sgrp
```
</details>

<details>
<summary>v3d</summary>

-  Rebase

```
$ git range-diff gh/master..gh/shadowgrp shadow/master..shadowgrp 
1:  0fb36eda = 1:  5032a3eb lib/: Include <gshadow.h> if it's available
2:  81334580 = 2:  d8478463 configure.ac, lib/gshadow.c: Presume working shadow group support in libc
3:  679d7552 = 3:  4a78c9cf lib/gshadow_.h: Fix compatibility with libc's struct sgrp
```
</details>

<details>
<summary>v3e</summary>

-  Rebase

```
$ git range-diff master..gh/shadowgrp shadow/master..shadowgrp 
1:  5032a3eb ! 1:  fb73d816 lib/: Include <gshadow.h> if it's available
    @@ lib/gshadow_.h
      
      /*
       * Shadow group security file structure
    -@@ lib/gshadow_.h: int putsgent ();
    - #endif
    +@@ lib/gshadow_.h: void endsgent (void);
    + int putsgent (const struct sgrp *, FILE *);
      
      #define   GSHADOW "/etc/gshadow"
     -#endif                            /* ifndef _H_GSHADOW */
2:  d8478463 = 2:  9a672ed6 configure.ac, lib/gshadow.c: Presume working shadow group support in libc
3:  4a78c9cf ! 3:  f5db1b5c lib/gshadow_.h: Fix compatibility with libc's struct sgrp
    @@ lib/gshadow.c: void endsgent (void)
        setsgent ();
      
        while ((sgrp = getsgent ()) != NULL) {
    --          if (strcmp (name, sgrp->sg_name) == 0) {
    -+          if (strcmp (name, sgrp->sg_namp) == 0) {
    +-          if (streq(name, sgrp->sg_name)) {
    ++          if (streq(name, sgrp->sg_namp)) {
                        break;
                }
        }
    @@ src/grpck.c: static void check_sgr_file (int *errors, bool *changed)
                                continue;
                        }
      
    --                  if (strcmp (sgr->sg_name, ent->sg_name) != 0) {
    -+                  if (strcmp (sgr->sg_namp, ent->sg_namp) != 0) {
    +-                  if (!streq(sgr->sg_name, ent->sg_name)) {
    ++                  if (!streq(sgr->sg_name, ent->sg_namp)) {
                                continue;
                        }
      
```
</details>

<details>
<summary>v3f</summary>

-  Rebase

```
$ git range-diff master..gh/shadowgrp shadow/master..shadowgrp 
1:  fb73d816 = 1:  bbb45215 lib/: Include <gshadow.h> if it's available
2:  9a672ed6 = 2:  a61aead2 configure.ac, lib/gshadow.c: Presume working shadow group support in libc
3:  f5db1b5c = 3:  4f5b8c59 lib/gshadow_.h: Fix compatibility with libc's struct sgrp
```
</details>

<details>
<summary>v3g</summary>

-  Fix typo introduced in v3e.

```
$ git range-diff master gh/shadowgrp shadowgrp 
1:  bbb45215 = 1:  bbb45215 lib/: Include <gshadow.h> if it's available
2:  a61aead2 = 2:  a61aead2 configure.ac, lib/gshadow.c: Presume working shadow group support in libc
3:  4f5b8c59 ! 3:  c8a122a2 lib/gshadow_.h: Fix compatibility with libc's struct sgrp
    @@ src/grpck.c: static void check_sgr_file (int *errors, bool *changed)
                        }
      
     -                  if (!streq(sgr->sg_name, ent->sg_name)) {
    -+                  if (!streq(sgr->sg_name, ent->sg_namp)) {
    ++                  if (!streq(sgr->sg_namp, ent->sg_namp)) {
                                continue;
                        }
```
</details>

<details>
<summary>v3h</summary>

-  Rebase

```
$ git range-diff master..gh/shadowgrp shadow/master..shadowgrp 
1:  bbb45215 = 1:  d2a28602 lib/: Include <gshadow.h> if it's available
2:  a61aead2 = 2:  d9162817 configure.ac, lib/gshadow.c: Presume working shadow group support in libc
3:  c8a122a2 ! 3:  0f40b17b lib/gshadow_.h: Fix compatibility with libc's struct sgrp
    @@ src/groupadd.c: static void new_grent (struct group *grent)
        if (pflg) {
                sgent->sg_passwd = group_passwd;
        } else {
    -@@ src/groupadd.c: static void grp_update (void)
    +@@ src/groupadd.c: grp_update(void)
        if (is_shadow_grp && (sgr_update (&sgrp) == 0)) {
                fprintf (stderr,
                         _("%s: failed to prepare the new %s entry '%s'\n"),
    @@ src/groupmod.c: static void new_grent (struct group *grent)
        }
      
        /* Always update the shadowed password if there is a shadow entry
    -@@ src/groupmod.c: static void grp_update (void)
    +@@ src/groupmod.c: grp_update(void)
                         * gshadow entry when a new password is requested.
                         */
                        bzero(&sgrp, sizeof sgrp);
    @@ src/groupmod.c: static void grp_update (void)
                        sgrp.sg_passwd = xstrdup (grp.gr_passwd);
                        sgrp.sg_adm    = &empty;
                        sgrp.sg_mem    = dup_list (grp.gr_mem);
    -@@ src/groupmod.c: static void grp_update (void)
    +@@ src/groupmod.c: grp_update(void)
                if (sgr_update (&sgrp) == 0) {
                        fprintf (stderr,
                                 _("%s: failed to prepare the new %s entry '%s'\n"),
```
</details>

<details>
<summary>v3i</summary>

-  Rebase

```
$ git range-diff master..gh/shadowgrp shadow/master..shadowgrp 
1:  d2a28602 = 1:  833ddd00 lib/: Include <gshadow.h> if it's available
2:  d9162817 = 2:  5eb151a3 configure.ac, lib/gshadow.c: Presume working shadow group support in libc
3:  0f40b17b ! 3:  4d42143b lib/gshadow_.h: Fix compatibility with libc's struct sgrp
    @@ Commit message
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/gshadow.c ##
    -@@ lib/gshadow.c: void endsgent (void)
    +@@ lib/gshadow.c: sgetsgent(const char *string)
        if (NULL != cp || i != FIELDS)
    -           return 0;
    +           return NULL;
      
     -  sgroup.sg_name = fields[0];
     +  sgroup.sg_namp = fields[0];
        sgroup.sg_passwd = fields[1];
    -   if (0 != nadmins) {
    -           nadmins = 0;
    -@@ lib/gshadow.c: void endsgent (void)
    + 
    +   free(sgroup.sg_adm);
    +@@ lib/gshadow.c: sgetsgent(const char *string)
        setsgent ();
      
        while ((sgrp = getsgent ()) != NULL) {
```
</details>

<details>
<summary>v3j</summary>

-  Rebase

```
$ git range-diff master..gh/shadowgrp shadow/master..shadowgrp 
1:  833ddd00 = 1:  6dbb2331 lib/: Include <gshadow.h> if it's available
2:  5eb151a3 = 2:  5157fed4 configure.ac, lib/gshadow.c: Presume working shadow group support in libc
3:  4d42143b = 3:  0f45349c lib/gshadow_.h: Fix compatibility with libc's struct sgrp
```
</details>

<details>
<summary>v3k</summary>

-  Rebase

```
$ git range-diff alx/master..gh/shadowgrp master..shadowgrp 
1:  6dbb2331 = 1:  5a899fc7 lib/: Include <gshadow.h> if it's available
2:  5157fed4 = 2:  fb66ad56 configure.ac, lib/gshadow.c: Presume working shadow group support in libc
3:  0f45349c = 3:  498b847d lib/gshadow_.h: Fix compatibility with libc's struct sgrp
```
</details>

<details>
<summary>v3l</summary>

-  Rebase

```
$ git range-diff alx/master..gh/shadowgrp master..shadowgrp 
1:  5a899fc7 = 1:  365cedd7 lib/: Include <gshadow.h> if it's available
2:  fb66ad56 = 2:  c7a4d684 configure.ac, lib/gshadow.c: Presume working shadow group support in libc
3:  498b847d ! 3:  b22d6544 lib/gshadow_.h: Fix compatibility with libc's struct sgrp
    @@ src/chgpasswd.c: int main (int argc, char **argv)
     @@ src/chgpasswd.c: int main (int argc, char **argv)
                        if (sgr_update (&newsg) == 0) {
                                fprintf (stderr,
    -                                    _("%s: line %d: failed to prepare the new %s entry '%s'\n"),
    +                                    _("%s: line %jd: failed to prepare the new %s entry '%s'\n"),
     -                                   Prog, line, sgr_dbname (), newsg.sg_name);
     +                                   Prog, line, sgr_dbname (), newsg.sg_namp);
                                errors++;
```
</details>