### PR TITLE
lib/idmapping.c: Fix get_map_ranges regression

### DIFF
--- a/lib/idmapping.c
+++ b/lib/idmapping.c
@@ -52,23 +52,19 @@ get_map_ranges(int ranges, int argc, char **argv)
 	/* Gather up the ranges from the command line */
 	m = mappings;
 	for (int i = 0; i < ranges * 3; i+=3, m++) {
-		if (a2ul(&m->upper, argv[i + 0], NULL, 0, 0, UINT_MAX) == -1) {
+		if (a2ul(&m->upper, argv[i + 0], NULL, 0, 0, UINT_MAX - 1) == -1) {
 			if (errno == ERANGE)
 				fprintf(log_get_logfd(), _( "%s: subuid overflow detected.\n"), log_get_progname());
 			free(mappings);
 			return NULL;
 		}
-		if (a2ul(&m->lower, argv[i + 1], NULL, 0, 0, UINT_MAX) == -1) {
+		if (a2ul(&m->lower, argv[i + 1], NULL, 0, 0, UINT_MAX - 1) == -1) {
 			if (errno == ERANGE)
 				fprintf(log_get_logfd(), _( "%s: subuid overflow detected.\n"), log_get_progname());
 			free(mappings);
 			return NULL;
 		}
-		if (a2ul(&m->count, argv[i + 2], NULL, 0, 0,
-		         MIN(MIN(UINT_MAX, ULONG_MAX - 1) - m->lower,
-		             MIN(UINT_MAX, ULONG_MAX - 1) - m->upper))
-		    == -1)
-		{
+		if (a2ul(&m->count, argv[i + 2], NULL, 0, 1, UINT_MAX - MAX(m->lower, m->upper)) == -1) {
 			if (errno == ERANGE)
 				fprintf(log_get_logfd(), _( "%s: subuid overflow detected.\n"), log_get_progname());
 			free(mappings);


### PR DESCRIPTION
If get_map_ranges is called on a 32 bit system, where UINT_MAX equals ULONG_MAX, the count check allows illegal values if uid and loweruid are both UINT_MAX due to unsigned integer underflow.

Always use the fix size UINT_MAX as count limitation due to guarantee that sizeof(unsigned int) <= sizeof(unsigned long) in C language.

Fixes: 7c43eb2c4ea6 ("lib/idmapping.c: get_map_ranges(): Move range check to a2ul() call")

Proof of Concept (32 bit system):
```
newuidmap $$ 4294967295 4294967295 10
```

Output:
```
newuidmap: uid range [4294967295-9) -> [4294967295-9) not allowed
```

Expected:
```
newuidmap: subuid overflow detected.
usage: newuidmap [<pid>|fd:<pidfd>] <uid> <loweruid> <count> [ <uid> <loweruid> <count> ] ...
```