### PR TITLE
CI: avoid cancelling all jobs when one fails

### DIFF
--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -69,6 +69,7 @@ jobs:
   container-build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         os: [alpine, debian, fedora]
 


### PR DESCRIPTION
If a job in a matrix fails we don't want to cancel all jobs, thus we need to set `fail-fast: false` as a strategy property.