### PR TITLE
CI: update artifacts action

### DIFF
--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -90,7 +90,7 @@ jobs:
 
     - name: Store artifacts
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.os }}-build
         path: |


### PR DESCRIPTION
v3 of upload-artifact actions is being deprecated, so let's move to v4.

Link: https://github.com/actions/upload-artifact