### PR TITLE
src/useradd.c: E_BAD_NAME: Use a different error code for bad login names

### DIFF
--- a/src/useradd.c
+++ b/src/useradd.c
@@ -201,6 +201,7 @@ static bool home_added = false;
 #define E_SUB_UID_UPDATE 16	/* can't update the subordinate uid file */
 #define E_SUB_GID_UPDATE 18	/* can't update the subordinate gid file */
 #endif				/* ENABLE_SUBIDS */
+#define E_BAD_NAME	19	/* Bad login name */
 
 #define DGROUP			"GROUP"
 #define DGROUPS			"GROUPS"
@@ -1549,7 +1550,7 @@ static void process_flags (int argc, char **argv)
 			              user_name, AUDIT_NO_ID,
 			              SHADOW_AUDIT_FAILURE);
 #endif
-			exit (E_BAD_ARG);
+			exit (E_BAD_NAME);
 		}
 		if (!dflg) {
 			char  *uh;


### PR DESCRIPTION
```
Wrappers like adduser(8) want to do their own stuff if the login name is
bad.  For that, they need to be able to differentiate such an error.
```

Closes: <https://github.com/shadow-maint/shadow/issues/1103>
Suggested-by: @zeha
Cc: @zugschlus

---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git range-diff alx/master..gh/badname master..badname 
1:  4c084b1d = 1:  d288ade5 src/useradd.c: E_BAD_NAME: Use a different error code for bad login names
```
</details>

<details>
<summary>v1c</summary>

-  Rebase

```
$ git range-diff alx/master..gh/badname master..badname 
1:  d288ade5 = 1:  5b17bc41 src/useradd.c: E_BAD_NAME: Use a different error code for bad login names
```
</details>

<details>
<summary>v1d</summary>

-  Rebase

```
$ git range-diff master..gh/badname shadow/master..badname 
1:  5b17bc41 = 1:  f63fb09e src/useradd.c: E_BAD_NAME: Use a different error code for bad login names
```
</details>

<details>
<summary>v1e</summary>

-  Reviewed by @hallyn 

```
$ git range-diff master gh/badname badname 
1:  f63fb09e ! 1:  01ddd7d8 src/useradd.c: E_BAD_NAME: Use a different error code for bad login names
    @@ Commit message
         Closes: <https://github.com/shadow-maint/shadow/issues/1103>
         Suggested-by: Chris Hofstaedtler <zeha@debian.org>
         Cc: Marc 'Zugschlus' Haber <mh+githubvisible@zugschlus.de>
    +    Reviewed-by: Serge Hallyn <serge@hallyn.com>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## src/useradd.c ##
```
</details>

<details>
<summary>v1f</summary>

-  Rebase

```
$ git range-diff master..gh/badname shadow/master..badname 
1:  01ddd7d8 = 1:  00ca2301 src/useradd.c: E_BAD_NAME: Use a different error code for bad login names
```
</details>