### PR TITLE
gpasswd: fix invalid free in is_valid_user_list()

### DIFF
--- a/src/gpasswd.c
+++ b/src/gpasswd.c
@@ -174,7 +174,9 @@ static void catch_signals (int killed)
 static bool is_valid_user_list (const char *users)
 {
 	bool is_valid = true;
-	/*@owned@*/char *tmpusers = xstrdup (users);
+	char  *dup, *tmpusers;
+
+	tmpusers = dup = xstrdup(users);
 
 	while (NULL != tmpusers && '\0' != *tmpusers) {
 		const char  *u;
@@ -193,7 +195,7 @@ static bool is_valid_user_list (const char *users)
 		}
 	}
 
-	free (tmpusers);
+	free(dup);
 
 	return is_valid;
 }


### PR DESCRIPTION
This fix addresses an issue in is_valid_user_list() where the free operation was attempted on an address not allocated with malloc(). By duplicating the pointer with xstrdup(users) into dup, and using dup as the original pointer, we ensure that only the valid pointer is freed, avoiding an invalid free operation.

Suggested-by: <https://github.com/frostb1ten>
Reported-by: <https://github.com/frostb1ten>
Cc: Serge Hallyn <serge@hallyn.com>