### PR TITLE
lib/: Some improvements to sizes of array parameters

### DIFF
--- a/lib/alloc/malloc.c
+++ b/lib/alloc/malloc.c
@@ -13,4 +13,4 @@
 #include <stddef.h>
 
 
-extern inline void *mallocarray(size_t nmemb, size_t size);
+extern inline void *mallocarray(size_t n, size_t size);

--- a/lib/alloc/malloc.h
+++ b/lib/alloc/malloc.h
@@ -30,13 +30,13 @@
 // mallocarray - malloc array
 ATTR_ALLOC_SIZE(1, 2)
 ATTR_MALLOC(free)
-inline void *mallocarray(size_t nmemb, size_t size);
+inline void *mallocarray(size_t n, size_t size);
 
 
 inline void *
-mallocarray(size_t nmemb, size_t size)
+mallocarray(size_t n, size_t size)
 {
-	return reallocarray(NULL, nmemb, size);
+	return reallocarray(NULL, n, size);
 }
 
 

--- a/lib/alloc/reallocf.c
+++ b/lib/alloc/reallocf.c
@@ -13,4 +13,4 @@
 #include <stddef.h>
 
 
-extern inline void *reallocarrayf(void *p, size_t nmemb, size_t size);
+extern inline void *reallocarrayf(void *p, size_t n, size_t size);

--- a/lib/alloc/reallocf.h
+++ b/lib/alloc/reallocf.h
@@ -29,15 +29,15 @@
 // reallocarrayf - realloc array free-on-error
 ATTR_ALLOC_SIZE(2, 3)
 ATTR_MALLOC(free)
-inline void *reallocarrayf(void *p, size_t nmemb, size_t size);
+inline void *reallocarrayf(void *p, size_t n, size_t size);
 
 
 inline void *
-reallocarrayf(void *p, size_t nmemb, size_t size)
+reallocarrayf(void *p, size_t n, size_t size)
 {
 	void  *q;
 
-	q = reallocarray(p, nmemb ?: 1, size ?: 1);
+	q = reallocarray(p, n ?: 1, size ?: 1);
 
 	if (q == NULL)
 		free(p);

--- a/lib/fs/readlink/readlinknul.c
+++ b/lib/fs/readlink/readlinknul.c
@@ -9,5 +9,5 @@
 #include <sys/types.h>
 
 
-extern inline ssize_t readlinknul(const char *restrict link, char *restrict buf,
-    ssize_t size);
+extern inline ssize_t readlinknul(ssize_t size;
+    const char *restrict link, char buf[restrict size], ssize_t size);

--- a/lib/fs/readlink/readlinknul.h
+++ b/lib/fs/readlink/readlinknul.h
@@ -22,13 +22,14 @@
 
 
 ATTR_STRING(1)
-inline ssize_t readlinknul(const char *restrict link, char *restrict buf,
-    ssize_t size);
+inline ssize_t readlinknul(ssize_t size;
+    const char *restrict link, char buf[restrict size], ssize_t size);
 
 
 // readlinknul - read link nul-terminate
 inline ssize_t
-readlinknul(const char *restrict link, char *restrict buf, ssize_t size)
+readlinknul(ssize_t size;
+    const char *restrict link, char buf[restrict size], ssize_t size)
 {
 	ssize_t  len;
 

--- a/lib/string/sprintf/seprintf.c
+++ b/lib/string/sprintf/seprintf.c
@@ -10,8 +10,8 @@
 
 
 #if !defined(HAVE_SEPRINTF)
-extern inline char *seprintf(char *dst, const char *end,
-    const char *restrict fmt, ...);
-extern inline char *vseprintf(char *dst, const char *end,
-    const char *restrict fmt, va_list ap);
+extern inline char *seprintf(char dst[], const char end[];
+    char dst[dst?end-dst:0], const char end[0], const char *restrict fmt, ...);
+extern inline char *vseprintf(char dst[], const char end[];
+    char dst[dst?end-dst:0], const char end[0], const char *restrict fmt, va_list ap);
 #endif

--- a/lib/string/sprintf/seprintf.h
+++ b/lib/string/sprintf/seprintf.h
@@ -18,18 +18,19 @@
 #if !defined(HAVE_SEPRINTF)
 // seprintf - string end-pointer print formatted
 format_attr(printf, 3, 4)
-inline char *seprintf(char *dst, const char *end, const char *restrict fmt,
-    ...);
+inline char *seprintf(char dst[], const char end[];
+    char dst[dst?end-dst:0], const char end[0], const char *restrict fmt, ...);
 // vseprintf - va_list string end-pointer print formatted
 format_attr(printf, 3, 0)
-inline char *vseprintf(char *dst, const char *end, const char *restrict fmt,
-    va_list ap);
+inline char *vseprintf(char dst[], const char end[];
+    char dst[dst?end-dst:0], const char end[0], const char *restrict fmt, va_list ap);
 #endif
 
 
 #if !defined(HAVE_SEPRINTF)
 inline char *
-seprintf(char *dst, const char *end, const char *restrict fmt, ...)
+seprintf(char dst[], const char end[];
+    char dst[dst?end-dst:0], const char end[0], const char *restrict fmt, ...)
 {
 	char     *p;
 	va_list  ap;
@@ -45,7 +46,8 @@ seprintf(char *dst, const char *end, const char *restrict fmt, ...)
 
 #if !defined(HAVE_SEPRINTF)
 inline char *
-vseprintf(char *dst, const char *end, const char *restrict fmt, va_list ap)
+vseprintf(char dst[], const char end[];
+    char dst[dst?end-dst:0], const char end[0], const char *restrict fmt, va_list ap)
 {
 	int        len;
 	ptrdiff_t  size;

--- a/lib/string/sprintf/stprintf.c
+++ b/lib/string/sprintf/stprintf.c
@@ -10,7 +10,7 @@
 #include <sys/types.h>
 
 
-extern inline int stprintf(char *restrict s, ssize_t size,
-    const char *restrict fmt, ...);
-extern inline int vstprintf(char *restrict s, ssize_t size,
-    const char *restrict fmt, va_list ap);
+extern inline int stprintf(ssize_t size;
+    char s[restrict size], ssize_t size, const char *restrict fmt, ...);
+extern inline int vstprintf(ssize_t size;
+    char s[restrict size], ssize_t size, const char *restrict fmt, va_list ap);

--- a/lib/string/sprintf/stprintf.h
+++ b/lib/string/sprintf/stprintf.h
@@ -27,16 +27,17 @@
 
 // stprintf - string truncate print formatted
 format_attr(printf, 3, 4)
-inline int stprintf(char *restrict s, ssize_t size,
-    const char *restrict fmt, ...);
+inline int stprintf(ssize_t size;
+    char s[restrict size], ssize_t size, const char *restrict fmt, ...);
 // vstprintf - va_list string truncate print formatted
 format_attr(printf, 3, 0)
-inline int vstprintf(char *restrict s, ssize_t size,
-    const char *restrict fmt, va_list ap);
+inline int vstprintf(ssize_t size;
+    char s[restrict size], ssize_t size, const char *restrict fmt, va_list ap);
 
 
 inline int
-stprintf(char *restrict s, ssize_t size, const char *restrict fmt, ...)
+stprintf(ssize_t size;
+    char s[restrict size], ssize_t size, const char *restrict fmt, ...)
 {
 	int      len;
 	va_list  ap;
@@ -50,7 +51,8 @@ stprintf(char *restrict s, ssize_t size, const char *restrict fmt, ...)
 
 
 inline int
-vstprintf(char *restrict s, ssize_t size, const char *restrict fmt, va_list ap)
+vstprintf(ssize_t size;
+    char s[restrict size], ssize_t size, const char *restrict fmt, va_list ap)
 {
 	int  len;
 

--- a/lib/string/strcpy/stpecpy.c
+++ b/lib/string/strcpy/stpecpy.c
@@ -8,6 +8,6 @@
 
 
 #if !defined(HAVE_STPECPY)
-extern inline char *stpecpy(char *dst, const char *end,
-    const char *restrict src);
+extern inline char *stpecpy(char dst[], const char end[];
+    char dst[dst ? end - dst : 0], const char end[0], const char *restrict src);
 #endif

--- a/lib/string/strcpy/stpecpy.h
+++ b/lib/string/strcpy/stpecpy.h
@@ -20,13 +20,15 @@
 #if !defined(HAVE_STPECPY)
 // stpecpy - string offset-pointer end-pointer copy
 ATTR_STRING(3)
-inline char *stpecpy(char *dst, const char *end, const char *restrict src);
+inline char *stpecpy(char dst[], const char end[];
+    char dst[dst ? end - dst : 0], const char end[0], const char *restrict src);
 #endif
 
 
 #if !defined(HAVE_STPECPY)
 inline char *
-stpecpy(char *dst, const char *end, const char *restrict src)
+stpecpy(char dst[], const char end[];
+    char dst[dst ? end - dst : 0], const char end[0], const char *restrict src)
 {
 	ssize_t  dlen;
 

--- a/lib/string/strcpy/strtcpy.c
+++ b/lib/string/strcpy/strtcpy.c
@@ -10,5 +10,5 @@
 #include "string/strcpy/strtcpy.h"
 
 
-extern inline ssize_t strtcpy(char *restrict dst, const char *restrict src,
-    size_t dsize);
+extern inline ssize_t strtcpy(size_t dsize;
+    char dst[restrict dsize], const char *restrict src, size_t dsize);

--- a/lib/string/strcpy/strtcpy.h
+++ b/lib/string/strcpy/strtcpy.h
@@ -24,13 +24,14 @@
 
 
 ATTR_STRING(2)
-inline ssize_t strtcpy(char *restrict dst, const char *restrict src,
-    size_t dsize);
+inline ssize_t strtcpy(size_t dsize;
+    char dst[restrict dsize], const char *restrict src, size_t dsize);
 
 
 // strtcpy - string truncate copy
 inline ssize_t
-strtcpy(char *restrict dst, const char *restrict src, size_t dsize)
+strtcpy(size_t dsize;
+    char dst[restrict dsize], const char *restrict src, size_t dsize)
 {
 	bool    trunc;
 	size_t  dlen, slen;


### PR DESCRIPTION
The first commit is just readability stuff, but the second one is an important safety improvement.

Cc: @uecker, @kees

---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git range-diff master..gh/arrayparam shadow/master..arrayparam 
1:  208d2461 = 1:  21a2e3d7 lib/alloc/: Compact parameter names
2:  6652239e = 2:  74c8c193 lib/string/: Use array notation with forward declarations
```
</details>

<details>
<summary>v1c</summary>

-  Rebase

```
$ git range-diff master..gh/arrayparam shadow/master..arrayparam 
1:  21a2e3d7 = 1:  c6b33e71 lib/alloc/: Compact parameter names
2:  74c8c193 = 2:  108e00b2 lib/string/: Use array notation with forward declarations
```
</details>

<details>
<summary>v1d</summary>

-  Rebase

```
$ git range-diff master..gh/arrayparam shadow/master..arrayparam 
1:  c6b33e71 = 1:  ec3e7478 lib/alloc/: Compact parameter names
2:  108e00b2 = 2:  839aa80e lib/string/: Use array notation with forward declarations
```
</details>

<details>
<summary>v1e</summary>

-  Rebase

```
$ git range-diff master..gh/arrayparam shadow/master..arrayparam 
1:  ec3e7478 = 1:  ed3d9a60 lib/alloc/: Compact parameter names
2:  839aa80e = 2:  fea5bcf1 lib/string/: Use array notation with forward declarations
```
</details>

<details>
<summary>v1f</summary>

-  Rebase

```
$ git range-diff master..gh/arrayparam shadow/master..arrayparam 
1:  ed3d9a60 = 1:  639a287d lib/alloc/: Compact parameter names
2:  fea5bcf1 = 2:  40bd9363 lib/string/: Use array notation with forward declarations
```
</details>

<details>
<summary>v1g</summary>

-  Rebase

```
$ git range-diff alx/master..gh/arrayparam master..arrayparam 
1:  639a287d = 1:  b20779a4 lib/alloc/: Compact parameter names
2:  40bd9363 = 2:  91af1e44 lib/string/: Use array notation with forward declarations
```
</details>

<details>
<summary>v1h</summary>

-  Rebase

```
$ git range-diff alx/master..gh/arrayparam master..arrayparam 
1:  b20779a4 = 1:  3c3052ad lib/alloc/: Compact parameter names
2:  91af1e44 = 2:  133e9cca lib/string/: Use array notation with forward declarations
```
</details>

<details>
<summary>v1i</summary>

-  Rebase

```
$ git range-diff master..gh/arrayparam shadow/master..arrayparam 
1:  3c3052ad = 1:  a03c31a6 lib/alloc/: Compact parameter names
2:  133e9cca = 2:  b0589f79 lib/string/: Use array notation with forward declarations
```
</details>

<details>
<summary>v1j</summary>

-  Rebase

```
$ git range-diff master..gh/arrayparam shadow/master..arrayparam 
1:  a03c31a6 = 1:  e6ba045f lib/alloc/: Compact parameter names
2:  b0589f79 = 2:  087d85ed lib/string/: Use array notation with forward declarations
```
</details>

<details>
<summary>v2</summary>

-  Do the same for lib/fs/

```
$ git range-diff master gh/arrayparam arrayparam 
1:  e6ba045f = 1:  e6ba045f lib/alloc/: Compact parameter names
2:  087d85ed = 2:  087d85ed lib/string/: Use array notation with forward declarations
-:  -------- > 3:  ee6ce25e lib/fs/: Use array notation with forward declarations
```
</details>

<details>
<summary>v2b</summary>

-  Rebase

```
$ git range-diff master..gh/arrayparam shadow/master..arrayparam 
1:  e6ba045f = 1:  9d17ed47 lib/alloc/: Compact parameter names
2:  087d85ed = 2:  4f70f9f4 lib/string/: Use array notation with forward declarations
3:  ee6ce25e = 3:  b9be41f3 lib/fs/: Use array notation with forward declarations
```
</details>

<details>
<summary>v2c</summary>

-  Rebase

```
$ git range-diff master..gh/arrayparam shadow/master..arrayparam 
1:  9d17ed47 = 1:  49c27768 lib/alloc/: Compact parameter names
2:  4f70f9f4 = 2:  c0ac4db5 lib/string/: Use array notation with forward declarations
3:  b9be41f3 = 3:  94a72033 lib/fs/: Use array notation with forward declarations
```
</details>

<details>
<summary>v2d</summary>

-  Rebase

```
$ git range-diff master..gh/arrayparam shadow/master..arrayparam 
1:  49c27768 = 1:  06655043 lib/alloc/: Compact parameter names
2:  c0ac4db5 = 2:  69290f14 lib/string/: Use array notation with forward declarations
3:  94a72033 = 3:  34c2c098 lib/fs/: Use array notation with forward declarations
```
</details>

<details>
<summary>v2e</summary>

-  Rebase

```
$ git range-diff --creation-factor=99 master..gh/arrayparam shadow/master..arrayparam 
1:  06655043 = 1:  fa543f1f lib/alloc/: Compact parameter names
2:  69290f14 = 2:  8eb8ff29 lib/string/: Use array notation with forward declarations
3:  34c2c098 ! 3:  dc7167fd lib/fs/: Use array notation with forward declarations
    @@ lib/fs/readlink/readlinknul.c
      
      
     -extern inline ssize_t readlinknul(const char *restrict link, char *restrict buf,
    --    size_t size);
    +-    ssize_t size);
     +extern inline ssize_t readlinknul(size_t size;
    -+    const char *restrict link, char buf[restrict size], size_t size);
    ++    const char *restrict link, char buf[restrict size], ssize_t size);
     
      ## lib/fs/readlink/readlinknul.h ##
     @@
    @@ lib/fs/readlink/readlinknul.h
      
      ATTR_STRING(1)
     -inline ssize_t readlinknul(const char *restrict link, char *restrict buf,
    --    size_t size);
    +-    ssize_t size);
     +inline ssize_t readlinknul(size_t size;
    -+    const char *restrict link, char buf[restrict size], size_t size);
    ++    const char *restrict link, char buf[restrict size], ssize_t size);
      
      
      // Similar to readlink(2), but terminate the string.
      inline ssize_t
    --readlinknul(const char *restrict link, char *restrict buf, size_t size)
    +-readlinknul(const char *restrict link, char *restrict buf, ssize_t size)
     +readlinknul(size_t size;
    -+    const char *restrict link, char buf[restrict size], size_t size)
    ++    const char *restrict link, char buf[restrict size], ssize_t size)
      {
    -   size_t   ulen;
    -   ssize_t  slen;
    +   ssize_t  len;
    + 
```
</details>

<details>
<summary>v2f</summary>

-  Rebase

```
$ git rd
1:  fa543f1f = 1:  41ad41c9 lib/alloc/: Compact parameter names
2:  8eb8ff29 = 2:  838dfa21 lib/string/: Use array notation with forward declarations
3:  dc7167fd = 3:  0926e791 lib/fs/: Use array notation with forward declarations
```
</details>

<details>
<summary>v2g</summary>

-  Rebase

```
$ git rd 
1:  41ad41c9 = 1:  8486d3ec lib/alloc/: Compact parameter names
2:  838dfa21 = 2:  10f33fe8 lib/string/: Use array notation with forward declarations
3:  0926e791 = 3:  31afd7d2 lib/fs/: Use array notation with forward declarations
```
</details>

<details>
<summary>v2h</summary>

-  Rebase

```
$ git rd
1:  8486d3ec = 1:  0ebe7f5d lib/alloc/: Compact parameter names
2:  10f33fe8 = 2:  5a3fbce8 lib/string/: Use array notation with forward declarations
3:  31afd7d2 = 3:  ad533df9 lib/fs/: Use array notation with forward declarations
```
</details>

<details>
<summary>v2i</summary>

-  Rebase

```
$ git rd
1:  0ebe7f5d = 1:  d1cafe3e lib/alloc/: Compact parameter names
2:  5a3fbce8 = 2:  f1c50dbc lib/string/: Use array notation with forward declarations
3:  ad533df9 = 3:  c6238539 lib/fs/: Use array notation with forward declarations
```
</details>

<details>
<summary>v2j</summary>

-  Rebase

```
$ git rd
1:  d1cafe3e = 1:  9d30db42 lib/alloc/: Compact parameter names
2:  f1c50dbc = 2:  ee4d94bd lib/string/: Use array notation with forward declarations
3:  c6238539 = 3:  10dad35a lib/fs/: Use array notation with forward declarations
```
</details>

<details>
<summary>v2k</summary>

-  Rebase

```
$ git rd 
1:  9d30db42 = 1:  7c1162ed lib/alloc/: Compact parameter names
2:  ee4d94bd = 2:  d30cea9e lib/string/: Use array notation with forward declarations
3:  10dad35a = 3:  88778fd6 lib/fs/: Use array notation with forward declarations
```
</details>

<details>
<summary>v2l</summary>

-  Rebase

```
$ git rd 
1:  7c1162ed = 1:  1467c1e0 lib/alloc/: Compact parameter names
2:  d30cea9e = 2:  24f6dc33 lib/string/: Use array notation with forward declarations
3:  88778fd6 = 3:  d2a0110a lib/fs/: Use array notation with forward declarations
```
</details>

<details>
<summary>v2m</summary>

-  Rebase

```
$ git rd
1:  1467c1e0 = 1:  3fe155d3 lib/alloc/: Compact parameter names
2:  24f6dc33 = 2:  fcca9ef8 lib/string/: Use array notation with forward declarations
3:  d2a0110a = 3:  6ec4643d lib/fs/: Use array notation with forward declarations
```
</details>

<details>
<summary>v2n</summary>

-  Rebase

```
$ git rd 
1:  3fe155d3 = 1:  02149ac1 lib/alloc/: Compact parameter names
2:  fcca9ef8 = 2:  25cd50d6 lib/string/: Use array notation with forward declarations
3:  6ec4643d = 3:  04a53ba1 lib/fs/: Use array notation with forward declarations
```
</details>

<details>
<summary>v3</summary>

-  Update type of forward-declared parameter after some changes in master.

```
$ git rd 
1:  810601e5 ! 1:  32f13c9c lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/, src/: Use str[n]cmp(3) instead of explicit byte comparisons
    +    lib/, src/: Use strncmp(3) instead of explicit byte comparisons
     
         This is simpler to read, IMO.
     
    @@ lib/utmp.c: active_sessions_count(const char *name, unsigned long limit)
                        continue;
                }
     -          if ('\0' == ut->ut_user[0]) {
    -+          if (strncmp(ut->ut_user, "", NITEMS(ut->ut_user)) == 0)
    ++          if (strncmp(ut->ut_user, "", countof(ut->ut_user)) == 0)
                        continue;
     -          }
     -          if (strncmp (name, ut->ut_user, sizeof (ut->ut_user)) != 0) {
     +
    -+          if (strncmp(ut->ut_user, name, NITEMS(ut->ut_user)) != 0)
    ++          if (strncmp(ut->ut_user, name, countof(ut->ut_user)) != 0)
                        continue;
     -          }
     +
    @@ src/logoutd.c: main(int argc, char **argv)
                                continue;
                        }
     -                  if (ut->ut_user[0] == '\0') {
    -+                  if (strncmp(ut->ut_user, "", NITEMS(ut->ut_user)) == 0)
    ++                  if (strncmp(ut->ut_user, "", countof(ut->ut_user)) == 0)
                                continue;
     -                  }
     +
2:  044bfd89 = 2:  4a514b51 contrib/, lib/, src/: Use consistent style using strchr(3) in conditionals
```
</details>

<details>
<summary>v3b</summary>

-  Rebase

```
$ git rd 
1:  02149ac1 = 1:  31a131bf lib/alloc/: Compact parameter names
2:  25cd50d6 = 2:  46a7afa8 lib/string/: Use array notation with forward declarations
3:  254206e3 = 3:  69d4db2c lib/fs/: Use array notation with forward declarations
```
</details>

<details>
<summary>v3c</summary>

-  Rebase

```
$ git rd 
1:  31a131bf = 1:  b74695b7 lib/alloc/: Compact parameter names
2:  46a7afa8 = 2:  a7d939fc lib/string/: Use array notation with forward declarations
3:  69d4db2c = 3:  1b6eedcb lib/fs/: Use array notation with forward declarations
```
</details>

<details>
<summary>v3d</summary>

-  Rebase

```
$ git rd 
1:  b74695b7 = 1:  1f06623e lib/alloc/: Compact parameter names
2:  a7d939fc = 2:  6da03ac1 lib/string/: Use array notation with forward declarations
3:  1b6eedcb = 3:  26dd4aeb lib/fs/: Use array notation with forward declarations
```
</details>

<details>
<summary>v4</summary>

-  Use array notation in stpecpy() and [v]stpeprintf().

```
$ git range-diff master gh/arrayparam arrayparam 
1:  1f06623e = 1:  1f06623e lib/alloc/: Compact parameter names
2:  6da03ac1 = 2:  6da03ac1 lib/string/: Use array notation with forward declarations
3:  26dd4aeb = 3:  26dd4aeb lib/fs/: Use array notation with forward declarations
-:  -------- > 4:  ba4ee389 lib/string/: Use array notation with forward declarations
```
</details>

<details>
<summary>v4b</summary>

-  wfix

```
$ git range-diff master gh/arrayparam arrayparam 
1:  1f06623e = 1:  1f06623e lib/alloc/: Compact parameter names
2:  6da03ac1 = 2:  6da03ac1 lib/string/: Use array notation with forward declarations
3:  26dd4aeb = 3:  26dd4aeb lib/fs/: Use array notation with forward declarations
4:  ba4ee389 ! 4:  76a7a61d lib/string/: Use array notation with forward declarations
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/string/: Use array notation with forward declarations
    +    lib/string/: stpe*(): Use array notation with forward declarations
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
```
</details>

<details>
<summary>v4c</summary>

-  Rebase

```
$ git rd 
1:  1f06623e = 1:  ec0639ac lib/alloc/: Compact parameter names
2:  6da03ac1 = 2:  de49e9ba lib/string/: Use array notation with forward declarations
3:  26dd4aeb = 3:  64e70dd9 lib/fs/: Use array notation with forward declarations
4:  76a7a61d = 4:  37e3e7b3 lib/string/: stpe*(): Use array notation with forward declarations
```
</details>

<details>
<summary>v5</summary>

-  Be careful with NULL.

```
$ git rd 
1:  ec0639ac = 1:  ec0639ac lib/alloc/: Compact parameter names
2:  de49e9ba = 2:  de49e9ba lib/string/: Use array notation with forward declarations
3:  64e70dd9 = 3:  64e70dd9 lib/fs/: Use array notation with forward declarations
4:  37e3e7b3 ! 4:  e23d3d18 lib/string/: stpe*(): Use array notation with forward declarations
    @@ lib/string/sprintf/stpeprintf.c
     -extern inline char *vstpeprintf(char *dst, char *end, const char *restrict fmt,
     -    va_list ap);
     +extern inline char *stpeprintf(char *dst, char *end;
    -+    char dst[end - dst], char end[0], const char *restrict fmt, ...);
    ++    char dst[dst ? end - dst : 0], char end[0], const char *restrict fmt, ...);
     +extern inline char *vstpeprintf(char *dst, char *end;
    -+    char dst[end - dst], char end[0], const char *restrict fmt, va_list ap);
    ++    char dst[dst ? end - dst : 0], char end[0], const char *restrict fmt, va_list ap);
      #endif
     
      ## lib/string/sprintf/stpeprintf.h ##
    @@ lib/string/sprintf/stpeprintf.h
      format_attr(printf, 3, 4)
     -inline char *stpeprintf(char *dst, char *end, const char *restrict fmt, ...);
     +inline char *stpeprintf(char *dst, char *end;
    -+    char dst[end - dst], char end[0], const char *restrict fmt, ...);
    ++    char dst[dst ? end - dst : 0], char end[0], const char *restrict fmt, ...);
      format_attr(printf, 3, 0)
     -inline char *vstpeprintf(char *dst, char *end, const char *restrict fmt,
     -    va_list ap);
     +inline char *vstpeprintf(char *dst, char *end;
    -+    char dst[end - dst], char end[0], const char *restrict fmt, va_list ap);
    ++    char dst[dst ? end - dst : 0], char end[0], const char *restrict fmt, va_list ap);
      #endif
      
      
    @@ lib/string/sprintf/stpeprintf.h: inline char *vstpeprintf(char *dst, char *end,
      inline char *
     -stpeprintf(char *dst, char *end, const char *restrict fmt, ...)
     +stpeprintf(char *dst, char *end;
    -+    char dst[end - dst], char end[0], const char *restrict fmt, ...)
    ++    char dst[dst ? end - dst : 0], char end[0], const char *restrict fmt, ...)
      {
        char     *p;
        va_list  ap;
    @@ lib/string/sprintf/stpeprintf.h: stpeprintf(char *dst, char *end, const char *re
      inline char *
     -vstpeprintf(char *dst, char *end, const char *restrict fmt, va_list ap)
     +vstpeprintf(char *dst, char *end;
    -+    char dst[end - dst], char end[0], const char *restrict fmt, va_list ap)
    ++    char dst[dst ? end - dst : 0], char end[0], const char *restrict fmt, va_list ap)
      {
        int        len;
        ptrdiff_t  size;
    @@ lib/string/strcpy/stpecpy.c
      #if !defined(HAVE_STPECPY)
     -extern inline char *stpecpy(char *dst, char *end, const char *restrict src);
     +extern inline char *stpecpy(char *dst, char *end;
    -+    char dst[end - dst], char end[0], const char *restrict src);
    ++    char dst[dst ? end - dst : 0], char end[0], const char *restrict src);
      #endif
     
      ## lib/string/strcpy/stpecpy.h ##
    @@ lib/string/strcpy/stpecpy.h
      ATTR_STRING(3)
     -inline char *stpecpy(char *dst, char *end, const char *restrict src);
     +inline char *stpecpy(char *dst, char *end;
    -+    char dst[end - dst], char end[0], const char *restrict src);
    ++    char dst[dst ? end - dst : 0], char end[0], const char *restrict src);
      #endif
      
      
    @@ lib/string/strcpy/stpecpy.h: inline char *stpecpy(char *dst, char *end, const ch
      inline char *
     -stpecpy(char *dst, char *end, const char *restrict src)
     +stpecpy(char *dst, char *end;
    -+    char dst[end - dst], char end[0], const char *restrict src)
    ++    char dst[dst ? end - dst : 0], char end[0], const char *restrict src)
      {
        bool    trunc;
        size_t  dsize, dlen, slen;
```
</details>

<details>
<summary>v6</summary>

-  Use array notation consistently.

```
$ git rd 
1:  ec0639ac = 1:  ec0639ac lib/alloc/: Compact parameter names
2:  de49e9ba = 2:  de49e9ba lib/string/: Use array notation with forward declarations
3:  64e70dd9 = 3:  64e70dd9 lib/fs/: Use array notation with forward declarations
4:  e23d3d18 ! 4:  7f953953 lib/string/: stpe*(): Use array notation with forward declarations
    @@ lib/string/sprintf/stpeprintf.c
     -    ...);
     -extern inline char *vstpeprintf(char *dst, char *end, const char *restrict fmt,
     -    va_list ap);
    -+extern inline char *stpeprintf(char *dst, char *end;
    ++extern inline char *stpeprintf(char dst[], char end[];
     +    char dst[dst ? end - dst : 0], char end[0], const char *restrict fmt, ...);
    -+extern inline char *vstpeprintf(char *dst, char *end;
    ++extern inline char *vstpeprintf(char dst[], char end[];
     +    char dst[dst ? end - dst : 0], char end[0], const char *restrict fmt, va_list ap);
      #endif
     
    @@ lib/string/sprintf/stpeprintf.h
      #if !defined(HAVE_STPEPRINTF)
      format_attr(printf, 3, 4)
     -inline char *stpeprintf(char *dst, char *end, const char *restrict fmt, ...);
    -+inline char *stpeprintf(char *dst, char *end;
    ++inline char *stpeprintf(char dst[], char end[];
     +    char dst[dst ? end - dst : 0], char end[0], const char *restrict fmt, ...);
      format_attr(printf, 3, 0)
     -inline char *vstpeprintf(char *dst, char *end, const char *restrict fmt,
     -    va_list ap);
    -+inline char *vstpeprintf(char *dst, char *end;
    ++inline char *vstpeprintf(char dst[], char end[];
     +    char dst[dst ? end - dst : 0], char end[0], const char *restrict fmt, va_list ap);
      #endif
      
    @@ lib/string/sprintf/stpeprintf.h: inline char *vstpeprintf(char *dst, char *end,
      #if !defined(HAVE_STPEPRINTF)
      inline char *
     -stpeprintf(char *dst, char *end, const char *restrict fmt, ...)
    -+stpeprintf(char *dst, char *end;
    ++stpeprintf(char dst[], char end[];
     +    char dst[dst ? end - dst : 0], char end[0], const char *restrict fmt, ...)
      {
        char     *p;
    @@ lib/string/sprintf/stpeprintf.h: stpeprintf(char *dst, char *end, const char *re
      #if !defined(HAVE_STPEPRINTF)
      inline char *
     -vstpeprintf(char *dst, char *end, const char *restrict fmt, va_list ap)
    -+vstpeprintf(char *dst, char *end;
    ++vstpeprintf(char dst[], char end[];
     +    char dst[dst ? end - dst : 0], char end[0], const char *restrict fmt, va_list ap)
      {
        int        len;
    @@ lib/string/strcpy/stpecpy.c
      
      #if !defined(HAVE_STPECPY)
     -extern inline char *stpecpy(char *dst, char *end, const char *restrict src);
    -+extern inline char *stpecpy(char *dst, char *end;
    ++extern inline char *stpecpy(char dst[], char end[];
     +    char dst[dst ? end - dst : 0], char end[0], const char *restrict src);
      #endif
     
    @@ lib/string/strcpy/stpecpy.h
      #if !defined(HAVE_STPECPY)
      ATTR_STRING(3)
     -inline char *stpecpy(char *dst, char *end, const char *restrict src);
    -+inline char *stpecpy(char *dst, char *end;
    ++inline char *stpecpy(char dst[], char end[];
     +    char dst[dst ? end - dst : 0], char end[0], const char *restrict src);
      #endif
      
    @@ lib/string/strcpy/stpecpy.h: inline char *stpecpy(char *dst, char *end, const ch
      #if !defined(HAVE_STPECPY)
      inline char *
     -stpecpy(char *dst, char *end, const char *restrict src)
    -+stpecpy(char *dst, char *end;
    ++stpecpy(char dst[], char end[];
     +    char dst[dst ? end - dst : 0], char end[0], const char *restrict src)
      {
        bool    trunc;
```
</details>


<details>
<summary>v6b</summary>

-  Rebase

```
$ git rd 
1:  ec0639ac = 1:  a58b4d82 lib/alloc/: Compact parameter names
2:  de49e9ba = 2:  55c315cd lib/string/: Use array notation with forward declarations
3:  64e70dd9 = 3:  8f7cc9c8 lib/fs/: Use array notation with forward declarations
4:  7f953953 = 4:  9c468a5f lib/string/: stpe*(): Use array notation with forward declarations
```
</details>

<details>
<summary>v6c</summary>

-  Rebase

```
$ git rd 
1:  a58b4d82 = 1:  acab2961 lib/alloc/: Compact parameter names
2:  55c315cd = 2:  fb5ce090 lib/string/: Use array notation with forward declarations
3:  8f7cc9c8 = 3:  dd5e7720 lib/fs/: Use array notation with forward declarations
4:  9c468a5f = 4:  daf25218 lib/string/: stpe*(): Use array notation with forward declarations
```
</details>

<details>
<summary>v6d</summary>

-  Rebase

```
$ git rd 
1:  acab2961 = 1:  dc6bde34 lib/alloc/: Compact parameter names
2:  fb5ce090 = 2:  c728f52b lib/string/: Use array notation with forward declarations
3:  dd5e7720 = 3:  29665517 lib/fs/: Use array notation with forward declarations
4:  daf25218 = 4:  79d59a11 lib/string/: stpe*(): Use array notation with forward declarations
```
</details>

<details>
<summary>v6e</summary>

-  Rebase

```
$ git rd 
1:  dc6bde34 = 1:  a4a0e87a lib/alloc/: Compact parameter names
2:  c728f52b = 2:  89f63c96 lib/string/: Use array notation with forward declarations
3:  29665517 = 3:  11e40ee2 lib/fs/: Use array notation with forward declarations
4:  79d59a11 = 4:  bc4d8154 lib/string/: stpe*(): Use array notation with forward declarations
```
</details>

<details>
<summary>v6f</summary>

-  Rebase

```
$ git rd 
1:  a4a0e87a ! 1:  030f205f lib/alloc/: Compact parameter names
    @@ lib/alloc/reallocf.h
      
        if (q == NULL)
                free(p);
    -
    - ## lib/alloc/x/xcalloc.c ##
    -@@
    - 
    - 
    - void *
    --xcalloc(size_t nmemb, size_t size)
    -+xcalloc(size_t n, size_t size)
    - {
    -   void  *p;
    - 
    --  p = calloc(nmemb, size);
    -+  p = calloc(n, size);
    -   if (p == NULL)
    -           goto x;
    - 
    -
    - ## lib/alloc/x/xcalloc.h ##
    -@@
    - 
    - ATTR_ALLOC_SIZE(1, 2)
    - ATTR_MALLOC(free)
    --void *xcalloc(size_t nmemb, size_t size);
    -+void *xcalloc(size_t n, size_t size);
    - 
    - 
    - #endif  // include guard
    -
    - ## lib/alloc/x/xmalloc.c ##
    -@@
    - #include <stddef.h>
    - 
    - 
    --extern inline void *xmallocarray(size_t nmemb, size_t size);
    -+extern inline void *xmallocarray(size_t n, size_t size);
    -
    - ## lib/alloc/x/xmalloc.h ##
    -@@
    - 
    - ATTR_ALLOC_SIZE(1, 2)
    - ATTR_MALLOC(free)
    --inline void *xmallocarray(size_t nmemb, size_t size);
    -+inline void *xmallocarray(size_t n, size_t size);
    - 
    - 
    - inline void *
    --xmallocarray(size_t nmemb, size_t size)
    -+xmallocarray(size_t n, size_t size)
    - {
    --  return xreallocarray(NULL, nmemb, size);
    -+  return xreallocarray(NULL, n, size);
    - }
    - 
    - 
    -
    - ## lib/alloc/x/xrealloc.c ##
    -@@
    - 
    - 
    - void *
    --xreallocarray(void *p, size_t nmemb, size_t size)
    -+xreallocarray(void *p, size_t n, size_t size)
    - {
    --  p = reallocarrayf(p, nmemb, size);
    -+  p = reallocarrayf(p, n, size);
    -   if (p == NULL)
    -           goto x;
    - 
    -
    - ## lib/alloc/x/xrealloc.h ##
    -@@
    - 
    - ATTR_ALLOC_SIZE(2, 3)
    - ATTR_MALLOC(free)
    --void *xreallocarray(void *p, size_t nmemb, size_t size);
    -+void *xreallocarray(void *p, size_t n, size_t size);
    - 
    - 
    - #endif  // include guard
2:  89f63c96 = 2:  24cec0c0 lib/string/: Use array notation with forward declarations
3:  11e40ee2 = 3:  1134b8be lib/fs/: Use array notation with forward declarations
4:  bc4d8154 = 4:  747d09c8 lib/string/: stpe*(): Use array notation with forward declarations
```
</details>

<details>
<summary>v6g</summary>

-  Rebase

```
$ git rd 
1:  030f205f1 = 1:  e2d45e9df lib/alloc/: Compact parameter names
2:  24cec0c04 = 2:  a564c8c54 lib/string/: Use array notation with forward declarations
3:  1134b8be9 = 3:  77df07f81 lib/fs/: Use array notation with forward declarations
4:  747d09c86 = 4:  34b5d026f lib/string/: stpe*(): Use array notation with forward declarations
```
</details>

<details>
<summary>v6h</summary>

-  Rebase

```
$ git rd 
1:  e2d45e9df = 1:  99b3e6d84 lib/alloc/: Compact parameter names
2:  a564c8c54 ! 2:  5ae3597e6 lib/string/: Use array notation with forward declarations
    @@ lib/string/strcpy/strtcpy.h
     +    char dst[restrict dsize], const char *restrict src, size_t dsize);
      
      
    + // strtcpy - string truncate copy
      inline ssize_t
     -strtcpy(char *restrict dst, const char *restrict src, size_t dsize)
     +strtcpy(size_t dsize;
3:  77df07f81 ! 3:  e06bad150 lib/fs/: Use array notation with forward declarations
    @@ lib/fs/readlink/readlinknul.h
     +    const char *restrict link, char buf[restrict size], ssize_t size);
      
      
    - // Similar to readlink(2), but terminate the string.
    + // readlinknul - read link nul-terminate
      inline ssize_t
     -readlinknul(const char *restrict link, char *restrict buf, ssize_t size)
     +readlinknul(ssize_t size;
4:  34b5d026f = 4:  ec80a0480 lib/string/: stpe*(): Use array notation with forward declarations
```
</details>

<details>
<summary>v6i</summary>

-  Rebase

```
$ git rd 
1:  99b3e6d84 = 1:  2b9fe2711 lib/alloc/: Compact parameter names
2:  5ae3597e6 = 2:  c5fa3ac66 lib/string/: Use array notation with forward declarations
3:  e06bad150 = 3:  b0b9dcc0f lib/fs/: Use array notation with forward declarations
4:  ec80a0480 = 4:  0b7ff25c7 lib/string/: stpe*(): Use array notation with forward declarations
```
</details>

<details>
<summary>v6j</summary>

-  Rebase

```
$ git rd 
1:  2b9fe2711 ! 1:  4c3783b3d lib/alloc/: Compact parameter names
    @@ lib/alloc/malloc.c
     
      ## lib/alloc/malloc.h ##
     @@
    - 
    + // mallocarray - malloc array
      ATTR_ALLOC_SIZE(1, 2)
      ATTR_MALLOC(free)
     -inline void *mallocarray(size_t nmemb, size_t size);
    @@ lib/alloc/reallocf.c
     
      ## lib/alloc/reallocf.h ##
     @@
    - 
    + // reallocarrayf - realloc array free-on-error
      ATTR_ALLOC_SIZE(2, 3)
      ATTR_MALLOC(free)
     -inline void *reallocarrayf(void *p, size_t nmemb, size_t size);
2:  c5fa3ac66 = 2:  82dc66260 lib/string/: Use array notation with forward declarations
3:  b0b9dcc0f = 3:  892e20c14 lib/fs/: Use array notation with forward declarations
4:  0b7ff25c7 = 4:  8d4aa1e4f lib/string/: stpe*(): Use array notation with forward declarations
```
</details>

<details>
<summary>v6k</summary>

-  Rebase

```
$ git rd 
1:  4c3783b3d = 1:  5498e81f7 lib/alloc/: Compact parameter names
2:  82dc66260 = 2:  cb0ce3e97 lib/string/: Use array notation with forward declarations
3:  892e20c14 = 3:  abf7a24eb lib/fs/: Use array notation with forward declarations
4:  8d4aa1e4f = 4:  835b91195 lib/string/: stpe*(): Use array notation with forward declarations
```
</details>

<details>
<summary>v6l</summary>

-  Rebase

```
$ git rd 
1:  5498e81f7 = 1:  ae8c5a580 lib/alloc/: Compact parameter names
2:  cb0ce3e97 = 2:  5b583dbeb lib/string/: Use array notation with forward declarations
3:  abf7a24eb = 3:  ab5db29e9 lib/fs/: Use array notation with forward declarations
4:  835b91195 = 4:  083c1130b lib/string/: stpe*(): Use array notation with forward declarations
```
</details>

<details>
<summary>v6m</summary>

-  Rebase

```
$ git rd 
1:  ae8c5a580bf1 = 1:  f0246ad2bb2a lib/alloc/: Compact parameter names
2:  5b583dbeb196 = 2:  4524bff9a7dc lib/string/: Use array notation with forward declarations
3:  ab5db29e97d9 = 3:  f4ab28ef6ebb lib/fs/: Use array notation with forward declarations
4:  083c1130b64b = 4:  4c7f5de4c3f5 lib/string/: stpe*(): Use array notation with forward declarations
```
</details>

<details>
<summary>v6n</summary>

-  Rebase

```
$ git rd 
1:  f0246ad2 = 1:  3f6717e4 lib/alloc/: Compact parameter names
2:  4524bff9 = 2:  3485d750 lib/string/: Use array notation with forward declarations
3:  f4ab28ef = 3:  3953d06d lib/fs/: Use array notation with forward declarations
4:  4c7f5de4 = 4:  fd10e1ae lib/string/: stpe*(): Use array notation with forward declarations
```
</details>

<details>
<summary>v7</summary>

-  Rebase

```
$ git rd --creation-factor=99
1:  3f6717e4 = 1:  092b296f lib/alloc/: Compact parameter names
2:  3485d750 ! 2:  af36118d lib/string/: Use array notation with forward declarations
    @@ Commit message
         Cc: Martin Uecker <uecker@tugraz.at>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    - ## lib/string/sprintf/snprintf.c ##
    + ## lib/string/sprintf/stprintf.c ##
     @@
    - #include <stddef.h>
    + #include <sys/types.h>
      
      
    --extern inline int snprintf_(char *restrict s, size_t size,
    +-extern inline int stprintf(char *restrict s, ssize_t size,
     -    const char *restrict fmt, ...);
    --extern inline int vsnprintf_(char *restrict s, size_t size,
    +-extern inline int vstprintf(char *restrict s, ssize_t size,
     -    const char *restrict fmt, va_list ap);
    -+extern inline int snprintf_(size_t size;
    -+    char s[restrict size], size_t size, const char *restrict fmt, ...);
    -+extern inline int vsnprintf_(size_t size;
    -+    char s[restrict size], size_t size, const char *restrict fmt, va_list ap);
    ++extern inline int stprintf(ssize_t size;
    ++    char s[restrict size], ssize_t size, const char *restrict fmt, ...);
    ++extern inline int vstprintf(ssize_t size;
    ++    char s[restrict size], ssize_t size, const char *restrict fmt, va_list ap);
     
    - ## lib/string/sprintf/snprintf.h ##
    + ## lib/string/sprintf/stprintf.h ##
     @@
      
    - 
    + // stprintf - string truncate print formatted
      format_attr(printf, 3, 4)
    --inline int snprintf_(char *restrict s, size_t size, const char *restrict fmt,
    --    ...);
    -+inline int snprintf_(size_t size;
    -+    char s[restrict size], size_t size, const char *restrict fmt, ...);
    +-inline int stprintf(char *restrict s, ssize_t size,
    +-    const char *restrict fmt, ...);
    ++inline int stprintf(ssize_t size;
    ++    char s[restrict size], ssize_t size, const char *restrict fmt, ...);
    + // vstprintf - va_list string truncate print formatted
      format_attr(printf, 3, 0)
    --inline int vsnprintf_(char *restrict s, size_t size, const char *restrict fmt,
    --    va_list ap);
    -+inline int vsnprintf_(size_t size;
    -+    char s[restrict size], size_t size, const char *restrict fmt, va_list ap);
    +-inline int vstprintf(char *restrict s, ssize_t size,
    +-    const char *restrict fmt, va_list ap);
    ++inline int vstprintf(ssize_t size;
    ++    char s[restrict size], ssize_t size, const char *restrict fmt, va_list ap);
      
      
      inline int
    --snprintf_(char *restrict s, size_t size, const char *restrict fmt, ...)
    -+snprintf_(size_t size;
    -+    char s[restrict size], size_t size, const char *restrict fmt, ...)
    +-stprintf(char *restrict s, ssize_t size, const char *restrict fmt, ...)
    ++stprintf(ssize_t size;
    ++    char s[restrict size], ssize_t size, const char *restrict fmt, ...)
      {
        int      len;
        va_list  ap;
    -@@ lib/string/sprintf/snprintf.h: snprintf_(char *restrict s, size_t size, const char *restrict fmt, ...)
    +@@ lib/string/sprintf/stprintf.h: stprintf(char *restrict s, ssize_t size, const char *restrict fmt, ...)
      
      
      inline int
    --vsnprintf_(char *restrict s, size_t size, const char *restrict fmt, va_list ap)
    -+vsnprintf_(size_t size;
    -+    char s[restrict size], size_t size, const char *restrict fmt, va_list ap)
    +-vstprintf(char *restrict s, ssize_t size, const char *restrict fmt, va_list ap)
    ++vstprintf(ssize_t size;
    ++    char s[restrict size], ssize_t size, const char *restrict fmt, va_list ap)
      {
        int  len;
      
3:  3953d06d = 3:  ccbb565b lib/fs/: Use array notation with forward declarations
4:  fd10e1ae ! 4:  cdab5b5c lib/string/: stpe*(): Use array notation with forward declarations
    @@ Commit message
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    - ## lib/string/sprintf/stpeprintf.c ##
    -@@
    --// SPDX-FileCopyrightText: 2022-2024, Alejandro Colomar <alx@kernel.org>
    -+// SPDX-FileCopyrightText: 2022-2025, Alejandro Colomar <alx@kernel.org>
    - // SPDX-License-Identifier: BSD-3-Clause
    - 
    - 
    + ## lib/string/sprintf/seprintf.c ##
     @@
      
      
    - #if !defined(HAVE_STPEPRINTF)
    --extern inline char *stpeprintf(char *dst, char *end, const char *restrict fmt,
    --    ...);
    --extern inline char *vstpeprintf(char *dst, char *end, const char *restrict fmt,
    --    va_list ap);
    -+extern inline char *stpeprintf(char dst[], char end[];
    -+    char dst[dst ? end - dst : 0], char end[0], const char *restrict fmt, ...);
    -+extern inline char *vstpeprintf(char dst[], char end[];
    -+    char dst[dst ? end - dst : 0], char end[0], const char *restrict fmt, va_list ap);
    + #if !defined(HAVE_SEPRINTF)
    +-extern inline char *seprintf(char *dst, const char *end,
    +-    const char *restrict fmt, ...);
    +-extern inline char *vseprintf(char *dst, const char *end,
    +-    const char *restrict fmt, va_list ap);
    ++extern inline char *seprintf(char dst[], const char end[];
    ++    char dst[dst?end-dst:0], const char end[0], const char *restrict fmt, ...);
    ++extern inline char *vseprintf(char dst[], const char end[];
    ++    char dst[dst?end-dst:0], const char end[0], const char *restrict fmt, va_list ap);
      #endif
     
    - ## lib/string/sprintf/stpeprintf.h ##
    + ## lib/string/sprintf/seprintf.h ##
     @@
    --// SPDX-FileCopyrightText: 2022-2024, Alejandro Colomar <alx@kernel.org>
    -+// SPDX-FileCopyrightText: 2022-2025, Alejandro Colomar <alx@kernel.org>
    - // SPDX-License-Identifier: BSD-3-Clause
    - 
    - 
    -@@
    - 
    - #if !defined(HAVE_STPEPRINTF)
    + #if !defined(HAVE_SEPRINTF)
    + // seprintf - string end-pointer print formatted
      format_attr(printf, 3, 4)
    --inline char *stpeprintf(char *dst, char *end, const char *restrict fmt, ...);
    -+inline char *stpeprintf(char dst[], char end[];
    -+    char dst[dst ? end - dst : 0], char end[0], const char *restrict fmt, ...);
    +-inline char *seprintf(char *dst, const char *end, const char *restrict fmt,
    +-    ...);
    ++inline char *seprintf(char dst[], const char end[];
    ++    char dst[dst?end-dst:0], const char end[0], const char *restrict fmt, ...);
    + // vseprintf - va_list string end-pointer print formatted
      format_attr(printf, 3, 0)
    --inline char *vstpeprintf(char *dst, char *end, const char *restrict fmt,
    +-inline char *vseprintf(char *dst, const char *end, const char *restrict fmt,
     -    va_list ap);
    -+inline char *vstpeprintf(char dst[], char end[];
    -+    char dst[dst ? end - dst : 0], char end[0], const char *restrict fmt, va_list ap);
    ++inline char *vseprintf(char dst[], const char end[];
    ++    char dst[dst?end-dst:0], const char end[0], const char *restrict fmt, va_list ap);
      #endif
      
      
    -@@ lib/string/sprintf/stpeprintf.h: inline char *vstpeprintf(char *dst, char *end, const char *restrict fmt,
    - 
    - #if !defined(HAVE_STPEPRINTF)
    + #if !defined(HAVE_SEPRINTF)
      inline char *
    --stpeprintf(char *dst, char *end, const char *restrict fmt, ...)
    -+stpeprintf(char dst[], char end[];
    -+    char dst[dst ? end - dst : 0], char end[0], const char *restrict fmt, ...)
    +-seprintf(char *dst, const char *end, const char *restrict fmt, ...)
    ++seprintf(char dst[], const char end[];
    ++    char dst[dst?end-dst:0], const char end[0], const char *restrict fmt, ...)
      {
        char     *p;
        va_list  ap;
    -@@ lib/string/sprintf/stpeprintf.h: stpeprintf(char *dst, char *end, const char *restrict fmt, ...)
    +@@ lib/string/sprintf/seprintf.h: seprintf(char *dst, const char *end, const char *restrict fmt, ...)
      
    - #if !defined(HAVE_STPEPRINTF)
    + #if !defined(HAVE_SEPRINTF)
      inline char *
    --vstpeprintf(char *dst, char *end, const char *restrict fmt, va_list ap)
    -+vstpeprintf(char dst[], char end[];
    -+    char dst[dst ? end - dst : 0], char end[0], const char *restrict fmt, va_list ap)
    +-vseprintf(char *dst, const char *end, const char *restrict fmt, va_list ap)
    ++vseprintf(char dst[], const char end[];
    ++    char dst[dst?end-dst:0], const char end[0], const char *restrict fmt, va_list ap)
      {
        int        len;
        ptrdiff_t  size;
    @@ lib/string/strcpy/stpecpy.c
      
      
      #if !defined(HAVE_STPECPY)
    --extern inline char *stpecpy(char *dst, char *end, const char *restrict src);
    -+extern inline char *stpecpy(char dst[], char end[];
    -+    char dst[dst ? end - dst : 0], char end[0], const char *restrict src);
    +-extern inline char *stpecpy(char *dst, const char *end,
    +-    const char *restrict src);
    ++extern inline char *stpecpy(char dst[], const char end[];
    ++    char dst[dst ? end - dst : 0], const char end[0], const char *restrict src);
      #endif
     
      ## lib/string/strcpy/stpecpy.h ##
     @@
    - 
      #if !defined(HAVE_STPECPY)
    + // stpecpy - string offset-pointer end-pointer copy
      ATTR_STRING(3)
    --inline char *stpecpy(char *dst, char *end, const char *restrict src);
    -+inline char *stpecpy(char dst[], char end[];
    -+    char dst[dst ? end - dst : 0], char end[0], const char *restrict src);
    +-inline char *stpecpy(char *dst, const char *end, const char *restrict src);
    ++inline char *stpecpy(char dst[], const char end[];
    ++    char dst[dst ? end - dst : 0], const char end[0], const char *restrict src);
      #endif
      
      
    -@@ lib/string/strcpy/stpecpy.h: inline char *stpecpy(char *dst, char *end, const char *restrict src);
    - 
      #if !defined(HAVE_STPECPY)
      inline char *
    --stpecpy(char *dst, char *end, const char *restrict src)
    -+stpecpy(char dst[], char end[];
    -+    char dst[dst ? end - dst : 0], char end[0], const char *restrict src)
    +-stpecpy(char *dst, const char *end, const char *restrict src)
    ++stpecpy(char dst[], const char end[];
    ++    char dst[dst ? end - dst : 0], const char end[0], const char *restrict src)
      {
    -   bool    trunc;
    -   size_t  dsize, dlen, slen;
    +   ssize_t  dlen;
    + 
```
</details>

<details>
<summary>v7b</summary>

-  Rebase

```
$ git rd 
1:  092b296fb100 = 1:  09c8be852cd9 lib/alloc/: Compact parameter names
2:  af36118db9a0 = 2:  183bfbb057fd lib/string/: Use array notation with forward declarations
3:  ccbb565b0ee0 = 3:  a62b59639378 lib/fs/: Use array notation with forward declarations
4:  cdab5b5c12cd = 4:  a62015b09d4e lib/string/: stpe*(): Use array notation with forward declarations
```
</details>

<details>
<summary>v7c</summary>

-  Rebase

```
$ git rd 
1:  09c8be852cd9 = 1:  08551abb774a lib/alloc/: Compact parameter names
2:  183bfbb057fd = 2:  158ec93b61a0 lib/string/: Use array notation with forward declarations
3:  a62b59639378 = 3:  1dffe04d9388 lib/fs/: Use array notation with forward declarations
4:  a62015b09d4e = 4:  12c49f9c58da lib/string/: stpe*(): Use array notation with forward declarations
```
</details>

<details>
<summary>v7d</summary>

-  Rebase

```
$ git rd 
1:  08551abb774a = 1:  9570e97345d5 lib/alloc/: Compact parameter names
2:  158ec93b61a0 = 2:  8a2e80909432 lib/string/: Use array notation with forward declarations
3:  1dffe04d9388 = 3:  5e8b14096d20 lib/fs/: Use array notation with forward declarations
4:  12c49f9c58da = 4:  e9d3f9fdc3cd lib/string/: stpe*(): Use array notation with forward declarations
```
</details>