### PR TITLE
lib/sgetgrent.c: sgetgrent(): Fix use-after-free bug

### DIFF
--- a/lib/sgetgrent.c
+++ b/lib/sgetgrent.c
@@ -89,7 +89,7 @@ struct group *sgetgrent (const char *buf)
 	for (cp = grpbuf, i = 0; (i < NFIELDS) && (NULL != cp); i++)
 		grpfields[i] = strsep(&cp, ":");
 
-	if (i < (NFIELDS - 1) || *grpfields[2] == '\0' || cp != NULL) {
+	if (i < NFIELDS || *grpfields[2] == '\0' || cp != NULL) {
 		return NULL;
 	}
 	grent.gr_name = grpfields[0];


### PR DESCRIPTION
We were possibly using an old value if (i == NFIELDS-1).  A few lines below this check, we use the element in [3] (that is, [NFIELDS-1]), but it might be old, since we didn't necessarily fill it ourselves.

Be stricter, and require that all NFIELDS fields are found.

Closes: <https://github.com/shadow-maint/shadow/issues/1144>
Cc: Serge Hallyn <serge@hallyn.com>
Cc: Iker Pedrosa <ipedrosa@redhat.com>

---

Revisions:

<details>
<summary>v1b</summary>

-  It's not UB; it's just a behavior bug.

```
$ git range-diff master gh/nfields nfields 
1:  aef7dfa9 ! 1:  54ec0af5 lib/sgetgrent.c: sgetgrent(): Fix use of uninitialized value
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/sgetgrent.c: sgetgrent(): Fix use of uninitialized value
    +    lib/sgetgrent.c: sgetgrent(): Fix use of spurious value
     
    -    We were triggering undefined behavior if (i == NFIELDS-1).  A few lines
    -    below this check, we use read the element in [3] (that is, [NFIELDS-1]),
    -    but it might be uninitialized, since we allowed that.
    +    We were reusing a leftover from parsing a previous line if
    +    (i == NFIELDS-1).  A few lines below this check, we use read the element
    +    in [3] (that is, [NFIELDS-1]), without having written it in this call.
     
         Be stricter, and require that all NFIELDS fields are found.
     
```
</details>

<details>
<summary>v1c</summary>

-  It is a use-after-free bug.

```$ git range-diff master gh/nfields nfields 
1:  54ec0af5 ! 1:  8d2a94e3 lib/sgetgrent.c: sgetgrent(): Fix use of spurious value
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/sgetgrent.c: sgetgrent(): Fix use of spurious value
    +    lib/sgetgrent.c: sgetgrent(): Fix use-after-free bug
     
         We were reusing a leftover from parsing a previous line if
         (i == NFIELDS-1).  A few lines below this check, we use read the element
```
</details>

<details>
<summary>v1d</summary>

-  Add Fixes tag.

```
$ git range-diff master gh/nfields nfields 
1:  8d2a94e3 ! 1:  4e64f977 lib/sgetgrent.c: sgetgrent(): Fix use-after-free bug
    @@ Commit message
     
         Be stricter, and require that all NFIELDS fields are found.
     
    +    Fixes: 45c6603cc86c (2007-10-07, "[svn-upgrade] Integrating new upstream version, shadow (19990709)")
         Closes: <https://github.com/shadow-maint/shadow/issues/1144>
         Cc: Serge Hallyn <serge@hallyn.com>
         Cc: Iker Pedrosa <ipedrosa@redhat.com>
```
</details>