### PR TITLE
lib/, src/: Use streq() instead of its pattern

### DIFF
--- a/lib/chkname.c
+++ b/lib/chkname.c
@@ -33,6 +33,7 @@
 
 #include "defines.h"
 #include "chkname.h"
+#include "string/strcmp/streq.h"
 
 
 int allow_bad_names = false;
@@ -85,7 +86,7 @@ is_valid_name(const char *name)
 
 	numeric = isdigit(*name);
 
-	while ('\0' != *++name) {
+	while (!streq(++name, "")) {
 		if (!((*name >= 'a' && *name <= 'z') ||
 		      (*name >= 'A' && *name <= 'Z') ||
 		      (*name >= '0' && *name <= '9') ||

--- a/lib/fields.c
+++ b/lib/fields.c
@@ -18,6 +18,7 @@
 #include "prototypes.h"
 #include "string/strchr/stpspn.h"
 #include "string/strchr/strrspn.h"
+#include "string/strcmp/streq.h"
 #include "string/strtok/stpsep.h"
 
 
@@ -47,7 +48,7 @@ int valid_field (const char *field, const char *illegal)
 	}
 
 	/* Search if there are non-printable or control characters */
-	for (cp = field; '\0' != *cp; cp++) {
+	for (cp = field; !streq(cp, ""); cp++) {
 		unsigned char c = *cp;
 		if (!isprint (c)) {
 			err = 1;
@@ -86,7 +87,7 @@ change_field(char *buf, size_t maxsize, const char *prompt)
 	if (stpsep(newf, "\n") == NULL)
 		return;
 
-	if ('\0' != newf[0]) {
+	if (!streq(newf, "")) {
 		/*
 		 * Remove leading and trailing whitespace.  This also
 		 * makes it possible to change the field to empty, by

--- a/lib/fputsx.c
+++ b/lib/fputsx.c
@@ -14,8 +14,7 @@
 
 #include "defines.h"
 #include "prototypes.h"
-
-#ident "$Id$"
+#include "string/strcmp/streq.h"
 
 
 /*@null@*/char *
@@ -48,7 +47,7 @@ int fputsx (const char *s, FILE * stream)
 {
 	int i;
 
-	for (i = 0; '\0' != *s; i++, s++) {
+	for (i = 0; !streq(s, ""); i++, s++) {
 		if (putc (*s, stream) == EOF) {
 			return EOF;
 		}

--- a/lib/getdate.y
+++ b/lib/getdate.y
@@ -627,7 +627,7 @@ static int LookupWord (char *buff)
   bool abbrev;
 
   /* Make it lowercase. */
-  for (p = buff; '\0' != *p; p++)
+  for (p = buff; !streq(p, ""); p++)
     if (isupper (*p))
       *p = tolower (*p);
 
@@ -720,7 +720,7 @@ static int LookupWord (char *buff)
     }
 
   /* Drop out any periods and try the timezone table again. */
-  for (i = 0, p = q = buff; '\0' != *q; q++)
+  for (i = 0, p = q = buff; !streq(q, ""); q++)
     if (*q != '.')
       *p++ = *q;
     else

--- a/lib/getdef.c
+++ b/lib/getdef.c
@@ -567,7 +567,7 @@ static void def_load (void)
 		 * Break the line into two fields.
 		 */
 		name = stpspn(buf, " \t");	/* first nonwhite */
-		if (*name == '\0' || *name == '#')
+		if (streq(name, "") || *name == '#')
 			continue;	/* comment or empty */
 
 		s = stpsep(name, " \t");  /* next field */

--- a/lib/getrange.c
+++ b/lib/getrange.c
@@ -13,6 +13,7 @@
 #include "atoi/a2i/a2u.h"
 #include "defines.h"
 #include "prototypes.h"
+#include "string/strcmp/streq.h"
 
 
 /*
@@ -53,7 +54,7 @@ getrange(const char *range,
 		return 0;  /* <long> */
 
 	case '-':
-		if ('\0' == *end)
+		if (streq(end, ""))
 			return 0;  /* <long>- */
 parse_max:
 		if (!isdigit((unsigned char) *end))

--- a/lib/gshadow.c
+++ b/lib/gshadow.c
@@ -42,7 +42,7 @@ build_list(char *s)
 
 	l = XMALLOC(strchrcnt(s, ',') + 2, char *);
 
-	for (i = 0; s != NULL && *s != '\0'; i++)
+	for (i = 0; s != NULL && !streq(s, ""); i++)
 		l[i] = strsep(&s, ",");
 
 	l[i] = NULL;

--- a/lib/limits.c
+++ b/lib/limits.c
@@ -203,7 +203,7 @@ static int do_user_limits (const char *buf, const char *name)
 		pp = "A- C- D- F- I- L- M- N- O- P- R- S- T- U-";
 	}
 
-	while ('\0' != *pp) {
+	while (!streq(pp, "")) {
 		switch (*pp++) {
 		case 'a':
 		case 'A':

--- a/lib/limits.c
+++ b/lib/limits.c
@@ -413,9 +413,9 @@ static int setup_user_limits (const char *uname)
 		}
 	}
 	(void) fclose (fil);
-	if (limits[0] == '\0') {
+	if (streq(limits, "")) {
 		/* no user specific limits */
-		if (deflimits[0] == '\0') {	/* no default limits */
+		if (streq(deflimits, "")) {	/* no default limits */
 			return 0;
 		}
 		strcpy (limits, deflimits);	/* use the default limits */

--- a/lib/list.c
+++ b/lib/list.c
@@ -209,7 +209,7 @@ comma_to_list(const char *comma)
 	 * Empty list is special - 0 members, not 1 empty member.  --marekm
 	 */
 
-	if ('\0' == *members) {
+	if (streq(members, "")) {
 		*array = NULL;
 		free (members);
 		return array;

--- a/lib/myname.c
+++ b/lib/myname.c
@@ -15,9 +15,13 @@
 
 #ident "$Id$"
 
-#include "defines.h"
 #include <pwd.h>
+
+#include "defines.h"
 #include "prototypes.h"
+#include "string/strcmp/streq.h"
+
+
 /*@null@*/ /*@only@*/struct passwd *get_my_pwent (void)
 {
 	struct passwd *pw;
@@ -34,7 +38,7 @@
 	 * XXX - when running from su, will return the current user (not
 	 * the original user, like getlogin() does).  Does this matter?
 	 */
-	if ((NULL != cp) && ('\0' != *cp)) {
+	if ((NULL != cp) && !streq(cp, "")) {
 		pw = xgetpwnam (cp);
 		if ((NULL != pw) && (pw->pw_uid == ruid)) {
 			return pw;

--- a/lib/nss.c
+++ b/lib/nss.c
@@ -87,7 +87,7 @@ nss_init(const char *nsswitch_path) {
 			continue;
 		p = &line[6];
 		p = stpspn(p, " \t\n");
-		if (*p != '\0')
+		if (!streq(p, ""))
 			break;
 		p = NULL;
 	}

--- a/lib/obscure.c
+++ b/lib/obscure.c
@@ -82,7 +82,7 @@ static char *str_lower (/*@returned@*/char *string)
 {
 	char *cp;
 
-	for (cp = string; '\0' != *cp; cp++) {
+	for (cp = string; !streq(cp, ""); cp++) {
 		*cp = tolower (*cp);
 	}
 	return string;

--- a/lib/port.c
+++ b/lib/port.c
@@ -39,7 +39,7 @@ static int portcmp (const char *pattern, const char *port)
 {
 	const char *orig = port;
 
-	while (('\0' != *pattern) && (*pattern == *port)) {
+	while (!streq(pattern, "") && (*pattern == *port)) {
 		pattern++;
 		port++;
 	}
@@ -215,7 +215,7 @@ next:
 	 * Get the next comma separated entry
 	 */
 
-	for (j = 0; ('\0' != *cp) && (j < PORT_TIMES); j++) {
+	for (j = 0; !streq(cp, "") && (j < PORT_TIMES); j++) {
 
 		/*
 		 * Start off with no days of the week

--- a/lib/port.c
+++ b/lib/port.c
@@ -44,7 +44,7 @@ static int portcmp (const char *pattern, const char *port)
 		port++;
 	}
 
-	if (('\0' == *pattern) && ('\0' == *port)) {
+	if (streq(pattern, "") && streq(port, "")) {
 		return 0;
 	}
 	if (streq(orig, "SU"))
@@ -204,7 +204,7 @@ next:
 
 	cp = field;
 
-	if ('\0' == *cp) {
+	if (streq(cp, "")) {
 		port.pt_times = NULL;
 		return &port;
 	}

--- a/lib/prefix_flag.c
+++ b/lib/prefix_flag.c
@@ -98,7 +98,7 @@ extern const char* process_prefix_flag (const char* short_opt, int argc, char **
 			exit (EXIT_FAILURE);
 		}
 
-		if (prefix[0] == '\0' || streq(prefix, "/"))
+		if (streq(prefix, "") || streq(prefix, "/"))
 			return ""; /* if prefix is "/" then we ignore the flag option */
 		/* should we prevent symbolic link from being used as a prefix? */
 

--- a/lib/pwauth.c
+++ b/lib/pwauth.c
@@ -26,6 +26,7 @@
 #include "getdef.h"
 #include "string/memset/memzero.h"
 #include "string/sprintf/snprintf.h"
+#include "string/strcmp/streq.h"
 
 #ifdef SKEY
 #include <skey.h>
@@ -102,7 +103,7 @@ int pw_auth (const char *cipher,
 	 * matter.
 	 */
 
-	if ((NULL == cipher) || ('\0' == *cipher)) {
+	if ((NULL == cipher) || streq(cipher, "")) {
 		return 0;
 	}
 
@@ -169,7 +170,7 @@ int pw_auth (const char *cipher,
 	 * ...Re-prompt, with echo on.
 	 * -- AR 8/22/1999
 	 */
-	if ((0 != retval) && ('\0' == input[0]) && use_skey) {
+	if ((0 != retval) && streq(input, "") && use_skey) {
 		erase_pass(clear);
 		clear = agetpass(prompt);
 		input = (clear == NULL) ? "" : clear;

--- a/lib/salt.c
+++ b/lib/salt.c
@@ -419,7 +419,7 @@ static /*@observer@*/const char *gensalt (size_t salt_size)
 	 * Prepare DES setting for crypt_gensalt(), if result
 	 * has not been filled with anything previously.
 	 */
-	if ('\0' == result[0]) {
+	if (streq(result, "")) {
 		/* Avoid -Wunused-but-set-variable. */
 		salt_len = GENSALT_SETTING_SIZE - 1;
 		rounds = 0;

--- a/lib/setupenv.c
+++ b/lib/setupenv.c
@@ -28,6 +28,7 @@
 #include "shadowlog.h"
 #include "string/sprintf/xasprintf.h"
 #include "string/strchr/stpspn.h"
+#include "string/strcmp/streq.h"
 #include "string/strdup/xstrdup.h"
 #include "string/strtok/stpsep.h"
 
@@ -60,7 +61,7 @@ static void read_env_file (const char *filename)
 		cp = buf;
 		/* ignore whitespace and comments */
 		cp = stpspn(cp, " \t");
-		if (('\0' == *cp) || ('#' == *cp)) {
+		if (streq(cp, "") || ('#' == *cp)) {
 			continue;
 		}
 		/*
@@ -209,7 +210,7 @@ void setup_env (struct passwd *info)
 	 * Create the SHELL environmental variable and export it.
 	 */
 
-	if ((NULL == info->pw_shell) || ('\0' == *info->pw_shell)) {
+	if ((NULL == info->pw_shell) || streq(info->pw_shell, "")) {
 		free (info->pw_shell);
 		info->pw_shell = xstrdup (SHELL);
 	}

--- a/lib/sgetgrent.c
+++ b/lib/sgetgrent.c
@@ -21,6 +21,7 @@
 #include "atoi/getnum.h"
 #include "defines.h"
 #include "prototypes.h"
+#include "string/strcmp/streq.h"
 #include "string/strtok/stpsep.h"
 
 
@@ -54,7 +55,7 @@ list(char *s)
 				return NULL;
 			}
 		}
-		if (!s || s[0] == '\0')
+		if (!s || streq(s, ""))
 			break;
 		members[i++] = strsep(&s, ",");
 	}
@@ -89,7 +90,7 @@ struct group *sgetgrent (const char *buf)
 	for (cp = grpbuf, i = 0; (i < NFIELDS) && (NULL != cp); i++)
 		grpfields[i] = strsep(&cp, ":");
 
-	if (i < NFIELDS || *grpfields[2] == '\0' || cp != NULL) {
+	if (i < NFIELDS || streq(grpfields[2], "") || cp != NULL) {
 		return NULL;
 	}
 	grent.gr_name = grpfields[0];

--- a/lib/sgetpwent.c
+++ b/lib/sgetpwent.c
@@ -20,6 +20,7 @@
 #include "defines.h"
 #include "prototypes.h"
 #include "shadowlog_internal.h"
+#include "string/strcmp/streq.h"
 
 
 #define	NFIELDS	7
@@ -76,7 +77,11 @@ sgetpwent(const char *buf)
 	 * the entry is invalid.  Also, the UID and GID must be non-blank.
 	 */
 
-	if (i != NFIELDS || *fields[2] == '\0' || *fields[3] == '\0')
+	if (i != NFIELDS)
+		return NULL;
+	if (streq(fields[2], ""))
+		return NULL;
+	if (streq(fields[3], ""))
 		return NULL;
 
 	/*

--- a/lib/sgetspent.c
+++ b/lib/sgetspent.c
@@ -24,6 +24,7 @@
 #include "defines.h"
 #include "prototypes.h"
 #include "shadowlog_internal.h"
+#include "string/strcmp/streq.h"
 #include "string/strtok/stpsep.h"
 
 
@@ -85,7 +86,7 @@ sgetspent(const char *string)
 	 * incorrectly formatted number.
 	 */
 
-	if (fields[2][0] == '\0')
+	if (streq(fields[2], ""))
 		spwd.sp_lstchg = -1;
 	else if (a2sl(&spwd.sp_lstchg, fields[2], NULL, 0, 0, LONG_MAX) == -1)
 		return NULL;
@@ -94,7 +95,7 @@ sgetspent(const char *string)
 	 * Get the minimum period between password changes.
 	 */
 
-	if (fields[3][0] == '\0')
+	if (streq(fields[3], ""))
 		spwd.sp_min = -1;
 	else if (a2sl(&spwd.sp_min, fields[3], NULL, 0, 0, LONG_MAX) == -1)
 		return NULL;
@@ -103,7 +104,7 @@ sgetspent(const char *string)
 	 * Get the maximum number of days a password is valid.
 	 */
 
-	if (fields[4][0] == '\0')
+	if (streq(fields[4], ""))
 		spwd.sp_max = -1;
 	else if (a2sl(&spwd.sp_max, fields[4], NULL, 0, 0, LONG_MAX) == -1)
 		return NULL;
@@ -126,7 +127,7 @@ sgetspent(const char *string)
 	 * Get the number of days of password expiry warning.
 	 */
 
-	if (fields[5][0] == '\0')
+	if (streq(fields[5], ""))
 		spwd.sp_warn = -1;
 	else if (a2sl(&spwd.sp_warn, fields[5], NULL, 0, 0, LONG_MAX) == -1)
 		return NULL;
@@ -136,7 +137,7 @@ sgetspent(const char *string)
 	 * disabled.
 	 */
 
-	if (fields[6][0] == '\0')
+	if (streq(fields[6], ""))
 		spwd.sp_inact = -1;
 	else if (a2sl(&spwd.sp_inact, fields[6], NULL, 0, 0, LONG_MAX) == -1)
 		return NULL;
@@ -146,7 +147,7 @@ sgetspent(const char *string)
 	 * set to expire.
 	 */
 
-	if (fields[7][0] == '\0')
+	if (streq(fields[7], ""))
 		spwd.sp_expire = -1;
 	else if (a2sl(&spwd.sp_expire, fields[7], NULL, 0, 0, LONG_MAX) == -1)
 		return NULL;
@@ -156,7 +157,7 @@ sgetspent(const char *string)
 	 * to have anything other than a valid integer in it.
 	 */
 
-	if (fields[8][0] == '\0')
+	if (streq(fields[8], ""))
 		spwd.sp_flag = SHADOW_SP_FLAG_UNSET;
 	else if (str2ul(&spwd.sp_flag, fields[8]) == -1)
 		return NULL;

--- a/lib/sssd.c
+++ b/lib/sssd.c
@@ -1,7 +1,9 @@
 /* Author: Peter Vrabec <pvrabec@redhat.com> */
 
 #include <config.h>
+
 #ifdef USE_SSSD
+#include "sssd.h"
 
 #include <stdio.h>
 #include <sys/stat.h>
@@ -12,9 +14,8 @@
 #include "exitcodes.h"
 #include "defines.h"
 #include "prototypes.h"
-#include "sssd.h"
-
 #include "shadowlog_internal.h"
+#include "string/strcmp/streq.h"
 
 
 #define MSG_SSSD_FLUSH_CACHE_FAILED "%s: Failed to flush the sssd cache."
@@ -46,7 +47,7 @@ sssd_flush_cache(int dbflags)
 	if (dbflags & SSSD_DB_GROUP)
 		stpcpy(p, "G");
 
-	if (*p == '\0') {
+	if (streq(p, "")) {
 		/* Neither passwd nor group, nothing to do */
 		free(sss_cache_args);
 		return 0;

--- a/lib/strtoday.c
+++ b/lib/strtoday.c
@@ -11,12 +11,11 @@
 
 #include <ctype.h>
 
-#ident "$Id$"
-
 #include "atoi/str2i/str2s.h"
 #include "getdate.h"
 #include "prototypes.h"
 #include "string/strchr/stpspn.h"
+#include "string/strcmp/streq.h"
 
 
 /*
@@ -44,7 +43,7 @@ long strtoday (const char *str)
 	 * which is not what we expect, unless you're a BOFH :-).
 	 * (useradd sets sp_expire = current date for new lusers)
 	 */
-	if ((NULL == str) || ('\0' == *str)) {
+	if ((NULL == str) || streq(str, "")) {
 		return -1;
 	}
 

--- a/lib/strtoday.c
+++ b/lib/strtoday.c
@@ -54,7 +54,7 @@ long strtoday (const char *str)
 		s++;
 	}
 	s = stpspn(s, " ");
-	while (isnum && ('\0' != *s)) {
+	while (isnum && !streq(s, "")) {
 		if (!isdigit (*s)) {
 			isnum = false;
 		}

--- a/lib/subordinateio.c
+++ b/lib/subordinateio.c
@@ -108,7 +108,13 @@ subordinate_parse(const char *line)
 	 * There must be exactly SUBID_NFIELDS colon separated fields or
 	 * the entry is invalid.  Also, fields must be non-blank.
 	 */
-	if (i != SUBID_NFIELDS || *fields[0] == '\0' || *fields[1] == '\0' || *fields[2] == '\0')
+	if (i != SUBID_NFIELDS)
+		return NULL;
+	if (streq(fields[0], ""))
+		return NULL;
+	if (streq(fields[1], ""))
+		return NULL;
+	if (streq(fields[2], ""))
 		return NULL;
 	range.owner = fields[0];
 	if (str2ul(&range.start, fields[1]) == -1)

--- a/lib/ttytype.c
+++ b/lib/ttytype.c
@@ -58,7 +58,7 @@ void ttytype (const char *line)
 			break;
 		}
 	}
-	if ((feof (fp) == 0) && (ferror (fp) == 0) && (type[0] != '\0')) {
+	if ((feof(fp) == 0) && (ferror(fp) == 0) && !streq(type, "")) {
 		addenv ("TERM", type);
 	}
 

--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -53,13 +53,13 @@ is_my_tty(const char tty[UTX_LINESIZE])
 		strcpy (full_tty, "/dev/");
 	strncat(full_tty, tty, UTX_LINESIZE);
 
-	if ('\0' == tmptty[0]) {
+	if (streq(tmptty, "")) {
 		const char *tname = ttyname (STDIN_FILENO);
 		if (NULL != tname)
 			STRTCPY(tmptty, tname);
 	}
 
-	if ('\0' == tmptty[0]) {
+	if (streq(tmptty, "")) {
 		(void) puts (_("Unable to determine your tty name."));
 		exit (EXIT_FAILURE);
 	}

--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -254,7 +254,7 @@ prepare_utmp(const char *name, const char *line, const char *host,
 
 
 
-	if (NULL != host && '\0' != host[0])
+	if (NULL != host && !streq(host, ""))
 		hostname = xstrdup(host);
 #if defined(HAVE_STRUCT_UTMPX_UT_HOST)
 	else if (NULL != ut && '\0' != ut->ut_host[0])

--- a/lib/valid.c
+++ b/lib/valid.c
@@ -42,8 +42,8 @@ bool valid (const char *password, const struct passwd *ent)
 	 * routine is meant to waste CPU time.
 	 */
 
-	if ((NULL != ent->pw_name) && ('\0' == ent->pw_passwd[0])) {
-		if ('\0' == password[0]) {
+	if ((NULL != ent->pw_name) && streq(ent->pw_passwd, "")) {
+		if (streq(password, "")) {
 			return true;	/* user entered nothing */
 		} else {
 			return false;	/* user entered something! */
@@ -54,7 +54,7 @@ bool valid (const char *password, const struct passwd *ent)
 	 * If there is no entry then we need a salt to use.
 	 */
 
-	if ((NULL == ent->pw_name) || ('\0' == ent->pw_passwd[0])) {
+	if ((NULL == ent->pw_name) || streq(ent->pw_passwd, "")) {
 		salt = "xx";
 	} else {
 		salt = ent->pw_passwd;

--- a/src/chfn.c
+++ b/src/chfn.c
@@ -225,7 +225,7 @@ static char *copy_field (char *in, char *out, char *extra)
 			break;
 
 		if (NULL != extra) {
-			if ('\0' != extra[0]) {
+			if (!streq(extra, "")) {
 				strcat (extra, ",");
 			}
 
@@ -543,7 +543,7 @@ static void get_old_fields (const char *gecos)
 	 * Anything left over is "slop".
 	 */
 	if ((NULL != cp) && !oflg) {
-		if ('\0' != slop[0]) {
+		if (!streq(slop, "")) {
 			strcat (slop, ",");
 		}
 
@@ -702,7 +702,7 @@ int main (int argc, char **argv)
 	}
 	SNPRINTF(new_gecos, "%s,%s,%s,%s%s%s",
 	         fullnm, roomno, workph, homeph,
-	         ('\0' != slop[0]) ? "," : "", slop);
+	         (!streq(slop, "")) ? "," : "", slop);
 
 	/* Rewrite the user's gecos in the passwd file */
 	update_gecos (user, new_gecos);

--- a/src/gpasswd.c
+++ b/src/gpasswd.c
@@ -179,7 +179,7 @@ static bool is_valid_user_list (const char *users)
 
 	tmpusers = dup = xstrdup(users);
 
-	while (NULL != tmpusers && '\0' != *tmpusers) {
+	while (NULL != tmpusers && !streq(tmpusers, "")) {
 		const char  *u;
 
 		u = strsep(&tmpusers, ",");

--- a/src/grpck.c
+++ b/src/grpck.c
@@ -580,7 +580,8 @@ static void check_grp_file (int *errors, bool *changed)
 		 */
 		if (   (NULL != grp->gr_mem[0])
 		    && (NULL == grp->gr_mem[1])
-		    && ('\0' == grp->gr_mem[0][0])) {
+		    && streq(grp->gr_mem[0], ""))
+		{
 			grp->gr_mem[0] = NULL;
 		}
 

--- a/src/login.c
+++ b/src/login.c
@@ -661,7 +661,7 @@ int main (int argc, char **argv)
 		/* if we didn't get a user on the command line,
 		   set it to NULL */
 		get_pam_user (&pam_user);
-		if ((NULL != pam_user) && ('\0' == pam_user[0])) {
+		if ((NULL != pam_user) && streq(pam_user, "")) {
 			retcode = pam_set_item (pamh, PAM_USER, NULL);
 			PAM_FAIL_CHECK;
 		}
@@ -838,7 +838,7 @@ int main (int argc, char **argv)
 			username = XMALLOC(max_size, char);
 			login_prompt(username, max_size);
 
-			if ('\0' == username[0]) {
+			if (streq(username, "")) {
 				/* Prompt for a new login */
 				free (username);
 				username = NULL;
@@ -963,7 +963,7 @@ int main (int argc, char **argv)
 		 * guys won't see that the passwordless account exists at
 		 * all).  --marekm
 		 */
-		if (user_passwd[0] == '\0') {
+		if (streq(user_passwd, "")) {
 			pw_auth ("!", username, reason, NULL);
 		}
 

--- a/src/login.c
+++ b/src/login.c
@@ -422,7 +422,7 @@ static /*@observer@*/const char *get_failent_user (/*@returned@*/const char *use
 	const char *failent_user = "UNKNOWN";
 	bool log_unkfail_enab = getdef_bool("LOG_UNKFAIL_ENAB");
 
-	if ((NULL != user) && ('\0' != user[0])) {
+	if ((NULL != user) && !streq(user, "")) {
 		if (   log_unkfail_enab
 		    || (getpwnam (user) != NULL)) {
 			failent_user = user;
@@ -589,13 +589,13 @@ int main (int argc, char **argv)
 
 	if (hflg) {
 		cp = hostname;
-	} else if ((host != NULL) && (host[0] != '\0')) {
+	} else if ((host != NULL) && !streq(host, "")) {
 		cp = host;
 	} else {
 		cp = "";
 	}
 
-	if ('\0' != *cp) {
+	if (!streq(cp, "")) {
 		SNPRINTF(fromhost, " on '%.100s' from '%.200s'", tty, cp);
 	} else {
 		SNPRINTF(fromhost, " on '%.100s'", tty);
@@ -925,7 +925,7 @@ int main (int argc, char **argv)
 			failed = true;
 		}
 		if (   !failed
-		    && !login_access (username, ('\0' != *hostname) ? hostname : tty)) {
+		    && !login_access(username, (!streq(hostname, "")) ? hostname : tty)) {
 			SYSLOG ((LOG_WARN, "LOGIN '%s' REFUSED %s",
 			         username, fromhost));
 			failed = true;

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -29,7 +29,6 @@
 #ifndef USE_PAM
 #ident "$Id$"
 
-#include "prototypes.h"
     /*
      * This module implements a simple but effective form of login access
      * control based on login names and on host (or domain) names, internet
@@ -38,27 +37,29 @@
      *
      * Author: Wietse Venema, Eindhoven University of Technology, The Netherlands.
      */
-#include <sys/types.h>
-#include <stddef.h>
-#include <stdio.h>
-#include <syslog.h>
+#include <arpa/inet.h>		/* for inet_ntoa() */
 #include <ctype.h>
-#include <netdb.h>
+#include <errno.h>
 #include <grp.h>
+#include <netdb.h>
+#include <netinet/in.h>
 #ifdef PRIMARY_GROUP_MATCH
 #include <pwd.h>
 #endif
-#include <errno.h>
-#include <string.h>
-#include <unistd.h>
+#include <stddef.h>
+#include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/param.h>
 #include <sys/socket.h>
-#include <netinet/in.h>
-#include <arpa/inet.h>		/* for inet_ntoa() */
+#include <sys/types.h>
+#include <syslog.h>
+#include <unistd.h>
 
+#include "prototypes.h"
 #include "sizeof.h"
 #include "string/strchr/strrspn.h"
+#include "string/strcmp/streq.h"
 #include "string/strtok/stpsep.h"
 
 
@@ -110,7 +111,7 @@ login_access(const char *user, const char *from)
 				continue;	/* comment line */
 			}
 			stpcpy(strrspn(line, " \t"), "");
-			if (line[0] == '\0') {	/* skip blank lines */
+			if (streq(line, "")) {	/* skip blank lines */
 				continue;
 			}
 			p = line;
@@ -182,7 +183,7 @@ static char *myhostname (void)
 {
 	static char name[MAXHOSTNAMELEN + 1] = "";
 
-	if (name[0] == '\0') {
+	if (streq(name, "")) {
 		gethostname (name, sizeof (name));
 		stpcpy(&name[MAXHOSTNAMELEN], "");
 	}

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -320,7 +320,7 @@ static bool from_match (const char *tok, const char *string)
 		if (strchr (string, '.') == NULL) {
 			return true;
 		}
-	} else if (   (tok[0] != '\0' && tok[(tok_len = strlen (tok)) - 1] == '.') /* network */
+	} else if (   (!streq(tok, "") && tok[(tok_len = strlen(tok)) - 1] == '.') /* network */
 		   && (strncmp (tok, resolve_hostname (string), tok_len) == 0)) {
 		return true;
 	}

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -150,7 +150,7 @@ static void check_perms (const struct group *grp,
 		spw_free (spwd);
 	}
 
-	if (streq(pwd->pw_passwd, "") && (grp->gr_passwd[0] != '\0')) {
+	if (streq(pwd->pw_passwd, "") && !streq(grp->gr_passwd, "")) {
 		needspasswd = true;
 	}
 
@@ -786,7 +786,7 @@ int main (int argc, char **argv)
 	cp = getenv ("SHELL");
 	if (!initflag && (NULL != cp)) {
 		prog = cp;
-	} else if ((NULL != pwd->pw_shell) && ('\0' != pwd->pw_shell[0])) {
+	} else if ((NULL != pwd->pw_shell) && !streq(pwd->pw_shell, "")) {
 		prog = pwd->pw_shell;
 	} else {
 		prog = SHELL;

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -150,7 +150,7 @@ static void check_perms (const struct group *grp,
 		spw_free (spwd);
 	}
 
-	if ((pwd->pw_passwd[0] == '\0') && (grp->gr_passwd[0] != '\0')) {
+	if (streq(pwd->pw_passwd, "") && (grp->gr_passwd[0] != '\0')) {
 		needspasswd = true;
 	}
 
@@ -188,8 +188,8 @@ static void check_perms (const struct group *grp,
 			goto failure;
 		}
 
-		if (grp->gr_passwd[0] == '\0' ||
-		    !streq(cpasswd, grp->gr_passwd)) {
+		if (streq(grp->gr_passwd, "") ||
+		    !streq(grp->gr_passwd, cpasswd)) {
 #ifdef WITH_AUDIT
 			SNPRINTF(audit_buf, "authentication new-gid=%lu",
 			         (unsigned long) grp->gr_gid);

--- a/src/newusers.c
+++ b/src/newusers.c
@@ -282,7 +282,7 @@ static int add_group (const char *name, const char *gid, gid_t *ngid, uid_t uid)
 	/*
 	 * Now I have all of the fields required to create the new group.
 	 */
-	if (('\0' != gid[0]) && (!isdigit (gid[0]))) {
+	if (!streq(gid, "") && (!isdigit(gid[0]))) {
 		grent.gr_name = xstrdup (gid);
 	} else {
 		grent.gr_name = xstrdup (name);
@@ -355,7 +355,7 @@ static int get_user_id (const char *uid, uid_t *nuid) {
 			return -1;
 		}
 	} else {
-		if ('\0' != uid[0]) {
+		if (!streq(uid, "")) {
 			const struct passwd *pwd;
 			/* local, no need for xgetpwnam */
 			pwd = getpwnam (uid);
@@ -1222,19 +1222,19 @@ int main (int argc, char **argv)
 			         Prog, line);
 			fail_exit (EXIT_FAILURE);
 		}
-		if ('\0' != fields[4][0]) {
+		if (!streq(fields[4], "")) {
 			newpw.pw_gecos = fields[4];
 		}
 
-		if ('\0' != fields[5][0]) {
+		if (!streq(fields[5], "")) {
 			newpw.pw_dir = fields[5];
 		}
 
-		if ('\0' != fields[6][0]) {
+		if (!streq(fields[6], "")) {
 			newpw.pw_shell = fields[6];
 		}
 
-		if (   ('\0' != fields[5][0])
+		if (   !streq(fields[5], "")
 		    && (access (newpw.pw_dir, F_OK) != 0)) {
 /* FIXME: should check for directory */
 			mode_t mode = getdef_num ("HOME_MODE",

--- a/src/passwd.c
+++ b/src/passwd.c
@@ -441,7 +441,7 @@ static /*@observer@*/const char *pw_status (const char *pass)
 	if (*pass == '*' || *pass == '!') {
 		return "L";
 	}
-	if (*pass == '\0') {
+	if (streq(pass, "")) {
 		return "NP";
 	}
 	return "P";

--- a/src/passwd.c
+++ b/src/passwd.c
@@ -194,7 +194,7 @@ static int new_password (const struct passwd *pw)
 	 * password.
 	 */
 
-	if (!amroot && ('\0' != crypt_passwd[0])) {
+	if (!amroot && !streq(crypt_passwd, "")) {
 		clear = agetpass (_("Old password: "));
 		if (NULL == clear) {
 			return -1;

--- a/src/pwck.c
+++ b/src/pwck.c
@@ -533,7 +533,7 @@ static void check_pw_file (int *errors, bool *changed)
 		 * Make sure the login shell is executable
 		 */
 		if (   !quiet
-		    && ('\0' != pwd->pw_shell[0])
+		    && !streq(pwd->pw_shell, "")
 		    && (access (pwd->pw_shell, F_OK) != 0)) {
 
 			/*

--- a/src/su.c
+++ b/src/su.c
@@ -1087,8 +1087,8 @@ int main (int argc, char **argv)
 	sulog (caller_tty, true, caller_name, name);	/* save SU information */
 	if (getdef_bool ("SYSLOG_SU_ENAB")) {
 		SYSLOG ((LOG_INFO, "+ %s %s:%s", caller_tty,
-		         ('\0' != caller_name[0]) ? caller_name : "???",
-		         ('\0' != name[0]) ? name : "???"));
+		         (!streq(caller_name, "")) ? caller_name : "???",
+		         (!streq(name, "")) ? name : "???"));
 	}
 
 #ifdef USE_PAM
@@ -1143,7 +1143,7 @@ int main (int argc, char **argv)
 				AUDIT_USER_ROLE_CHANGE,
 				NULL,    /* Prog. name */
 				"su",
-				('\0' != caller_name[0]) ? caller_name : "???",
+				(!streq(caller_name, "")) ? caller_name : "???",
 				AUDIT_NO_ID,
 				"localhost",
 				NULL,    /* addr */

--- a/src/su.c
+++ b/src/su.c
@@ -862,7 +862,7 @@ static void process_flags (int argc, char **argv)
 	if (optind < argc) {
 		STRTCPY(name, argv[optind++]);	/* use this login id */
 	}
-	if ('\0' == name[0]) {		/* use default user */
+	if (streq(name, "")) {		/* use default user */
 		struct passwd *root_pw = getpwnam ("root");
 		if ((NULL != root_pw) && (0 == root_pw->pw_uid)) {
 			(void) strcpy (name, "root");
@@ -1080,7 +1080,7 @@ int main (int argc, char **argv)
 	/*
 	 * Set the default shell.
 	 */
-	if ((NULL == shellstr) || ('\0' == shellstr[0])) {
+	if ((NULL == shellstr) || streq(shellstr, "")) {
 		shellstr = SHELL;
 	}
 

--- a/src/suauth.c
+++ b/src/suauth.c
@@ -86,7 +86,7 @@ check_su_auth(const char *actual_id, const char *wanted_id, bool su_to_root)
 		stpcpy(strrspn(temp, " \t"), "");
 
 		p = stpspn(temp, " \t");
-		if (*p == '#' || *p == '\0')
+		if (*p == '#' || streq(p, ""))
 			continue;
 
 		to_users = strsep(&p, ":");

--- a/src/sulogin.c
+++ b/src/sulogin.c
@@ -27,6 +27,7 @@
 /*@-exitarg@*/
 #include "exitcodes.h"
 #include "shadowlog.h"
+#include "string/strcmp/streq.h"
 #include "string/strdup/xstrdup.h"
 
 
@@ -153,7 +154,7 @@ main(int argc, char *argv[])
 		 * it will work with standard getpass() (no NULL on EOF).
 		 * --marekm
 		 */
-		if ((NULL == pass) || ('\0' == *pass)) {
+		if ((NULL == pass) || streq(pass, "")) {
 			erase_pass (pass);
 			(void) puts ("");
 #ifdef	TELINIT

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -439,7 +439,7 @@ get_defaults(void)
 		 * Default Skeleton information
 		 */
 		else if (streq(buf, DSKEL)) {
-			if ('\0' == *ccp)
+			if (streq(ccp, ""))
 				ccp = SKEL_DIR;
 
 			if (prefix[0]) {
@@ -456,7 +456,7 @@ get_defaults(void)
 		 * Default Usr Skeleton information
 		 */
 		else if (streq(buf, DUSRSKEL)) {
-			if ('\0' == *ccp)
+			if (streq(ccp, ""))
 				ccp = USRSKELDIR;
 
 			if (prefix[0]) {
@@ -472,7 +472,7 @@ get_defaults(void)
 		 * Create by default user mail spool or not ?
 		 */
 		else if (streq(buf, DCREATE_MAIL_SPOOL)) {
-			if (*ccp == '\0')
+			if (streq(ccp, ""))
 				ccp = "no";
 
 			def_create_mail_spool = xstrdup(ccp);
@@ -482,7 +482,7 @@ get_defaults(void)
 		 * By default do we add the user to the lastlog and faillog databases ?
 		 */
 		else if (streq(buf, DLOG_INIT)) {
-			if (*ccp == '\0')
+			if (streq(ccp, ""))
 				ccp = def_log_init;
 
 			def_log_init = xstrdup(ccp);
@@ -770,7 +770,7 @@ static int get_groups (char *list)
 		user_groups[i++] = NULL;
 	}
 
-	if ('\0' == *list) {
+	if (streq(list, "")) {
 		return 0;
 	}
 

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -177,7 +177,7 @@ static bool
     Uflg = false;		/* create a group having the same name as the user */
 
 #ifdef WITH_SELINUX
-#define Zflg ('\0' != *user_selinux)
+#define Zflg  (!streq(user_selinux, ""))
 #endif				/* WITH_SELINUX */
 
 static bool home_added = false;
@@ -1268,7 +1268,7 @@ static void process_flags (int argc, char **argv)
 				Dflg = true;
 				break;
 			case 'e':
-				if ('\0' != *optarg) {
+				if (!streq(optarg, "")) {
 					user_expire = strtoday (optarg);
 					if (user_expire < -1) {
 						fprintf (stderr,
@@ -1403,7 +1403,7 @@ static void process_flags (int argc, char **argv)
 				break;
 			case 's':
 				if (   ( !VALID (optarg) )
-				    || (   ('\0' != optarg[0])
+				    || (   !streq(optarg, "")
 				        && ('/'  != optarg[0])
 				        && ('*'  != optarg[0]) )) {
 					fprintf (stderr,
@@ -1411,7 +1411,7 @@ static void process_flags (int argc, char **argv)
 					         Prog, optarg);
 					exit (E_BAD_ARG);
 				}
-				if (    '\0' != optarg[0]
+				if (!streq(optarg, "")
 				     && '*'  != optarg[0]
 				     && !streq(optarg, "/sbin/nologin")
 				     && (   stat(optarg, &st) != 0

--- a/src/userdel.c
+++ b/src/userdel.c
@@ -1131,7 +1131,7 @@ int main (int argc, char **argv)
 	 * Note: This is a best effort basis. The user may log in between,
 	 * a cron job may be started on her behalf, etc.
 	 */
-	if ((prefix[0] == '\0') && !Rflg && user_busy (user_name, user_id) != 0) {
+	if (streq(prefix, "") && !Rflg && user_busy(user_name, user_id) != 0) {
 		if (!fflg) {
 #ifdef WITH_AUDIT
 			audit_logger (AUDIT_DEL_USER, Prog,
@@ -1264,7 +1264,7 @@ int main (int argc, char **argv)
 	 * Cancel any crontabs or at jobs. Have to do this before we remove
 	 * the entry from /etc/passwd.
 	 */
-	if (prefix[0] == '\0')
+	if (streq(prefix, ""))
 		user_cancel (user_name);
 	close_files ();
 

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -227,7 +227,7 @@ static int get_groups (char *list)
 	 */
 	user_groups[0] = NULL;
 
-	if ('\0' == *list) {
+	if (streq(list, "")) {
 		return 0;
 	}
 
@@ -2186,7 +2186,7 @@ int main (int argc, char **argv)
 	 * be changed while the user is logged in.
 	 * Note: no need to check if a prefix is specified...
 	 */
-	if ( (prefix[0] == '\0') &&  (uflg || lflg || dflg
+	if (streq(prefix, "") && (uflg || lflg || dflg
 #ifdef ENABLE_SUBIDS
 	        || Vflg || Wflg
 #endif				/* ENABLE_SUBIDS */

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -1154,7 +1154,7 @@ process_flags(int argc, char **argv)
 				break;
 			case 's':
 				if (   ( !VALID (optarg) )
-				    || (   ('\0' != optarg[0])
+				    || (   !streq(optarg, "")
 				        && ('/'  != optarg[0])
 				        && ('*'  != optarg[0]) )) {
 					fprintf (stderr,
@@ -1162,7 +1162,7 @@ process_flags(int argc, char **argv)
 					         Prog, optarg);
 					exit (E_BAD_ARG);
 				}
-				if (    '\0' != optarg[0]
+				if (!streq(optarg, "")
 				     && '*'  != optarg[0]
 				     && !streq(optarg, "/sbin/nologin")
 				     && (   stat(optarg, &st) != 0
@@ -2334,7 +2334,7 @@ int main (int argc, char **argv)
 
 #ifdef WITH_SELINUX
 	if (Zflg) {
-		if ('\0' != *user_selinux) {
+		if (!streq(user_selinux, "")) {
 			if (set_seuser (user_name, user_selinux, user_selinux_range) != 0) {
 				fprintf (stderr,
 				         _("%s: warning: the user name %s to %s SELinux user mapping failed.\n"),


### PR DESCRIPTION
Except for the added (and sorted) includes, the removal of redundant
parentheses, a few cases that have been refactored for readability, and
a couple of non-string cases that I've left out of the change, this
patch can be approximated with semantic patches (see commit messages).

---

Revisions:

<details>
<summary>v2</summary>

-  Fix typo in commit message.
-  Add patch 2 (`!streq()`).

```
$ git range-diff master gh/streq_empty streq_empty 
1:  a7d14373 ! 1:  7e329852 lib/, src/: Use streq() instead of its pattern
    @@ Commit message
                 + streq(s, "")
     
                 $ find contrib/ lib* src/ -type f \
    -            | xargs spatch --sp-file --in-place ~/tmp/spatch/streq.sp;
    +            | xargs spatch --in-place --sp-file ~/tmp/spatch/streq.sp;
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
-:  -------- > 2:  20460298 lib/, src/: Use !streq() instead of its pattern
```
</details>

<details>
<summary>v3</summary>

-  Expand patch 3 thanks to spatch(1).

```
$ git range-diff --creation-factor=99 master gh/streq_empty streq_empty 
1:  7e329852 = 1:  7e329852 lib/, src/: Use streq() instead of its pattern
2:  20460298 ! 2:  eb9c40c2 lib/, src/: Use !streq() instead of its pattern
    @@ Metadata
      ## Commit message ##
         lib/, src/: Use !streq() instead of its pattern
     
    +    Except for the added (and sorted) includes, the removal of redundant
    +    parentheses, and a few non-string cases that I've left out of the
    +    change, this patch can be approximated with the following semantic
    +    patch:
    +
    +            $ cat ~/tmp/spatch/strneq.sp
    +            @@
    +            expression s;
    +            @@
    +
    +            - '\0' != *s
    +            + !streq(s, "")
    +
    +            @@
    +            expression s;
    +            @@
    +
    +            - '\0' != s[0]
    +            + !streq(s, "")
    +
    +            @@
    +            expression s;
    +            @@
    +
    +            - *s != '\0'
    +            + !streq(s, "")
    +
    +            @@
    +            expression s;
    +            @@
    +
    +            - s[0] != '\0'
    +            + !streq(s, "")
    +
    +            $ find contrib/ lib* src/ -type f \
    +            | xargs spatch --in-place --sp-file ~/tmp/spatch/strneq.sp;
    +
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    + ## lib/chkname.c ##
    +@@
    + 
    + #include "defines.h"
    + #include "chkname.h"
    ++#include "string/strcmp/streq.h"
    + 
    + 
    + int allow_bad_names = false;
    +@@ lib/chkname.c: is_valid_name(const char *name)
    + 
    +   numeric = isdigit(*name);
    + 
    +-  while ('\0' != *++name) {
    ++  while (!streq(++name, "")) {
    +           if (!((*name >= 'a' && *name <= 'z') ||
    +                 (*name >= 'A' && *name <= 'Z') ||
    +                 (*name >= '0' && *name <= '9') ||
    +
    + ## lib/fields.c ##
    +@@
    + #include "prototypes.h"
    + #include "string/strchr/stpspn.h"
    + #include "string/strchr/strrspn.h"
    ++#include "string/strcmp/streq.h"
    + #include "string/strtok/stpsep.h"
    + 
    + 
    +@@ lib/fields.c: int valid_field (const char *field, const char *illegal)
    +   }
    + 
    +   /* Search if there are non-printable or control characters */
    +-  for (cp = field; '\0' != *cp; cp++) {
    ++  for (cp = field; !streq(cp, ""); cp++) {
    +           unsigned char c = *cp;
    +           if (!isprint (c)) {
    +                   err = 1;
    +@@ lib/fields.c: change_field(char *buf, size_t maxsize, const char *prompt)
    +   if (stpsep(newf, "\n") == NULL)
    +           return;
    + 
    +-  if ('\0' != newf[0]) {
    ++  if (!streq(newf, "")) {
    +           /*
    +            * Remove leading and trailing whitespace.  This also
    +            * makes it possible to change the field to empty, by
    +
    + ## lib/fputsx.c ##
    +@@
    + 
    + #include "defines.h"
    + #include "prototypes.h"
    +-
    +-#ident "$Id$"
    ++#include "string/strcmp/streq.h"
    + 
    + 
    + /*@null@*/char *
    +@@ lib/fputsx.c: int fputsx (const char *s, FILE * stream)
    + {
    +   int i;
    + 
    +-  for (i = 0; '\0' != *s; i++, s++) {
    ++  for (i = 0; !streq(s, ""); i++, s++) {
    +           if (putc (*s, stream) == EOF) {
    +                   return EOF;
    +           }
    +
    + ## lib/getdate.y ##
    +@@ lib/getdate.y: static int LookupWord (char *buff)
    +   bool abbrev;
    + 
    +   /* Make it lowercase. */
    +-  for (p = buff; '\0' != *p; p++)
    ++  for (p = buff; !streq(p, ""); p++)
    +     if (isupper (*p))
    +       *p = tolower (*p);
    + 
    +@@ lib/getdate.y: static int LookupWord (char *buff)
    +     }
    + 
    +   /* Drop out any periods and try the timezone table again. */
    +-  for (i = 0, p = q = buff; '\0' != *q; q++)
    ++  for (i = 0, p = q = buff; !streq(q, ""); q++)
    +     if (*q != '.')
    +       *p++ = *q;
    +     else
    +
    + ## lib/gshadow.c ##
    +@@ lib/gshadow.c: static /*@null@*/char **build_list (char *s, char **list[], size_t * nlist)
    +   char **ptr = *list;
    +   size_t nelem = *nlist, size;
    + 
    +-  while (s != NULL && *s != '\0') {
    ++  while (s != NULL && !streq(s, "")) {
    +           ptr = XREALLOC(*list, nelem + 1, char *);
    +           ptr[nelem] = strsep(&s, ",");
    +           nelem++;
    +
    + ## lib/limits.c ##
    +@@ lib/limits.c: static int do_user_limits (const char *buf, const char *name)
    +           pp = "A- C- D- F- I- L- M- N- O- P- R- S- T- U-";
    +   }
    + 
    +-  while ('\0' != *pp) {
    ++  while (!streq(pp, "")) {
    +           switch (*pp++) {
    +           case 'a':
    +           case 'A':
    +
    + ## lib/myname.c ##
    +@@
    + 
    + #ident "$Id$"
    + 
    +-#include "defines.h"
    + #include <pwd.h>
    ++
    ++#include "defines.h"
    + #include "prototypes.h"
    ++#include "string/strcmp/streq.h"
    ++
    ++
    + /*@null@*/ /*@only@*/struct passwd *get_my_pwent (void)
    + {
    +   struct passwd *pw;
    +@@
    +    * XXX - when running from su, will return the current user (not
    +    * the original user, like getlogin() does).  Does this matter?
    +    */
    +-  if ((NULL != cp) && ('\0' != *cp)) {
    ++  if ((NULL != cp) && !streq(cp, "")) {
    +           pw = xgetpwnam (cp);
    +           if ((NULL != pw) && (pw->pw_uid == ruid)) {
    +                   return pw;
    +
    + ## lib/nss.c ##
    +@@ lib/nss.c: nss_init(const char *nsswitch_path) {
    +                   continue;
    +           p = &line[6];
    +           p = stpspn(p, " \t\n");
    +-          if (*p != '\0')
    ++          if (!streq(p, ""))
    +                   break;
    +           p = NULL;
    +   }
    +
    + ## lib/obscure.c ##
    +@@ lib/obscure.c: static char *str_lower (/*@returned@*/char *string)
    + {
    +   char *cp;
    + 
    +-  for (cp = string; '\0' != *cp; cp++) {
    ++  for (cp = string; !streq(cp, ""); cp++) {
    +           *cp = tolower (*cp);
    +   }
    +   return string;
    +
      ## lib/port.c ##
    +@@ lib/port.c: static int portcmp (const char *pattern, const char *port)
    + {
    +   const char *orig = port;
    + 
    +-  while (('\0' != *pattern) && (*pattern == *port)) {
    ++  while (!streq(pattern, "") && (*pattern == *port)) {
    +           pattern++;
    +           port++;
    +   }
     @@ lib/port.c: next:
         * Get the next comma separated entry
         */
    @@ lib/port.c: next:
                /*
                 * Start off with no days of the week
     
    + ## lib/strtoday.c ##
    +@@ lib/strtoday.c: long strtoday (const char *str)
    +           s++;
    +   }
    +   s = stpspn(s, " ");
    +-  while (isnum && ('\0' != *s)) {
    ++  while (isnum && !streq(s, "")) {
    +           if (!isdigit (*s)) {
    +                   isnum = false;
    +           }
    +
    + ## lib/ttytype.c ##
    +@@ lib/ttytype.c: void ttytype (const char *line)
    +                   break;
    +           }
    +   }
    +-  if ((feof (fp) == 0) && (ferror (fp) == 0) && (type[0] != '\0')) {
    ++  if ((feof(fp) == 0) && (ferror(fp) == 0) && !streq(type, "")) {
    +           addenv ("TERM", type);
    +   }
    + 
    +
    + ## lib/utmp.c ##
    +@@ lib/utmp.c: prepare_utmp(const char *name, const char *line, const char *host,
    + 
    + 
    + 
    +-  if (NULL != host && '\0' != host[0])
    ++  if (NULL != host && !streq(host, ""))
    +           hostname = xstrdup(host);
    + #if defined(HAVE_STRUCT_UTMPX_UT_HOST)
    +   else if (NULL != ut && '\0' != ut->ut_host[0])
    +
    + ## src/chfn.c ##
    +@@ src/chfn.c: static char *copy_field (char *in, char *out, char *extra)
    +                   break;
    + 
    +           if (NULL != extra) {
    +-                  if ('\0' != extra[0]) {
    ++                  if (!streq(extra, "")) {
    +                           strcat (extra, ",");
    +                   }
    + 
    +@@ src/chfn.c: static void get_old_fields (const char *gecos)
    +    * Anything left over is "slop".
    +    */
    +   if ((NULL != cp) && !oflg) {
    +-          if ('\0' != slop[0]) {
    ++          if (!streq(slop, "")) {
    +                   strcat (slop, ",");
    +           }
    + 
    +@@ src/chfn.c: int main (int argc, char **argv)
    +   }
    +   SNPRINTF(new_gecos, "%s,%s,%s,%s%s%s",
    +            fullnm, roomno, workph, homeph,
    +-           ('\0' != slop[0]) ? "," : "", slop);
    ++           (!streq(slop, "")) ? "," : "", slop);
    + 
    +   /* Rewrite the user's gecos in the passwd file */
    +   update_gecos (user, new_gecos);
    +
    + ## src/gpasswd.c ##
    +@@ src/gpasswd.c: static bool is_valid_user_list (const char *users)
    + 
    +   tmpusers = dup = xstrdup(users);
    + 
    +-  while (NULL != tmpusers && '\0' != *tmpusers) {
    ++  while (NULL != tmpusers && !streq(tmpusers, "")) {
    +           const char  *u;
    + 
    +           u = strsep(&tmpusers, ",");
    +
    + ## src/login.c ##
    +@@ src/login.c: static /*@observer@*/const char *get_failent_user (/*@returned@*/const char *use
    +   const char *failent_user = "UNKNOWN";
    +   bool log_unkfail_enab = getdef_bool("LOG_UNKFAIL_ENAB");
    + 
    +-  if ((NULL != user) && ('\0' != user[0])) {
    ++  if ((NULL != user) && !streq(user, "")) {
    +           if (   log_unkfail_enab
    +               || (getpwnam (user) != NULL)) {
    +                   failent_user = user;
    +@@ src/login.c: int main (int argc, char **argv)
    + 
    +   if (hflg) {
    +           cp = hostname;
    +-  } else if ((host != NULL) && (host[0] != '\0')) {
    ++  } else if ((host != NULL) && !streq(host, "")) {
    +           cp = host;
    +   } else {
    +           cp = "";
    +   }
    + 
    +-  if ('\0' != *cp) {
    ++  if (!streq(cp, "")) {
    +           SNPRINTF(fromhost, " on '%.100s' from '%.200s'", tty, cp);
    +   } else {
    +           SNPRINTF(fromhost, " on '%.100s'", tty);
    +@@ src/login.c: int main (int argc, char **argv)
    +                   failed = true;
    +           }
    +           if (   !failed
    +-              && !login_access (username, ('\0' != *hostname) ? hostname : tty)) {
    ++              && !login_access(username, (!streq(hostname, "")) ? hostname : tty)) {
    +                   SYSLOG ((LOG_WARN, "LOGIN '%s' REFUSED %s",
    +                            username, fromhost));
    +                   failed = true;
    +
      ## src/login_nopam.c ##
     @@ src/login_nopam.c: static bool from_match (const char *tok, const char *string)
                if (strchr (string, '.') == NULL) {
                        return true;
                }
     -  } else if (   (tok[0] != '\0' && tok[(tok_len = strlen (tok)) - 1] == '.') /* network */
    -+  } else if (   (!streq(tok != '\0') && tok[(tok_len = strlen (tok)) - 1] == '.') /* network */
    ++  } else if (   (!streq(tok, "") && tok[(tok_len = strlen(tok)) - 1] == '.') /* network */
                   && (strncmp (tok, resolve_hostname (string), tok_len) == 0)) {
                return true;
        }
    @@ src/newgrp.c: static void check_perms (const struct group *grp,
                needspasswd = true;
        }
      
    +@@ src/newgrp.c: int main (int argc, char **argv)
    +   cp = getenv ("SHELL");
    +   if (!initflag && (NULL != cp)) {
    +           prog = cp;
    +-  } else if ((NULL != pwd->pw_shell) && ('\0' != pwd->pw_shell[0])) {
    ++  } else if ((NULL != pwd->pw_shell) && !streq(pwd->pw_shell, "")) {
    +           prog = pwd->pw_shell;
    +   } else {
    +           prog = SHELL;
    +
    + ## src/newusers.c ##
    +@@ src/newusers.c: static int add_group (const char *name, const char *gid, gid_t *ngid, uid_t uid)
    +   /*
    +    * Now I have all of the fields required to create the new group.
    +    */
    +-  if (('\0' != gid[0]) && (!isdigit (gid[0]))) {
    ++  if (!streq(gid, "") && (!isdigit(gid[0]))) {
    +           grent.gr_name = xstrdup (gid);
    +   } else {
    +           grent.gr_name = xstrdup (name);
    +@@ src/newusers.c: static int get_user_id (const char *uid, uid_t *nuid) {
    +                   return -1;
    +           }
    +   } else {
    +-          if ('\0' != uid[0]) {
    ++          if (!streq(uid, "")) {
    +                   const struct passwd *pwd;
    +                   /* local, no need for xgetpwnam */
    +                   pwd = getpwnam (uid);
    +@@ src/newusers.c: int main (int argc, char **argv)
    +                            Prog, line);
    +                   fail_exit (EXIT_FAILURE);
    +           }
    +-          if ('\0' != fields[4][0]) {
    ++          if (!streq(fields[4], "")) {
    +                   newpw.pw_gecos = fields[4];
    +           }
    + 
    +-          if ('\0' != fields[5][0]) {
    ++          if (!streq(fields[5], "")) {
    +                   newpw.pw_dir = fields[5];
    +           }
    + 
    +-          if ('\0' != fields[6][0]) {
    ++          if (!streq(fields[6], "")) {
    +                   newpw.pw_shell = fields[6];
    +           }
    + 
    +-          if (   ('\0' != fields[5][0])
    ++          if (   !streq(fields[5], "")
    +               && (access (newpw.pw_dir, F_OK) != 0)) {
    + /* FIXME: should check for directory */
    +                   mode_t mode = getdef_num ("HOME_MODE",
    +
    + ## src/passwd.c ##
    +@@ src/passwd.c: static int new_password (const struct passwd *pw)
    +    * password.
    +    */
    + 
    +-  if (!amroot && ('\0' != crypt_passwd[0])) {
    ++  if (!amroot && !streq(crypt_passwd, "")) {
    +           clear = agetpass (_("Old password: "));
    +           if (NULL == clear) {
    +                   return -1;
    +
    + ## src/pwck.c ##
    +@@ src/pwck.c: static void check_pw_file (int *errors, bool *changed)
    +            * Make sure the login shell is executable
    +            */
    +           if (   !quiet
    +-              && ('\0' != pwd->pw_shell[0])
    ++              && !streq(pwd->pw_shell, "")
    +               && (access (pwd->pw_shell, F_OK) != 0)) {
    + 
    +                   /*
    +
    + ## src/su.c ##
    +@@ src/su.c: int main (int argc, char **argv)
    +   sulog (caller_tty, true, caller_name, name);    /* save SU information */
    +   if (getdef_bool ("SYSLOG_SU_ENAB")) {
    +           SYSLOG ((LOG_INFO, "+ %s %s:%s", caller_tty,
    +-                   ('\0' != caller_name[0]) ? caller_name : "???",
    +-                   ('\0' != name[0]) ? name : "???"));
    ++                   (!streq(caller_name, "")) ? caller_name : "???",
    ++                   (!streq(name, "")) ? name : "???"));
    +   }
    + 
    + #ifdef USE_PAM
    +@@ src/su.c: int main (int argc, char **argv)
    +                           AUDIT_USER_ROLE_CHANGE,
    +                           NULL,    /* Prog. name */
    +                           "su",
    +-                          ('\0' != caller_name[0]) ? caller_name : "???",
    ++                          (!streq(caller_name, "")) ? caller_name : "???",
    +                           AUDIT_NO_ID,
    +                           "localhost",
    +                           NULL,    /* addr */
    +
    + ## src/useradd.c ##
    +@@ src/useradd.c: static bool
    +     Uflg = false;         /* create a group having the same name as the user */
    + 
    + #ifdef WITH_SELINUX
    +-#define Zflg ('\0' != *user_selinux)
    ++#define Zflg  (!streq(user_selinux, ""))
    + #endif                            /* WITH_SELINUX */
    + 
    + static bool home_added = false;
    +@@ src/useradd.c: static void process_flags (int argc, char **argv)
    +                           Dflg = true;
    +                           break;
    +                   case 'e':
    +-                          if ('\0' != *optarg) {
    ++                          if (!streq(optarg, "")) {
    +                                   user_expire = strtoday (optarg);
    +                                   if (user_expire < -1) {
    +                                           fprintf (stderr,
    +@@ src/useradd.c: static void process_flags (int argc, char **argv)
    +                           break;
    +                   case 's':
    +                           if (   ( !VALID (optarg) )
    +-                              || (   ('\0' != optarg[0])
    ++                              || (   !streq(optarg, "")
    +                                   && ('/'  != optarg[0])
    +                                   && ('*'  != optarg[0]) )) {
    +                                   fprintf (stderr,
    +@@ src/useradd.c: static void process_flags (int argc, char **argv)
    +                                            Prog, optarg);
    +                                   exit (E_BAD_ARG);
    +                           }
    +-                          if (    '\0' != optarg[0]
    ++                          if (!streq(optarg, "")
    +                                && '*'  != optarg[0]
    +                                && !streq(optarg, "/sbin/nologin")
    +                                && (   stat(optarg, &st) != 0
    +
    + ## src/usermod.c ##
    +@@ src/usermod.c: process_flags(int argc, char **argv)
    +                           break;
    +                   case 's':
    +                           if (   ( !VALID (optarg) )
    +-                              || (   ('\0' != optarg[0])
    ++                              || (   !streq(optarg, "")
    +                                   && ('/'  != optarg[0])
    +                                   && ('*'  != optarg[0]) )) {
    +                                   fprintf (stderr,
    +@@ src/usermod.c: process_flags(int argc, char **argv)
    +                                            Prog, optarg);
    +                                   exit (E_BAD_ARG);
    +                           }
    +-                          if (    '\0' != optarg[0]
    ++                          if (!streq(optarg, "")
    +                                && '*'  != optarg[0]
    +                                && !streq(optarg, "/sbin/nologin")
    +                                && (   stat(optarg, &st) != 0
    +@@ src/usermod.c: int main (int argc, char **argv)
    + 
    + #ifdef WITH_SELINUX
    +   if (Zflg) {
    +-          if ('\0' != *user_selinux) {
    ++          if (!streq(user_selinux, "")) {
    +                   if (set_seuser (user_name, user_selinux, user_selinux_range) != 0) {
    +                           fprintf (stderr,
    +                                    _("%s: warning: the user name %s to %s SELinux user mapping failed.\n"),
```
</details>

<details>
<summary>v3b</summary>

-  Rebase

```
$ git range-diff master..gh/streq_empty shadow/master..streq_empty 
1:  7e329852 = 1:  bd4f4f04 lib/, src/: Use streq() instead of its pattern
2:  eb9c40c2 ! 2:  c19d559a lib/, src/: Use !streq() instead of its pattern
    @@ lib/getdate.y: static int LookupWord (char *buff)
          else
     
      ## lib/gshadow.c ##
    -@@ lib/gshadow.c: static /*@null@*/char **build_list (char *s, char **list[], size_t * nlist)
    -   char **ptr = *list;
    -   size_t nelem = *nlist, size;
    +@@ lib/gshadow.c: build_list(char *s)
      
    --  while (s != NULL && *s != '\0') {
    -+  while (s != NULL && !streq(s, "")) {
    -           ptr = XREALLOC(*list, nelem + 1, char *);
    -           ptr[nelem] = strsep(&s, ",");
    -           nelem++;
    +   l = XMALLOC(strchrcnt(s, ',') + 2, char *);
    + 
    +-  for (i = 0; s != NULL && *s != '\0'; i++)
    ++  for (i = 0; s != NULL && !streq(s, ""); i++)
    +           l[i] = strsep(&s, ",");
    + 
    +   l[i] = NULL;
     
      ## lib/limits.c ##
     @@ lib/limits.c: static int do_user_limits (const char *buf, const char *name)
```
</details>

<details>
<summary>v3c</summary>

-  Rebase

```
$ git range-diff master..gh/streq_empty shadow/master..streq_empty 
1:  bd4f4f04 ! 1:  22adffdb lib/, src/: Use streq() instead of its pattern
    @@ lib/sgetgrent.c: struct group *sgetgrent (const char *buf)
        for (cp = grpbuf, i = 0; (i < NFIELDS) && (NULL != cp); i++)
                grpfields[i] = strsep(&cp, ":");
      
    --  if (i < (NFIELDS - 1) || *grpfields[2] == '\0' || cp != NULL) {
    -+  if (i < (NFIELDS - 1) || streq(grpfields[2], "") || cp != NULL) {
    +-  if (i < NFIELDS || *grpfields[2] == '\0' || cp != NULL) {
    ++  if (i < NFIELDS || streq(grpfields[2], "") || cp != NULL) {
                return NULL;
        }
        grent.gr_name = grpfields[0];
2:  c19d559a = 2:  fdbd9651 lib/, src/: Use !streq() instead of its pattern
```
</details>