### PR TITLE
share/container-build.sh: Fix path

### DIFF
--- a/share/container-build.sh
+++ b/share/container-build.sh
@@ -8,7 +8,7 @@
 #
 
 set -eE
-cd ansible/
+cd share/ansible/
 ansible-playbook playbook.yml -i inventory.ini -e 'distribution=alpine'
 ansible-playbook playbook.yml -i inventory.ini -e 'distribution=debian'
 ansible-playbook playbook.yml -i inventory.ini -e 'distribution=fedora'


### PR DESCRIPTION
The instructions are written so that this script should be run from the root of the repository.  Specify the path from the root of the repo. Before this fix, the command needed to be run from within `<share/>`.