### PR TITLE
lib/shadow.c: my_sgetspent(): There can be only one!

### DIFF
--- a/lib/shadow.c
+++ b/lib/shadow.c
@@ -58,138 +58,6 @@ void endspent (void)
 }
 
 /*
- * my_sgetspent - convert string in shadow file format to (struct spwd *)
- */
-
-static struct spwd *my_sgetspent (const char *string)
-{
-	int                 i;
-	char                *fields[FIELDS];
-	char                *cp;
-	static char         spwbuf[BUFSIZ];
-	static char         empty[] = "";
-	static struct spwd  spwd;
-
-	/*
-	 * Copy string to local buffer.  It has to be tokenized and we
-	 * have to do that to our private copy.
-	 */
-
-	if (strlen (string) >= sizeof spwbuf)
-		return 0;
-	strcpy (spwbuf, string);
-	stpsep(spwbuf, "\n");
-
-	/*
-	 * Tokenize the string into colon separated fields.  Allow up to
-	 * FIELDS different fields.
-	 */
-
-	for (cp = spwbuf, i = 0; cp != NULL && i < FIELDS; i++)
-		fields[i] = strsep(&cp, ":");
-
-	if (i == (FIELDS - 1))
-		fields[i++] = empty;
-
-	if (cp != NULL || (i != FIELDS && i != OFIELDS))
-		return 0;
-
-	/*
-	 * Start populating the structure.  The fields are all in
-	 * static storage, as is the structure we pass back.  If we
-	 * ever see a name with '+' as the first character, we try
-	 * to turn on NIS processing.
-	 */
-
-	spwd.sp_namp = fields[0];
-	spwd.sp_pwdp = fields[1];
-
-	/*
-	 * Get the last changed date.  For all of the integer fields,
-	 * we check for proper format.  It is an error to have an
-	 * incorrectly formatted number, unless we are using NIS.
-	 */
-
-	if (fields[2][0] == '\0')
-		spwd.sp_lstchg = -1;
-	else if (a2sl(&spwd.sp_lstchg, fields[2], NULL, 0, 0, LONG_MAX) == -1)
-		return 0;
-
-	/*
-	 * Get the minimum period between password changes.
-	 */
-
-	if (fields[3][0] == '\0')
-		spwd.sp_min = -1;
-	else if (a2sl(&spwd.sp_min, fields[3], NULL, 0, 0, LONG_MAX) == -1)
-		return 0;
-
-	/*
-	 * Get the maximum number of days a password is valid.
-	 */
-
-	if (fields[4][0] == '\0')
-		spwd.sp_max = -1;
-	else if (a2sl(&spwd.sp_max, fields[4], NULL, 0, 0, LONG_MAX) == -1)
-		return 0;
-
-	/*
-	 * If there are only OFIELDS fields (this is a SVR3.2 /etc/shadow
-	 * formatted file), initialize the other field members to -1.
-	 */
-
-	if (i == OFIELDS) {
-		spwd.sp_warn   = -1;
-		spwd.sp_inact  = -1;
-		spwd.sp_expire = -1;
-		spwd.sp_flag   = SHADOW_SP_FLAG_UNSET;
-
-		return &spwd;
-	}
-
-	/*
-	 * Get the number of days of password expiry warning.
-	 */
-
-	if (fields[5][0] == '\0')
-		spwd.sp_warn = -1;
-	else if (a2sl(&spwd.sp_warn, fields[5], NULL, 0, 0, LONG_MAX) == -1)
-		return 0;
-
-	/*
-	 * Get the number of days of inactivity before an account is
-	 * disabled.
-	 */
-
-	if (fields[6][0] == '\0')
-		spwd.sp_inact = -1;
-	else if (a2sl(&spwd.sp_inact, fields[6], NULL, 0, 0, LONG_MAX) == -1)
-		return 0;
-
-	/*
-	 * Get the number of days after the epoch before the account is
-	 * set to expire.
-	 */
-
-	if (fields[7][0] == '\0')
-		spwd.sp_expire = -1;
-	else if (a2sl(&spwd.sp_expire, fields[7], NULL, 0, 0, LONG_MAX) == -1)
-		return 0;
-
-	/*
-	 * This field is reserved for future use.  But it isn't supposed
-	 * to have anything other than a valid integer in it.
-	 */
-
-	if (fields[8][0] == '\0')
-		spwd.sp_flag = SHADOW_SP_FLAG_UNSET;
-	else if (str2ul(&spwd.sp_flag, fields[8]) == -1)
-		return 0;
-
-	return (&spwd);
-}
-
-/*
  * fgetspent - get an entry from a /etc/shadow formatted stream
  */
 
@@ -204,7 +72,7 @@ struct spwd *fgetspent (FILE * fp)
 	if (fgets (buf, sizeof buf, fp) != NULL)
 	{
 		stpsep(buf, "\n");
-		return my_sgetspent (buf);
+		return sgetspent(buf);
 	}
 	return 0;
 }


### PR DESCRIPTION
We already have sgetspent(), with identical semantics, defined in <lib/sgetspent.c>.

```diff
$ diff -u <(grepc sgetspent .) <(grepc my_sgetspent .)
--- /dev/fd/63	2024-11-11 11:56:55.444055921 +0100
+++ /dev/fd/62	2024-11-11 11:56:55.444055921 +0100
@@ -1,23 +1,19 @@
-./lib/sgetspent.c:struct spwd *
-sgetspent(const char *string)
+./lib/shadow.c:static struct spwd *my_sgetspent (const char string)
 {
-	static char spwbuf[PASSWD_ENTRY_MAX_LENGTH];
-	static struct spwd spwd;
-	char *fields[FIELDS];
-	char *cp;
-	int i;
+	int                 i;
+	char                *fields[FIELDS];
+	char                *cp;
+	static char         spwbuf[BUFSIZ];
+	static char         empty[] = "";
+	static struct spwd  spwd;

	/*
	 * Copy string to local buffer.  It has to be tokenized and we
	 * have to do that to our private copy. */

-	if (strlen (string) >= sizeof spwbuf) {
-		fprintf (shadow_logfd,
-		         "%s: Too long passwd entry encountered, file corruption?\n",
-		         shadow_progname);
-		return NULL;	/* fail if too long */
-	}
+	if (strlen (string) >= sizeof spwbuf)
+		return 0;
	strcpy (spwbuf, string);
	stpsep(spwbuf, "\n");

@@ -30,14 +26,16 @@
		fields[i] = strsep(&cp, ":");

	if (i == (FIELDS - 1))
-		fields[i++] = "";
+		fields[i++] = empty;

	if (cp != NULL || (i != FIELDS && i != OFIELDS))
-		return NULL;
+		return 0;

	/*
	 * Start populating the structure.  The fields are all in
-	 * static storage, as is the structure we pass back.
+	 * static storage, as is the structure we pass back.  If we
+	 * ever see a name with '+' as the first character, we try
+	 * to turn on NIS processing. */

	spwd.sp_namp = fields[0];
@@ -46,13 +44,13 @@
	/*
	 * Get the last changed date.  For all of the integer fields,
	 * we check for proper format.  It is an error to have an
-	 * incorrectly formatted number.
+	 * incorrectly formatted number, unless we are using NIS. */

	if (fields[2][0] == '\0')
		spwd.sp_lstchg = -1;
	else if (a2sl(&spwd.sp_lstchg, fields[2], NULL, 0, 0, LONG_MAX) == -1)
-		return NULL;
+		return 0;

	/*
	 * Get the minimum period between password changes. @@ -61,7 +59,7 @@ if (fields[3][0] == '\0') spwd.sp_min = -1; else if (a2sl(&spwd.sp_min, fields[3], NULL, 0, 0, LONG_MAX) == -1)
-		return NULL;
+		return 0;

	/*
	 * Get the maximum number of days a password is valid. @@ -70,7 +68,7 @@ if (fields[4][0] == '\0') spwd.sp_max = -1; else if (a2sl(&spwd.sp_max, fields[4], NULL, 0, 0, LONG_MAX) == -1)
-		return NULL;
+		return 0;

	/*
	 * If there are only OFIELDS fields (this is a SVR3.2 /etc/shadow @@ -93,7 +91,7 @@ if (fields[5][0] == '\0') spwd.sp_warn = -1; else if (a2sl(&spwd.sp_warn, fields[5], NULL, 0, 0, LONG_MAX) == -1)
-		return NULL;
+		return 0;

	/*
	 * Get the number of days of inactivity before an account is @@ -103,7 +101,7 @@ if (fields[6][0] == '\0') spwd.sp_inact = -1; else if (a2sl(&spwd.sp_inact, fields[6], NULL, 0, 0, LONG_MAX) == -1)
-		return NULL;
+		return 0;

	/*
	 * Get the number of days after the epoch before the account is @@ -113,7 +111,7 @@ if (fields[7][0] == '\0') spwd.sp_expire = -1; else if (a2sl(&spwd.sp_expire, fields[7], NULL, 0, 0, LONG_MAX) == -1)
-		return NULL;
+		return 0;

	/*
	 * This field is reserved for future use.  But it isn't supposed @@ -123,8 +121,7 @@ if (fields[8][0] == '\0') spwd.sp_flag = SHADOW_SP_FLAG_UNSET; else if (str2ul(&spwd.sp_flag, fields[8]) == -1)
-		return NULL;
+		return 0;

	return (&spwd);
 }
-./lib/prototypes.h:extern struct spwd *sgetspent (const char *string);
```

Closes: <https://github.com/shadow-maint/shadow/issues/1114>
Link: <https://www.youtube.com/watch?v=IpbvtSQvgWM>