### PR TITLE
contrib/, lib/, src/: Use streq() instead of its pattern

### DIFF
--- a/contrib/adduser.c
+++ b/contrib/adduser.c
@@ -118,6 +118,8 @@
 #include <sys/stat.h>
 #include <syslog.h>
 
+#include "string/strcmp/streq.h"
+
 
 #define IMMEDIATE_CHANGE	/* Expire newly created password, must be changed
 				 * immediately upon next login */
@@ -315,7 +317,7 @@ main (void)
 #ifdef HAVE_GETUSERSHELL
 	  setusershell ();
 	  while ((sh = getusershell ()) != NULL)
-	    if (!strcmp (shell, sh))
+	    if (streq(shell, sh))
 	      ok = 1;
 	  endusershell ();
 #endif

--- a/lib/chowndir.c
+++ b/lib/chowndir.c
@@ -13,11 +13,14 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include "prototypes.h"
-#include "defines.h"
 #include <fcntl.h>
 #include <stdio.h>
 #include <unistd.h>
+
+#include "defines.h"
+#include "prototypes.h"
+#include "string/strcmp/streq.h"
+
 
 static int chown_tree_at (int at_fd,
                 const char *path,
@@ -56,8 +59,8 @@ static int chown_tree_at (int at_fd,
 		/*
 		 * Skip the "." and ".." entries
 		 */
-		if (   (strcmp (ent->d_name, ".") == 0)
-		    || (strcmp (ent->d_name, "..") == 0)) {
+		if (   streq(ent->d_name, ".")
+		    || streq(ent->d_name, "..")) {
 			continue;
 		}
 

--- a/lib/commonio.c
+++ b/lib/commonio.c
@@ -36,6 +36,7 @@
 #include "sssd.h"
 #include "string/memset/memzero.h"
 #include "string/sprintf/snprintf.h"
+#include "string/strcmp/streq.h"
 #include "string/strtok/stpsep.h"
 
 
@@ -830,10 +831,8 @@ int commonio_sort_wrt (struct commonio_db *shadow,
 			if (NULL == spw_ptr->eptr) {
 				continue;
 			}
-			if (strcmp (name, shadow->ops->getname (spw_ptr->eptr))
-			    == 0) {
+			if (streq(name, shadow->ops->getname(spw_ptr->eptr)))
 				break;
-			}
 		}
 		if (NULL == spw_ptr) {
 			continue;
@@ -1034,7 +1033,7 @@ static /*@dependent@*/ /*@null@*/struct commonio_entry *next_entry_by_name (
 	for (p = pos; NULL != p; p = p->next) {
 		ep = p->eptr;
 		if (   (NULL != ep)
-		    && (strcmp (db->ops->getname (ep), name) == 0)) {
+		    && streq(db->ops->getname(ep), name)) {
 			break;
 		}
 	}

--- a/lib/console.c
+++ b/lib/console.c
@@ -16,6 +16,7 @@
 #include "defines.h"
 #include "getdef.h"
 #include "prototypes.h"
+#include "string/strcmp/streq.h"
 #include "string/strcpy/strtcpy.h"
 #include "string/strtok/stpsep.h"
 
@@ -51,7 +52,7 @@ static bool is_listed (const char *cfgin, const char *tty, bool def)
 		STRTCPY(buf, cons);
 		pbuf = &buf[0];
 		while ((s = strtok (pbuf, ":")) != NULL) {
-			if (strcmp (s, tty) == 0) {
+			if (streq(s, tty)) {
 				return true;
 			}
 
@@ -76,7 +77,7 @@ static bool is_listed (const char *cfgin, const char *tty, bool def)
 
 	while (fgets (buf, sizeof (buf), fp) != NULL) {
 		stpsep(buf, "\n");
-		if (strcmp (buf, tty) == 0) {
+		if (streq(buf, tty)) {
 			(void) fclose (fp);
 			return true;
 		}

--- a/lib/copydir.c
+++ b/lib/copydir.c
@@ -39,6 +39,7 @@
 #endif				/* WITH_ATTR */
 #include "shadowlog.h"
 #include "string/sprintf/xasprintf.h"
+#include "string/strcmp/streq.h"
 
 
 static /*@null@*/const char *src_orig;
@@ -314,8 +315,8 @@ static int copy_tree_impl (const struct path_info *src, const struct path_info *
 		/*
 		 * Skip the "." and ".." entries
 		 */
-		if (strcmp(ent->d_name, ".") == 0 ||
-		    strcmp(ent->d_name, "..") == 0)
+		if (streq(ent->d_name, ".") ||
+		    streq(ent->d_name, ".."))
 		{
 			continue;
 		}

--- a/lib/getdate.y
+++ b/lib/getdate.y
@@ -32,6 +32,7 @@
 #include "attr.h"
 #include "getdate.h"
 #include "string/strchr/stpspn.h"
+#include "string/strcmp/streq.h"
 
 
 /* Some old versions of bison generate parsers that use bcopy.
@@ -630,12 +631,12 @@ static int LookupWord (char *buff)
     if (isupper (*p))
       *p = tolower (*p);
 
-  if (strcmp (buff, "am") == 0 || strcmp (buff, "a.m.") == 0)
+  if (streq(buff, "am") || streq(buff, "a.m."))
     {
       yylval.Meridian = MERam;
       return tMERIDIAN;
     }
-  if (strcmp (buff, "pm") == 0 || strcmp (buff, "p.m.") == 0)
+  if (streq(buff, "pm") || streq(buff, "p.m."))
     {
       yylval.Meridian = MERpm;
       return tMERIDIAN;
@@ -662,7 +663,7 @@ static int LookupWord (char *buff)
 	      return tp->type;
 	    }
 	}
-      else if (strcmp (buff, tp->name) == 0)
+      else if (streq(buff, tp->name))
 	{
 	  yylval.Number = tp->value;
 	  return tp->type;
@@ -670,17 +671,17 @@ static int LookupWord (char *buff)
     }
 
   for (tp = TimezoneTable; tp->name; tp++)
-    if (strcmp (buff, tp->name) == 0)
+    if (streq(buff, tp->name))
       {
 	yylval.Number = tp->value;
 	return tp->type;
       }
 
-  if (strcmp (buff, "dst") == 0)
+  if (streq(buff, "dst"))
     return tDST;
 
   for (tp = UnitsTable; tp->name; tp++)
-    if (strcmp (buff, tp->name) == 0)
+    if (streq(buff, tp->name))
       {
 	yylval.Number = tp->value;
 	return tp->type;
@@ -692,7 +693,7 @@ static int LookupWord (char *buff)
     {
       stpcpy(&buff[i], "");
       for (tp = UnitsTable; tp->name; tp++)
-	if (strcmp (buff, tp->name) == 0)
+	if (streq(buff, tp->name))
 	  {
 	    yylval.Number = tp->value;
 	    return tp->type;
@@ -701,7 +702,7 @@ static int LookupWord (char *buff)
     }
 
   for (tp = OtherTable; tp->name; tp++)
-    if (strcmp (buff, tp->name) == 0)
+    if (streq(buff, tp->name))
       {
 	yylval.Number = tp->value;
 	return tp->type;
@@ -711,7 +712,7 @@ static int LookupWord (char *buff)
   if (buff[1] == '\0' && isalpha (*buff))
     {
       for (tp = MilitaryTable; tp->name; tp++)
-	if (strcmp (buff, tp->name) == 0)
+	if (streq(buff, tp->name))
 	  {
 	    yylval.Number = tp->value;
 	    return tp->type;
@@ -727,7 +728,7 @@ static int LookupWord (char *buff)
   stpcpy(p, "");
   if (0 != i)
     for (tp = TimezoneTable; NULL != tp->name; tp++)
-      if (strcmp (buff, tp->name) == 0)
+      if (streq(buff, tp->name))
 	{
 	  yylval.Number = tp->value;
 	  return tp->type;

--- a/lib/getdef.c
+++ b/lib/getdef.c
@@ -32,6 +32,7 @@
 #include "string/sprintf/xasprintf.h"
 #include "string/strchr/stpspn.h"
 #include "string/strchr/strrspn.h"
+#include "string/strcmp/streq.h"
 #include "string/strtok/stpsep.h"
 
 
@@ -419,7 +420,7 @@ static /*@observer@*/ /*@null@*/struct itemdef *def_find (const char *name, cons
 	 */
 
 	for (ptr = def_table; NULL != ptr->name; ptr++) {
-		if (strcmp (ptr->name, name) == 0) {
+		if (streq(ptr->name, name)) {
 			return ptr;
 		}
 	}
@@ -429,7 +430,7 @@ static /*@observer@*/ /*@null@*/struct itemdef *def_find (const char *name, cons
 	 */
 
 	for (ptr = knowndef_table; NULL != ptr->name; ptr++) {
-		if (strcmp (ptr->name, name) == 0) {
+		if (streq(ptr->name, name)) {
 			goto out;
 		}
 	}

--- a/lib/groupio.c
+++ b/lib/groupio.c
@@ -17,11 +17,12 @@
 
 #include "alloc/calloc.h"
 #include "alloc/malloc.h"
-#include "prototypes.h"
-#include "defines.h"
 #include "commonio.h"
+#include "defines.h"
 #include "getdef.h"
 #include "groupio.h"
+#include "prototypes.h"
+#include "string/strcmp/streq.h"
 
 
 static /*@null@*/struct commonio_entry *merge_group_entries (
@@ -263,8 +264,8 @@ static int group_open_hook (void)
 			struct group *g2 = gr2->eptr;
 			if (NULL != g1 &&
 			    NULL != g2 &&
-			    0 == strcmp (g1->gr_name, g2->gr_name) &&
-			    0 == strcmp (g1->gr_passwd, g2->gr_passwd) &&
+			    streq(g1->gr_name, g2->gr_name) &&
+			    streq(g1->gr_passwd, g2->gr_passwd) &&
 			    g1->gr_gid == g2->gr_gid) {
 				/* Both group entries refer to the same
 				 * group. It is a split group. Merge the
@@ -332,7 +333,7 @@ static /*@null@*/struct commonio_entry *merge_group_entries (
 	for (i=0; NULL != gptr2->gr_mem[i]; i++) {
 		char **pmember = gptr1->gr_mem;
 		while (NULL != *pmember) {
-			if (0 == strcmp(*pmember, gptr2->gr_mem[i])) {
+			if (streq(*pmember, gptr2->gr_mem[i])) {
 				break;
 			}
 			pmember++;
@@ -355,7 +356,7 @@ static /*@null@*/struct commonio_entry *merge_group_entries (
 	for (i=0; NULL != gptr2->gr_mem[i]; i++) {
 		char **pmember = new_members;
 		while (NULL != *pmember) {
-			if (0 == strcmp(*pmember, gptr2->gr_mem[i])) {
+			if (streq(*pmember, gptr2->gr_mem[i])) {
 				break;
 			}
 			pmember++;

--- a/lib/gshadow.c
+++ b/lib/gshadow.c
@@ -22,6 +22,7 @@
 #include "alloc/x/xrealloc.h"
 #include "defines.h"
 #include "prototypes.h"
+#include "string/strcmp/streq.h"
 #include "string/strtok/stpsep.h"
 
 
@@ -203,7 +204,7 @@ void endsgent (void)
 	setsgent ();
 
 	while ((sgrp = getsgent ()) != NULL) {
-		if (strcmp (name, sgrp->sg_name) == 0) {
+		if (streq(name, sgrp->sg_name)) {
 			break;
 		}
 	}

--- a/lib/hushed.c
+++ b/lib/hushed.c
@@ -21,6 +21,7 @@
 #include "getdef.h"
 #include "prototypes.h"
 #include "string/sprintf/snprintf.h"
+#include "string/strcmp/streq.h"
 #include "string/strtok/stpsep.h"
 
 
@@ -74,8 +75,8 @@ bool hushed (const char *username)
 	}
 	for (found = false; !found && (fgets (buf, sizeof buf, fp) == buf);) {
 		stpsep(buf, "\n");
-		found = (strcmp (buf, pw->pw_shell) == 0) ||
-		        (strcmp (buf, pw->pw_name) == 0);
+		found = streq(buf, pw->pw_shell) ||
+		        streq(buf, pw->pw_name);
 	}
 	(void) fclose (fp);
 	return found;

--- a/lib/idmapping.c
+++ b/lib/idmapping.c
@@ -12,19 +12,20 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <strings.h>
-
-#include "alloc/calloc.h"
-#include "alloc/x/xmalloc.h"
-#include "atoi/a2i/a2u.h"
-#include "prototypes.h"
-#include "string/sprintf/stpeprintf.h"
-#include "idmapping.h"
 #if HAVE_SYS_CAPABILITY_H
 #include <sys/prctl.h>
 #include <sys/capability.h>
 #endif
+
+#include "alloc/calloc.h"
+#include "alloc/x/xmalloc.h"
+#include "atoi/a2i/a2u.h"
+#include "idmapping.h"
+#include "prototypes.h"
 #include "shadowlog.h"
 #include "sizeof.h"
+#include "string/sprintf/stpeprintf.h"
+#include "string/strcmp/streq.h"
 
 
 struct map_range *
@@ -133,9 +134,9 @@ void write_mapping(int proc_dir_fd, int ranges, const struct map_range *mappings
 	struct __user_cap_header_struct hdr = {_LINUX_CAPABILITY_VERSION_3, 0};
 	struct __user_cap_data_struct data[2] = {{0}};
 
-	if (strcmp(map_file, "uid_map") == 0) {
+	if (streq(map_file, "uid_map")) {
 		cap = CAP_SETUID;
-	} else if (strcmp(map_file, "gid_map") == 0) {
+	} else if (streq(map_file, "gid_map")) {
 		cap = CAP_SETGID;
 	} else {
 		fprintf(log_get_logfd(), _("%s: Invalid map file %s specified\n"), log_get_progname(), map_file);

--- a/lib/isexpired.c
+++ b/lib/isexpired.c
@@ -21,6 +21,7 @@
 #include "adds.h"
 #include "defines.h"
 #include "prototypes.h"
+#include "string/strcmp/streq.h"
 
 #ident "$Id$"
 
@@ -67,7 +68,7 @@ int isexpired (const struct passwd *pw, /*@null@*/const struct spwd *sp)
 	 * returns sp_lstchg==0 (must change password) instead of -1!
 	 */
 	if (   (0 == sp->sp_lstchg)
-	    && (strcmp (pw->pw_passwd, SHADOW_PASSWD_STRING) == 0)) {
+	    && streq(pw->pw_passwd, SHADOW_PASSWD_STRING)) {
 		return 1;
 	}
 

--- a/lib/limits.c
+++ b/lib/limits.c
@@ -37,6 +37,7 @@
 #include "atoi/str2i/str2u.h"
 #include "string/memset/memzero.h"
 #include "string/strchr/stpspn.h"
+#include "string/strcmp/streq.h"
 #include "typetraits.h"
 
 
@@ -194,7 +195,7 @@ static int do_user_limits (const char *buf, const char *name)
 	 * being ignored if a limit type is not known to the system.
 	 * Though, there will be complaining for unknown limit types.
 	 */
-	if (strcmp (pp, "-") == 0) {
+	if (streq(pp, "-")) {
 		/* Remember to extend this, too, when adding new limits!
 		 * Oh... but "unlimited" does not make sense for umask,
 		 * or does it? (K-)
@@ -395,10 +396,10 @@ static int setup_user_limits (const char *uname)
 		 */
 		if (sscanf (buf, "%s%[ACDFIKLMNOPRSTUacdfiklmnoprstu0-9 \t-]",
 		            name, tempbuf) == 2) {
-			if (strcmp (name, uname) == 0) {
+			if (streq(name, uname)) {
 				strcpy (limits, tempbuf);
 				break;
-			} else if (strcmp (name, "*") == 0) {
+			} else if (streq(name, "*")) {
 				strcpy (deflimits, tempbuf);
 			} else if (name[0] == '@') {
 				/* If the user is in the group, the group
@@ -436,7 +437,7 @@ static void setup_usergroups (const struct passwd *info)
 		/* local, no need for xgetgrgid */
 		grp = getgrgid (info->pw_gid);
 		if (   (NULL != grp)
-		    && (strcmp (info->pw_name, grp->gr_name) == 0)) {
+		    && streq(info->pw_name, grp->gr_name)) {
 			mode_t tmpmask;
 			tmpmask = umask (0777);
 			tmpmask = (tmpmask & ~070) | ((tmpmask >> 3) & 070);

--- a/lib/list.c
+++ b/lib/list.c
@@ -93,7 +93,7 @@ del_list(/*@returned@*/ /*@only@*/char **list, const char *member)
 	 */
 
 	for (i = j = 0; list[i] != NULL; i++) {
-		if (strcmp (list[i], member) != 0) {
+		if (!streq(list[i], member)) {
 			j++;
 		}
 	}
@@ -116,7 +116,7 @@ del_list(/*@returned@*/ /*@only@*/char **list, const char *member)
 	 */
 
 	for (i = j = 0; list[i] != NULL; i++) {
-		if (strcmp (list[i], member) != 0) {
+		if (!streq(list[i], member)) {
 			tmp[j] = list[i];
 			j++;
 		}

--- a/lib/list.c
+++ b/lib/list.c
@@ -16,6 +16,7 @@
 #include "prototypes.h"
 #include "defines.h"
 #include "string/strchr/strchrcnt.h"
+#include "string/strcmp/streq.h"
 #include "string/strdup/xstrdup.h"
 
 
@@ -41,7 +42,7 @@ add_list(/*@returned@*/ /*@only@*/char **list, const char *member)
 	 */
 
 	for (i = 0; list[i] != NULL; i++) {
-		if (strcmp (list[i], member) == 0) {
+		if (streq(list[i], member)) {
 			return list;
 		}
 	}
@@ -167,7 +168,7 @@ bool is_on_list (char *const *list, const char *member)
 	assert (NULL != list);
 
 	while (NULL != *list) {
-		if (strcmp (*list, member) == 0) {
+		if (streq(*list, member)) {
 			return true;
 		}
 		list++;

--- a/lib/nss.c
+++ b/lib/nss.c
@@ -15,8 +15,9 @@
 #include "shadowlog_internal.h"
 #include "shadowlog.h"
 #include "string/sprintf/snprintf.h"
-#include "string/strtok/stpsep.h"
 #include "string/strchr/stpspn.h"
+#include "string/strcmp/streq.h"
+#include "string/strtok/stpsep.h"
 
 
 #define NSSWITCH "/etc/nsswitch.conf"
@@ -98,7 +99,7 @@ nss_init(const char *nsswitch_path) {
 		// subid_nss has to be null here, but to ease reviews:
 		goto null_subid;
 	}
-	if (strcmp(p, "files") == 0) {
+	if (streq(p, "files")) {
 		goto null_subid;
 	}
 	if (strlen(p) > 50) {

--- a/lib/obscure.c
+++ b/lib/obscure.c
@@ -21,6 +21,7 @@
 #include "getdef.h"
 #include "string/memset/memzero.h"
 #include "string/sprintf/xasprintf.h"
+#include "string/strcmp/streq.h"
 #include "string/strdup/xstrdup.h"
 
 
@@ -95,7 +96,7 @@ static /*@observer@*//*@null@*/const char *password_check (
 	const char *msg = NULL;
 	char *oldmono, *newmono, *wrapped;
 
-	if (strcmp (new, old) == 0) {
+	if (streq(new, old)) {
 		return _("no change");
 	}
 
@@ -105,7 +106,7 @@ static /*@observer@*//*@null@*/const char *password_check (
 
 	if (palindrome (oldmono, newmono)) {
 		msg = _("a palindrome");
-	} else if (strcmp (oldmono, newmono) == 0) {
+	} else if (streq(oldmono, newmono)) {
 		msg = _("case changes only");
 	} else if (similar (oldmono, newmono)) {
 		msg = _("too similar");
@@ -162,16 +163,16 @@ static /*@observer@*//*@null@*/const char *obscure_msg (
 
 	} else {
 
-		if (   (strcmp (result, "MD5")    == 0)
+		if (   streq(result, "MD5")
 #ifdef USE_SHA_CRYPT
-		    || (strcmp (result, "SHA256") == 0)
-		    || (strcmp (result, "SHA512") == 0)
+		    || streq(result, "SHA256")
+		    || streq(result, "SHA512")
 #endif
 #ifdef USE_BCRYPT
-		    || (strcmp (result, "BCRYPT") == 0)
+		    || streq(result, "BCRYPT")
 #endif
 #ifdef USE_YESCRYPT
-		    || (strcmp (result, "YESCRYPT") == 0)
+		    || streq(result, "YESCRYPT")
 #endif
 		    ) {
 			return NULL;

--- a/lib/port.c
+++ b/lib/port.c
@@ -19,6 +19,7 @@
 #include "defines.h"
 #include "port.h"
 #include "prototypes.h"
+#include "string/strcmp/streq.h"
 #include "string/strtok/stpsep.h"
 
 
@@ -46,7 +47,7 @@ static int portcmp (const char *pattern, const char *port)
 	if (('\0' == *pattern) && ('\0' == *port)) {
 		return 0;
 	}
-	if (strcmp(orig, "SU") == 0)
+	if (streq(orig, "SU"))
 		return 1;
 
 	return (*pattern == '*') ? 0 : 1;
@@ -339,9 +340,9 @@ getttyuser(const char *tty, const char *user)
 			continue;
 
 		for (ptu = port->pt_users; *ptu != NULL; ptu++) {
-			if (strcmp(*ptu, user) == 0)
+			if (streq(*ptu, user))
 				goto end;
-			if (strcmp(*ptu, "*") == 0)
+			if (streq(*ptu, "*"))
 				goto end;
 		}
 	}

--- a/lib/prefix_flag.c
+++ b/lib/prefix_flag.c
@@ -29,6 +29,7 @@
 #include "getdef.h"
 #include "shadowlog.h"
 #include "string/sprintf/xasprintf.h"
+#include "string/strcmp/streq.h"
 
 
 static char *passwd_db_file = NULL;
@@ -60,10 +61,11 @@ extern const char* process_prefix_flag (const char* short_opt, int argc, char **
 
 	for (i = 0; i < argc; i++) {
 		val = NULL;
-		if (   (strcmp (argv[i], "--prefix") == 0)
+		if (   streq(argv[i], "--prefix")
 		    || ((strncmp (argv[i], "--prefix=", 9) == 0)
 			&& (val = argv[i] + 9))
-		    || (strcmp (argv[i], short_opt) == 0)) {
+		    || streq(argv[i], short_opt))
+		{
 			if (NULL != prefix) {
 				fprintf (log_get_logfd(),
 				         _("%s: multiple --prefix options\n"),
@@ -96,7 +98,7 @@ extern const char* process_prefix_flag (const char* short_opt, int argc, char **
 			exit (EXIT_FAILURE);
 		}
 
-		if ( prefix[0] == '\0' || !strcmp(prefix, "/"))
+		if (prefix[0] == '\0' || streq(prefix, "/"))
 			return ""; /* if prefix is "/" then we ignore the flag option */
 		/* should we prevent symbolic link from being used as a prefix? */
 
@@ -153,7 +155,7 @@ extern struct group *prefix_getgrnam(const char *name)
 		if (!fg)
 			return NULL;
 		while ((grp = fgetgrent(fg)) != NULL) {
-			if (!strcmp(name, grp->gr_name))
+			if (streq(name, grp->gr_name))
 				break;
 		}
 		fclose(fg);
@@ -213,7 +215,7 @@ extern struct passwd *prefix_getpwnam(const char* name)
 		if (!fg)
 			return NULL;
 		while ((pwd = fgetpwent(fg)) != NULL) {
-			if (!strcmp(name, pwd->pw_name))
+			if (streq(name, pwd->pw_name))
 				break;
 		}
 		fclose(fg);
@@ -235,7 +237,7 @@ extern int prefix_getpwnam_r(const char* name, struct passwd* pwd,
 		if (!fg)
 			return errno;
 		while ((ret = fgetpwent_r(fg, pwd, buf, buflen, result)) == 0) {
-			if (!strcmp(name, pwd->pw_name))
+			if (streq(name, pwd->pw_name))
 				break;
 		}
 		fclose(fg);
@@ -256,7 +258,7 @@ extern struct spwd *prefix_getspnam(const char* name)
 		if (!fg)
 			return NULL;
 		while ((sp = fgetspent(fg)) != NULL) {
-			if (!strcmp(name, sp->sp_namp))
+			if (streq(name, sp->sp_namp))
 				break;
 		}
 		fclose(fg);

--- a/lib/remove_tree.c
+++ b/lib/remove_tree.c
@@ -19,8 +19,11 @@
 #include <sys/stat.h>
 #include <dirent.h>
 #include <unistd.h>
-#include "prototypes.h"
+
 #include "defines.h"
+#include "prototypes.h"
+#include "string/strcmp/streq.h"
+
 
 static int remove_tree_at (int at_fd, const char *path, bool remove_root)
 {
@@ -48,8 +51,8 @@ static int remove_tree_at (int at_fd, const char *path, bool remove_root)
 		/*
 		 * Skip the "." and ".." entries
 		 */
-		if (strcmp (ent->d_name, ".") == 0 ||
-		    strcmp (ent->d_name, "..") == 0) {
+		if (streq(ent->d_name, ".") ||
+		    streq(ent->d_name, "..")) {
 			continue;
 		}
 

--- a/lib/root_flag.c
+++ b/lib/root_flag.c
@@ -10,12 +10,16 @@
 #ident "$Id$"
 
 #include <stdio.h>
-#include <assert.h>
+
 #include "defines.h"
-#include "prototypes.h"
 /*@-exitarg@*/
 #include "exitcodes.h"
+#include "prototypes.h"
 #include "shadowlog.h"
+#include "string/strcmp/streq.h"
+
+#include <assert.h>
+
 
 static void change_root (const char* newroot);
 
@@ -38,10 +42,10 @@ extern void process_root_flag (const char* short_opt, int argc, char **argv)
 
 	for (i = 0; i < argc; i++) {
 		val = NULL;
-		if (   (strcmp (argv[i], "--root") == 0)
+		if (   streq(argv[i], "--root")
 		    || ((strncmp (argv[i], "--root=", 7) == 0)
 			&& (val = argv[i] + 7))
-		    || (strcmp (argv[i], short_opt) == 0)) {
+		    || streq(argv[i], short_opt)) {
 			if (NULL != newroot) {
 				fprintf (log_get_logfd(),
 				         _("%s: multiple --root options\n"),

--- a/lib/salt.c
+++ b/lib/salt.c
@@ -22,10 +22,12 @@
 #include <string.h>
 #include <strings.h>
 
-#include "prototypes.h"
 #include "defines.h"
 #include "getdef.h"
+#include "prototypes.h"
 #include "shadowlog.h"
+#include "string/strcmp/streq.h"
+
 
 #if (defined CRYPT_GENSALT_IMPLEMENTS_AUTO_ENTROPY && \
      CRYPT_GENSALT_IMPLEMENTS_AUTO_ENTROPY)
@@ -372,31 +374,31 @@ static /*@observer@*/const char *gensalt (size_t salt_size)
 		}
 	}
 
-	if (0 == strcmp (method, "MD5")) {
+	if (streq(method, "MD5")) {
 		MAGNUM(result, '1');
 		salt_len = MD5_CRYPT_SALT_SIZE;
 		rounds = 0;
 #ifdef USE_BCRYPT
-	} else if (0 == strcmp (method, "BCRYPT")) {
+	} else if (streq(method, "BCRYPT")) {
 		BCRYPTMAGNUM(result);
 		salt_len = BCRYPT_SALT_SIZE;
 		rounds = BCRYPT_get_salt_rounds (arg);
 		BCRYPT_salt_rounds_to_buf (result, rounds);
 #endif /* USE_BCRYPT */
 #ifdef USE_YESCRYPT
-	} else if (0 == strcmp (method, "YESCRYPT")) {
+	} else if (streq(method, "YESCRYPT")) {
 		MAGNUM(result, 'y');
 		salt_len = YESCRYPT_SALT_SIZE;
 		rounds = YESCRYPT_get_salt_cost (arg);
 		YESCRYPT_salt_cost_to_buf (result, rounds);
 #endif /* USE_YESCRYPT */
 #ifdef USE_SHA_CRYPT
-	} else if (0 == strcmp (method, "SHA256")) {
+	} else if (streq(method, "SHA256")) {
 		MAGNUM(result, '5');
 		salt_len = SHA_CRYPT_SALT_SIZE;
 		rounds = SHA_get_salt_rounds (arg);
 		SHA_salt_rounds_to_buf (result, rounds);
-	} else if (0 == strcmp (method, "SHA512")) {
+	} else if (streq(method, "SHA512")) {
 		MAGNUM(result, '6');
 		salt_len = SHA_CRYPT_SALT_SIZE;
 		rounds = SHA_get_salt_rounds (arg);

--- a/lib/salt.c
+++ b/lib/salt.c
@@ -404,7 +404,7 @@ static /*@observer@*/const char *gensalt (size_t salt_size)
 		rounds = SHA_get_salt_rounds (arg);
 		SHA_salt_rounds_to_buf (result, rounds);
 #endif /* USE_SHA_CRYPT */
-	} else if (0 != strcmp (method, "DES")) {
+	} else if (!streq(method, "DES")) {
 		fprintf (log_get_logfd(),
 			 _("Invalid ENCRYPT_METHOD value: '%s'.\n"
 			   "Defaulting to DES.\n"),

--- a/lib/shadow.c
+++ b/lib/shadow.c
@@ -22,6 +22,7 @@
 #include "atoi/str2i/str2u.h"
 #include "defines.h"
 #include "prototypes.h"
+#include "string/strcmp/streq.h"
 #include "string/strtok/stpsep.h"
 
 
@@ -100,7 +101,7 @@ struct spwd *getspnam (const char *name)
 	setspent ();
 
 	while ((sp = getspent ()) != NULL) {
-		if (strcmp (name, sp->sp_namp) == 0) {
+		if (streq(name, sp->sp_namp)) {
 			break;
 		}
 	}

--- a/lib/subordinateio.c
+++ b/lib/subordinateio.c
@@ -23,6 +23,7 @@
 #include "alloc/reallocf.h"
 #include "atoi/str2i/str2u.h"
 #include "string/sprintf/snprintf.h"
+#include "string/strcmp/streq.h"
 
 
 #define ID_SIZE 31
@@ -161,7 +162,7 @@ static bool range_exists(struct commonio_db *db, const char *owner)
 	const struct subordinate_range *range;
 	commonio_rewind(db);
 	while ((range = commonio_next(db)) != NULL) {
-		if (0 == strcmp(range->owner, owner))
+		if (streq(range->owner, owner))
 			return true;
 	}
 	return false;
@@ -246,7 +247,7 @@ static const struct subordinate_range *find_range(struct commonio_db *db,
                  * Range matches. Check if range owner is specified
                  * as numeric UID and if it matches.
                  */
-                if (0 == strcmp(range->owner, owner_uid_string)) {
+                if (streq(range->owner, owner_uid_string)) {
                         return range;
                 }
 
@@ -889,7 +890,7 @@ int list_owner_ranges(const char *owner, enum subid_type id_type, struct subid_r
 
 	commonio_rewind(db);
 	while ((range = commonio_next(db)) != NULL) {
-		if (0 == strcmp(range->owner, owner)) {
+		if (streq(range->owner, owner)) {
 			if (!append_range(&ranges, range, count++)) {
 				free(ranges);
 				ranges = NULL;
@@ -899,7 +900,7 @@ int list_owner_ranges(const char *owner, enum subid_type id_type, struct subid_r
 		}
 
 		// Let's also compare with the ID
-		if (have_owner_id == true && 0 == strcmp(range->owner, id)) {
+		if (have_owner_id == true && streq(range->owner, id)) {
 			if (!append_range(&ranges, range, count++)) {
 				free(ranges);
 				ranges = NULL;

--- a/lib/subordinateio.c
+++ b/lib/subordinateio.c
@@ -197,7 +197,7 @@ static const struct subordinate_range *find_range(struct commonio_db *db,
 		unsigned long first = range->start;
 		unsigned long last = first + range->count - 1;
 
-		if (0 != strcmp(range->owner, owner))
+		if (!streq(range->owner, owner))
 			continue;
 
 		if ((val >= first) && (val <= last))
@@ -208,7 +208,7 @@ static const struct subordinate_range *find_range(struct commonio_db *db,
         /*
          * We only do special handling for these two files
          */
-        if ((0 != strcmp(db->filename, SUBUID_FILE)) && (0 != strcmp(db->filename, SUBGID_FILE)))
+        if (!streq(db->filename, SUBUID_FILE) && !streq(db->filename, SUBGID_FILE))
                 return NULL;
 
         /*
@@ -465,7 +465,7 @@ static int remove_range (struct commonio_db *db,
 		last = first + range->count - 1;
 
 		/* Skip entries with a different owner */
-		if (0 != strcmp (range->owner, owner)) {
+		if (!streq(range->owner, owner)) {
 			continue;
 		}
 
@@ -1062,7 +1062,7 @@ bool new_subid_range(struct subordinate_range *range, enum subid_type id_type, b
 	if (reuse) {
 		while ((r = commonio_next(db)) != NULL) {
 			// TODO account for username vs uid_t
-			if (0 != strcmp(r->owner, range->owner))
+			if (!streq(r->owner, range->owner))
 				continue;
 			if (r->count >= range->count) {
 				range->count = r->count;

--- a/lib/tcbfuncs.c
+++ b/lib/tcbfuncs.c
@@ -5,6 +5,8 @@
 
 #define _GNU_SOURCE
 
+#include <config.h>
+
 #include <errno.h>
 #include <fcntl.h>
 #include <grp.h>
@@ -15,15 +17,14 @@
 #include <tcb.h>
 #include <unistd.h>
 
-#include "config.h"
-
 #include "defines.h"
-#include "prototypes.h"
 #include "fs/readlink/readlinknul.h"
 #include "getdef.h"
-#include "shadowio.h"
+#include "prototypes.h"
 #include "tcbfuncs.h"
+#include "shadowio.h"
 #include "shadowlog_internal.h"
+#include "string/strcmp/streq.h"
 
 
 #define SHADOWTCB_HASH_BY 1000
@@ -308,7 +309,7 @@ static shadowtcb_status move_dir (const char *user_newname, uid_t user_newid)
 	if (NULL == real_new_dir) {
 		goto out_free;
 	}
-	if (strcmp (real_old_dir, real_new_dir) == 0) {
+	if (streq(real_old_dir, real_new_dir)) {
 		ret = SHADOWTCB_SUCCESS;
 		goto out_free;
 	}

--- a/lib/tcbfuncs.c
+++ b/lib/tcbfuncs.c
@@ -342,7 +342,7 @@ static shadowtcb_status move_dir (const char *user_newname, uid_t user_newid)
 	if (NULL == real_new_dir_rel) {
 		goto out_free;
 	}
-	if (   (strcmp (real_new_dir, newdir) != 0)
+	if (   !streq(real_new_dir, newdir)
 	    && (symlink (real_new_dir_rel, newdir) != 0)) {
 		fprintf (shadow_logfd,
 		         _("%s: Cannot create symbolic link %s: %s\n"),

--- a/lib/ttytype.c
+++ b/lib/ttytype.c
@@ -17,6 +17,7 @@
 #include "defines.h"
 #include "getdef.h"
 #include "prototypes.h"
+#include "string/strcmp/streq.h"
 #include "string/strtok/stpsep.h"
 
 
@@ -53,7 +54,7 @@ void ttytype (const char *line)
 		stpsep(buf, "\n");
 
 		if (   (sscanf (buf, "%1023s %1023s", type, port) == 2)
-		    && (strcmp (line, port) == 0)) {
+		    && streq(line, port)) {
 			break;
 		}
 	}

--- a/lib/user_busy.c
+++ b/lib/user_busy.c
@@ -28,6 +28,7 @@
 #endif				/* ENABLE_SUBIDS */
 #include "shadowlog.h"
 #include "string/sprintf/snprintf.h"
+#include "string/strcmp/streq.h"
 
 
 #ifdef __linux__
@@ -103,7 +104,7 @@ static int different_namespace (const char *sname)
 	if (READLINKNUL("/proc/self/ns/user", buf2) == -1)
 		return 0;
 
-	if (strcmp(buf, buf2) == 0)
+	if (streq(buf, buf2))
 		return 0; /* same namespace */
 
 	return 1;
@@ -199,8 +200,8 @@ static int user_busy_processes (const char *name, uid_t uid)
 		 * This patch is applied by default in some RedHat
 		 * kernels.
 		 */
-		if (   (strcmp (tmp_d_name, ".") == 0)
-		    || (strcmp (tmp_d_name, "..") == 0)) {
+		if (   streq(tmp_d_name, ".")
+		    || streq(tmp_d_name, "..")) {
 			continue;
 		}
 		if (*tmp_d_name == '.') {

--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -26,6 +26,7 @@
 #include "alloc/x/xcalloc.h"
 #include "alloc/x/xmalloc.h"
 #include "sizeof.h"
+#include "string/strcmp/streq.h"
 #include "string/strcpy/strncpy.h"
 #include "string/strcpy/strtcpy.h"
 #include "string/strdup/xstrdup.h"
@@ -63,7 +64,7 @@ is_my_tty(const char tty[UTX_LINESIZE])
 		exit (EXIT_FAILURE);
 	}
 
-	return strcmp (full_tty, tmptty) == 0;
+	return streq(full_tty, tmptty);
 }
 
 

--- a/lib/valid.c
+++ b/lib/valid.c
@@ -11,11 +11,15 @@
 
 #ident "$Id$"
 
-#include <sys/types.h>
-#include <stdio.h>
-#include "prototypes.h"
-#include "defines.h"
 #include <pwd.h>
+#include <stdio.h>
+#include <sys/types.h>
+
+#include "defines.h"
+#include "prototypes.h"
+#include "string/strcmp/streq.h"
+
+
 /*
  * valid - compare encrypted passwords
  *
@@ -73,7 +77,7 @@ bool valid (const char *password, const struct passwd *ent)
 
 	if (   (NULL != ent->pw_name)
 	    && (NULL != encrypted)
-	    && (strcmp (encrypted, ent->pw_passwd) == 0)) {
+	    && streq(encrypted, ent->pw_passwd)) {
 		return true;
 	} else {
 		return false;

--- a/src/chage.c
+++ b/src/chage.c
@@ -34,6 +34,7 @@
 #include "shadowlog.h"
 #include "string/memset/memzero.h"
 #include "string/sprintf/snprintf.h"
+#include "string/strcmp/streq.h"
 #include "string/strcpy/strtcpy.h"
 #include "string/strdup/xstrdup.h"
 #include "string/strftime.h"
@@ -186,7 +187,7 @@ static int new_fields (void)
 
 	change_field (buf, sizeof buf, _("Last Password Change (YYYY-MM-DD)"));
 
-	if (strcmp (buf, "-1") == 0) {
+	if (streq(buf, "-1")) {
 		lstchgdate = -1;
 	} else {
 		lstchgdate = strtoday (buf);
@@ -213,7 +214,7 @@ static int new_fields (void)
 	change_field (buf, sizeof buf,
 	              _("Account Expiration Date (YYYY-MM-DD)"));
 
-	if (strcmp (buf, "-1") == 0) {
+	if (streq(buf, "-1")) {
 		expdate = -1;
 	} else {
 		expdate = strtoday (buf);

--- a/src/chfn.c
+++ b/src/chfn.c
@@ -18,23 +18,24 @@
 #include <sys/types.h>
 #include <getopt.h>
 
+#include "chkname.h"
 #include "defines.h"
+/*@-exitarg@*/
+#include "exitcodes.h"
 #include "getdef.h"
 #include "nscd.h"
-#include "sssd.h"
 #ifdef USE_PAM
 #include "pam_defs.h"
 #endif
 #include "prototypes.h"
 #include "pwauth.h"
 #include "pwio.h"
-/*@-exitarg@*/
-#include "exitcodes.h"
 #include "shadowlog.h"
+#include "sssd.h"
 #include "string/sprintf/snprintf.h"
+#include "string/strcmp/streq.h"
 #include "string/strcpy/strtcpy.h"
 #include "string/strdup/xstrdup.h"
-#include "chkname.h"
 
 
 /*
@@ -151,9 +152,9 @@ static bool may_change_field (int field)
 	cp = getdef_str ("CHFN_RESTRICT");
 	if (NULL == cp) {
 		cp = "";
-	} else if (strcmp (cp, "yes") == 0) {
+	} else if (streq(cp, "yes")) {
 		cp = "rwh";
-	} else if (strcmp (cp, "no") == 0) {
+	} else if (streq(cp, "no")) {
 		cp = "frwh";
 	}
 

--- a/src/chgpasswd.c
+++ b/src/chgpasswd.c
@@ -260,18 +260,18 @@ static void check_flags (void)
 	}
 
 	if (cflg) {
-		if (   (0 != strcmp (crypt_method, "DES"))
-		    && (0 != strcmp (crypt_method, "MD5"))
-		    && (0 != strcmp (crypt_method, "NONE"))
+		if (   !streq(crypt_method, "DES")
+		    && !streq(crypt_method, "MD5")
+		    && !streq(crypt_method, "NONE")
 #ifdef USE_SHA_CRYPT
-		    && (0 != strcmp (crypt_method, "SHA256"))
-		    && (0 != strcmp (crypt_method, "SHA512"))
+		    && !streq(crypt_method, "SHA256")
+		    && !streq(crypt_method, "SHA512")
 #endif				/* USE_SHA_CRYPT */
 #ifdef USE_BCRYPT
-		    && (0 != strcmp (crypt_method, "BCRYPT"))
+		    && !streq(crypt_method, "BCRYPT")
 #endif				/* USE_BCRYPT */
 #ifdef USE_YESCRYPT
-		    && (0 != strcmp (crypt_method, "YESCRYPT"))
+		    && !streq(crypt_method, "YESCRYPT")
 #endif				/* USE_YESCRYPT */
 		    ) {
 			fprintf (stderr,
@@ -490,7 +490,7 @@ int main (int argc, char **argv)
 		newpwd = cp;
 		if (   (!eflg)
 		    && (   (NULL == crypt_method)
-		        || (0 != strcmp (crypt_method, "NONE")))) {
+		        || !streq(crypt_method, "NONE"))) {
 			void *arg = NULL;
 			const char *salt;
 			if (md5flg) {
@@ -577,7 +577,7 @@ int main (int argc, char **argv)
 			newsg.sg_passwd = cp;
 		}
 		if (   (NULL == sg)
-		    || (strcmp (gr->gr_passwd, SHADOW_PASSWD_STRING) != 0))
+		    || !streq(gr->gr_passwd, SHADOW_PASSWD_STRING))
 #endif
 		{
 			newgr = *gr;
@@ -600,7 +600,7 @@ int main (int argc, char **argv)
 			}
 		}
 		if (   (NULL == sg)
-		    || (strcmp (gr->gr_passwd, SHADOW_PASSWD_STRING) != 0))
+		    || !streq(gr->gr_passwd, SHADOW_PASSWD_STRING))
 #endif
 		{
 			if (gr_update (&newgr) == 0) {

--- a/src/chgpasswd.c
+++ b/src/chgpasswd.c
@@ -34,6 +34,7 @@
 /*@-exitarg@*/
 #include "exitcodes.h"
 #include "shadowlog.h"
+#include "string/strcmp/streq.h"
 #include "string/strtok/stpsep.h"
 
 
@@ -198,19 +199,19 @@ static void process_flags (int argc, char **argv)
 				usage (E_USAGE);
 			}
 #if defined(USE_SHA_CRYPT)
-			if (  (   ((0 == strcmp (crypt_method, "SHA256")) || (0 == strcmp (crypt_method, "SHA512")))
+			if (  (   (streq(crypt_method, "SHA256") || streq(crypt_method, "SHA512"))
 			       && (-1 == str2sl(&sha_rounds, optarg)))) {
                             bad_s = 1;
                         }
 #endif				/* USE_SHA_CRYPT */
 #if defined(USE_BCRYPT)
-                        if ((   (0 == strcmp (crypt_method, "BCRYPT"))
+                        if ((   streq(crypt_method, "BCRYPT")
 			       && (-1 == str2sl(&bcrypt_rounds, optarg)))) {
                             bad_s = 1;
                         }
 #endif				/* USE_BCRYPT */
 #if defined(USE_YESCRYPT)
-                        if ((   (0 == strcmp (crypt_method, "YESCRYPT"))
+                        if ((   streq(crypt_method, "YESCRYPT")
 			       && (-1 == str2sl(&yescrypt_cost, optarg)))) {
                             bad_s = 1;
                         }
@@ -498,18 +499,18 @@ int main (int argc, char **argv)
 #if defined(USE_SHA_CRYPT) || defined(USE_BCRYPT) || defined(USE_YESCRYPT)
 			if (sflg) {
 #if defined(USE_SHA_CRYPT)
-				if (   (0 == strcmp (crypt_method, "SHA256"))
-					|| (0 == strcmp (crypt_method, "SHA512"))) {
+				if (   streq(crypt_method, "SHA256")
+					|| streq(crypt_method, "SHA512")) {
 					arg = &sha_rounds;
 				}
 #endif				/* USE_SHA_CRYPT */
 #if defined(USE_BCRYPT)
-				if (0 == strcmp (crypt_method, "BCRYPT")) {
+				if (streq(crypt_method, "BCRYPT")) {
 					arg = &bcrypt_rounds;
 				}
 #endif				/* USE_BCRYPT */
 #if defined(USE_YESCRYPT)
-				if (0 == strcmp (crypt_method, "YESCRYPT")) {
+				if (streq(crypt_method, "YESCRYPT")) {
 					arg = &yescrypt_cost;
 				}
 #endif				/* USE_YESCRYPT */
@@ -548,8 +549,8 @@ int main (int argc, char **argv)
 			sg = sgr_locate (name);
 
 			if (   (NULL == sg)
-			    && (strcmp (gr->gr_passwd,
-			                SHADOW_PASSWD_STRING) == 0)) {
+			    && streq(gr->gr_passwd, SHADOW_PASSWD_STRING))
+			{
 				static char *empty = NULL;
 				/* If the password is set to 'x' in
 				 * group, but there are no entries in

--- a/src/chpasswd.c
+++ b/src/chpasswd.c
@@ -31,10 +31,11 @@
 /*@-exitarg@*/
 #include "exitcodes.h"
 #include "shadowlog.h"
+#include "string/strcmp/streq.h"
 #include "string/strtok/stpsep.h"
 
 
-#define IS_CRYPT_METHOD(str) ((crypt_method != NULL && strcmp(crypt_method, str) == 0) ? true : false)
+#define IS_CRYPT_METHOD(str) ((crypt_method != NULL && streq(crypt_method, str)) ? true : false)
 
 /*
  * Global variables
@@ -588,8 +589,8 @@ int main (int argc, char **argv)
 			sp = spw_locate (name);
 
 			if (   (NULL == sp)
-			    && (strcmp (pw->pw_passwd,
-			                SHADOW_PASSWD_STRING) == 0)) {
+			    && streq(pw->pw_passwd, SHADOW_PASSWD_STRING))
+			{
 				/* If the password is set to 'x' in
 				 * passwd, but there are no entries in
 				 * shadow, create one.

--- a/src/chpasswd.c
+++ b/src/chpasswd.c
@@ -627,7 +627,7 @@ int main (int argc, char **argv)
 		}
 
 		if (   (NULL == sp)
-		    || (strcmp (pw->pw_passwd, SHADOW_PASSWD_STRING) != 0)) {
+		    || !streq(pw->pw_passwd, SHADOW_PASSWD_STRING)) {
 			newpw = *pw;
 			newpw.pw_passwd = cp;
 		}
@@ -647,7 +647,7 @@ int main (int argc, char **argv)
 			}
 		}
 		if (   (NULL == sp)
-		    || (strcmp (pw->pw_passwd, SHADOW_PASSWD_STRING) != 0)) {
+		    || !streq(pw->pw_passwd, SHADOW_PASSWD_STRING)) {
 			if (pw_update (&newpw) == 0) {
 				fprintf (stderr,
 				         _("%s: line %d: failed to prepare the new %s entry '%s'\n"),

--- a/src/chsh.c
+++ b/src/chsh.c
@@ -17,22 +17,23 @@
 #include <stdio.h>
 #include <sys/types.h>
 
+#include "chkname.h"
 #include "defines.h"
+/*@-exitarg@*/
+#include "exitcodes.h"
 #include "getdef.h"
 #include "nscd.h"
-#include "sssd.h"
 #include "prototypes.h"
 #include "pwauth.h"
 #include "pwio.h"
 #ifdef USE_PAM
 #include "pam_defs.h"
 #endif
-/*@-exitarg@*/
-#include "exitcodes.h"
 #include "shadowlog.h"
+#include "sssd.h"
+#include "string/strcmp/streq.h"
 #include "string/strcpy/strtcpy.h"
 #include "string/strdup/xstrdup.h"
-#include "chkname.h"
 
 
 #ifndef SHELLS_FILE
@@ -179,7 +180,7 @@ static bool shell_is_listed (const char *sh)
 	}
 
 	for (size_t i = 0; i < size; i++) {
-		if (strcmp (keys[i], sh) == 0) {
+		if (streq(keys[i], sh)) {
 			found = true;
 			break;
 		}
@@ -200,7 +201,7 @@ static bool shell_is_listed (const char *sh)
 	char *cp;
 	setusershell ();
 	while ((cp = getusershell ())) {
-		if (strcmp (cp, sh) == 0) {
+		if (streq(cp, sh)) {
 			found = true;
 			break;
 		}
@@ -221,7 +222,7 @@ static bool shell_is_listed (const char *sh)
 			continue;
 		}
 
-		if (strcmp (buf, sh) == 0) {
+		if (streq(buf, sh)) {
 			found = true;
 			break;
 		}

--- a/src/get_subid_owners.c
+++ b/src/get_subid_owners.c
@@ -4,10 +4,11 @@
 #include <stdio.h>
 
 #include "atoi/getnum.h"
-#include "subid.h"
-#include "stdlib.h"
 #include "prototypes.h"
 #include "shadowlog.h"
+#include "stdlib.h"
+#include "string/strcmp/streq.h"
+#include "subid.h"
 
 
 static const char Prog[] = "get_subid_owners";
@@ -32,10 +33,10 @@ int main(int argc, char *argv[])
 	if (argc < 2) {
 		usage();
 	}
-	if (argc == 3 && strcmp(argv[1], "-g") == 0) {
+	if (argc == 3 && streq(argv[1], "-g")) {
 		get_uid(argv[2], &u);
 		n = subid_get_gid_owners(u, &uids);
-	} else if (argc == 2 && strcmp(argv[1], "-h") == 0) {
+	} else if (argc == 2 && streq(argv[1], "-h")) {
 		usage();
 	} else {
 		get_gid(argv[1], &u);

--- a/src/getsubids.c
+++ b/src/getsubids.c
@@ -1,11 +1,13 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 
 #include <stdio.h>
-#include <string.h>
 #include <stdlib.h>
-#include "subid.h"
+#include <string.h>
+
 #include "prototypes.h"
 #include "shadowlog.h"
+#include "string/strcmp/streq.h"
+#include "subid.h"
 
 static const char Prog[] = "getsubids";
 
@@ -28,10 +30,10 @@ int main(int argc, char *argv[])
 	if (argc < 2)
 		usage();
 	owner = argv[1];
-	if (argc == 3 && strcmp(argv[1], "-g") == 0) {
+	if (argc == 3 && streq(argv[1], "-g")) {
 		owner = argv[2];
 		count = subid_get_gid_ranges(owner, &ranges);
-	} else if (argc == 2 && strcmp(argv[1], "-h") == 0) {
+	} else if (argc == 2 && streq(argv[1], "-h")) {
 		usage();
 	} else {
 		count = subid_get_uid_ranges(owner, &ranges);

--- a/src/gpasswd.c
+++ b/src/gpasswd.c
@@ -24,18 +24,19 @@
 #include "alloc/x/xmalloc.h"
 #include "attr.h"
 #include "defines.h"
+/*@-exitarg@*/
+#include "exitcodes.h"
 #include "groupio.h"
 #include "nscd.h"
-#include "sssd.h"
 #include "prototypes.h"
 #ifdef SHADOWGRP
 #include "sgroupio.h"
 #endif
-/*@-exitarg@*/
-#include "exitcodes.h"
 #include "shadowlog.h"
+#include "sssd.h"
 #include "string/memset/memzero.h"
 #include "string/sprintf/snprintf.h"
+#include "string/strcmp/streq.h"
 #include "string/strcpy/strtcpy.h"
 #include "string/strdup/xstrdup.h"
 
@@ -843,7 +844,7 @@ static void change_passwd (struct group *gr)
 			exit (1);
 		}
 
-		if (strcmp (pass, cp) == 0) {
+		if (streq(pass, cp)) {
 			erase_pass (cp);
 			break;
 		}

--- a/src/groupmems.c
+++ b/src/groupmems.c
@@ -21,12 +21,13 @@
 
 #include "alloc/x/xmalloc.h"
 #include "defines.h"
-#include "prototypes.h"
 #include "groupio.h"
+#include "prototypes.h"
 #ifdef SHADOWGRP
 #include "sgroupio.h"
 #endif
 #include "shadowlog.h"
+#include "string/strcmp/streq.h"
 #include "string/strdup/xstrdup.h"
 
 
@@ -85,7 +86,7 @@ static char *whoami (void)
 
 	if (   (NULL != usr)
 	    && (NULL != grp)
-	    && (0 == strcmp (usr->pw_name, grp->gr_name))) {
+	    && streq(usr->pw_name, grp->gr_name)) {
 		return xstrdup (usr->pw_name);
 	} else {
 		return NULL;

--- a/src/groupmod.c
+++ b/src/groupmod.c
@@ -155,7 +155,7 @@ static void new_grent (struct group *grent)
 	if (   pflg
 #ifdef SHADOWGRP
 	    && (   (!is_shadow_grp)
-	        || (strcmp (grent->gr_passwd, SHADOW_PASSWD_STRING) != 0))
+	        || !streq(grent->gr_passwd, SHADOW_PASSWD_STRING))
 #endif
 		) {
 		/* Update the password in group if there is no gshadow

--- a/src/groupmod.c
+++ b/src/groupmod.c
@@ -31,15 +31,16 @@
 #include "chkname.h"
 #include "defines.h"
 #include "groupio.h"
-#include "pwio.h"
 #include "nscd.h"
-#include "sssd.h"
 #include "prototypes.h"
+#include "pwio.h"
 #ifdef	SHADOWGRP
 #include "sgroupio.h"
 #endif
 #include "shadowlog.h"
+#include "sssd.h"
 #include "string/sprintf/stpeprintf.h"
+#include "string/strcmp/streq.h"
 #include "string/strcpy/stpecpy.h"
 #include "string/strdup/xstrdup.h"
 
@@ -227,7 +228,7 @@ static void grp_update (void)
 			sgrp = *osgrp;
 			new_sgent (&sgrp);
 		} else if (   pflg
-		           && (strcmp (grp.gr_passwd, SHADOW_PASSWD_STRING) == 0)) {
+		           && streq(grp.gr_passwd, SHADOW_PASSWD_STRING)) {
 			static char *empty = NULL;
 			/* If there is a gshadow file with no entries for
 			 * the group, but the group file indicates a
@@ -357,7 +358,7 @@ check_new_name(void)
 	/*
 	 * Make sure they are actually changing the name.
 	 */
-	if (strcmp (group_name, group_newname) == 0) {
+	if (streq(group_name, group_newname)) {
 		nflg = 0;
 		return;
 	}

--- a/src/grpck.c
+++ b/src/grpck.c
@@ -537,7 +537,7 @@ static void check_grp_file (int *errors, bool *changed)
 				continue;
 			}
 
-			if (strcmp (grp->gr_name, ent->gr_name) != 0) {
+			if (!streq(grp->gr_name, ent->gr_name)) {
 				continue;
 			}
 
@@ -649,7 +649,7 @@ static void check_grp_file (int *errors, bool *changed)
 				/* The group entry has a gshadow counterpart.
 				 * Make sure no passwords are in group.
 				 */
-				if (strcmp (grp->gr_passwd, SHADOW_PASSWD_STRING) != 0) {
+				if (!streq(grp->gr_passwd, SHADOW_PASSWD_STRING)) {
 					printf (_("group %s has an entry in %s, but its password field in %s is not set to 'x'\n"),
 					        grp->gr_name, sgr_file, grp_file);
 					*errors += 1;
@@ -739,7 +739,7 @@ static void check_sgr_file (int *errors, bool *changed)
 				continue;
 			}
 
-			if (strcmp (sgr->sg_name, ent->sg_name) != 0) {
+			if (!streq(sgr->sg_name, ent->sg_name)) {
 				continue;
 			}
 

--- a/src/grpck.c
+++ b/src/grpck.c
@@ -15,14 +15,16 @@
 #include <pwd.h>
 #include <stdio.h>
 #include <getopt.h>
+
 #include "chkname.h"
 #include "commonio.h"
 #include "defines.h"
 #include "groupio.h"
 #include "nscd.h"
-#include "sssd.h"
 #include "prototypes.h"
 #include "shadowlog.h"
+#include "sssd.h"
+#include "string/strcmp/streq.h"
 
 #ifdef SHADOWGRP
 #include "sgroupio.h"
@@ -436,7 +438,7 @@ static void compare_members_lists (const char *groupname,
 
 	for (pmem = members; NULL != *pmem; pmem++) {
 		for (other_pmem = other_members; NULL != *other_pmem; other_pmem++) {
-			if (strcmp (*pmem, *other_pmem) == 0) {
+			if (streq(*pmem, *other_pmem)) {
 				break;
 			}
 		}

--- a/src/grpconv.c
+++ b/src/grpconv.c
@@ -17,6 +17,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <getopt.h>
 #include <grp.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -24,18 +25,21 @@
 #include <strings.h>
 #include <time.h>
 #include <unistd.h>
-#include <getopt.h>
 
 #include "attr.h"
-#include "nscd.h"
-#include "sssd.h"
-#include "prototypes.h"
 /*@-exitarg@*/
 #include "exitcodes.h"
+#include "nscd.h"
+#include "prototypes.h"
+#include "string/strcmp/streq.h"
+
 #ifdef SHADOWGRP
 #include "groupio.h"
 #include "sgroupio.h"
 #include "shadowlog.h"
+#include "sssd.h"
+
+
 /*
  * Global variables
  */
@@ -194,7 +198,7 @@ int main (int argc, char **argv)
 		if (NULL != sg) {
 			/* update existing shadow group entry */
 			sgent = *sg;
-			if (strcmp (gr->gr_passwd, SHADOW_PASSWD_STRING) != 0)
+			if (!streq(gr->gr_passwd, SHADOW_PASSWD_STRING))
 				sgent.sg_passwd = gr->gr_passwd;
 		} else {
 			static char *empty = NULL;

--- a/src/grpunconv.c
+++ b/src/grpunconv.c
@@ -26,15 +26,19 @@
 #include <getopt.h>
 
 #include "attr.h"
-#include "nscd.h"
-#include "sssd.h"
-#include "prototypes.h"
 /*@-exitarg@*/
 #include "exitcodes.h"
+#include "nscd.h"
+#include "prototypes.h"
+#include "sssd.h"
+#include "string/strcmp/streq.h"
+
 #ifdef SHADOWGRP
 #include "groupio.h"
 #include "sgroupio.h"
 #include "shadowlog.h"
+
+
 /*
  * Global variables
  */
@@ -174,7 +178,7 @@ int main (int argc, char **argv)
 	while ((gr = gr_next ()) != NULL) {
 		sg = sgr_locate (gr->gr_name);
 		if (   (NULL != sg)
-		    && (strcmp (gr->gr_passwd, SHADOW_PASSWD_STRING) == 0)) {
+		    && streq(gr->gr_passwd, SHADOW_PASSWD_STRING)) {
 			/* add password to /etc/group */
 			grent = *gr;
 			grent.gr_passwd = sg->sg_passwd;

--- a/src/login.c
+++ b/src/login.c
@@ -29,16 +29,17 @@
 #include "attr.h"
 #include "chkname.h"
 #include "defines.h"
+/*@-exitarg@*/
+#include "exitcodes.h"
 #include "faillog.h"
 #include "failure.h"
 #include "getdef.h"
 #include "prototypes.h"
 #include "pwauth.h"
-/*@-exitarg@*/
-#include "exitcodes.h"
 #include "shadowlog.h"
 #include "string/memset/memzero.h"
 #include "string/sprintf/snprintf.h"
+#include "string/strcmp/streq.h"
 #include "string/strcpy/strtcpy.h"
 #include "string/strdup/xstrdup.h"
 #include "string/strftime.h"
@@ -269,7 +270,7 @@ static void process_flags (int argc, char *const *argv)
 		if (argv[arg][0] == '-' && strlen (argv[arg]) > 2) {
 			usage ();
 		}
-		if (strcmp(argv[arg], "--") == 0) {
+		if (streq(argv[arg], "--")) {
 			break; /* stop checking on a "--" */
 		}
 	}
@@ -864,22 +865,22 @@ int main (int argc, char **argv)
 				failed = true;
 			}
 
-			if (strcmp (user_passwd, "") == 0) {
+			if (streq(user_passwd, "")) {
 				const char *prevent_no_auth = getdef_str("PREVENT_NO_AUTH");
 
 				if (prevent_no_auth == NULL) {
 					prevent_no_auth = "superuser";
 				}
-				if (strcmp(prevent_no_auth, "yes") == 0) {
+				if (streq(prevent_no_auth, "yes")) {
 					failed = true;
 				} else if ((pwd->pw_uid == 0)
-					&& (strcmp(prevent_no_auth, "superuser") == 0)) {
+					&& streq(prevent_no_auth, "superuser")) {
 					failed = true;
 				}
 			}
 		}
 
-		if (strcmp (user_passwd, SHADOW_PASSWD_STRING) == 0) {
+		if (streq(user_passwd, SHADOW_PASSWD_STRING)) {
 			spwd = xgetspnam (username);
 			if (NULL != spwd) {
 				user_passwd = spwd->sp_pwdp;

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -75,7 +75,7 @@ static bool ingroup(const char *name, struct group *gr)
 
 	look = gr->gr_mem;
 	while (*look && notfound)
-		notfound = strcmp (*look++, name);
+		notfound = !streq(*look++, name);
 
 	return !notfound;
 }
@@ -189,7 +189,7 @@ static void check_perms (const struct group *grp,
 		}
 
 		if (grp->gr_passwd[0] == '\0' ||
-		    strcmp (cpasswd, grp->gr_passwd) != 0) {
+		    !streq(cpasswd, grp->gr_passwd)) {
 #ifdef WITH_AUDIT
 			SNPRINTF(audit_buf, "authentication new-gid=%lu",
 			         (unsigned long) grp->gr_gid);

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -19,15 +19,16 @@
 
 #include "agetpass.h"
 #include "alloc/x/xmalloc.h"
+#include "chkname.h"
 #include "defines.h"
-#include "getdef.h"
-#include "prototypes.h"
 /*@-exitarg@*/
 #include "exitcodes.h"
+#include "getdef.h"
+#include "prototypes.h"
 #include "shadowlog.h"
 #include "string/sprintf/snprintf.h"
+#include "string/strcmp/streq.h"
 #include "string/strdup/xstrdup.h"
-#include "chkname.h"
 
 
 /*
@@ -428,7 +429,7 @@ int main (int argc, char **argv)
 	 * injecting arbitrary strings into our stderr/stdout, as this can
 	 * be an exploit vector.
 	 */
-	is_newgrp = (strcmp (Basename (argv[0]), "newgrp") == 0);
+	is_newgrp = streq(Basename (argv[0]), "newgrp");
 	Prog = is_newgrp ? "newgrp" : "sg";
 
 	log_set_progname(Prog);
@@ -472,8 +473,8 @@ int main (int argc, char **argv)
 	 *      sg [-] groupid [[-c command]
 	 */
 	if (   (argc > 0)
-	    && (   (strcmp (argv[0], "-")  == 0)
-	        || (strcmp (argv[0], "-l") == 0))) {
+	    && (   streq(argv[0], "-")
+	        || streq(argv[0], "-l"))) {
 		argc--;
 		argv++;
 		initflag = true;
@@ -505,7 +506,7 @@ int main (int argc, char **argv)
 			 * "sg group -c command" (as in the man page) or
 			 * "sg group command" (as in the usage message).
 			 */
-			if ((argc > 1) && (strcmp (argv[0], "-c") == 0)) {
+			if ((argc > 1) && streq(argv[0], "-c")) {
 				command = argv[1];
 			} else {
 				command = argv[0];

--- a/src/newusers.c
+++ b/src/newusers.c
@@ -38,21 +38,22 @@
 #include "pam_defs.h"
 #endif				/* USE_PAM */
 #endif				/* ACCT_TOOLS_SETUID */
-#include "prototypes.h"
+#include "chkname.h"
 #include "defines.h"
 #include "getdef.h"
 #include "groupio.h"
 #include "nscd.h"
-#include "sssd.h"
+#include "prototypes.h"
 #include "pwio.h"
 #include "sgroupio.h"
 #include "shadowio.h"
 #ifdef ENABLE_SUBIDS
 #include "subordinateio.h"
 #endif				/* ENABLE_SUBIDS */
-#include "chkname.h"
 #include "shadowlog.h"
+#include "sssd.h"
 #include "string/sprintf/snprintf.h"
+#include "string/strcmp/streq.h"
 #include "string/strdup/xstrdup.h"
 #include "string/strtok/stpsep.h"
 
@@ -428,29 +429,29 @@ static int update_passwd (struct passwd *pwd, const char *password)
 	if (NULL != crypt_method) {
 #if defined(USE_SHA_CRYPT)
 		if (sflg) {
-			if (   (0 == strcmp (crypt_method, "SHA256"))
-				|| (0 == strcmp (crypt_method, "SHA512"))) {
+			if (   streq(crypt_method, "SHA256")
+				|| streq(crypt_method, "SHA512")) {
 				crypt_arg = &sha_rounds;
 			}
 		}
 #endif				/* USE_SHA_CRYPT */
 #if defined(USE_BCRYPT)
 		if (sflg) {
-			if (0 == strcmp (crypt_method, "BCRYPT")) {
+			if (streq(crypt_method, "BCRYPT")) {
 				crypt_arg = &bcrypt_rounds;
 			}
 		}
 #endif				/* USE_BCRYPT */
 #if defined(USE_YESCRYPT)
 		if (sflg) {
-			if (0 == strcmp (crypt_method, "YESCRYPT")) {
+			if (streq(crypt_method, "YESCRYPT")) {
 				crypt_arg = &yescrypt_cost;
 			}
 		}
 #endif				/* USE_YESCRYPT */
 	}
 
-	if ((NULL != crypt_method) && (0 == strcmp(crypt_method, "NONE"))) {
+	if ((NULL != crypt_method) && streq(crypt_method, "NONE")) {
 		pwd->pw_passwd = (char *)password;
 	} else {
 		const char *salt = crypt_make_salt (crypt_method, crypt_arg);
@@ -484,22 +485,23 @@ static int add_passwd (struct passwd *pwd, const char *password)
 	if (NULL != crypt_method) {
 #if defined(USE_SHA_CRYPT)
 		if (sflg) {
-			if (   (0 == strcmp (crypt_method, "SHA256"))
-				|| (0 == strcmp (crypt_method, "SHA512"))) {
+			if (streq(crypt_method, "SHA256")
+			    || streq(crypt_method, "SHA512"))
+			{
 				crypt_arg = &sha_rounds;
 			}
 		}
 #endif				/* USE_SHA_CRYPT */
 #if defined(USE_BCRYPT)
 		if (sflg) {
-			if (0 == strcmp (crypt_method, "BCRYPT")) {
+			if (streq(crypt_method, "BCRYPT")) {
 				crypt_arg = &bcrypt_rounds;
 			}
 		}
 #endif				/* USE_BCRYPT */
 #if defined(USE_YESCRYPT)
 		if (sflg) {
-			if (0 == strcmp (crypt_method, "YESCRYPT")) {
+			if (streq(crypt_method, "YESCRYPT")) {
 				crypt_arg = &yescrypt_cost;
 			}
 		}
@@ -525,7 +527,8 @@ static int add_passwd (struct passwd *pwd, const char *password)
 	if (NULL != sp) {
 		spent = *sp;
 		if (   (NULL != crypt_method)
-		    && (0 == strcmp(crypt_method, "NONE"))) {
+		    && streq(crypt_method, "NONE"))
+		{
 			spent.sp_pwdp = (char *)password;
 		} else {
 			const char *salt = crypt_make_salt (crypt_method,
@@ -576,7 +579,7 @@ static int add_passwd (struct passwd *pwd, const char *password)
 	 */
 	spent.sp_namp = pwd->pw_name;
 #ifndef USE_PAM
-	if ((crypt_method != NULL) && (0 == strcmp(crypt_method, "NONE"))) {
+	if ((crypt_method != NULL) && streq(crypt_method, "NONE")) {
 		spent.sp_pwdp = (char *)password;
 	} else {
 		const char *salt = crypt_make_salt (crypt_method, crypt_arg);
@@ -682,19 +685,19 @@ static void process_flags (int argc, char **argv)
 				usage (EXIT_FAILURE);
 			}
 #if defined(USE_SHA_CRYPT)
-			if (  (   ((0 == strcmp (crypt_method, "SHA256")) || (0 == strcmp (crypt_method, "SHA512")))
+			if (  (   (streq(crypt_method, "SHA256") || streq(crypt_method, "SHA512"))
 			       && (-1 == str2sl(&sha_rounds, optarg)))) {
                             bad_s = 1;
                         }
 #endif				/* USE_SHA_CRYPT */
 #if defined(USE_BCRYPT)
-                        if ((   (0 == strcmp (crypt_method, "BCRYPT"))
+                        if ((   streq(crypt_method, "BCRYPT")
 			       && (-1 == str2sl(&bcrypt_rounds, optarg)))) {
                             bad_s = 1;
                         }
 #endif				/* USE_BCRYPT */
 #if defined(USE_YESCRYPT)
-                        if ((   (0 == strcmp (crypt_method, "YESCRYPT"))
+                        if ((   streq(crypt_method, "YESCRYPT")
 			       && (-1 == str2sl(&yescrypt_cost, optarg)))) {
                             bad_s = 1;
                         }

--- a/src/newusers.c
+++ b/src/newusers.c
@@ -557,7 +557,7 @@ static int add_passwd (struct passwd *pwd, const char *password)
 	 * when the entry was created, so this user would have to have had
 	 * the password set someplace else.
 	 */
-	if (strcmp (pwd->pw_passwd, "x") != 0) {
+	if (!streq(pwd->pw_passwd, "x")) {
 		return update_passwd (pwd, password);
 	}
 #else				/* USE_PAM */
@@ -568,7 +568,7 @@ static int add_passwd (struct passwd *pwd, const char *password)
 	 * The password will be updated later for all users using PAM.
 	 */
 	if (   (NULL != sp)
-	    || (strcmp (pwd->pw_passwd, "x") != 0)) {
+	    || !streq(pwd->pw_passwd, "x")) {
 		return 0;
 	}
 #endif				/* USE_PAM */
@@ -754,18 +754,18 @@ static void check_flags (void)
 #endif				/* USE_SHA_CRYPT || USE_BCRYPT || USE_YESCRYPT */
 
 	if (cflg) {
-		if (   (0 != strcmp (crypt_method, "DES"))
-		    && (0 != strcmp (crypt_method, "MD5"))
-		    && (0 != strcmp (crypt_method, "NONE"))
+		if (   !streq(crypt_method, "DES")
+		    && !streq(crypt_method, "MD5")
+		    && !streq(crypt_method, "NONE")
 #ifdef USE_SHA_CRYPT
-		    && (0 != strcmp (crypt_method, "SHA256"))
-		    && (0 != strcmp (crypt_method, "SHA512"))
+		    && !streq(crypt_method, "SHA256")
+		    && !streq(crypt_method, "SHA512")
 #endif				/* USE_SHA_CRYPT */
 #ifdef USE_BCRYPT
-		    && (0 != strcmp (crypt_method, "BCRYPT"))
+		    && !streq(crypt_method, "BCRYPT")
 #endif				/* USE_BCRYPT */
 #ifdef USE_YESCRYPT
-		    && (0 != strcmp (crypt_method, "YESCRYPT"))
+		    && !streq(crypt_method, "YESCRYPT")
 #endif				/* USE_YESCRYPT */
 		    ) {
 			fprintf (stderr,

--- a/src/passwd.c
+++ b/src/passwd.c
@@ -22,21 +22,22 @@
 
 #include "agetpass.h"
 #include "atoi/a2i/a2s.h"
+#include "chkname.h"
 #include "defines.h"
 #include "getdef.h"
 #include "nscd.h"
-#include "sssd.h"
 #include "prototypes.h"
 #include "pwauth.h"
 #include "pwio.h"
 #include "shadowio.h"
 #include "shadowlog.h"
+#include "sssd.h"
 #include "string/memset/memzero.h"
 #include "string/sprintf/xasprintf.h"
+#include "string/strcmp/streq.h"
 #include "string/strcpy/strtcpy.h"
 #include "string/strdup/xstrdup.h"
 #include "time/day_to_str.h"
-#include "chkname.h"
 
 
 /*
@@ -242,16 +243,16 @@ static int new_password (const struct passwd *pw)
 			pass_max_len = getdef_num ("PASS_MAX_LEN", 8);
 		}
 	} else {
-		if (   (strcmp (method, "MD5")    == 0)
+		if (   streq(method, "MD5")
 #ifdef USE_SHA_CRYPT
-		    || (strcmp (method, "SHA256") == 0)
-		    || (strcmp (method, "SHA512") == 0)
+		    || streq(method, "SHA256")
+		    || streq(method, "SHA512")
 #endif /* USE_SHA_CRYPT */
 #ifdef USE_BCRYPT
-		    || (strcmp (method, "BCRYPT") == 0)
+		    || streq(method, "BCRYPT")
 #endif /* USE_BCRYPT*/
 #ifdef USE_YESCRYPT
-		    || (strcmp (method, "YESCRYPT") == 0)
+		    || streq(method, "YESCRYPT")
 #endif /* USE_YESCRYPT*/
 
 		    ) {

--- a/src/passwd.c
+++ b/src/passwd.c
@@ -213,7 +213,7 @@ static int new_password (const struct passwd *pw)
 			return -1;
 		}
 
-		if (strcmp (cipher, crypt_passwd) != 0) {
+		if (!streq(cipher, crypt_passwd)) {
 			erase_pass (clear);
 			strzero (cipher);
 			SYSLOG ((LOG_WARN, "incorrect password for %s",
@@ -299,7 +299,7 @@ static int new_password (const struct passwd *pw)
 				MEMZERO(pass);
 				return -1;
 			}
-			if (warned && (strcmp (pass, cp) != 0)) {
+			if (warned && !streq(pass, cp)) {
 				warned = false;
 			}
 			ret = STRTCPY (pass, cp);
@@ -333,7 +333,7 @@ static int new_password (const struct passwd *pw)
 				MEMZERO(pass);
 				return -1;
 			}
-			if (strcmp (cp, pass) != 0) {
+			if (!streq(cp, pass)) {
 				erase_pass (cp);
 				(void) fputs (_("They don't match; try again.\n"), stderr);
 			} else {
@@ -839,7 +839,7 @@ main(int argc, char **argv)
 			case 'r':
 				/* -r repository (files|nis|nisplus) */
 				/* only "files" supported for now */
-				if (strcmp (optarg, "files") != 0) {
+				if (!streq(optarg, "files")) {
 					fprintf (stderr,
 					         _("%s: repository %s not supported\n"),
 						 Prog, optarg);

--- a/src/pwck.c
+++ b/src/pwck.c
@@ -13,23 +13,26 @@
 #ident "$Id$"
 
 #include <fcntl.h>
+#include <getopt.h>
 #include <grp.h>
 #include <pwd.h>
 #include <stdio.h>
-#include <getopt.h>
+
 #include "chkname.h"
 #include "commonio.h"
 #include "defines.h"
+#include "getdef.h"
+#include "nscd.h"
 #include "prototypes.h"
 #include "pwio.h"
 #include "shadowio.h"
-#include "getdef.h"
-#include "nscd.h"
+#include "shadowlog.h"
 #include "sssd.h"
+#include "string/strcmp/streq.h"
 #ifdef WITH_TCB
 #include "tcbfuncs.h"
 #endif				/* WITH_TCB */
-#include "shadowlog.h"
+
 
 /*
  * Exit codes
@@ -447,7 +450,7 @@ static void check_pw_file (int *errors, bool *changed)
 				continue;
 			}
 
-			if (strcmp (pwd->pw_name, ent->pw_name) != 0) {
+			if (!streq(pwd->pw_name, ent->pw_name)) {
 				continue;
 			}
 
@@ -518,7 +521,7 @@ static void check_pw_file (int *errors, bool *changed)
 				/*
 				 * Home directory does not exist, give a warning (unless intentional)
 				 */
-				if (NULL == nonexistent || strcmp (pwd->pw_dir, nonexistent) != 0) {
+				if (NULL == nonexistent || !streq(pwd->pw_dir, nonexistent)) {
 					printf (_("user '%s': directory '%s' does not exist\n"),
 							pwd->pw_name, pwd->pw_dir);
 					*errors += 1;
@@ -644,8 +647,7 @@ static void check_pw_file (int *errors, bool *changed)
 				 * Make sure no passwords are in passwd.
 				 */
 				if (   !quiet
-				    && (strcmp (pwd->pw_passwd,
-				                SHADOW_PASSWD_STRING) != 0)) {
+				    && !streq(pwd->pw_passwd, SHADOW_PASSWD_STRING)) {
 					printf (_("user %s has an entry in %s, but its password field in %s is not set to 'x'\n"),
 					        pwd->pw_name, spw_dbname (), pw_dbname ());
 					*errors += 1;
@@ -773,7 +775,7 @@ static void check_spw_file (int *errors, bool *changed)
 				continue;
 			}
 
-			if (strcmp (spw->sp_namp, ent->sp_namp) != 0) {
+			if (!streq(spw->sp_namp, ent->sp_namp)) {
 				continue;
 			}
 

--- a/src/pwconv.c
+++ b/src/pwconv.c
@@ -47,12 +47,14 @@
 
 #include "defines.h"
 #include "getdef.h"
+#include "nscd.h"
 #include "prototypes.h"
 #include "pwio.h"
-#include "shadowio.h"
-#include "nscd.h"
 #include "sssd.h"
+#include "shadowio.h"
 #include "shadowlog.h"
+#include "string/strcmp/streq.h"
+
 
 /*
  * exit status values
@@ -231,7 +233,7 @@ int main (int argc, char **argv)
 		sp = spw_locate (pw->pw_name);
 		if (NULL != sp) {
 			/* do we need to update this entry? */
-			if (strcmp (pw->pw_passwd, SHADOW_PASSWD_STRING) == 0) {
+			if (streq(pw->pw_passwd, SHADOW_PASSWD_STRING)) {
 				continue;
 			}
 			/* update existing shadow entry */

--- a/src/pwunconv.c
+++ b/src/pwunconv.c
@@ -17,16 +17,19 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <getopt.h>
+
 #include "defines.h"
+/*@-exitarg@*/
+#include "exitcodes.h"
 #include "getdef.h"
 #include "nscd.h"
-#include "sssd.h"
 #include "prototypes.h"
 #include "pwio.h"
 #include "shadowio.h"
-/*@-exitarg@*/
-#include "exitcodes.h"
 #include "shadowlog.h"
+#include "sssd.h"
+#include "string/strcmp/streq.h"
+
 
 /*
  * Global variables
@@ -180,7 +183,7 @@ int main (int argc, char **argv)
 		/*
 		 * Update password if non-shadow is "x".
 		 */
-		if (strcmp (pw->pw_passwd, SHADOW_PASSWD_STRING) == 0) {
+		if (streq(pw->pw_passwd, SHADOW_PASSWD_STRING)) {
 			pwent.pw_passwd = spwd->sp_pwdp;
 		}
 

--- a/src/su.c
+++ b/src/su.c
@@ -681,7 +681,7 @@ static /*@only@*/struct passwd * do_check_perms (void)
 		su_failure (caller_tty, 0 == pw->pw_uid);
 	}
 	tmp_name = item;
-	if (strcmp (name, tmp_name) != 0) {
+	if (!streq(name, tmp_name)) {
 		SYSLOG ((LOG_INFO,
 		         "Change user from '%s' to '%s' as requested by PAM",
 		         name, tmp_name));

--- a/src/su.c
+++ b/src/su.c
@@ -49,18 +49,19 @@
 #include "alloc/x/xmalloc.h"
 #include "attr.h"
 #include "cast.h"
-#include "prototypes.h"
 #include "defines.h"
-#include "pwauth.h"
+/*@-exitarg@*/
+#include "exitcodes.h"
 #include "getdef.h"
 #ifdef USE_PAM
 #include "pam_defs.h"
 #endif				/* USE_PAM */
-/*@-exitarg@*/
-#include "exitcodes.h"
+#include "pwauth.h"
+#include "prototypes.h"
 #include "shadowlog.h"
 #include "string/sprintf/snprintf.h"
 #include "string/sprintf/xasprintf.h"
+#include "string/strcmp/streq.h"
 #include "string/strcpy/strtcpy.h"
 #include "string/strdup/xstrdup.h"
 
@@ -186,7 +187,7 @@ static bool restricted_shell (const char *shellname)
 
 	setusershell ();
 	while ((line = getusershell ()) != NULL) {
-		if (('#' != *line) && (strcmp (line, shellname) == 0)) {
+		if (('#' != *line) && streq(line, shellname)) {
 			endusershell ();
 			return false;
 		}
@@ -511,17 +512,17 @@ static void check_perms_nopam (const struct passwd *pw)
 		return;
 	}
 
-	if (strcmp (pw->pw_passwd, "") == 0) {
+	if (streq(pw->pw_passwd, "")) {
 		const char  *prevent_no_auth = getdef_str("PREVENT_NO_AUTH");
 
 		if (prevent_no_auth == NULL) {
 			prevent_no_auth = "superuser";
 		}
-		if (strcmp(prevent_no_auth, "yes") == 0) {
+		if (streq(prevent_no_auth, "yes")) {
 			fprintf(stderr, _("Password field is empty, this is forbidden for all accounts.\n"));
 			exit(1);
 		} else if ((pw->pw_uid == 0)
-				&& (strcmp(prevent_no_auth, "superuser") == 0)) {
+				&& streq(prevent_no_auth, "superuser")) {
 			fprintf(stderr, _("Password field is empty, this is forbidden for super-user.\n"));
 			exit(1);
 		}
@@ -555,7 +556,7 @@ static void check_perms_nopam (const struct passwd *pw)
 	}
 	spwd = getspnam (name); /* !USE_PAM, no need for xgetspnam */
 #ifdef SU_ACCESS
-	if (strcmp (pw->pw_passwd, SHADOW_PASSWD_STRING) == 0) {
+	if (streq(pw->pw_passwd, SHADOW_PASSWD_STRING)) {
 		if (NULL != spwd) {
 			password = spwd->sp_pwdp;
 		}
@@ -792,7 +793,7 @@ save_caller_context(void)
 	 * -- chris
 	 */
 	password = pw->pw_passwd;
-	if (strcmp (pw->pw_passwd, SHADOW_PASSWD_STRING) == 0) {
+	if (streq(pw->pw_passwd, SHADOW_PASSWD_STRING)) {
 		const struct spwd *spwd = getspnam (caller_name);
 		if (NULL != spwd) {
 			password = spwd->sp_pwdp;
@@ -853,7 +854,7 @@ static void process_flags (int argc, char **argv)
 		}
 	}
 
-	if ((optind < argc) && (strcmp (argv[optind], "-") == 0)) {
+	if ((optind < argc) && streq(argv[optind], "-")) {
 		fakelogin = true;
 		optind++;
 	}

--- a/src/suauth.c
+++ b/src/suauth.c
@@ -20,6 +20,7 @@
 #include "prototypes.h"
 #include "string/strchr/stpspn.h"
 #include "string/strchr/strrspn.h"
+#include "string/strcmp/streq.h"
 #include "string/strtok/stpsep.h"
 
 
@@ -104,7 +105,7 @@ int check_su_auth (const char *actual_id,
 			continue;
 		if (!applies (actual_id, from_users))
 			continue;
-		if (!strcmp (action, "DENY")) {
+		if (streq(action, "DENY")) {
 			SYSLOG ((su_to_root ? LOG_WARN : LOG_NOTICE,
 				 "DENIED su from '%s' to '%s' (%s)\n",
 				 actual_id, wanted_id, SUAUTHFILE));
@@ -112,14 +113,14 @@ int check_su_auth (const char *actual_id,
 			       stderr);
 			fclose (authfile_fd);
 			return DENY;
-		} else if (!strcmp (action, "NOPASS")) {
+		} else if (streq(action, "NOPASS")) {
 			SYSLOG ((su_to_root ? LOG_NOTICE : LOG_INFO,
 				 "NO password asked for su from '%s' to '%s' (%s)\n",
 				 actual_id, wanted_id, SUAUTHFILE));
 			fputs (_("Password authentication bypassed.\n"),stderr);
 			fclose (authfile_fd);
 			return NOPWORD;
-		} else if (!strcmp (action, "OWNPASS")) {
+		} else if (streq(action, "OWNPASS")) {
 			SYSLOG ((su_to_root ? LOG_NOTICE : LOG_INFO,
 				 "su from '%s' to '%s': asking for user's own password (%s)\n",
 				 actual_id, wanted_id, SUAUTHFILE));
@@ -147,7 +148,7 @@ static int applies (const char *single, char *list)
 	for (tok = strtok (list, split); tok != NULL;
 	     tok = strtok (NULL, split)) {
 
-		if (!strcmp (tok, "ALL")) {
+		if (streq(tok, "ALL")) {
 			if (state != 0) {
 				SYSLOG ((LOG_ERR,
 					 "%s, line %d: ALL in bad place\n",
@@ -155,7 +156,7 @@ static int applies (const char *single, char *list)
 				return 0;
 			}
 			state = 1;
-		} else if (!strcmp (tok, "EXCEPT")) {
+		} else if (streq(tok, "EXCEPT")) {
 			if (state != 1) {
 				SYSLOG ((LOG_ERR,
 					 "%s, line %d: EXCEPT in bas place\n",
@@ -163,7 +164,7 @@ static int applies (const char *single, char *list)
 				return 0;
 			}
 			state = 2;
-		} else if (!strcmp (tok, "GROUP")) {
+		} else if (streq(tok, "GROUP")) {
 			if ((state != 0) && (state != 2)) {
 				SYSLOG ((LOG_ERR,
 					 "%s, line %d: GROUP in bad place\n",
@@ -174,7 +175,7 @@ static int applies (const char *single, char *list)
 		} else {
 			switch (state) {
 			case 0:	/* No control words yet */
-				if (!strcmp (tok, single))
+				if (streq(tok, single))
 					return 1;
 				break;
 			case 1:	/* An all */
@@ -183,7 +184,7 @@ static int applies (const char *single, char *list)
 					 SUAUTHFILE, lines));
 				return 0;
 			case 2:	/* All except */
-				if (!strcmp (tok, single))
+				if (streq(tok, single))
 					return 0;
 				break;
 			case 3:	/* Group */

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -1413,7 +1413,7 @@ static void process_flags (int argc, char **argv)
 				}
 				if (    '\0' != optarg[0]
 				     && '*'  != optarg[0]
-				     && strcmp(optarg, "/sbin/nologin") != 0
+				     && !streq(optarg, "/sbin/nologin")
 				     && (   stat(optarg, &st) != 0
 				         || S_ISDIR(st.st_mode)
 				         || access(optarg, X_OK) != 0)) {

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -45,7 +45,6 @@
 #include "getdef.h"
 #include "groupio.h"
 #include "nscd.h"
-#include "sssd.h"
 #include "prototypes.h"
 #include "pwauth.h"
 #include "pwio.h"
@@ -64,9 +63,11 @@
 #include "tcbfuncs.h"
 #endif
 #include "shadowlog.h"
+#include "sssd.h"
 #include "string/memset/memzero.h"
 #include "string/sprintf/snprintf.h"
 #include "string/sprintf/xasprintf.h"
+#include "string/strcmp/streq.h"
 #include "string/strdup/xstrdup.h"
 #include "string/strtok/stpsep.h"
 
@@ -370,7 +371,7 @@ get_defaults(void)
 		/*
 		 * Primary GROUP identifier
 		 */
-		if (strcmp(buf, DGROUP) == 0) {
+		if (streq(buf, DGROUP)) {
 			const struct group *grp = prefix_getgr_nam_gid (cp);
 			if (NULL == grp) {
 				fprintf (stderr,
@@ -387,7 +388,7 @@ get_defaults(void)
 
 		ccp = cp;
 
-		if (strcmp(buf, DGROUPS) == 0) {
+		if (streq(buf, DGROUPS)) {
 			if (get_groups (cp) != 0) {
 				fprintf (stderr,
 				         _("%s: the '%s=' configuration in %s has an invalid group, ignoring the bad group\n"),
@@ -401,21 +402,21 @@ get_defaults(void)
 		/*
 		 * Default HOME filesystem
 		 */
-		else if (strcmp(buf, DHOME) == 0) {
+		else if (streq(buf, DHOME)) {
 			def_home = xstrdup(ccp);
 		}
 
 		/*
 		 * Default Login Shell command
 		 */
-		else if (strcmp(buf, DSHELL) == 0) {
+		else if (streq(buf, DSHELL)) {
 			def_shell = xstrdup(ccp);
 		}
 
 		/*
 		 * Default Password Inactive value
 		 */
-		else if (strcmp(buf, DINACT) == 0) {
+		else if (streq(buf, DINACT)) {
 			if (a2sl(&def_inactive, ccp, NULL, 0, -1, LONG_MAX) == -1) {
 				fprintf (stderr,
 				         _("%s: invalid numeric argument '%s'\n"),
@@ -430,14 +431,14 @@ get_defaults(void)
 		/*
 		 * Default account expiration date
 		 */
-		else if (strcmp(buf, DEXPIRE) == 0) {
+		else if (streq(buf, DEXPIRE)) {
 			def_expire = xstrdup(ccp);
 		}
 
 		/*
 		 * Default Skeleton information
 		 */
-		else if (strcmp(buf, DSKEL) == 0) {
+		else if (streq(buf, DSKEL)) {
 			if ('\0' == *ccp)
 				ccp = SKEL_DIR;
 
@@ -454,7 +455,7 @@ get_defaults(void)
 		/*
 		 * Default Usr Skeleton information
 		 */
-		else if (strcmp(buf, DUSRSKEL) == 0) {
+		else if (streq(buf, DUSRSKEL)) {
 			if ('\0' == *ccp)
 				ccp = USRSKELDIR;
 
@@ -470,7 +471,7 @@ get_defaults(void)
 		/*
 		 * Create by default user mail spool or not ?
 		 */
-		else if (strcmp(buf, DCREATE_MAIL_SPOOL) == 0) {
+		else if (streq(buf, DCREATE_MAIL_SPOOL)) {
 			if (*ccp == '\0')
 				ccp = "no";
 
@@ -480,7 +481,7 @@ get_defaults(void)
 		/*
 		 * By default do we add the user to the lastlog and faillog databases ?
 		 */
-		else if (strcmp(buf, DLOG_INIT) == 0) {
+		else if (streq(buf, DLOG_INIT)) {
 			if (*ccp == '\0')
 				ccp = def_log_init;
 
@@ -620,38 +621,38 @@ set_defaults(void)
 		val = stpsep(buf, "=");
 		if (val == NULL) {
 			fprintf(ofp, "%s\n", buf);
-		} else if (!out_group && strcmp(buf, DGROUP) == 0) {
+		} else if (!out_group && streq(buf, DGROUP)) {
 			fprintf(ofp, DGROUP "=%u\n", (unsigned int) def_group);
 			out_group = true;
-		} else if (!out_groups && strcmp(buf, DGROUPS) == 0) {
+		} else if (!out_groups && streq(buf, DGROUPS)) {
 			fprintf(ofp, DGROUPS "=%s\n", def_groups);
 			out_groups = true;
-		} else if (!out_home && strcmp(buf, DHOME) == 0) {
+		} else if (!out_home && streq(buf, DHOME)) {
 			fprintf(ofp, DHOME "=%s\n", def_home);
 			out_home = true;
-		} else if (!out_inactive && strcmp(buf, DINACT) == 0) {
+		} else if (!out_inactive && streq(buf, DINACT)) {
 			fprintf(ofp, DINACT "=%ld\n", def_inactive);
 			out_inactive = true;
-		} else if (!out_expire && strcmp(buf, DEXPIRE) == 0) {
+		} else if (!out_expire && streq(buf, DEXPIRE)) {
 			fprintf(ofp, DEXPIRE "=%s\n", def_expire);
 			out_expire = true;
-		} else if (!out_shell && strcmp(buf, DSHELL) == 0) {
+		} else if (!out_shell && streq(buf, DSHELL)) {
 			fprintf(ofp, DSHELL "=%s\n", def_shell);
 			out_shell = true;
-		} else if (!out_skel && strcmp(buf, DSKEL) == 0) {
+		} else if (!out_skel && streq(buf, DSKEL)) {
 			fprintf(ofp, DSKEL "=%s\n", def_template);
 			out_skel = true;
-		} else if (!out_usrskel && strcmp(buf, DUSRSKEL) == 0) {
+		} else if (!out_usrskel && streq(buf, DUSRSKEL)) {
 			fprintf(ofp, DUSRSKEL "=%s\n", def_usrtemplate);
 			out_usrskel = true;
 		} else if (!out_create_mail_spool
-			   && strcmp(buf, DCREATE_MAIL_SPOOL) == 0)
+			   && streq(buf, DCREATE_MAIL_SPOOL))
 		{
 			fprintf(ofp,
 			        DCREATE_MAIL_SPOOL "=%s\n",
 			        def_create_mail_spool);
 			out_create_mail_spool = true;
-		} else if (!out_log_init && strcmp(buf, DLOG_INIT) == 0) {
+		} else if (!out_log_init && streq(buf, DLOG_INIT)) {
 			fprintf(ofp, DLOG_INIT "=%s\n", def_log_init);
 			out_log_init = true;
 		} else {
@@ -1583,7 +1584,7 @@ static void process_flags (int argc, char **argv)
 	if (!lflg) {
 		/* If we are missing the flag lflg aka -l, check the defaults
 		* file to see if we need to disable it as a default*/
-		if (strcmp (def_log_init, "no") == 0) {
+		if (streq(def_log_init, "no")) {
 			lflg = true;
 		}
 	}

--- a/src/userdel.c
+++ b/src/userdel.c
@@ -52,6 +52,7 @@
 #endif				/* ENABLE_SUBIDS */
 #include "shadowlog.h"
 #include "string/sprintf/xasprintf.h"
+#include "string/strcmp/streq.h"
 #include "string/strdup/xstrdup.h"
 
 
@@ -319,7 +320,7 @@ static void remove_usergroup (void)
 		 */
 		prefix_setpwent ();
 		while ((pwd = prefix_getpwent ()) != NULL) {
-			if (strcmp (pwd->pw_name, user_name) == 0) {
+			if (streq(pwd->pw_name, user_name)) {
 				continue;
 			}
 			if (pwd->pw_gid == grp->gr_gid) {
@@ -1183,7 +1184,7 @@ int main (int argc, char **argv)
 		 */
 		prefix_setpwent ();
 		while ((pwd = prefix_getpwent ())) {
-			if (strcmp (pwd->pw_name, user_name) == 0) {
+			if (streq(pwd->pw_name, user_name)) {
 				continue;
 			}
 			if (path_prefix (user_home, pwd->pw_dir)) {

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -44,7 +44,6 @@
 #include "groupio.h"
 #include "must_be.h"
 #include "nscd.h"
-#include "sssd.h"
 #include "prototypes.h"
 #include "pwauth.h"
 #include "pwio.h"
@@ -62,8 +61,10 @@
 #include "tcbfuncs.h"
 #endif
 #include "shadowlog.h"
+#include "sssd.h"
 #include "string/memset/memzero.h"
 #include "string/sprintf/xasprintf.h"
+#include "string/strcmp/streq.h"
 #include "string/strdup/xstrdup.h"
 #include "time/day_to_str.h"
 
@@ -1373,10 +1374,10 @@ process_flags(int argc, char **argv)
 		gflg = false;
 	}
 	if (   (NULL != user_newshell)
-	    && (strcmp (user_newshell, user_shell) == 0)) {
+	    && streq(user_newshell, user_shell)) {
 		sflg = false;
 	}
-	if (strcmp (user_newname, user_name) == 0) {
+	if (streq(user_newname, user_name)) {
 		lflg = false;
 	}
 	if (user_newinactive == user_inactive) {
@@ -1386,12 +1387,12 @@ process_flags(int argc, char **argv)
 		eflg = false;
 	}
 	if (   (NULL != user_newhome)
-	    && (strcmp (user_newhome, user_home) == 0)) {
+	    && streq(user_newhome, user_home)) {
 		dflg = false;
 		mflg = false;
 	}
 	if (   (NULL != user_newcomment)
-	    && (strcmp (user_newcomment, user_comment) == 0)) {
+	    && streq(user_newcomment, user_comment)) {
 		cflg = false;
 	}
 
@@ -1726,7 +1727,7 @@ static void usr_update (void)
 			spent = *spwd;
 			new_spent (&spent);
 		} else if (   (    pflg
-		               && (strcmp (pwent.pw_passwd, SHADOW_PASSWD_STRING) == 0))
+		               && streq(pwent.pw_passwd, SHADOW_PASSWD_STRING))
 		           || eflg || fflg) {
 			/* In some cases, we force the creation of a
 			 * shadow entry:

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -496,7 +496,7 @@ static void new_pwent (struct passwd *pwent)
 	 * used for this account.
 	 */
 	if (   (!is_shadow_pwd)
-	    || (strcmp (pwent->pw_passwd, SHADOW_PASSWD_STRING) != 0)) {
+	    || !streq(pwent->pw_passwd, SHADOW_PASSWD_STRING)) {
 		pwent->pw_passwd = new_pw_passwd (pwent->pw_passwd);
 	}
 
@@ -1164,7 +1164,7 @@ process_flags(int argc, char **argv)
 				}
 				if (    '\0' != optarg[0]
 				     && '*'  != optarg[0]
-				     && strcmp(optarg, "/sbin/nologin") != 0
+				     && !streq(optarg, "/sbin/nologin")
 				     && (   stat(optarg, &st) != 0
 				         || S_ISDIR(st.st_mode)
 				         || access(optarg, X_OK) != 0)) {

--- a/src/vipw.c
+++ b/src/vipw.c
@@ -31,7 +31,6 @@
 #include "getdef.h"
 #include "groupio.h"
 #include "nscd.h"
-#include "sssd.h"
 #include "prototypes.h"
 #include "pwio.h"
 #include "sgroupio.h"
@@ -43,8 +42,10 @@
 #include "tcbfuncs.h"
 #endif				/* WITH_TCB */
 #include "shadowlog.h"
+#include "sssd.h"
 #include "string/sprintf/snprintf.h"
 #include "string/sprintf/xasprintf.h"
+#include "string/strcmp/streq.h"
 
 
 #define MSG_WARN_EDIT_OTHER_FILE _( \
@@ -471,7 +472,7 @@ int main (int argc, char **argv)
 	bool  editshadow = false;
 	bool  do_vigr;
 
-	do_vigr = (strcmp(Basename(argv[0]), "vigr") == 0);
+	do_vigr = streq(Basename(argv[0]), "vigr");
 
 	Prog = do_vigr ? "vigr" : "vipw";
 	log_set_progname(Prog);


### PR DESCRIPTION
Except for the added (and sorted) includes, and the removal of redundant parentheses, this patch can be approximated with the following semantic patch:

	$ cat ~/tmp/spatch/streq.sp;
	@@
	expression a, b;
	@@

	- strcmp(a, b) == 0
	+ streq(a, b)

	@@
	expression a, b;
	@@

	- 0 == strcmp(a, b)
	+ streq(a, b)

	@@
	expression a, b;
	@@

	- !strcmp(a, b)
	+ streq(a, b)

	$ find contrib/ lib* src/ -type f \
	| xargs spatch --sp-file ~/tmp/spatch/streq.sp --in-place;
	$ git restore lib/string/strcmp/streq.h;

---

Revisions:

<details>
<summary>v2</summary>

-  Use `!streq()` instead of its pattern.

```
$ git range-diff shadow/master gh/streq streq 
1:  10fea159 = 1:  10fea159 contrib/, lib/, src/: Use streq() instead of its pattern
-:  -------- > 2:  985ac5e5 lib/, src/: Use !streq() instead of its pattern
```
</details>