### PR TITLE
lib/, src/: Use NULL instead of 0 as a null pointer constant

### DIFF
--- a/lib/commonio.c
+++ b/lib/commonio.c
@@ -1240,7 +1240,7 @@ int commonio_rewind (struct commonio_db *db)
 
 	if (!db->isopen) {
 		errno = EINVAL;
-		return 0;
+		return NULL;
 	}
 	if (NULL == db->cursor) {
 		db->cursor = db->head;

--- a/lib/fputsx.c
+++ b/lib/fputsx.c
@@ -27,7 +27,7 @@ fgetsx(/*@returned@*/char *restrict buf, int cnt, FILE *restrict f)
 	while (cnt > 0) {
 		if (fgets (cp, cnt, f) != cp) {
 			if (cp == buf) {
-				return 0;
+				return NULL;
 			} else {
 				break;
 			}

--- a/lib/port.c
+++ b/lib/port.c
@@ -121,7 +121,7 @@ getportent(void)
 
 	if (NULL == ports) {
 		errno = saveerr;
-		return 0;
+		return NULL;
 	}
 
 	/*
@@ -204,7 +204,7 @@ next:
 	cp = field;
 
 	if ('\0' == *cp) {
-		port.pt_times = 0;
+		port.pt_times = NULL;
 		return &port;
 	}
 
@@ -259,7 +259,7 @@ next:
 				break;
 			default:
 				errno = EINVAL;
-				return 0;
+				return NULL;
 			}
 		}
 
@@ -380,7 +380,7 @@ bool isttytime (const char *id, const char *port, time_t when)
 	 * ever let them login.
 	 */
 
-	if (0 == pp->pt_times) {
+	if (NULL == pp->pt_times) {
 		return false;
 	}
 

--- a/lib/run_part.c
+++ b/lib/run_part.c
@@ -51,7 +51,7 @@ int run_parts(const char *directory, const char *name, const char *action)
 	int n;
 	int execute_result = 0;
 
-	scanlist = scandir(directory, &namelist, 0, alphasort);
+	scanlist = scandir(directory, &namelist, NULL, alphasort);
 	if (scanlist<=0) {
 		return (0);
 	}

--- a/lib/sgetpwent.c
+++ b/lib/sgetpwent.c
@@ -54,7 +54,7 @@ sgetpwent(const char *buf)
 		fprintf (shadow_logfd,
 		         "%s: Too long passwd entry encountered, file corruption?\n",
 		         shadow_progname);
-		return 0;	/* fail if too long */
+		return NULL;	/* fail if too long */
 	}
 	strcpy (pwdbuf, buf);
 

--- a/src/grpconv.c
+++ b/src/grpconv.c
@@ -197,7 +197,7 @@ int main (int argc, char **argv)
 			if (strcmp (gr->gr_passwd, SHADOW_PASSWD_STRING) != 0)
 				sgent.sg_passwd = gr->gr_passwd;
 		} else {
-			static char *empty = 0;
+			static char *empty = NULL;
 
 			/* add new shadow group entry */
 			bzero(&sgent, sizeof sgent);

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -166,7 +166,7 @@ static bool list_match (char *list, const char *item, bool (*match_fn) (const ch
 		while (   ((tok = strtok (NULL, sep)) != NULL)
 		       && (strcasecmp (tok, "EXCEPT") != 0))
 			/* VOID */ ;
-		if (tok == 0 || !list_match (NULL, item, match_fn)) {
+		if (tok == NULL || !list_match(NULL, item, match_fn)) {
 			return (match);
 		}
 	}

--- a/src/vipw.c
+++ b/src/vipw.c
@@ -389,7 +389,7 @@ vipwedit (const char *file, int (*file_lock) (void), int (*file_unlock) (void))
 		vipwexit (fileedit, 1, 1);
 	}
 	if (st1.st_mtime == st2.st_mtime) {
-		vipwexit (0, 0, 0);
+		vipwexit(NULL, 0, 0);
 	}
 #ifdef WITH_SELINUX
 	/* unset the fscreatecon */
@@ -446,7 +446,7 @@ vipwedit (const char *file, int (*file_lock) (void), int (*file_unlock) (void))
 			free(to_rename);
 		}
 #endif				/* WITH_TCB */
-		vipwexit (0, 0, 1);
+		vipwexit(NULL, 0, 1);
 	}
 
 #ifdef WITH_TCB


### PR DESCRIPTION
GCC 15 will add -Wzero-as-null-pointer-constant for deprecating it, and I'm working on a paper for deprecating it from ISO C too. Let's remove any uses in our code base.

I've done this change by building GCC from master, adding -Werror=zero-as-null-pointer-constant to ./autogen.sh, and fixing every error that showed up.

Closes: <https://github.com/shadow-maint/shadow/issues/1120>
Link: <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117059>
Link: <https://software.codidact.com/posts/292718/292759#answer-292759>