### PR TITLE
Use cc(1)'s __has_include() instead of build-system checks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,10 +37,7 @@ LT_LIB_DLLOAD
 dnl Checks for libraries.
 
 dnl Checks for header files.
-AC_CHECK_HEADERS(utmp.h \
-	termio.h sgtty.h sys/ioctl.h paths.h \
-	gshadow.h lastlog.h rpc/key_prot.h acl/libacl.h \
-	attr/libattr.h attr/error_context.h)
+AC_CHECK_HEADERS(gshadow.h)
 
 dnl shadow now uses the libc's shadow implementation
 AC_CHECK_HEADER([shadow.h],,[AC_MSG_ERROR([You need a libc with shadow.h])])

--- a/configure.ac
+++ b/configure.ac
@@ -39,7 +39,6 @@ dnl Checks for libraries.
 dnl Checks for header files.
 AC_CHECK_HEADERS(utmp.h \
 	termio.h sgtty.h sys/ioctl.h paths.h \
-	sys/capability.h \
 	gshadow.h lastlog.h rpc/key_prot.h acl/libacl.h \
 	attr/libattr.h attr/error_context.h)
 

--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,7 @@ LT_LIB_DLLOAD
 dnl Checks for libraries.
 
 dnl Checks for header files.
-AC_CHECK_HEADERS(crypt.h utmp.h \
+AC_CHECK_HEADERS(utmp.h \
 	termio.h sgtty.h sys/ioctl.h paths.h \
 	sys/capability.h sys/random.h \
 	gshadow.h lastlog.h rpc/key_prot.h acl/libacl.h \

--- a/configure.ac
+++ b/configure.ac
@@ -39,7 +39,7 @@ dnl Checks for libraries.
 dnl Checks for header files.
 AC_CHECK_HEADERS(utmp.h \
 	termio.h sgtty.h sys/ioctl.h paths.h \
-	sys/capability.h sys/random.h \
+	sys/capability.h \
 	gshadow.h lastlog.h rpc/key_prot.h acl/libacl.h \
 	attr/libattr.h attr/error_context.h)
 

--- a/configure.ac
+++ b/configure.ac
@@ -36,9 +36,6 @@ LT_LIB_DLLOAD
 
 dnl Checks for libraries.
 
-dnl Checks for header files.
-AC_CHECK_HEADERS(gshadow.h)
-
 dnl shadow now uses the libc's shadow implementation
 AC_CHECK_HEADER([shadow.h],,[AC_MSG_ERROR([You need a libc with shadow.h])])
 

--- a/lib/csrand.c
+++ b/lib/csrand.c
@@ -10,8 +10,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <unistd.h>
-#if HAVE_SYS_RANDOM_H
-#include <sys/random.h>
+#if __has_include(<sys/random.h>)
+# include <sys/random.h>
 #endif
 
 #include "bit.h"

--- a/lib/defines.h
+++ b/lib/defines.h
@@ -41,7 +41,7 @@
  * crypt(3), crypt_gensalt(3), and their
  * feature test macros may be defined in here.
  */
-#if HAVE_CRYPT_H
+#if __has_include(<crypt.h>)
 # include <crypt.h>
 #endif
 

--- a/lib/gshadow.c
+++ b/lib/gshadow.c
@@ -9,7 +9,7 @@
 
 #include <config.h>
 
-#if defined(SHADOWGRP) && !defined(HAVE_GSHADOW_H)
+#if defined(SHADOWGRP) && !__has_include(<gshadow.h>)
 
 #ident "$Id$"
 

--- a/lib/gshadow_.h
+++ b/lib/gshadow_.h
@@ -9,7 +9,7 @@
 #define SHADOW_INCLUDE_LIB_GSHADOW__H_
 
 
-#if defined(HAVE_GSHADOW_H)
+#if __has_include(<gshadow.h>)
 # include <gshadow.h>
 #else
 
@@ -41,5 +41,5 @@ int putsgent (const struct sgrp *, FILE *);
 #define	GSHADOW	"/etc/gshadow"
 
 
-#endif  // !HAVE_GSHADOW_H
+#endif  // !__has_include(<gshadow.h>)
 #endif  // include guard

--- a/lib/idmapping.c
+++ b/lib/idmapping.c
@@ -13,8 +13,8 @@
 #include <stdio.h>
 #include <strings.h>
 #include <sys/prctl.h>
-#if HAVE_SYS_CAPABILITY_H
-#include <sys/capability.h>
+#if __has_include(<sys/capability.h>)
+# include <sys/capability.h>
 #endif
 
 #include "alloc/calloc.h"
@@ -86,7 +86,7 @@ get_map_ranges(int ranges, int argc, char **argv)
  */
 #define ULONG_DIGITS (((WIDTHOF(unsigned long) + 9)/10)*3)
 
-#if HAVE_SYS_CAPABILITY_H
+#if __has_include(<sys/capability.h>)
 static inline bool maps_lower_root(int cap, int ranges, const struct map_range *mappings)
 {
 	int idx;
@@ -129,7 +129,7 @@ void write_mapping(int proc_dir_fd, int ranges, const struct map_range *mappings
 	char *buf, *pos, *end;
 	int fd;
 
-#if HAVE_SYS_CAPABILITY_H
+#if __has_include(<sys/capability.h>)
 	int cap;
 	struct __user_cap_header_struct hdr = {_LINUX_CAPABILITY_VERSION_3, 0};
 	struct __user_cap_data_struct data[2] = {{0}};

--- a/lib/idmapping.c
+++ b/lib/idmapping.c
@@ -12,8 +12,8 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <strings.h>
-#if HAVE_SYS_CAPABILITY_H
 #include <sys/prctl.h>
+#if HAVE_SYS_CAPABILITY_H
 #include <sys/capability.h>
 #endif
 

--- a/lib/pam_defs.h
+++ b/lib/pam_defs.h
@@ -11,7 +11,7 @@
 #if __has_include(<security/pam_misc.h>)
 # include <security/pam_misc.h>
 #endif
-#ifdef HAVE_SECURITY_OPENPAM_H
+#if __has_include(<security/openpam.h>)
 # include <security/openpam.h>
 #endif
 

--- a/lib/pam_defs.h
+++ b/lib/pam_defs.h
@@ -6,8 +6,9 @@
  */
 
 #include <config.h>
+
 #include <security/pam_appl.h>
-#ifdef HAVE_SECURITY_PAM_MISC_H
+#if __has_include(<security/pam_misc.h>)
 # include <security/pam_misc.h>
 #endif
 #ifdef HAVE_SECURITY_OPENPAM_H


### PR DESCRIPTION
All relevant compilers have had __has_include() since immemorial times (GCC since version 5, according to <https://en.cppreference.com/w/c/compiler_support>).  It's now a C23 standard feature.

This reduces the complexity of the build system.

---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git range-diff master..gh/has_include shadow/master..has_include 
1:  f716f558 = 1:  1afc7448 configure.ac, lib/: Use __has_include(<crypt.h>) instead of HAVE_CRYPT_H
2:  95ca17af = 2:  6107b7f8 configure.ac, lib/: Use __has_include(<sys/random.h>) instead of HAVE_SYS_RANDOM_H
3:  3d98527a = 3:  0a32d621 lib/: Use __has_include(<security/pam_misc.h>) instead of HAVE_SECURITY_PAM_MISC_H
4:  8052bd28 = 4:  fe3a23d3 lib/: Use __has_include(<security/openpam.h>) instead of HAVE_SECURITY_OPENPAM_H
5:  114cfa89 = 5:  3fd1baab lib/idmapping.c: Unconditionally include <sys/prctl.h>
6:  4c72c6c3 = 6:  17eef32a configure.ac, lib/: Use __has_include(<sys/capability.h>) instead of HAVE_SYS_CAPABILITY_H
7:  60583eb9 = 7:  c4a55a7a configure.ac: Remove unused AC_CHECK_HEADERS() checks
```
</details>

<details>
<summary>v2</summary>

-  Rebase

```
$ git range-diff --creation-factor=99 master..gh/has_include shadow/master..has_include 
1:  1afc7448 = 1:  25b8fb8f configure.ac, lib/: Use __has_include(<crypt.h>) instead of HAVE_CRYPT_H
2:  6107b7f8 ! 2:  6a9992c2 configure.ac, lib/: Use __has_include(<sys/random.h>) instead of HAVE_SYS_RANDOM_H
    @@ configure.ac: dnl Checks for libraries.
     
      ## lib/csrand.c ##
     @@
    - #include <stdio.h>
    + #include <stdint.h>
      #include <stdlib.h>
      #include <unistd.h>
     -#if HAVE_SYS_RANDOM_H
    @@ lib/csrand.c
     +#if __has_include(<sys/random.h>)
     +# include <sys/random.h>
      #endif
    -+
    + 
      #include "bit.h"
    - #include "defines.h"
    - #include "prototypes.h"
3:  0a32d621 = 3:  6df8270f lib/: Use __has_include(<security/pam_misc.h>) instead of HAVE_SECURITY_PAM_MISC_H
4:  fe3a23d3 = 4:  39255d70 lib/: Use __has_include(<security/openpam.h>) instead of HAVE_SECURITY_OPENPAM_H
5:  3fd1baab ! 5:  00f96fc4 lib/idmapping.c: Unconditionally include <sys/prctl.h>
    @@ lib/idmapping.c
      #include <stdlib.h>
      #include <stdio.h>
      #include <strings.h>
    -+#include <sys/prctl.h>
    - 
    - #include "alloc/calloc.h"
    - #include "alloc/x/xmalloc.h"
    -@@
    - #include "string/sprintf/stpeprintf.h"
    - #include "idmapping.h"
    - #if HAVE_SYS_CAPABILITY_H
    --#include <sys/prctl.h>
    +-#if HAVE_SYS_CAPABILITY_H
    + #include <sys/prctl.h>
    ++#if HAVE_SYS_CAPABILITY_H
      #include <sys/capability.h>
      #endif
    - #include "shadowlog.h"
    + 
6:  17eef32a ! 6:  3ace1b19 configure.ac, lib/: Use __has_include(<sys/capability.h>) instead of HAVE_SYS_CAPABILITY_H
    @@ lib/idmapping.c
      #include <stdio.h>
      #include <strings.h>
      #include <sys/prctl.h>
    -+#if __has_include(<sys/capability.h>)
    -+# include <sys/capability.h>
    -+#endif
    - 
    - #include "alloc/calloc.h"
    - #include "alloc/x/xmalloc.h"
    -@@
    - #include "prototypes.h"
    - #include "string/sprintf/stpeprintf.h"
    - #include "idmapping.h"
     -#if HAVE_SYS_CAPABILITY_H
     -#include <sys/capability.h>
    --#endif
    - #include "shadowlog.h"
    - #include "sizeof.h"
    ++#if __has_include(<sys/capability.h>)
    ++# include <sys/capability.h>
    + #endif
      
    + #include "alloc/calloc.h"
     @@ lib/idmapping.c: get_map_ranges(int ranges, int argc, char **argv)
       */
      #define ULONG_DIGITS (((WIDTHOF(unsigned long) + 9)/10)*3)
7:  c4a55a7a = 7:  2759f057 configure.ac: Remove unused AC_CHECK_HEADERS() checks
```
</details>

<details>
<summary>v2b</summary>

-  Rebase

```
$ git range-diff master..gh/has_include shadow/master..has_include 
1:  25b8fb8f = 1:  2db33cc3 configure.ac, lib/: Use __has_include(<crypt.h>) instead of HAVE_CRYPT_H
2:  6a9992c2 = 2:  510f63d8 configure.ac, lib/: Use __has_include(<sys/random.h>) instead of HAVE_SYS_RANDOM_H
3:  6df8270f = 3:  5631ed7d lib/: Use __has_include(<security/pam_misc.h>) instead of HAVE_SECURITY_PAM_MISC_H
4:  39255d70 = 4:  5c845329 lib/: Use __has_include(<security/openpam.h>) instead of HAVE_SECURITY_OPENPAM_H
5:  00f96fc4 = 5:  d127343b lib/idmapping.c: Unconditionally include <sys/prctl.h>
6:  3ace1b19 = 6:  705dc77d configure.ac, lib/: Use __has_include(<sys/capability.h>) instead of HAVE_SYS_CAPABILITY_H
7:  2759f057 = 7:  a5510806 configure.ac: Remove unused AC_CHECK_HEADERS() checks
```
</details>

<details>
<summary>v2c</summary>

-  Rebase

```
$ git range-diff master..gh/has_include shadow/master..has_include 
1:  2db33cc3 = 1:  f2febe08 configure.ac, lib/: Use __has_include(<crypt.h>) instead of HAVE_CRYPT_H
2:  510f63d8 = 2:  b64be8ee configure.ac, lib/: Use __has_include(<sys/random.h>) instead of HAVE_SYS_RANDOM_H
3:  5631ed7d = 3:  4bd80878 lib/: Use __has_include(<security/pam_misc.h>) instead of HAVE_SECURITY_PAM_MISC_H
4:  5c845329 = 4:  731ee529 lib/: Use __has_include(<security/openpam.h>) instead of HAVE_SECURITY_OPENPAM_H
5:  d127343b = 5:  d5344369 lib/idmapping.c: Unconditionally include <sys/prctl.h>
6:  705dc77d = 6:  7e6aa4cc configure.ac, lib/: Use __has_include(<sys/capability.h>) instead of HAVE_SYS_CAPABILITY_H
7:  a5510806 = 7:  8e2ad8cc configure.ac: Remove unused AC_CHECK_HEADERS() checks
```
</details>

<details>
<summary>v2d</summary>

-  Rebase

```
$ git range-diff master..gh/has_include shadow/master..has_include 
1:  f2febe08 = 1:  f3f3e72b configure.ac, lib/: Use __has_include(<crypt.h>) instead of HAVE_CRYPT_H
2:  b64be8ee = 2:  88b29038 configure.ac, lib/: Use __has_include(<sys/random.h>) instead of HAVE_SYS_RANDOM_H
3:  4bd80878 = 3:  a655dfaf lib/: Use __has_include(<security/pam_misc.h>) instead of HAVE_SECURITY_PAM_MISC_H
4:  731ee529 = 4:  10331b50 lib/: Use __has_include(<security/openpam.h>) instead of HAVE_SECURITY_OPENPAM_H
5:  d5344369 = 5:  2a2a3770 lib/idmapping.c: Unconditionally include <sys/prctl.h>
6:  7e6aa4cc = 6:  27b5fae8 configure.ac, lib/: Use __has_include(<sys/capability.h>) instead of HAVE_SYS_CAPABILITY_H
7:  8e2ad8cc = 7:  36a0b6ed configure.ac: Remove unused AC_CHECK_HEADERS() checks
```
</details>

<details>
<summary>v2e</summary>

-  Rebase

```
$ git range-diff master..gh/has_include shadow/master..has_include 
1:  f3f3e72b = 1:  f1a28710 configure.ac, lib/: Use __has_include(<crypt.h>) instead of HAVE_CRYPT_H
2:  88b29038 = 2:  087830e9 configure.ac, lib/: Use __has_include(<sys/random.h>) instead of HAVE_SYS_RANDOM_H
3:  a655dfaf = 3:  a839189a lib/: Use __has_include(<security/pam_misc.h>) instead of HAVE_SECURITY_PAM_MISC_H
4:  10331b50 = 4:  b39aecd5 lib/: Use __has_include(<security/openpam.h>) instead of HAVE_SECURITY_OPENPAM_H
5:  2a2a3770 = 5:  f91f5769 lib/idmapping.c: Unconditionally include <sys/prctl.h>
6:  27b5fae8 = 6:  0b111675 configure.ac, lib/: Use __has_include(<sys/capability.h>) instead of HAVE_SYS_CAPABILITY_H
7:  36a0b6ed = 7:  94cbd060 configure.ac: Remove unused AC_CHECK_HEADERS() checks
```
</details>

<details>
<summary>v2f</summary>

-  Rebase

```
$ git range-diff alx/master..gh/has_include master..has_include 
1:  f1a28710 = 1:  cc9d0795 configure.ac, lib/: Use __has_include(<crypt.h>) instead of HAVE_CRYPT_H
2:  087830e9 = 2:  8e058d00 configure.ac, lib/: Use __has_include(<sys/random.h>) instead of HAVE_SYS_RANDOM_H
3:  a839189a = 3:  cc33d38c lib/: Use __has_include(<security/pam_misc.h>) instead of HAVE_SECURITY_PAM_MISC_H
4:  b39aecd5 = 4:  96edc18d lib/: Use __has_include(<security/openpam.h>) instead of HAVE_SECURITY_OPENPAM_H
5:  f91f5769 = 5:  53ce2f1e lib/idmapping.c: Unconditionally include <sys/prctl.h>
6:  0b111675 = 6:  56b1ccbf configure.ac, lib/: Use __has_include(<sys/capability.h>) instead of HAVE_SYS_CAPABILITY_H
7:  94cbd060 = 7:  d38bb06b configure.ac: Remove unused AC_CHECK_HEADERS() checks
```
</details>

<details>
<summary>v2g</summary>

-  Rebase

```
$ git range-diff alx/master..gh/has_include master..has_include 
1:  cc9d0795 = 1:  6b898c52 configure.ac, lib/: Use __has_include(<crypt.h>) instead of HAVE_CRYPT_H
2:  8e058d00 = 2:  46c5e84e configure.ac, lib/: Use __has_include(<sys/random.h>) instead of HAVE_SYS_RANDOM_H
3:  cc33d38c = 3:  920d850b lib/: Use __has_include(<security/pam_misc.h>) instead of HAVE_SECURITY_PAM_MISC_H
4:  96edc18d = 4:  5816f8cb lib/: Use __has_include(<security/openpam.h>) instead of HAVE_SECURITY_OPENPAM_H
5:  53ce2f1e = 5:  952b0e5b lib/idmapping.c: Unconditionally include <sys/prctl.h>
6:  56b1ccbf = 6:  3e1590ba configure.ac, lib/: Use __has_include(<sys/capability.h>) instead of HAVE_SYS_CAPABILITY_H
7:  d38bb06b = 7:  49cd87ba configure.ac: Remove unused AC_CHECK_HEADERS() checks
```
</details>

<details>
<summary>v2h</summary>

-  Rebase

```
$ git range-diff master..gh/has_include shadow/master..has_include 
1:  6b898c52 = 1:  701cfaf2 configure.ac, lib/: Use __has_include(<crypt.h>) instead of HAVE_CRYPT_H
2:  46c5e84e = 2:  0528518f configure.ac, lib/: Use __has_include(<sys/random.h>) instead of HAVE_SYS_RANDOM_H
3:  920d850b = 3:  6b8b181c lib/: Use __has_include(<security/pam_misc.h>) instead of HAVE_SECURITY_PAM_MISC_H
4:  5816f8cb = 4:  def67acb lib/: Use __has_include(<security/openpam.h>) instead of HAVE_SECURITY_OPENPAM_H
5:  952b0e5b = 5:  fb3ceb68 lib/idmapping.c: Unconditionally include <sys/prctl.h>
6:  3e1590ba = 6:  d3981f3a configure.ac, lib/: Use __has_include(<sys/capability.h>) instead of HAVE_SYS_CAPABILITY_H
7:  49cd87ba = 7:  fdba1d15 configure.ac: Remove unused AC_CHECK_HEADERS() checks
```
</details>

<details>
<summary>v3</summary>

-  Do the same with `<gshadow.h>`.

```
$ git range-diff master gh/has_include has_include 
1:  701cfaf2 = 1:  701cfaf2 configure.ac, lib/: Use __has_include(<crypt.h>) instead of HAVE_CRYPT_H
2:  0528518f = 2:  0528518f configure.ac, lib/: Use __has_include(<sys/random.h>) instead of HAVE_SYS_RANDOM_H
3:  6b8b181c = 3:  6b8b181c lib/: Use __has_include(<security/pam_misc.h>) instead of HAVE_SECURITY_PAM_MISC_H
4:  def67acb = 4:  def67acb lib/: Use __has_include(<security/openpam.h>) instead of HAVE_SECURITY_OPENPAM_H
5:  fb3ceb68 = 5:  fb3ceb68 lib/idmapping.c: Unconditionally include <sys/prctl.h>
6:  d3981f3a = 6:  d3981f3a configure.ac, lib/: Use __has_include(<sys/capability.h>) instead of HAVE_SYS_CAPABILITY_H
7:  fdba1d15 = 7:  fdba1d15 configure.ac: Remove unused AC_CHECK_HEADERS() checks
-:  -------- > 8:  d091b40b configure.ac, lib/: Use __has_include(<gshadow.h>) instead of HAVE_GSHADOW_H
```
</details>