### PR TITLE
lib/, src/: Use streq() instead of its pattern

### DIFF
--- a/lib/chkname.c
+++ b/lib/chkname.c
@@ -73,9 +73,9 @@ is_valid_name(const char *name)
          */
 	int numeric;
 
-	if ('\0' == *name ||
-	    ('.' == *name && (('.' == name[1] && '\0' == name[2]) ||
-			      '\0' == name[1])) ||
+	if (streq(name, "") ||
+	    streq(name, ".") ||
+	    streq(name, "..") ||
 	    !((*name >= 'a' && *name <= 'z') ||
 	      (*name >= 'A' && *name <= 'Z') ||
 	      (*name >= '0' && *name <= '9') ||
@@ -95,7 +95,7 @@ is_valid_name(const char *name)
 		      *name == '_' ||
 		      *name == '.' ||
 		      *name == '-' ||
-		      (*name == '$' && name[1] == '\0')
+		      streq(name, "$")
 		     ))
 		{
 			errno = EINVAL;

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -2259,9 +2259,9 @@ static void create_home (void)
 	 */
 	for (cp = strtok(bhome, "/"); cp != NULL; cp = strtok(NULL, "/")) {
 		/* Avoid turning a relative path into an absolute path. */
-		if (bhome[0] == '/' || strlen(path) != 0) {
+		if (bhome[0] == '/' || !streq(path, ""))
 			strcat(path, "/");
-		}
+
 		strcat(path, cp);
 		if (access(path, F_OK) == 0) {
 			continue;


### PR DESCRIPTION
---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git range-diff master..gh/streq shadow/master..streq
1:  224930f8 = 1:  c122513c lib/chkname.c: is_valid_name(): Use streq() instead of its pattern
```
</details>

<details>
<summary>v1c</summary>

-  Rebase

```
$ git range-diff master..gh/streq shadow/master..streq
1:  c122513c = 1:  7a8f1e66 lib/chkname.c: is_valid_name(): Use streq() instead of its pattern
```
</details>

<details>
<summary>v1d</summary>

-  Rebase

```
$ git range-diff master..gh/streq shadow/master..streq
1:  7a8f1e66 = 1:  d335844d lib/chkname.c: is_valid_name(): Use streq() instead of its pattern
```
</details>

<details>
<summary>v1e</summary>

-  Rebase

```
$ git range-diff master..gh/streq shadow/master..streq 
1:  d335844d ! 1:  4aee5e06 lib/chkname.c: is_valid_name(): Use streq() instead of its pattern
    @@ Commit message
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/chkname.c ##
    -@@
    - #include <sys/param.h>
    - #include <unistd.h>
    - 
    --#include "defines.h"
    - #include "chkname.h"
    -+#include "defines.h"
    -+#include "string/strcmp/streq.h"
    - 
    - 
    - int allow_bad_names = false;
     @@ lib/chkname.c: is_valid_name(const char *name)
               */
        int numeric;
```
</details>

<details>
<summary>v2</summary>

-  Use !streq() instead of its pattern

```
$ git range-diff master gh/streq streq 
1:  4aee5e06 = 1:  4aee5e06 lib/chkname.c: is_valid_name(): Use streq() instead of its pattern
-:  -------- > 2:  dda02b8b src/useradd.c: create_home(): Use !streq() instead of its pattern
```
</details>

<details>
<summary>v2b</summary>

-  Rebase

```
$ git range-diff alx/master..gh/streq master..streq 
1:  4aee5e06 = 1:  6c440b9f lib/chkname.c: is_valid_name(): Use streq() instead of its pattern
2:  dda02b8b = 2:  a1bde477 src/useradd.c: create_home(): Use !streq() instead of its pattern
```
</details>

<details>
<summary>v2c</summary>

-  Rebase

```
$ git range-diff alx/master..gh/streq master..streq 
1:  6c440b9f = 1:  840a40d0 lib/chkname.c: is_valid_name(): Use streq() instead of its pattern
2:  a1bde477 = 2:  b19cf890 src/useradd.c: create_home(): Use !streq() instead of its pattern
```
</details>

<details>
<summary>v2d</summary>

-  Rebase

```
$ git range-diff master..gh/streq shadow/master..streq 
1:  840a40d0 = 1:  f67222ed lib/chkname.c: is_valid_name(): Use streq() instead of its pattern
2:  b19cf890 = 2:  6b0b92b5 src/useradd.c: create_home(): Use !streq() instead of its pattern
```
</details>