### PR TITLE
seprintf() and stpecpy() improvements.

### DIFF
--- a/lib/string/sprintf/seprintf.c
+++ b/lib/string/sprintf/seprintf.c
@@ -10,8 +10,8 @@
 
 
 #if !defined(HAVE_SEPRINTF)
-extern inline char *seprintf(char *dst, const char *end,
+extern inline char *seprintf(char *dst, const char end[0],
     const char *restrict fmt, ...);
-extern inline char *vseprintf(char *dst, const char *end,
+extern inline char *vseprintf(char *dst, const char end[0],
     const char *restrict fmt, va_list ap);
 #endif

--- a/lib/string/sprintf/seprintf.h
+++ b/lib/string/sprintf/seprintf.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-FileCopyrightText: 2022-2025, Alejandro Colomar <alx@kernel.org>
 // SPDX-License-Identifier: BSD-3-Clause
 
 
@@ -18,18 +18,18 @@
 #if !defined(HAVE_SEPRINTF)
 // seprintf - string end-pointer print formatted
 format_attr(printf, 3, 4)
-inline char *seprintf(char *dst, const char *end, const char *restrict fmt,
+inline char *seprintf(char *dst, const char end[0], const char *restrict fmt,
     ...);
 // vseprintf - va_list string end-pointer print formatted
 format_attr(printf, 3, 0)
-inline char *vseprintf(char *dst, const char *end, const char *restrict fmt,
+inline char *vseprintf(char *dst, const char end[0], const char *restrict fmt,
     va_list ap);
 #endif
 
 
 #if !defined(HAVE_SEPRINTF)
 inline char *
-seprintf(char *dst, const char *end, const char *restrict fmt, ...)
+seprintf(char *dst, const char end[0], const char *restrict fmt, ...)
 {
 	char     *p;
 	va_list  ap;
@@ -45,7 +45,7 @@ seprintf(char *dst, const char *end, const char *restrict fmt, ...)
 
 #if !defined(HAVE_SEPRINTF)
 inline char *
-vseprintf(char *dst, const char *end, const char *restrict fmt, va_list ap)
+vseprintf(char *dst, const char end[0], const char *restrict fmt, va_list ap)
 {
 	int        len;
 	ptrdiff_t  size;

--- a/lib/string/strcpy/stpecpy.c
+++ b/lib/string/strcpy/stpecpy.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-FileCopyrightText: 2022-2025, Alejandro Colomar <alx@kernel.org>
 // SPDX-License-Identifier: BSD-3-Clause
 
 
@@ -8,6 +8,6 @@
 
 
 #if !defined(HAVE_STPECPY)
-extern inline char *stpecpy(char *dst, const char *end,
+extern inline char *stpecpy(char *dst, const char end[0],
     const char *restrict src);
 #endif

--- a/lib/string/strcpy/stpecpy.h
+++ b/lib/string/strcpy/stpecpy.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022-2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-FileCopyrightText: 2022-2025, Alejandro Colomar <alx@kernel.org>
 // SPDX-License-Identifier: BSD-3-Clause
 
 
@@ -20,13 +20,13 @@
 #if !defined(HAVE_STPECPY)
 // stpecpy - string offset-pointer end-pointer copy
 ATTR_STRING(3)
-inline char *stpecpy(char *dst, const char *end, const char *restrict src);
+inline char *stpecpy(char *dst, const char end[0], const char *restrict src);
 #endif
 
 
 #if !defined(HAVE_STPECPY)
 inline char *
-stpecpy(char *dst, const char *end, const char *restrict src)
+stpecpy(char *dst, const char end[0], const char *restrict src)
 {
 	ssize_t  dlen;
 


### PR DESCRIPTION
Cc: @uecker 

---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git range-diff alx/master..gh/snprintf_ master..snprintf_ 
1:  6a656139 = 1:  99aef5b4 lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
```
</details>

<details>
<summary>v1c</summary>

-  Rebase

```
$ git range-diff alx/master..gh/snprintf_ master..snprintf_ 
1:  99aef5b4 = 1:  1fad167c lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
```
</details>

<details>
<summary>v1d</summary>

-  Rebase

```
$ git range-diff master..gh/snprintf_ shadow/master..snprintf_ 
1:  1fad167c = 1:  242ba524 lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
```
</details>

<details>
<summary>v1e</summary>

-  Rebase

```
$ git range-diff master..gh/snprintf_ shadow/master..snprintf_ 
1:  242ba524 = 1:  1c546325 lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
```
</details>

<details>
<summary>v2</summary>

-  Redesign stpecpy() and stpeprintf().

```
$ git range-diff shadow/master gh/snprintf_ snprintf_ 
1:  1c546325 = 1:  1c546325 lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
-:  -------- > 2:  edda7ae9 lib/string/: Redesign stpecpy() and stpeprintf()
```
</details>

<details>
<summary>v3</summary>

-  Also set errno from snprintf_(), and rename it to stprintf().

```
$ git range-diff master gh/snprintf_ snprintf_ 
1:  1c546325 = 1:  1c546325 lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
-:  -------- > 2:  593e767b lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
-:  -------- > 3:  8a5852a9 lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
2:  edda7ae9 = 4:  62d3f05c lib/string/: Redesign stpecpy() and stpeprintf()
-:  -------- > 5:  0d741164 lib/, src/, tests/: Rename snprintf() to stprintf()
```
</details>

<details>
<summary>v4</summary>

-  tfix in commit message.
-  Change remaining cases of SNPRINTF() by STPRINTF().
-  Change remaining calls to snprintf(3) by stprintf().

```
$ git range-diff master gh/snprintf_ snprintf_ 
1:  1c546325 = 1:  1c546325 lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
2:  593e767b = 2:  593e767b lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
3:  8a5852a9 = 3:  8a5852a9 lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
4:  62d3f05c = 4:  62d3f05c lib/string/: Redesign stpecpy() and stpeprintf()
5:  0d741164 ! 5:  7f2f76b1 lib/, src/, tests/: Rename snprintf() to stprintf()
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/, src/, tests/: Rename snprintf() to stprintf()
    +    lib/, src/, tests/: Rename snprintf_() to stprintf()
     
         For consistency with strTcpy(), call it sTprintf().
     
    @@ src/chage.c: static int new_fields (void)
        change_field (buf, sizeof buf, _("Maximum Password Age"));
        if (a2sl(&maxdays, buf, NULL, 0, -1, LONG_MAX) == -1)
                return 0;
    +@@ src/chage.c: static int new_fields (void)
    +           }
    +   }
    + 
    +-  SNPRINTF(buf, "%ld", warndays);
    ++  STPRINTF(buf, "%ld", warndays);
    +   change_field (buf, sizeof buf, _("Password Expiration Warning"));
    +   if (a2sl(&warndays, buf, NULL, 0, -1, LONG_MAX) == -1)
    +           return 0;
    + 
    +-  SNPRINTF(buf, "%ld", inactdays);
    ++  STPRINTF(buf, "%ld", inactdays);
    +   change_field (buf, sizeof buf, _("Password Inactive"));
    +   if (a2sl(&inactdays, buf, NULL, 0, -1, LONG_MAX) == -1)
    +           return 0;
     
      ## src/chfn.c ##
     @@
-:  -------- > 6:  48eac294 lib/salt.c: Use stprintf() instead of snprintf(3)
```
</details>

<details>
<summary>v5</summary>

-  Allow size==0 in stprintf().  [@chrisbazley]

```
$ git range-diff master gh/snprintf_ snprintf_ 
1:  1c546325 = 1:  1c546325 lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
2:  593e767b = 2:  593e767b lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
3:  8a5852a9 = 3:  8a5852a9 lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
4:  62d3f05c = 4:  62d3f05c lib/string/: Redesign stpecpy() and stpeprintf()
5:  7f2f76b1 = 5:  7f2f76b1 lib/, src/, tests/: Rename snprintf_() to stprintf()
6:  48eac294 = 6:  48eac294 lib/salt.c: Use stprintf() instead of snprintf(3)
-:  -------- > 7:  c4c52681 lib/string/sprintf/stprintf.h: stprintf(): Allow size==0 to succeed
```
</details>

<details>
<summary>v5b</summary>

-  Add missing include.

```
$ git range-diff master gh/snprintf_ snprintf_ 
1:  1c546325 = 1:  1c546325 lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
2:  593e767b = 2:  593e767b lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
3:  8a5852a9 = 3:  8a5852a9 lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
4:  62d3f05c ! 4:  0e13a8a7 lib/string/: Redesign stpecpy() and stpeprintf()
    @@ lib/string/sprintf/stpeprintf.h: vstpeprintf(char *dst, char *end, const char *r
      }
     
      ## lib/string/strcpy/stpecpy.h ##
    +@@
    + 
    + #include <config.h>
    + 
    ++#include <errno.h>
    + #include <stdbool.h>
    + #include <stddef.h>
    + #include <string.h>
     @@ lib/string/strcpy/stpecpy.h: inline char *stpecpy(char *dst, char *end, const char *restrict src);
       *
       * RETURN VALUE
5:  7f2f76b1 = 5:  c3a1e485 lib/, src/, tests/: Rename snprintf_() to stprintf()
6:  48eac294 = 6:  97318079 lib/salt.c: Use stprintf() instead of snprintf(3)
7:  c4c52681 = 7:  4a540a9c lib/string/sprintf/stprintf.h: stprintf(): Allow size==0 to succeed
```
</details>

<details>
<summary>v6</summary>

-  Drop the changes from v5 (thus, roll back to v4, but keep the fix in v5b).  Let's keep stprintf() simple, and let users call snprintf(3) for the few niche use cases where it's actually good: querying the length of the would-be string (note: we don't need it ourselves, but some projects do want that behavior in a few specific places).

```
$ git range-diff master gh/snprintf_ snprintf_ 
1:  1c546325 = 1:  1c546325 lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
2:  593e767b = 2:  593e767b lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
3:  8a5852a9 = 3:  8a5852a9 lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
4:  0e13a8a7 = 4:  0e13a8a7 lib/string/: Redesign stpecpy() and stpeprintf()
5:  c3a1e485 = 5:  c3a1e485 lib/, src/, tests/: Rename snprintf_() to stprintf()
6:  97318079 = 6:  97318079 lib/salt.c: Use stprintf() instead of snprintf(3)
7:  4a540a9c < -:  -------- lib/string/sprintf/stprintf.h: stprintf(): Allow size==0 to succeed
```
</details>

<details>
<summary>v7</summary>

-  Drop checks for existence of stpecpy() and stpeprintf() in libc.
-  Use [0] for end pointers in function prototypes.
-  Compact docs.
-  Rename stpeprintf() => seprintf().

```
$ git range-diff master gh/snprintf_ snprintf_ 
 1:  1c546325 =  1:  1c546325 lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  593e767b =  2:  593e767b lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
 3:  8a5852a9 =  3:  8a5852a9 lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  0e13a8a7 =  4:  0e13a8a7 lib/string/: Redesign stpecpy() and stpeprintf()
 5:  c3a1e485 =  5:  c3a1e485 lib/, src/, tests/: Rename snprintf_() to stprintf()
 6:  97318079 =  6:  97318079 lib/salt.c: Use stprintf() instead of snprintf(3)
 -:  -------- >  7:  bda0fe43 configure.ac, lib/string/: Drop checks for non-libc functions
 -:  -------- >  8:  0cfb2181 lib/string/: Use [0] for end pointers
 -:  -------- >  9:  2a62e094 lib/string/: Compact documentation
 -:  -------- > 10:  9de56f67 lib/, po/, src/: Rename stpeprintf() => seprintf()
```
</details>

<details>
<summary>v7b</summary>

-  Add link to GCC bug.

```
$ git range-diff master gh/snprintf_ snprintf_ 
 1:  1c546325 =  1:  1c546325 lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  593e767b =  2:  593e767b lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
 3:  8a5852a9 =  3:  8a5852a9 lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  0e13a8a7 =  4:  0e13a8a7 lib/string/: Redesign stpecpy() and stpeprintf()
 5:  c3a1e485 =  5:  c3a1e485 lib/, src/, tests/: Rename snprintf_() to stprintf()
 6:  97318079 =  6:  97318079 lib/salt.c: Use stprintf() instead of snprintf(3)
 7:  bda0fe43 =  7:  bda0fe43 configure.ac, lib/string/: Drop checks for non-libc functions
 8:  0cfb2181 !  8:  d89c7c4f lib/string/: Use [0] for end pointers
    @@ Commit message
         fine, and the diagnostic can be ignored.  We're working on removing that
         false positive in GCC, so the diagnostic will eventually disappear.
     
    +    Link: <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108036>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/string/sprintf/stpeprintf.c ##
 9:  2a62e094 =  9:  c3215c8d lib/string/: Compact documentation
10:  9de56f67 = 10:  eca92cf6 lib/, po/, src/: Rename stpeprintf() => seprintf()
```
</details>

<details>
<summary>v7c</summary>

-  Rebase

```
$ git range-diff master..gh/snprintf_ shadow/master..snprintf_ 
 1:  1c546325 =  1:  5b7e0f53 lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  593e767b =  2:  d74b340c lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
 3:  8a5852a9 =  3:  61ee52f5 lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  0e13a8a7 =  4:  d5e16d4a lib/string/: Redesign stpecpy() and stpeprintf()
 5:  c3a1e485 !  5:  233311be lib/, src/, tests/: Rename snprintf_() to stprintf()
    @@ src/useradd.c
     -#include "string/sprintf/snprintf.h"
     +#include "string/sprintf/stprintf.h"
      #include "string/sprintf/xasprintf.h"
    + #include "string/strcmp/strcaseeq.h"
      #include "string/strcmp/streq.h"
    - #include "string/strdup/xstrdup.h"
     @@ src/useradd.c: set_defaults(void)
        /*
         * Rename the current default file to its backup name.
 6:  97318079 =  6:  6064e746 lib/salt.c: Use stprintf() instead of snprintf(3)
 7:  bda0fe43 =  7:  e49a405d configure.ac, lib/string/: Drop checks for non-libc functions
 8:  d89c7c4f =  8:  6bfc2923 lib/string/: Use [0] for end pointers
 9:  c3215c8d =  9:  fdd60f02 lib/string/: Compact documentation
10:  eca92cf6 = 10:  1e4dfd2b lib/, po/, src/: Rename stpeprintf() => seprintf()
```
</details>

<details>
<summary>v8</summary>

-  Add comments spelling out the meaning of the letter-soup API names.  [@hallyn ]

```
$ git range-diff master gh/snprintf_ snprintf_ 
 1:  5b7e0f53 =  1:  5b7e0f53 lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  d74b340c =  2:  d74b340c lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
 3:  61ee52f5 =  3:  61ee52f5 lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  d5e16d4a =  4:  d5e16d4a lib/string/: Redesign stpecpy() and stpeprintf()
 5:  233311be !  5:  66747deb lib/, src/, tests/: Rename snprintf_() to stprintf()
    @@ lib/string/sprintf/snprintf.h => lib/string/sprintf/stprintf.h
          va_list ap);
      
      
    ++// string truncate print formatted
      inline int
     -snprintf_(char *restrict s, int size, const char *restrict fmt, ...)
     +stprintf(char *restrict s, int size, const char *restrict fmt, ...)
 6:  6064e746 =  6:  2d2e5ba5 lib/salt.c: Use stprintf() instead of snprintf(3)
 7:  e49a405d =  7:  1ae06a51 configure.ac, lib/string/: Drop checks for non-libc functions
 8:  6bfc2923 =  8:  19d30811 lib/string/: Use [0] for end pointers
 9:  fdd60f02 !  9:  7e145d0e lib/string/: Compact documentation
    @@ lib/string/sprintf/stpeprintf.h
      #include "string/sprintf/stprintf.h"
      
      
    ++// string pointer-to-end print formatted
     +// Like stpecpy(), but with a formatted string.
     +// Report internal snprintf(3) errors with NULL and errno.
     +// Calls to these functions can be chained with calls to stpecpy().
10:  1e4dfd2b = 10:  022e7197 lib/, po/, src/: Rename stpeprintf() => seprintf()
```
</details>

<details>
<summary>v8b</summary>

-  Rebase

```
$ git range-diff master..gh/snprintf_ shadow/master..snprintf_ 
 1:  5b7e0f53 =  1:  32422838 lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  d74b340c =  2:  2ecfdfaa lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
 3:  61ee52f5 =  3:  c12aa3ca lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  d5e16d4a =  4:  81fa5226 lib/string/: Redesign stpecpy() and stpeprintf()
 5:  66747deb !  5:  26d3b448 lib/, src/, tests/: Rename snprintf_() to stprintf()
    @@ lib/nss.c
      #include "shadowlog.h"
     -#include "string/sprintf/snprintf.h"
     +#include "string/sprintf/stprintf.h"
    - #include "string/strchr/stpspn.h"
      #include "string/strcmp/streq.h"
    + #include "string/strspn/stpspn.h"
      #include "string/strtok/stpsep.h"
     @@ lib/nss.c: nss_init(const char *nsswitch_path) {
                fprintf(shadow_logfd, "Using files\n");
 6:  2d2e5ba5 =  6:  be77d4ea lib/salt.c: Use stprintf() instead of snprintf(3)
 7:  1ae06a51 =  7:  10875fb9 configure.ac, lib/string/: Drop checks for non-libc functions
 8:  19d30811 =  8:  7e8d9b4c lib/string/: Use [0] for end pointers
 9:  7e145d0e =  9:  dd12188f lib/string/: Compact documentation
10:  022e7197 = 10:  e4469d92 lib/, po/, src/: Rename stpeprintf() => seprintf()
```
</details>

<details>
<summary>v8c</summary>

-  Rebase

```
$ git range-diff master..gh/snprintf_ shadow/master..snprintf_ 
 1:  32422838 =  1:  4552d5b1 lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  2ecfdfaa =  2:  a01ba1e5 lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
 3:  c12aa3ca =  3:  810dee35 lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  81fa5226 =  4:  62ca9100 lib/string/: Redesign stpecpy() and stpeprintf()
 5:  26d3b448 !  5:  b6949ccc lib/, src/, tests/: Rename snprintf_() to stprintf()
    @@ Commit message
     
      ## lib/Makefile.am ##
     @@ lib/Makefile.am: libshadow_la_SOURCES = \
    -   sssd.h \
    +   string/ctype/strisascii/strisdigit.h \
        string/memset/memzero.c \
        string/memset/memzero.h \
     -  string/sprintf/snprintf.c \
    @@ lib/string/sprintf/stprintf.h: snprintf_(char *restrict s, int size, const char
     
      ## lib/subordinateio.c ##
     @@
    - #include "alloc/realloc.h"
      #include "alloc/reallocf.h"
      #include "atoi/str2i/str2u.h"
    + #include "string/ctype/strisascii/strisdigit.h"
     -#include "string/sprintf/snprintf.h"
     +#include "string/sprintf/stprintf.h"
      #include "string/strcmp/streq.h"
 6:  be77d4ea =  6:  5e4639f1 lib/salt.c: Use stprintf() instead of snprintf(3)
 7:  10875fb9 =  7:  be311696 configure.ac, lib/string/: Drop checks for non-libc functions
 8:  7e8d9b4c =  8:  3cd0587c lib/string/: Use [0] for end pointers
 9:  dd12188f =  9:  ae365c0f lib/string/: Compact documentation
10:  e4469d92 ! 10:  a7e08cb6 lib/, po/, src/: Rename stpeprintf() => seprintf()
    @@ Commit message
     
      ## lib/Makefile.am ##
     @@ lib/Makefile.am: libshadow_la_SOURCES = \
    -   sssd.h \
    +   string/ctype/strisascii/strisdigit.h \
        string/memset/memzero.c \
        string/memset/memzero.h \
     -  string/sprintf/stpeprintf.c \
```
</details>

<details>
<summary>v8d</summary>

-  Rebase

```
$ git range-diff master..gh/snprintf_ shadow/master..snprintf_ 
 1:  4552d5b1 =  1:  9790039a lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  a01ba1e5 =  2:  10729667 lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
 3:  810dee35 =  3:  24d605f3 lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  62ca9100 =  4:  484b35d7 lib/string/: Redesign stpecpy() and stpeprintf()
 5:  b6949ccc !  5:  22cc511e lib/, src/, tests/: Rename snprintf_() to stprintf()
    @@ src/gpasswd.c
      #include "string/strcmp/streq.h"
      #include "string/strcpy/strtcpy.h"
      #include "string/strdup/xstrdup.h"
    -@@ src/gpasswd.c: static void log_gpasswd_failure (const char *suffix)
    -                    "%s failed to add user %s to group %s%s",
    -                    myname, user, group, suffix));
    - #ifdef WITH_AUDIT
    --          SNPRINTF(buf, "%s failed to add user %s to group %s%s",
    -+          STPRINTF(buf, "%s failed to add user %s to group %s%s",
    -                    myname, user, group, suffix);
    -           audit_logger (AUDIT_USER_ACCT, Prog,
    -                         buf,
    -@@ src/gpasswd.c: static void log_gpasswd_failure (const char *suffix)
    -                    "%s failed to remove user %s from group %s%s",
    -                    myname, user, group, suffix));
    - #ifdef WITH_AUDIT
    --          SNPRINTF(buf, "%s failed to remove user %s from group %s%s",
    -+          STPRINTF(buf, "%s failed to remove user %s from group %s%s",
    -                    myname, user, group, suffix);
    -           audit_logger (AUDIT_USER_ACCT, Prog,
    -                         buf,
    -@@ src/gpasswd.c: static void log_gpasswd_failure (const char *suffix)
    -                    "%s failed to remove password of group %s%s",
    -                    myname, group, suffix));
    - #ifdef WITH_AUDIT
    --          SNPRINTF(buf, "%s failed to remove password of group %s%s",
    -+          STPRINTF(buf, "%s failed to remove password of group %s%s",
    -                    myname, group, suffix);
    -           audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
    -                         buf,
    -@@ src/gpasswd.c: static void log_gpasswd_failure (const char *suffix)
    -                    "%s failed to restrict access to group %s%s",
    -                    myname, group, suffix));
    - #ifdef WITH_AUDIT
    --          SNPRINTF(buf, "%s failed to restrict access to group %s%s",
    -+          STPRINTF(buf, "%s failed to restrict access to group %s%s",
    -                    myname, group, suffix);
    -           audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
    -                         buf,
    -@@ src/gpasswd.c: static void log_gpasswd_failure (const char *suffix)
    -                            "%s failed to set the administrators of group %s to %s%s",
    -                            myname, group, admins, suffix));
    - #ifdef WITH_AUDIT
    --                  SNPRINTF(buf, "%s failed to set the administrators of group %s to %s%s",
    -+                  STPRINTF(buf, "%s failed to set the administrators of group %s to %s%s",
    -                            myname, group, admins, suffix);
    -                   audit_logger (AUDIT_USER_ACCT, Prog,
    -                                 buf,
    -@@ src/gpasswd.c: static void log_gpasswd_failure (const char *suffix)
    -                            "%s failed to set the members of group %s to %s%s",
    -                            myname, group, members, suffix));
    - #ifdef WITH_AUDIT
    --                  SNPRINTF(buf, "%s failed to set the members of group %s to %s%s",
    -+                  STPRINTF(buf, "%s failed to set the members of group %s to %s%s",
    -                            myname, group, members, suffix);
    -                   audit_logger (AUDIT_USER_ACCT, Prog,
    -                                 buf,
    -@@ src/gpasswd.c: static void log_gpasswd_failure (const char *suffix)
    -                    "%s failed to change password of group %s%s",
    -                    myname, group, suffix));
    - #ifdef WITH_AUDIT
    --          SNPRINTF(buf, "%s failed to change password of group %s%s",
    -+          STPRINTF(buf, "%s failed to change password of group %s%s",
    -                    myname, group, suffix);
    -           audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
    -                         buf,
     @@ src/gpasswd.c: static void log_gpasswd_failure_group (MAYBE_UNUSED void *arg)
      {
        char  buf[1024];
    @@ src/gpasswd.c: static void log_gpasswd_failure_gshadow (MAYBE_UNUSED void *arg)
        log_gpasswd_failure (buf);
      }
      #endif                            /* SHADOWGRP */
    -@@ src/gpasswd.c: static void log_gpasswd_success (const char *suffix)
    -                    "user %s added by %s to group %s%s",
    -                    user, myname, group, suffix));
    - #ifdef WITH_AUDIT
    --          SNPRINTF(buf, "user %s added by %s to group %s%s",
    -+          STPRINTF(buf, "user %s added by %s to group %s%s",
    -                    user, myname, group, suffix);
    -           audit_logger (AUDIT_USER_ACCT, Prog,
    -                         buf,
    -@@ src/gpasswd.c: static void log_gpasswd_success (const char *suffix)
    -                    "user %s removed by %s from group %s%s",
    -                    user, myname, group, suffix));
    - #ifdef WITH_AUDIT
    --          SNPRINTF(buf, "user %s removed by %s from group %s%s",
    -+          STPRINTF(buf, "user %s removed by %s from group %s%s",
    -                    user, myname, group, suffix);
    -           audit_logger (AUDIT_USER_ACCT, Prog,
    -                         buf,
     @@ src/gpasswd.c: static void log_gpasswd_success (const char *suffix)
                         "password of group %s removed by %s%s",
                         group, myname, suffix));
    @@ src/gpasswd.c: static void log_gpasswd_success (const char *suffix)
     -          SNPRINTF(buf, "password of group %s removed by %s%s",
     +          STPRINTF(buf, "password of group %s removed by %s%s",
                         group, myname, suffix);
    -           audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
    -                         buf,
    +           audit_logger_with_group (AUDIT_GRP_CHAUTHTOK,
    +                         "delete-group-password",
     @@ src/gpasswd.c: static void log_gpasswd_success (const char *suffix)
                         "access to group %s restricted by %s%s",
                         group, myname, suffix));
    @@ src/gpasswd.c: static void log_gpasswd_success (const char *suffix)
     -          SNPRINTF(buf, "access to group %s restricted by %s%s",
     +          STPRINTF(buf, "access to group %s restricted by %s%s",
                         group, myname, suffix);
    -           audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
    -                         buf,
    -@@ src/gpasswd.c: static void log_gpasswd_success (const char *suffix)
    -                            "administrators of group %s set by %s to %s%s",
    -                            group, myname, admins, suffix));
    - #ifdef WITH_AUDIT
    --                  SNPRINTF(buf, "administrators of group %s set by %s to %s%s",
    -+                  STPRINTF(buf, "administrators of group %s set by %s to %s%s",
    -                            group, myname, admins, suffix);
    -                   audit_logger (AUDIT_USER_ACCT, Prog,
    -                                 buf,
    -@@ src/gpasswd.c: static void log_gpasswd_success (const char *suffix)
    -                            "members of group %s set by %s to %s%s",
    -                            group, myname, members, suffix));
    - #ifdef WITH_AUDIT
    --                  SNPRINTF(buf, "members of group %s set by %s to %s%s",
    -+                  STPRINTF(buf, "members of group %s set by %s to %s%s",
    -                            group, myname, members, suffix);
    -                   audit_logger (AUDIT_USER_ACCT, Prog,
    -                                 buf,
    -@@ src/gpasswd.c: static void log_gpasswd_success (const char *suffix)
    -                    "password of group %s changed by %s%s",
    -                    group, myname, suffix));
    - #ifdef WITH_AUDIT
    --          SNPRINTF(buf, "password of group %s changed by %s%s",
    -+          STPRINTF(buf, "password of group %s changed by %s%s",
    -                    group, myname, suffix);
    -           audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
    -                         buf,
    +           audit_logger_with_group (AUDIT_GRP_MGMT,
    +                         "restrict-group",
     @@ src/gpasswd.c: static void log_gpasswd_success_group (MAYBE_UNUSED void *arg)
      {
        char  buf[1024];
    @@ src/newgrp.c: static void check_perms (const struct group *grp,
                if (streq(grp->gr_passwd, "") ||
                    !streq(grp->gr_passwd, cpasswd)) {
      #ifdef WITH_AUDIT
    --                  SNPRINTF(audit_buf, "authentication new-gid=%lu",
    -+                  STPRINTF(audit_buf, "authentication new-gid=%lu",
    +-                  SNPRINTF(audit_buf, "authentication new_gid=%lu",
    ++                  STPRINTF(audit_buf, "authentication new_gid=%lu",
                                 (unsigned long) grp->gr_gid);
                        audit_logger (AUDIT_GRP_AUTH, Prog,
    -                                 audit_buf, NULL, getuid (), 0);
    +                                 audit_buf, NULL, getuid (), SHADOW_AUDIT_FAILURE);
     @@ src/newgrp.c: static void check_perms (const struct group *grp,
                        goto failure;
                }
      #ifdef WITH_AUDIT
    --          SNPRINTF(audit_buf, "authentication new-gid=%lu",
    -+          STPRINTF(audit_buf, "authentication new-gid=%lu",
    +-          SNPRINTF(audit_buf, "authentication new_gid=%lu",
    ++          STPRINTF(audit_buf, "authentication new_gid=%lu",
                         (unsigned long) grp->gr_gid);
                audit_logger (AUDIT_GRP_AUTH, Prog,
    -                         audit_buf, NULL, getuid (), 1);
    -@@ src/newgrp.c: failure:
    -   closelog ();
    - #ifdef WITH_AUDIT
    -   if (groupname) {
    --          SNPRINTF(audit_buf, "changing new-group=%s", groupname);
    -+          STPRINTF(audit_buf, "changing new-group=%s", groupname);
    -           audit_logger (AUDIT_CHGRP_ID, Prog,
    -                         audit_buf, NULL, getuid (), 0);
    -   } else {
    -@@ src/newgrp.c: static void syslog_sg (const char *name, const char *group)
    -                            is_newgrp ? "newgrp" : "sg", strerror (errno));
    - #ifdef WITH_AUDIT
    -                   if (group) {
    --                          SNPRINTF(audit_buf,
    -+                          STPRINTF(audit_buf,
    -                                    "changing new-group=%s", group);
    -                           audit_logger (AUDIT_CHGRP_ID, Prog,
    -                                         audit_buf, NULL, getuid (), 0);
    -@@ src/newgrp.c: int main (int argc, char **argv)
    -           perror("agetgroups");
    - #ifdef WITH_AUDIT
    -           if (group) {
    --                  SNPRINTF(audit_buf, "changing new-group=%s", group);
    -+                  STPRINTF(audit_buf, "changing new-group=%s", group);
    -                   audit_logger(AUDIT_CHGRP_ID, Prog,
    -                                audit_buf, NULL, getuid(), 0);
    -           } else {
    +                         audit_buf, NULL, getuid (), SHADOW_AUDIT_SUCCESS);
     @@ src/newgrp.c: int main (int argc, char **argv)
        if (setgid (gid) != 0) {
                perror ("setgid");
      #ifdef WITH_AUDIT
    --          SNPRINTF(audit_buf, "changing new-gid=%lu", (unsigned long) gid);
    -+          STPRINTF(audit_buf, "changing new-gid=%lu", (unsigned long) gid);
    +-          SNPRINTF(audit_buf, "changing new_gid=%lu", (unsigned long) gid);
    ++          STPRINTF(audit_buf, "changing new_gid=%lu", (unsigned long) gid);
                audit_logger (AUDIT_CHGRP_ID, Prog,
    -                         audit_buf, NULL, getuid (), 0);
    +                         audit_buf, NULL, getuid (), SHADOW_AUDIT_FAILURE);
      #endif
     @@ src/newgrp.c: int main (int argc, char **argv)
        if (setuid (getuid ()) != 0) {
                perror ("setuid");
      #ifdef WITH_AUDIT
    --          SNPRINTF(audit_buf, "changing new-gid=%lu", (unsigned long) gid);
    -+          STPRINTF(audit_buf, "changing new-gid=%lu", (unsigned long) gid);
    +-          SNPRINTF(audit_buf, "changing new_gid=%lu", (unsigned long) gid);
    ++          STPRINTF(audit_buf, "changing new_gid=%lu", (unsigned long) gid);
                audit_logger (AUDIT_CHGRP_ID, Prog,
    -                         audit_buf, NULL, getuid (), 0);
    +                         audit_buf, NULL, getuid (), SHADOW_AUDIT_FAILURE);
      #endif
     @@ src/newgrp.c: int main (int argc, char **argv)
                closelog ();
                execl (SHELL, "sh", "-c", command, (char *) NULL);
      #ifdef WITH_AUDIT
    --          SNPRINTF(audit_buf, "changing new-gid=%lu", (unsigned long) gid);
    -+          STPRINTF(audit_buf, "changing new-gid=%lu", (unsigned long) gid);
    +-          SNPRINTF(audit_buf, "changing new_gid=%lu", (unsigned long) gid);
    ++          STPRINTF(audit_buf, "changing new_gid=%lu", (unsigned long) gid);
                audit_logger (AUDIT_CHGRP_ID, Prog,
    -                         audit_buf, NULL, getuid (), 0);
    +                         audit_buf, NULL, getuid (), SHADOW_AUDIT_FAILURE);
      #endif
     @@ src/newgrp.c: int main (int argc, char **argv)
        }
      
      #ifdef WITH_AUDIT
    --  SNPRINTF(audit_buf, "changing new-gid=%lu", (unsigned long) gid);
    -+  STPRINTF(audit_buf, "changing new-gid=%lu", (unsigned long) gid);
    +-  SNPRINTF(audit_buf, "changing new_gid=%lu", (unsigned long) gid);
    ++  STPRINTF(audit_buf, "changing new_gid=%lu", (unsigned long) gid);
        audit_logger (AUDIT_CHGRP_ID, Prog,
    -                 audit_buf, NULL, getuid (), 1);
    +                 audit_buf, NULL, getuid (), SHADOW_AUDIT_SUCCESS);
      #endif
    -@@ src/newgrp.c: int main (int argc, char **argv)
    -   closelog ();
    - #ifdef WITH_AUDIT
    -   if (NULL != group) {
    --          SNPRINTF(audit_buf, "changing new-group=%s", group);
    -+          STPRINTF(audit_buf, "changing new-group=%s", group);
    -           audit_logger (AUDIT_CHGRP_ID, Prog,
    -                         audit_buf, NULL, getuid (), 0);
    -   } else {
     
      ## src/newusers.c ##
     @@
 6:  5e4639f1 =  6:  b8cfc122 lib/salt.c: Use stprintf() instead of snprintf(3)
 7:  be311696 =  7:  23fb3928 configure.ac, lib/string/: Drop checks for non-libc functions
 8:  3cd0587c =  8:  fcee666c lib/string/: Use [0] for end pointers
 9:  ae365c0f =  9:  ce112266 lib/string/: Compact documentation
10:  a7e08cb6 = 10:  5f41652b lib/, po/, src/: Rename stpeprintf() => seprintf()
```
</details>

<details>
<summary>v8e</summary>

-  Fix v8d.  A recent change in master added a few new calls to SNPRINTF(), which we need to update too.

```
$ git range-diff shadow/master gh/snprintf_ snprintf_ 
 1:  9790039a =  1:  9790039a lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  10729667 =  2:  10729667 lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
 3:  24d605f3 =  3:  24d605f3 lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  484b35d7 =  4:  484b35d7 lib/string/: Redesign stpecpy() and stpeprintf()
 5:  22cc511e !  5:  1f4c64f3 lib/, src/, tests/: Rename snprintf_() to stprintf()
    @@ lib/Makefile.am: libshadow_la_SOURCES = \
        string/sprintf/xasprintf.h \
        string/strchr/strchrcnt.c \
     
    + ## lib/audit_help.c ##
    +@@
    + #include "attr.h"
    + #include "prototypes.h"
    + #include "shadowlog.h"
    +-#include "string/sprintf/snprintf.h"
    ++#include "string/sprintf/stprintf.h"
    + 
    + int audit_fd;
    + 
    +@@ lib/audit_help.c: audit_logger_with_group(int type, const char *op, const char *name,
    + 
    +   len = strnlen(grp, sizeof(enc_group)/2);
    +   if (audit_value_needs_encoding(grp, len)) {
    +-          SNPRINTF(buf, "%s %s=%s", op, grp_type,
    ++          STPRINTF(buf, "%s %s=%s", op, grp_type,
    +                   audit_encode_value(enc_group, grp, len));
    +   } else {
    +-          SNPRINTF(buf, "%s %s=\"%s\"", op, grp_type, grp);
    ++          STPRINTF(buf, "%s %s=\"%s\"", op, grp_type, grp);
    +   }
    + 
    +   audit_log_acct_message(audit_fd, type, NULL, buf, name, id,
    +
      ## lib/commonio.c ##
     @@
      #include "shadowlog_internal.h"
 6:  b8cfc122 =  6:  db1bbe61 lib/salt.c: Use stprintf() instead of snprintf(3)
 7:  23fb3928 =  7:  2e1382b6 configure.ac, lib/string/: Drop checks for non-libc functions
 8:  fcee666c =  8:  5646a44b lib/string/: Use [0] for end pointers
 9:  ce112266 =  9:  e5a32262 lib/string/: Compact documentation
10:  5f41652b = 10:  48f98b5a lib/, po/, src/: Rename stpeprintf() => seprintf()
```
</details>

<details>
<summary>v9</summary>

-  Add missing `const`.  [@chrisbazley]

```
$ git range-diff shadow/master gh/snprintf_ snprintf_ 
 1:  9790039a =  1:  9790039a lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  10729667 =  2:  10729667 lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
 3:  24d605f3 =  3:  24d605f3 lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  484b35d7 =  4:  484b35d7 lib/string/: Redesign stpecpy() and stpeprintf()
 5:  1f4c64f3 =  5:  1f4c64f3 lib/, src/, tests/: Rename snprintf_() to stprintf()
 6:  db1bbe61 =  6:  db1bbe61 lib/salt.c: Use stprintf() instead of snprintf(3)
 7:  2e1382b6 =  7:  2e1382b6 configure.ac, lib/string/: Drop checks for non-libc functions
 8:  5646a44b =  8:  5646a44b lib/string/: Use [0] for end pointers
 9:  e5a32262 =  9:  e5a32262 lib/string/: Compact documentation
10:  48f98b5a = 10:  48f98b5a lib/, po/, src/: Rename stpeprintf() => seprintf()
 -:  -------- > 11:  9ebd267e lib/string/: seprintf(), stpecpy(): Add missing const
```
</details>

<details>
<summary>v9b</summary>

-  Rebase

```
$ git range-diff db/master..gh/snprintf_ shadow/master..snprintf_ 
 1:  9790039a =  1:  6368bafe lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  10729667 =  2:  f5af7240 lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
 3:  24d605f3 =  3:  ff1c8757 lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  484b35d7 =  4:  a60692ef lib/string/: Redesign stpecpy() and stpeprintf()
 5:  1f4c64f3 =  5:  5b79e804 lib/, src/, tests/: Rename snprintf_() to stprintf()
 6:  db1bbe61 =  6:  a4a19269 lib/salt.c: Use stprintf() instead of snprintf(3)
 7:  2e1382b6 =  7:  377da8f4 configure.ac, lib/string/: Drop checks for non-libc functions
 8:  5646a44b =  8:  47a8ae83 lib/string/: Use [0] for end pointers
 9:  e5a32262 =  9:  91c84944 lib/string/: Compact documentation
10:  48f98b5a = 10:  8e7db9e4 lib/, po/, src/: Rename stpeprintf() => seprintf()
11:  9ebd267e = 11:  6f02db41 lib/string/: seprintf(), stpecpy(): Add missing const
```
</details>

<details>
<summary>v9c</summary>

-  Rebase

```
$ git rd
 1:  6368bafe =  1:  be499f20 lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  f5af7240 =  2:  283281bf lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
 3:  ff1c8757 =  3:  6d66d5bd lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  a60692ef =  4:  6e494408 lib/string/: Redesign stpecpy() and stpeprintf()
 5:  5b79e804 =  5:  ec48b63d lib/, src/, tests/: Rename snprintf_() to stprintf()
 6:  a4a19269 =  6:  1fb1d3b8 lib/salt.c: Use stprintf() instead of snprintf(3)
 7:  377da8f4 =  7:  fb47a52c configure.ac, lib/string/: Drop checks for non-libc functions
 8:  47a8ae83 =  8:  4a905c5b lib/string/: Use [0] for end pointers
 9:  91c84944 =  9:  4f25da34 lib/string/: Compact documentation
10:  8e7db9e4 = 10:  f818eb89 lib/, po/, src/: Rename stpeprintf() => seprintf()
11:  6f02db41 = 11:  11130d6d lib/string/: seprintf(), stpecpy(): Add missing const
```
</details>

<details>
<summary>v9d</summary>

-  Rebase

```
$ git rd
 1:  be499f20 =  1:  267c9cde lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  283281bf =  2:  5b037d21 lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
 3:  6d66d5bd =  3:  204890d7 lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  6e494408 =  4:  25293c84 lib/string/: Redesign stpecpy() and stpeprintf()
 5:  ec48b63d !  5:  dfac2b0f lib/, src/, tests/: Rename snprintf_() to stprintf()
    @@ lib/commonio.c
     -#include "string/sprintf/snprintf.h"
     +#include "string/sprintf/stprintf.h"
      #include "string/strcmp/streq.h"
    + #include "string/strcmp/strprefix.h"
      #include "string/strtok/stpsep.h"
    - 
     @@ lib/commonio.c: static int do_lock_file (const char *file, const char *lock, bool log)
        }
      
    @@ lib/env.c
     -#include "string/sprintf/snprintf.h"
     +#include "string/sprintf/stprintf.h"
      #include "string/sprintf/xasprintf.h"
    + #include "string/strcmp/strprefix.h"
      #include "string/strdup/xstrdup.h"
    - 
     @@ lib/env.c: void set_env (int argc, char *const *argv)
      
                cp = strchr (*argv, '=');
    @@ lib/nss.c
     -#include "string/sprintf/snprintf.h"
     +#include "string/sprintf/stprintf.h"
      #include "string/strcmp/streq.h"
    + #include "string/strcmp/strprefix.h"
      #include "string/strspn/stpspn.h"
    - #include "string/strtok/stpsep.h"
     @@ lib/nss.c: nss_init(const char *nsswitch_path) {
                fprintf(shadow_logfd, "Using files\n");
                goto null_subid;
    @@ lib/user_busy.c
     -#include "string/sprintf/snprintf.h"
     +#include "string/sprintf/stprintf.h"
      #include "string/strcmp/streq.h"
    - 
    + #include "string/strcmp/strprefix.h"
      
     @@ lib/user_busy.c: static int different_namespace (const char *sname)
        char     path[41];
    @@ src/login.c
     -#include "string/sprintf/snprintf.h"
     +#include "string/sprintf/stprintf.h"
      #include "string/strcmp/streq.h"
    + #include "string/strcmp/strprefix.h"
      #include "string/strcpy/strtcpy.h"
    - #include "string/strdup/xstrdup.h"
     @@ src/login.c: int main (int argc, char **argv)
        }
      
    @@ src/newgrp.c
     -#include "string/sprintf/snprintf.h"
     +#include "string/sprintf/stprintf.h"
      #include "string/strcmp/streq.h"
    + #include "string/strcmp/strprefix.h"
      #include "string/strdup/xstrdup.h"
    - 
     @@ src/newgrp.c: static void check_perms (const struct group *grp,
                if (streq(grp->gr_passwd, "") ||
                    !streq(grp->gr_passwd, cpasswd)) {
    @@ src/su.c
     +#include "string/sprintf/stprintf.h"
      #include "string/sprintf/xasprintf.h"
      #include "string/strcmp/streq.h"
    - #include "string/strcpy/strtcpy.h"
    + #include "string/strcmp/strprefix.h"
     @@ src/su.c: static void prepare_pam_close_session (void)
                              stderr);
                (void) kill (-pid_child, caught);
 6:  1fb1d3b8 =  6:  3f9b4057 lib/salt.c: Use stprintf() instead of snprintf(3)
 7:  fb47a52c =  7:  74221c45 configure.ac, lib/string/: Drop checks for non-libc functions
 8:  4a905c5b =  8:  395f5a81 lib/string/: Use [0] for end pointers
 9:  4f25da34 =  9:  97a219ed lib/string/: Compact documentation
10:  f818eb89 = 10:  07d0ed9d lib/, po/, src/: Rename stpeprintf() => seprintf()
11:  11130d6d = 11:  35f4c4d4 lib/string/: seprintf(), stpecpy(): Add missing const
```
</details>

<details>
<summary>v9e</summary>

-  Rebase

```
$ git rd
 1:  267c9cde =  1:  6506b599 lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  5b037d21 =  2:  550f8ea3 lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
 3:  204890d7 =  3:  09bcde0e lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  25293c84 =  4:  3c41abbc lib/string/: Redesign stpecpy() and stpeprintf()
 5:  dfac2b0f =  5:  4cf278a8 lib/, src/, tests/: Rename snprintf_() to stprintf()
 6:  3f9b4057 =  6:  9ee39fd6 lib/salt.c: Use stprintf() instead of snprintf(3)
 7:  74221c45 !  7:  39fb899b configure.ac, lib/string/: Drop checks for non-libc functions
    @@ Commit message
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## configure.ac ##
    -@@ configure.ac: AC_CHECK_FUNCS(arc4random_buf futimes \
    +@@ configure.ac: AC_CHECK_FUNCS(arc4random_buf \
        updwtmpx innetgr \
        getspnam_r \
        rpmatch \
 8:  395f5a81 =  8:  8a93eced lib/string/: Use [0] for end pointers
 9:  97a219ed =  9:  0f169dfa lib/string/: Compact documentation
10:  07d0ed9d = 10:  f741de13 lib/, po/, src/: Rename stpeprintf() => seprintf()
11:  35f4c4d4 = 11:  acbfe4f5 lib/string/: seprintf(), stpecpy(): Add missing const
```
</details>

<details>
<summary>v9f</summary>

-  Rebase

```
$ git rd
 1:  6506b599 =  1:  85820096 lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  550f8ea3 =  2:  a03b589a lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
 3:  09bcde0e =  3:  8e91ca6e lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  3c41abbc =  4:  9f651959 lib/string/: Redesign stpecpy() and stpeprintf()
 5:  4cf278a8 !  5:  aa87388f lib/, src/, tests/: Rename snprintf_() to stprintf()
    @@ Commit message
     
      ## lib/Makefile.am ##
     @@ lib/Makefile.am: libshadow_la_SOURCES = \
    -   string/ctype/strisascii/strisdigit.h \
    +   string/ctype/strtoascii/strtolower.h \
        string/memset/memzero.c \
        string/memset/memzero.h \
     -  string/sprintf/snprintf.c \
    @@ lib/string/sprintf/stprintf.h: snprintf_(char *restrict s, int size, const char
      ## lib/subordinateio.c ##
     @@
      #include "alloc/reallocf.h"
    - #include "atoi/str2i/str2u.h"
    + #include "atoi/str2i.h"
      #include "string/ctype/strisascii/strisdigit.h"
     -#include "string/sprintf/snprintf.h"
     +#include "string/sprintf/stprintf.h"
 6:  9ee39fd6 =  6:  b1ca1d6e lib/salt.c: Use stprintf() instead of snprintf(3)
 7:  39fb899b =  7:  4d6b6a98 configure.ac, lib/string/: Drop checks for non-libc functions
 8:  8a93eced =  8:  b839d3aa lib/string/: Use [0] for end pointers
 9:  0f169dfa =  9:  1b91bae1 lib/string/: Compact documentation
10:  f741de13 ! 10:  dca42acf lib/, po/, src/: Rename stpeprintf() => seprintf()
    @@ Commit message
     
      ## lib/Makefile.am ##
     @@ lib/Makefile.am: libshadow_la_SOURCES = \
    -   string/ctype/strisascii/strisdigit.h \
    +   string/ctype/strtoascii/strtolower.h \
        string/memset/memzero.c \
        string/memset/memzero.h \
     -  string/sprintf/stpeprintf.c \
11:  acbfe4f5 = 11:  9ee62bef lib/string/: seprintf(), stpecpy(): Add missing const
```
</details>

<details>
<summary>v9g</summary>

-  Rebase

```
$ git rd
 1:  85820096 =  1:  009a740d lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  a03b589a =  2:  4b39b53c lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
 3:  8e91ca6e =  3:  c0632c2a lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  9f651959 =  4:  5c3f32e7 lib/string/: Redesign stpecpy() and stpeprintf()
 5:  aa87388f =  5:  92f976eb lib/, src/, tests/: Rename snprintf_() to stprintf()
 6:  b1ca1d6e =  6:  c0744a3b lib/salt.c: Use stprintf() instead of snprintf(3)
 7:  4d6b6a98 =  7:  cfdd69e8 configure.ac, lib/string/: Drop checks for non-libc functions
 8:  b839d3aa =  8:  0642d655 lib/string/: Use [0] for end pointers
 9:  1b91bae1 =  9:  f8e8c0c9 lib/string/: Compact documentation
10:  dca42acf = 10:  fedb124d lib/, po/, src/: Rename stpeprintf() => seprintf()
11:  9ee62bef = 11:  58e68884 lib/string/: seprintf(), stpecpy(): Add missing const
```
</details>

<details>
<summary>v9h</summary>

-  Rebase

```
$ git rd 
 1:  009a740d =  1:  390626bc lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  4b39b53c =  2:  13e36ea8 lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
 3:  c0632c2a =  3:  0b2a1c56 lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  5c3f32e7 =  4:  3851599e lib/string/: Redesign stpecpy() and stpeprintf()
 5:  92f976eb =  5:  59c01151 lib/, src/, tests/: Rename snprintf_() to stprintf()
 6:  c0744a3b =  6:  df6db716 lib/salt.c: Use stprintf() instead of snprintf(3)
 7:  cfdd69e8 =  7:  e09a38bc configure.ac, lib/string/: Drop checks for non-libc functions
 8:  0642d655 =  8:  cbeb77ba lib/string/: Use [0] for end pointers
 9:  f8e8c0c9 =  9:  cbd8dcba lib/string/: Compact documentation
10:  fedb124d = 10:  89117f2b lib/, po/, src/: Rename stpeprintf() => seprintf()
11:  58e68884 = 11:  566a15d8 lib/string/: seprintf(), stpecpy(): Add missing const
```
</details>

<details>
<summary>v9i</summary>

-  Rebase

```
$ git rd 
 1:  390626bc =  1:  6493761c lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  13e36ea8 =  2:  4aa0aa98 lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
 3:  0b2a1c56 =  3:  0c6c32e7 lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  3851599e =  4:  89c75091 lib/string/: Redesign stpecpy() and stpeprintf()
 5:  59c01151 !  5:  4ef0b2a6 lib/, src/, tests/: Rename snprintf_() to stprintf()
    @@ lib/nss.c
      #include "shadowlog.h"
     -#include "string/sprintf/snprintf.h"
     +#include "string/sprintf/stprintf.h"
    + #include "string/strcmp/strcaseprefix.h"
      #include "string/strcmp/streq.h"
      #include "string/strcmp/strprefix.h"
    - #include "string/strspn/stpspn.h"
     @@ lib/nss.c: nss_init(const char *nsswitch_path) {
                fprintf(shadow_logfd, "Using files\n");
                goto null_subid;
 6:  df6db716 =  6:  12ad4247 lib/salt.c: Use stprintf() instead of snprintf(3)
 7:  e09a38bc =  7:  037b3688 configure.ac, lib/string/: Drop checks for non-libc functions
 8:  cbeb77ba =  8:  774e30cc lib/string/: Use [0] for end pointers
 9:  cbd8dcba =  9:  b8bc1126 lib/string/: Compact documentation
10:  89117f2b = 10:  6d3e1087 lib/, po/, src/: Rename stpeprintf() => seprintf()
11:  566a15d8 = 11:  122b34ac lib/string/: seprintf(), stpecpy(): Add missing const
```
</details>

<details>
<summary>v9j</summary>

-  Rebase

```
$ git rd 
 1:  6493761c =  1:  06bd4bd6 lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  4aa0aa98 =  2:  bfa563a5 lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
 3:  0c6c32e7 =  3:  d03dc55c lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  89c75091 =  4:  2badfdc8 lib/string/: Redesign stpecpy() and stpeprintf()
 5:  4ef0b2a6 !  5:  9308f6f3 lib/, src/, tests/: Rename snprintf_() to stprintf()
    @@ lib/string/sprintf/snprintf.h => lib/string/sprintf/stprintf.h
      
     -#define SNPRINTF(s, fmt, ...)                                                 \
     -(                                                                             \
    --  snprintf_(s, NITEMS(s), fmt __VA_OPT__(,) __VA_ARGS__)                \
    +-  snprintf_(s, countof(s), fmt __VA_OPT__(,) __VA_ARGS__)               \
     +#define STPRINTF(s, fmt, ...)                                         \
     +(                                                                     \
    -+  stprintf(s, NITEMS(s), fmt __VA_OPT__(,) __VA_ARGS__)         \
    ++  stprintf(s, countof(s), fmt __VA_OPT__(,) __VA_ARGS__)        \
      )
      
      
    @@ tests/unit/test_stprintf.c: main(void)
     -test_SNPRINTF_trunc(void **state)
     +test_STPRINTF_trunc(void **state)
      {
    -   char  buf[NITEMS("foo")];
    +   char  buf[countof("foo")];
      
        // Test that we're not returning SIZE_MAX
     -  assert_true(SNPRINTF(buf, "f%su", "oo") < 0);
    @@ tests/unit/test_stprintf.c: main(void)
     -test_SNPRINTF_ok(void **state)
     +test_STPRINTF_ok(void **state)
      {
    -   char  buf[NITEMS("foo")];
    +   char  buf[countof("foo")];
      
     -  assert_true(SNPRINTF(buf, "%s", "foo") == strlen("foo"));
     +  assert_true(STPRINTF(buf, "%s", "foo") == strlen("foo"));
 6:  12ad4247 =  6:  39827c97 lib/salt.c: Use stprintf() instead of snprintf(3)
 7:  037b3688 =  7:  555c819d configure.ac, lib/string/: Drop checks for non-libc functions
 8:  774e30cc =  8:  66a62351 lib/string/: Use [0] for end pointers
 9:  b8bc1126 !  9:  1436914c lib/string/: Compact documentation
    @@ lib/string/sprintf/stpeprintf.h: inline char *vstpeprintf(char *dst, char end[0]
     - *
     - *        end     Pointer to one after the last element of the buffer
     - *                pointed to by `dst`.  Usually, it should be calculated
    -- *                as `dst + NITEMS(dst)`.
    +- *                as `dst + countof(dst)`.
     - *
     - *        fmt     Format string
     - *
    @@ lib/string/strcpy/stpecpy.h: ATTR_STRING(3)
     - *
     - *        end     Pointer to one after the last element of the buffer
     - *                pointed to by `dst`.  Usually, it should be calculated
    -- *                as `dst + NITEMS(dst)`.
    +- *                as `dst + countof(dst)`.
     - *
     - *        src     Source string to be copied into dst.
     - *
10:  6d3e1087 = 10:  fd1038f0 lib/, po/, src/: Rename stpeprintf() => seprintf()
11:  122b34ac = 11:  19b7ece5 lib/string/: seprintf(), stpecpy(): Add missing const
```
</details>

<details>
<summary>v9k</summary>

-  Rebase

```
$ git rd
 1:  06bd4bd6 =  1:  76cabaf8 lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  bfa563a5 =  2:  b52120b2 lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
 3:  d03dc55c =  3:  443da8a1 lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  2badfdc8 =  4:  fd9ced97 lib/string/: Redesign stpecpy() and stpeprintf()
 5:  9308f6f3 !  5:  7bfa31e1 lib/, src/, tests/: Rename snprintf_() to stprintf()
    @@ Commit message
     
      ## lib/Makefile.am ##
     @@ lib/Makefile.am: libshadow_la_SOURCES = \
    -   string/ctype/strtoascii/strtolower.h \
    -   string/memset/memzero.c \
        string/memset/memzero.h \
    +   string/sprintf/aprintf.c \
    +   string/sprintf/aprintf.h \
     -  string/sprintf/snprintf.c \
     -  string/sprintf/snprintf.h \
        string/sprintf/stpeprintf.c \
        string/sprintf/stpeprintf.h \
     +  string/sprintf/stprintf.c \
     +  string/sprintf/stprintf.h \
    -   string/sprintf/xasprintf.c \
    -   string/sprintf/xasprintf.h \
    +   string/sprintf/xaprintf.c \
    +   string/sprintf/xaprintf.h \
        string/strchr/strchrcnt.c \
     
      ## lib/audit_help.c ##
    @@ lib/audit_help.c: audit_logger_with_group(int type, const char *op, const char *
     
      ## lib/commonio.c ##
     @@
    - #include "shadowlog_internal.h"
      #include "sssd.h"
      #include "string/memset/memzero.h"
    + #include "string/sprintf/aprintf.h"
     -#include "string/sprintf/snprintf.h"
     +#include "string/sprintf/stprintf.h"
      #include "string/strcmp/streq.h"
    @@ lib/env.c
      #include "shadowlog.h"
     -#include "string/sprintf/snprintf.h"
     +#include "string/sprintf/stprintf.h"
    - #include "string/sprintf/xasprintf.h"
    + #include "string/sprintf/xaprintf.h"
      #include "string/strcmp/strprefix.h"
      #include "string/strdup/xstrdup.h"
     @@ lib/env.c: void set_env (int argc, char *const *argv)
    @@ src/su.c
      #include "shadowlog.h"
     -#include "string/sprintf/snprintf.h"
     +#include "string/sprintf/stprintf.h"
    - #include "string/sprintf/xasprintf.h"
    + #include "string/sprintf/xaprintf.h"
      #include "string/strcmp/streq.h"
      #include "string/strcmp/strprefix.h"
     @@ src/su.c: static void prepare_pam_close_session (void)
    @@ src/su.c: static void prepare_pam_close_session (void)
     
      ## src/useradd.c ##
     @@
    - #include "shadowlog.h"
      #include "sssd.h"
      #include "string/memset/memzero.h"
    + #include "string/sprintf/aprintf.h"
     -#include "string/sprintf/snprintf.h"
     +#include "string/sprintf/stprintf.h"
    - #include "string/sprintf/xasprintf.h"
    + #include "string/sprintf/xaprintf.h"
      #include "string/strcmp/strcaseeq.h"
      #include "string/strcmp/streq.h"
     @@ src/useradd.c: set_defaults(void)
    @@ src/useradd.c: set_defaults(void)
     
      ## src/vipw.c ##
     @@
    - #endif                            /* WITH_TCB */
      #include "shadowlog.h"
      #include "sssd.h"
    + #include "string/sprintf/aprintf.h"
     -#include "string/sprintf/snprintf.h"
     +#include "string/sprintf/stprintf.h"
    - #include "string/sprintf/xasprintf.h"
    + #include "string/sprintf/xaprintf.h"
      #include "string/strcmp/streq.h"
      
     @@ src/vipw.c: vipwedit (const char *file, int (*file_lock) (void), int (*file_unlock) (void))
 6:  39827c97 =  6:  8b84ef9e lib/salt.c: Use stprintf() instead of snprintf(3)
 7:  555c819d =  7:  50add938 configure.ac, lib/string/: Drop checks for non-libc functions
 8:  66a62351 =  8:  bc89f789 lib/string/: Use [0] for end pointers
 9:  1436914c =  9:  3505e2a6 lib/string/: Compact documentation
10:  fd1038f0 ! 10:  67cd30e3 lib/, po/, src/: Rename stpeprintf() => seprintf()
    @@ Commit message
     
      ## lib/Makefile.am ##
     @@ lib/Makefile.am: libshadow_la_SOURCES = \
    -   string/ctype/strtoascii/strtolower.h \
    -   string/memset/memzero.c \
        string/memset/memzero.h \
    +   string/sprintf/aprintf.c \
    +   string/sprintf/aprintf.h \
     -  string/sprintf/stpeprintf.c \
     -  string/sprintf/stpeprintf.h \
     +  string/sprintf/seprintf.c \
     +  string/sprintf/seprintf.h \
        string/sprintf/stprintf.c \
        string/sprintf/stprintf.h \
    -   string/sprintf/xasprintf.c \
    +   string/sprintf/xaprintf.c \
     
      ## lib/idmapping.c ##
     @@
11:  19b7ece5 = 11:  9ff4c115 lib/string/: seprintf(), stpecpy(): Add missing const
```
</details>

<details>
<summary>v9l</summary>

-  Rebase

```
$ git rd 
 1:  76cabaf8 =  1:  2961b126 lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  b52120b2 =  2:  a4aa9820 lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
 3:  443da8a1 =  3:  7e5b3479 lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  fd9ced97 =  4:  50551d67 lib/string/: Redesign stpecpy() and stpeprintf()
 5:  7bfa31e1 !  5:  98dbdbc0 lib/, src/, tests/: Rename snprintf_() to stprintf()
    @@ lib/env.c: void set_env (int argc, char *const *argv)
     
      ## lib/get_pid.c ##
     @@
    - #include <fcntl.h>
    - 
      #include "atoi/getnum.h"
    + #include "defines.h"
    + #include "prototypes.h"
     -#include "string/sprintf/snprintf.h"
     +#include "string/sprintf/stprintf.h"
      
      
      /*
     @@ lib/get_pid.c: int open_pidfd(const char *pidstr)
    +   if (get_pid(pidstr, &target) == -1)
                return -ENOENT;
      
    -   /* max string length is 6 + 10 + 1 + 1 = 18, allocate 32 bytes */
    --  if (SNPRINTF(proc_dir_name, "/proc/%u/", target) == -1) {
    --          fprintf(stderr, "snprintf of proc path failed for %u: %s\n",
    -+  if (STPRINTF(proc_dir_name, "/proc/%u/", target) == -1) {
    -+          fprintf(stderr, "stprintf of proc path failed for %u: %s\n",
    +-  if (SNPRINTF(proc_dir_name, "/proc/%d/", target) == -1) {
    +-          fprintf(stderr, "snprintf of proc path failed for %d: %s\n",
    ++  if (STPRINTF(proc_dir_name, "/proc/%d/", target) == -1) {
    ++          fprintf(stderr, "stprintf of proc path failed for %d: %s\n",
                        target, strerror(errno));
                return -EINVAL;
        }
    @@ lib/subordinateio.c
     -#include "string/sprintf/snprintf.h"
     +#include "string/sprintf/stprintf.h"
      #include "string/strcmp/streq.h"
    - 
    + #include "string/strtok/strsep2arr.h"
      
     @@ lib/subordinateio.c: static const struct subordinate_range *find_range(struct commonio_db *db,
                      return NULL;
 6:  8b84ef9e =  6:  55511a85 lib/salt.c: Use stprintf() instead of snprintf(3)
 7:  50add938 =  7:  e083b5de configure.ac, lib/string/: Drop checks for non-libc functions
 8:  bc89f789 =  8:  dee2a76e lib/string/: Use [0] for end pointers
 9:  3505e2a6 =  9:  962966d3 lib/string/: Compact documentation
10:  67cd30e3 = 10:  62925705 lib/, po/, src/: Rename stpeprintf() => seprintf()
11:  9ff4c115 = 11:  b4b9ea90 lib/string/: seprintf(), stpecpy(): Add missing const
```
</details>

<details>
<summary>v9m</summary>

-  Rebase

```
$ git rd 
 1:  2961b126 =  1:  35716204 lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  a4aa9820 =  2:  929a61da lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
 3:  7e5b3479 =  3:  ea9f2fff lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  50551d67 =  4:  38e04cda lib/string/: Redesign stpecpy() and stpeprintf()
 5:  98dbdbc0 =  5:  fdc2d4fb lib/, src/, tests/: Rename snprintf_() to stprintf()
 6:  55511a85 =  6:  97087ff1 lib/salt.c: Use stprintf() instead of snprintf(3)
 7:  e083b5de =  7:  6020299f configure.ac, lib/string/: Drop checks for non-libc functions
 8:  dee2a76e =  8:  fc67d819 lib/string/: Use [0] for end pointers
 9:  962966d3 =  9:  3a7248d9 lib/string/: Compact documentation
10:  62925705 = 10:  49b28e26 lib/, po/, src/: Rename stpeprintf() => seprintf()
11:  b4b9ea90 = 11:  6bd4a978 lib/string/: seprintf(), stpecpy(): Add missing const
```
</details>

<details>
<summary>v10</summary>

-  Rebase
-  `#include "config.h"` with quotes.

```
$ git rd 
 1:  35716204 =  1:  219f55ce lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  929a61da =  2:  c4219723 lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
 3:  ea9f2fff =  3:  249dd865 lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  38e04cda =  4:  f25d92a8 lib/string/: Redesign stpecpy() and stpeprintf()
 5:  fdc2d4fb =  5:  f8d35b10 lib/, src/, tests/: Rename snprintf_() to stprintf()
 6:  97087ff1 =  6:  4f396268 lib/salt.c: Use stprintf() instead of snprintf(3)
 7:  6020299f =  7:  94e4a634 configure.ac, lib/string/: Drop checks for non-libc functions
 8:  fc67d819 =  8:  e1a1bf29 lib/string/: Use [0] for end pointers
 9:  3a7248d9 =  9:  0f0cd3a7 lib/string/: Compact documentation
10:  49b28e26 ! 10:  044b5456 lib/, po/, src/: Rename stpeprintf() => seprintf()
    @@ lib/string/sprintf/seprintf.c (new)
     +// SPDX-License-Identifier: BSD-3-Clause
     +
     +
    -+#include <config.h>
    ++#include "config.h"
     +
     +#include "string/sprintf/seprintf.h"
     +
11:  6bd4a978 = 11:  50512f1e lib/string/: seprintf(), stpecpy(): Add missing const
```
</details>

<details>
<summary>v11</summary>

-  Don't drop libc checks.  These APIs might become standard soon.

```
$ git range-diff shadow/master gh/snprintf_ snprintf_ 
 1:  219f55ce =  1:  219f55ce lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  c4219723 =  2:  c4219723 lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
 3:  249dd865 =  3:  249dd865 lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  f25d92a8 =  4:  f25d92a8 lib/string/: Redesign stpecpy() and stpeprintf()
 5:  f8d35b10 =  5:  f8d35b10 lib/, src/, tests/: Rename snprintf_() to stprintf()
 6:  4f396268 =  6:  4f396268 lib/salt.c: Use stprintf() instead of snprintf(3)
 7:  94e4a634 <  -:  -------- configure.ac, lib/string/: Drop checks for non-libc functions
 8:  e1a1bf29 !  7:  ac0962d8 lib/string/: Use [0] for end pointers
    @@ lib/string/sprintf/stpeprintf.c
      
      
     @@
    - #include <stdarg.h>
      
      
    + #if !defined(HAVE_STPEPRINTF)
     -extern inline char *stpeprintf(char *dst, char *end, const char *restrict fmt,
     +extern inline char *stpeprintf(char *dst, char end[0], const char *restrict fmt,
          ...);
     -extern inline char *vstpeprintf(char *dst, char *end, const char *restrict fmt,
     +extern inline char *vstpeprintf(char *dst, char end[0], const char *restrict fmt,
          va_list ap);
    + #endif
     
      ## lib/string/sprintf/stpeprintf.h ##
     @@
    @@ lib/string/sprintf/stpeprintf.h
      
     @@
      
    - 
    + #if !defined(HAVE_STPEPRINTF)
      format_attr(printf, 3, 4)
     -inline char *stpeprintf(char *dst, char *end, const char *restrict fmt, ...);
     +inline char *stpeprintf(char *dst, char end[0], const char *restrict fmt, ...);
    @@ lib/string/sprintf/stpeprintf.h
     -inline char *vstpeprintf(char *dst, char *end, const char *restrict fmt,
     +inline char *vstpeprintf(char *dst, char end[0], const char *restrict fmt,
          va_list ap);
    - 
    + #endif
      
     @@ lib/string/sprintf/stpeprintf.h: inline char *vstpeprintf(char *dst, char *end, const char *restrict fmt,
      
    - 
    + #if !defined(HAVE_STPEPRINTF)
      inline char *
     -stpeprintf(char *dst, char *end, const char *restrict fmt, ...)
     +stpeprintf(char *dst, char end[0], const char *restrict fmt, ...)
    @@ lib/string/sprintf/stpeprintf.h: inline char *vstpeprintf(char *dst, char *end,
        va_list  ap;
     @@ lib/string/sprintf/stpeprintf.h: stpeprintf(char *dst, char *end, const char *restrict fmt, ...)
      
    - 
    + #if !defined(HAVE_STPEPRINTF)
      inline char *
     -vstpeprintf(char *dst, char *end, const char *restrict fmt, va_list ap)
     +vstpeprintf(char *dst, char end[0], const char *restrict fmt, va_list ap)
    @@ lib/string/strcpy/stpecpy.c
      
      
     @@
    - #include "string/strcpy/stpecpy.h"
      
      
    + #if !defined(HAVE_STPECPY)
     -extern inline char *stpecpy(char *dst, char *end, const char *restrict src);
     +extern inline char *stpecpy(char *dst, char end[0], const char *restrict src);
    + #endif
     
      ## lib/string/strcpy/stpecpy.h ##
     @@
    @@ lib/string/strcpy/stpecpy.h
      
     @@
      
    - 
    + #if !defined(HAVE_STPECPY)
      ATTR_STRING(3)
     -inline char *stpecpy(char *dst, char *end, const char *restrict src);
     +inline char *stpecpy(char *dst, char end[0], const char *restrict src);
    + #endif
      
      
    - /*
     @@ lib/string/strcpy/stpecpy.h: inline char *stpecpy(char *dst, char *end, const char *restrict src);
      
    - 
    + #if !defined(HAVE_STPECPY)
      inline char *
     -stpecpy(char *dst, char *end, const char *restrict src)
     +stpecpy(char *dst, char end[0], const char *restrict src)
 9:  0f0cd3a7 !  8:  fde619f5 lib/string/: Compact documentation
    @@ Commit message
     
      ## lib/string/sprintf/stpeprintf.h ##
     @@
    - #include "string/sprintf/stprintf.h"
      
      
    + #if !defined(HAVE_STPEPRINTF)
     +// string pointer-to-end print formatted
     +// Like stpecpy(), but with a formatted string.
     +// Report internal snprintf(3) errors with NULL and errno.
    @@ lib/string/sprintf/stpeprintf.h
      inline char *stpeprintf(char *dst, char end[0], const char *restrict fmt, ...);
      format_attr(printf, 3, 0)
     @@ lib/string/sprintf/stpeprintf.h: inline char *vstpeprintf(char *dst, char end[0], const char *restrict fmt,
    -     va_list ap);
    + #endif
      
      
     -/*
    @@ lib/string/sprintf/stpeprintf.h: inline char *vstpeprintf(char *dst, char end[0]
     - */
     -
     -
    + #if !defined(HAVE_STPEPRINTF)
      inline char *
      stpeprintf(char *dst, char end[0], const char *restrict fmt, ...)
    - {
     
      ## lib/string/strcpy/stpecpy.h ##
    -@@ lib/string/strcpy/stpecpy.h: ATTR_STRING(3)
    - inline char *stpecpy(char *dst, char end[0], const char *restrict src);
    +@@ lib/string/strcpy/stpecpy.h: inline char *stpecpy(char *dst, char end[0], const char *restrict src);
    + #endif
      
      
     -/*
    @@ lib/string/strcpy/stpecpy.h: ATTR_STRING(3)
     - */
     -
     -
    + #if !defined(HAVE_STPECPY)
     +// Like stpcpy(3), but use an 'end' pointer to truncate.
     +// Report truncation with NULL and E2BIG.
     +// Transparently pass through a NULL input.
10:  044b5456 !  9:  22610fbc lib/, po/, src/: Rename stpeprintf() => seprintf()
    @@ Commit message
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    + ## configure.ac ##
    +@@ configure.ac: AC_CHECK_FUNCS(arc4random_buf \
    +   updwtmpx innetgr \
    +   getspnam_r \
    +   rpmatch \
    +-  memset_explicit explicit_bzero stpecpy stpeprintf)
    ++  memset_explicit explicit_bzero stpecpy seprintf)
    + AC_SYS_LARGEFILE
    + 
    + dnl Checks for typedefs, structures, and compiler characteristics.
    +
      ## lib/Makefile.am ##
     @@ lib/Makefile.am: libshadow_la_SOURCES = \
        string/memset/memzero.h \
    @@ lib/string/sprintf/seprintf.c (new)
     +#include <stdarg.h>
     +
     +
    ++#if !defined(HAVE_SEPRINTF)
     +extern inline char *seprintf(char *dst, char end[0], const char *restrict fmt,
     +    ...);
     +extern inline char *vseprintf(char *dst, char end[0], const char *restrict fmt,
     +    va_list ap);
    ++#endif
     
      ## lib/string/sprintf/stpeprintf.h => lib/string/sprintf/seprintf.h ##
     @@
    @@ lib/string/sprintf/stpeprintf.h => lib/string/sprintf/seprintf.h
      
      #include <config.h>
     @@
    + #include "string/sprintf/stprintf.h"
    + 
    + 
    +-#if !defined(HAVE_STPEPRINTF)
    ++#if !defined(HAVE_SEPRINTF)
    + // string pointer-to-end print formatted
    + // Like stpecpy(), but with a formatted string.
      // Report internal snprintf(3) errors with NULL and errno.
      // Calls to these functions can be chained with calls to stpecpy().
      format_attr(printf, 3, 4)
    @@ lib/string/sprintf/stpeprintf.h => lib/string/sprintf/seprintf.h
     -inline char *vstpeprintf(char *dst, char end[0], const char *restrict fmt,
     +inline char *vseprintf(char *dst, char end[0], const char *restrict fmt,
          va_list ap);
    + #endif
      
      
    +-#if !defined(HAVE_STPEPRINTF)
    ++#if !defined(HAVE_SEPRINTF)
      inline char *
     -stpeprintf(char *dst, char end[0], const char *restrict fmt, ...)
     +seprintf(char *dst, char end[0], const char *restrict fmt, ...)
    @@ lib/string/sprintf/stpeprintf.h => lib/string/sprintf/seprintf.h
      
        return p;
     @@ lib/string/sprintf/seprintf.h: stpeprintf(char *dst, char end[0], const char *restrict fmt, ...)
    + #endif
      
      
    +-#if !defined(HAVE_STPEPRINTF)
    ++#if !defined(HAVE_SEPRINTF)
      inline char *
     -vstpeprintf(char *dst, char end[0], const char *restrict fmt, va_list ap)
     +vseprintf(char *dst, char end[0], const char *restrict fmt, va_list ap)
    @@ lib/string/sprintf/stpeprintf.c (deleted)
     -#include <stdarg.h>
     -
     -
    +-#if !defined(HAVE_STPEPRINTF)
     -extern inline char *stpeprintf(char *dst, char end[0], const char *restrict fmt,
     -    ...);
     -extern inline char *vstpeprintf(char *dst, char end[0], const char *restrict fmt,
     -    va_list ap);
    +-#endif
     
      ## po/bs.po ##
     @@ po/bs.po: msgid "%s: Could not set caps\n"
11:  50512f1e ! 10:  7096975d lib/string/: seprintf(), stpecpy(): Add missing const
    @@ Commit message
     
      ## lib/string/sprintf/seprintf.c ##
     @@
    - #include <stdarg.h>
      
      
    + #if !defined(HAVE_SEPRINTF)
     -extern inline char *seprintf(char *dst, char end[0], const char *restrict fmt,
     -    ...);
     -extern inline char *vseprintf(char *dst, char end[0], const char *restrict fmt,
    @@ lib/string/sprintf/seprintf.c
     +    const char *restrict fmt, ...);
     +extern inline char *vseprintf(char *dst, const char end[0],
     +    const char *restrict fmt, va_list ap);
    + #endif
     
      ## lib/string/sprintf/seprintf.h ##
     @@
    @@ lib/string/sprintf/seprintf.h
     -inline char *vseprintf(char *dst, char end[0], const char *restrict fmt,
     +inline char *vseprintf(char *dst, const char end[0], const char *restrict fmt,
          va_list ap);
    + #endif
      
      
    + #if !defined(HAVE_SEPRINTF)
      inline char *
     -seprintf(char *dst, char end[0], const char *restrict fmt, ...)
     +seprintf(char *dst, const char end[0], const char *restrict fmt, ...)
    @@ lib/string/sprintf/seprintf.h
        va_list  ap;
     @@ lib/string/sprintf/seprintf.h: seprintf(char *dst, char end[0], const char *restrict fmt, ...)
      
    - 
    + #if !defined(HAVE_SEPRINTF)
      inline char *
     -vseprintf(char *dst, char end[0], const char *restrict fmt, va_list ap)
     +vseprintf(char *dst, const char end[0], const char *restrict fmt, va_list ap)
    @@ lib/string/sprintf/seprintf.h: seprintf(char *dst, char end[0], const char *rest
     
      ## lib/string/strcpy/stpecpy.c ##
     @@
    - #include "string/strcpy/stpecpy.h"
      
      
    + #if !defined(HAVE_STPECPY)
     -extern inline char *stpecpy(char *dst, char end[0], const char *restrict src);
     +extern inline char *stpecpy(char *dst, const char end[0],
     +    const char *restrict src);
    + #endif
     
      ## lib/string/strcpy/stpecpy.h ##
     @@
      
    - 
    + #if !defined(HAVE_STPECPY)
      ATTR_STRING(3)
     -inline char *stpecpy(char *dst, char end[0], const char *restrict src);
     +inline char *stpecpy(char *dst, const char end[0], const char *restrict src);
    + #endif
      
      
    - // Like stpcpy(3), but use an 'end' pointer to truncate.
     @@ lib/string/strcpy/stpecpy.h: inline char *stpecpy(char *dst, char end[0], const char *restrict src);
      // Transparently pass through a NULL input.
      // Calls to this function can be chained with calls to [v]seprintf().
```
</details>

<details>
<summary>v11b</summary>

-  Rebase

```
$ git rd 
 1:  219f55ce =  1:  c556a5a9 lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  c4219723 !  2:  4aed617b lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
    @@ lib/string/sprintf/snprintf.h
      
     @@
      
    - #include <config.h>
    + #include "config.h"
      
     +#include <errno.h>
      #include <stdarg.h>
 3:  249dd865 =  3:  35854516 lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  f25d92a8 !  4:  510408cf lib/string/: Redesign stpecpy() and stpeprintf()
    @@ lib/string/sprintf/stpeprintf.h: vstpeprintf(char *dst, char *end, const char *r
      ## lib/string/strcpy/stpecpy.h ##
     @@
      
    - #include <config.h>
    + #include "config.h"
      
     +#include <errno.h>
      #include <stdbool.h>
 5:  f8d35b10 !  5:  03f95d99 lib/, src/, tests/: Rename snprintf_() to stprintf()
    @@ lib/string/sprintf/stpeprintf.h: vstpeprintf(char *dst, char *end, const char *r
      ## lib/string/sprintf/snprintf.c => lib/string/sprintf/stprintf.c ##
     @@
      
    - #include <config.h>
    + #include "config.h"
      
     -#include "string/sprintf/snprintf.h"
     +#include "string/sprintf/stprintf.h"
    @@ lib/string/sprintf/snprintf.h => lib/string/sprintf/stprintf.h
     +#define SHADOW_INCLUDE_LIB_STRING_SPRINTF_STPRINTF_H_
      
      
    - #include <config.h>
    + #include "config.h"
     @@
      #include "sizeof.h"
      
 6:  4f396268 =  6:  187be4ce lib/salt.c: Use stprintf() instead of snprintf(3)
 7:  ac0962d8 =  7:  367af14f lib/string/: Use [0] for end pointers
 8:  fde619f5 =  8:  8ae697a0 lib/string/: Compact documentation
 9:  22610fbc !  9:  649c6051 lib/, po/, src/: Rename stpeprintf() => seprintf()
    @@ lib/string/sprintf/stpeprintf.h => lib/string/sprintf/seprintf.h
     +#define SHADOW_INCLUDE_LIB_STRING_SPRINTF_SEPRINTF_H_
      
      
    - #include <config.h>
    + #include "config.h"
     @@
      #include "string/sprintf/stprintf.h"
      
    @@ lib/string/sprintf/stpeprintf.c (deleted)
     -// SPDX-License-Identifier: BSD-3-Clause
     -
     -
    --#include <config.h>
    +-#include "config.h"
     -
     -#include "string/sprintf/stpeprintf.h"
     -
10:  7096975d = 10:  ef52e1cb lib/string/: seprintf(), stpecpy(): Add missing const
```
</details>

<details>
<summary>v12</summary>

-  Make strtcpy() consistent with stprintf().
-  Simplify the implementation of stpecpy().

```
$ git rd 
 1:  c556a5a9 =  1:  c556a5a9 lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  4aed617b =  2:  4aed617b lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
 3:  35854516 =  3:  35854516 lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  510408cf =  4:  510408cf lib/string/: Redesign stpecpy() and stpeprintf()
 5:  03f95d99 =  5:  03f95d99 lib/, src/, tests/: Rename snprintf_() to stprintf()
 6:  187be4ce =  6:  187be4ce lib/salt.c: Use stprintf() instead of snprintf(3)
 7:  367af14f =  7:  367af14f lib/string/: Use [0] for end pointers
 8:  8ae697a0 =  8:  8ae697a0 lib/string/: Compact documentation
 9:  649c6051 =  9:  649c6051 lib/, po/, src/: Rename stpeprintf() => seprintf()
10:  ef52e1cb = 10:  ef52e1cb lib/string/: seprintf(), stpecpy(): Add missing const
 -:  -------- > 11:  c4037f1b lib/string/strcpy/: strtcpy(): Set errno on error
 -:  -------- > 12:  64f1c3ce lib/string/strcpy/: stpecpy(): Use strtcpy() instead of its pattern
```
</details>

<details>
<summary>v13</summary>

-  Rebase

```
$ git rd 
 1:  c556a5a9 =  1:  a69caa43 lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  4aed617b =  2:  38e8ddd9 lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
 3:  35854516 =  3:  1c63db6c lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  510408cf =  4:  fc7f6d5e lib/string/: Redesign stpecpy() and stpeprintf()
 5:  03f95d99 !  5:  1bedf732 lib/, src/, tests/: Rename snprintf_() to stprintf()
    @@ lib/user_busy.c: static int user_busy_processes (const char *name, uid_t uid)
     +          STPRINTF(task_path, "/proc/%lu/task", (unsigned long) pid);
                task_dir = opendir (task_path);
                if (task_dir != NULL) {
    -                   while ((ent = readdir (task_dir)) != NULL) {
    +                   while (NULL != (ent = readdir(task_dir))) {
     
      ## src/chage.c ##
     @@
    @@ src/chage.c: static int new_fields (void)
        if (a2sl(&inactdays, buf, NULL, 0, -1, LONG_MAX) == -1)
                return 0;
     
    - ## src/chfn.c ##
    -@@
    - #include "pwio.h"
    - #include "shadowlog.h"
    - #include "sssd.h"
    --#include "string/sprintf/snprintf.h"
    -+#include "string/sprintf/stprintf.h"
    - #include "string/strcmp/streq.h"
    - #include "string/strcpy/strtcpy.h"
    - #include "string/strdup/xstrdup.h"
    -@@ src/chfn.c: int main (int argc, char **argv)
    -           fprintf (stderr, _("%s: fields too long\n"), Prog);
    -           fail_exit (E_NOPERM);
    -   }
    --  SNPRINTF(new_gecos, "%s,%s,%s,%s%s%s",
    -+  STPRINTF(new_gecos, "%s,%s,%s,%s%s%s",
    -            fullnm, roomno, workph, homeph,
    -            (!streq(slop, "")) ? "," : "", slop);
    - 
    -
      ## src/gpasswd.c ##
     @@
      #include "shadowlog.h"
 6:  187be4ce =  6:  1250e0a2 lib/salt.c: Use stprintf() instead of snprintf(3)
 7:  367af14f =  7:  abd92fbf lib/string/: Use [0] for end pointers
 8:  8ae697a0 =  8:  0f6b2f19 lib/string/: Compact documentation
 9:  649c6051 !  9:  9d0d3834 lib/, po/, src/: Rename stpeprintf() => seprintf()
    @@ Commit message
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## configure.ac ##
    -@@ configure.ac: AC_CHECK_FUNCS(arc4random_buf \
    +@@ configure.ac: AC_CHECK_FUNCS([arc4random_buf \
        updwtmpx innetgr \
        getspnam_r \
        rpmatch \
    --  memset_explicit explicit_bzero stpecpy stpeprintf)
    -+  memset_explicit explicit_bzero stpecpy seprintf)
    +-  memset_explicit explicit_bzero stpecpy stpeprintf])
    ++  memset_explicit explicit_bzero stpecpy seprintf])
      AC_SYS_LARGEFILE
      
      dnl Checks for typedefs, structures, and compiler characteristics.
10:  ef52e1cb = 10:  08a3d981 lib/string/: seprintf(), stpecpy(): Add missing const
11:  c4037f1b = 11:  8be7f9c8 lib/string/strcpy/: strtcpy(): Set errno on error
12:  64f1c3ce = 12:  f7adc46c lib/string/strcpy/: stpecpy(): Use strtcpy() instead of its pattern
```
</details>

<details>
<summary>v13b</summary>

-  Add missing include (fix v12).

```
$ git range-diff shadow/master gh/snprintf_ snprintf_ 
 1:  a69caa43 =  1:  a69caa43 lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  38e8ddd9 =  2:  38e8ddd9 lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
 3:  1c63db6c =  3:  1c63db6c lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  fc7f6d5e =  4:  fc7f6d5e lib/string/: Redesign stpecpy() and stpeprintf()
 5:  1bedf732 =  5:  1bedf732 lib/, src/, tests/: Rename snprintf_() to stprintf()
 6:  1250e0a2 =  6:  1250e0a2 lib/salt.c: Use stprintf() instead of snprintf(3)
 7:  abd92fbf =  7:  abd92fbf lib/string/: Use [0] for end pointers
 8:  0f6b2f19 =  8:  0f6b2f19 lib/string/: Compact documentation
 9:  9d0d3834 =  9:  9d0d3834 lib/, po/, src/: Rename stpeprintf() => seprintf()
10:  08a3d981 = 10:  08a3d981 lib/string/: seprintf(), stpecpy(): Add missing const
11:  8be7f9c8 = 11:  8be7f9c8 lib/string/strcpy/: strtcpy(): Set errno on error
12:  f7adc46c ! 12:  1fdaa768 lib/string/strcpy/: stpecpy(): Use strtcpy() instead of its pattern
    @@ Commit message
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/string/strcpy/stpecpy.h ##
    +@@
    + #include <string.h>
    + 
    + #include "attr.h"
    ++#include "string/strcpy/strtcpy.h"
    + 
    + 
    + #if !defined(HAVE_STPECPY)
     @@ lib/string/strcpy/stpecpy.h: inline char *stpecpy(char *dst, const char end[0], const char *restrict src);
      
      
```
</details>

<details>
<summary>v13c</summary>

-  Rebase

```
$ git rd 
 1:  a69caa43 =  1:  435042cd lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  38e8ddd9 =  2:  5661bd94 lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
 3:  1c63db6c =  3:  9f1dfed9 lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  fc7f6d5e =  4:  2c4e671a lib/string/: Redesign stpecpy() and stpeprintf()
 5:  1bedf732 =  5:  0d0918be lib/, src/, tests/: Rename snprintf_() to stprintf()
 6:  1250e0a2 =  6:  a4b12c4f lib/salt.c: Use stprintf() instead of snprintf(3)
 7:  abd92fbf =  7:  b360fac1 lib/string/: Use [0] for end pointers
 8:  0f6b2f19 =  8:  fbc8cd94 lib/string/: Compact documentation
 9:  9d0d3834 =  9:  12acfbd0 lib/, po/, src/: Rename stpeprintf() => seprintf()
10:  08a3d981 = 10:  ad65bb14 lib/string/: seprintf(), stpecpy(): Add missing const
11:  8be7f9c8 = 11:  eead83bc lib/string/strcpy/: strtcpy(): Set errno on error
12:  1fdaa768 = 12:  92e37347 lib/string/strcpy/: stpecpy(): Use strtcpy() instead of its pattern
```
</details>

<details>
<summary>v13d</summary>

-  Fix rebase from v13.  (I forgot to update some new uses of stpeprintf().)

```
$ git range-diff shadow/master gh/snprintf_ snprintf_ 
 1:  435042cd =  1:  435042cd lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  5661bd94 =  2:  5661bd94 lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
 3:  9f1dfed9 =  3:  9f1dfed9 lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  2c4e671a =  4:  2c4e671a lib/string/: Redesign stpecpy() and stpeprintf()
 5:  0d0918be =  5:  0d0918be lib/, src/, tests/: Rename snprintf_() to stprintf()
 6:  a4b12c4f =  6:  a4b12c4f lib/salt.c: Use stprintf() instead of snprintf(3)
 7:  b360fac1 =  7:  b360fac1 lib/string/: Use [0] for end pointers
 8:  fbc8cd94 =  8:  fbc8cd94 lib/string/: Compact documentation
 9:  12acfbd0 !  9:  61577a3a lib/, po/, src/: Rename stpeprintf() => seprintf()
    @@ po/zh_TW.po: msgstr "無法設定 %s 的名稱\n"
      
      #, fuzzy, c-format
     
    + ## src/chfn.c ##
    +@@
    + #include "shadowlog.h"
    + #include "sizeof.h"
    + #include "sssd.h"
    +-#include "string/sprintf/stpeprintf.h"
    ++#include "string/sprintf/seprintf.h"
    + #include "string/strcmp/streq.h"
    + #include "string/strcpy/strtcpy.h"
    + #include "string/strdup/xstrdup.h"
    +@@ src/chfn.c: int main (int argc, char **argv)
    +   /* Build the new GECOS field by plastering all the pieces together.  */
    +   p = new_gecos;
    +   e = new_gecos + countof(new_gecos);
    +-  p = stpeprintf(p, e, "%s", fullnm);
    +-  p = stpeprintf(p, e, ",%s", roomno);
    +-  p = stpeprintf(p, e, ",%s", workph);
    +-  p = stpeprintf(p, e, ",%s", homeph);
    ++  p = seprintf(p, e, "%s", fullnm);
    ++  p = seprintf(p, e, ",%s", roomno);
    ++  p = seprintf(p, e, ",%s", workph);
    ++  p = seprintf(p, e, ",%s", homeph);
    +   if (!streq(slop, ""))
    +-          p = stpeprintf(p, e, ",%s", slop);
    ++          p = seprintf(p, e, ",%s", slop);
    + 
    +   if (p == e || p == NULL) {
    +           fprintf (stderr, _("%s: fields too long\n"), Prog);
    +
      ## src/groupmod.c ##
     @@
      #endif
10:  ad65bb14 = 10:  e1871ea6 lib/string/: seprintf(), stpecpy(): Add missing const
11:  eead83bc = 11:  270352e0 lib/string/strcpy/: strtcpy(): Set errno on error
12:  92e37347 = 12:  0e93a8b3 lib/string/strcpy/: stpecpy(): Use strtcpy() instead of its pattern
```
</details>

<details>
<summary>v13e</summary>

-  Rebase

```
$ git rd 
 1:  435042cd =  1:  8600eac0 lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  5661bd94 =  2:  a2cd581f lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
 3:  9f1dfed9 =  3:  ca9556f5 lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  2c4e671a =  4:  71bfbff6 lib/string/: Redesign stpecpy() and stpeprintf()
 5:  0d0918be =  5:  fae99350 lib/, src/, tests/: Rename snprintf_() to stprintf()
 6:  a4b12c4f =  6:  89b743c7 lib/salt.c: Use stprintf() instead of snprintf(3)
 7:  b360fac1 =  7:  a4ab9bda lib/string/: Use [0] for end pointers
 8:  fbc8cd94 =  8:  4cd166d7 lib/string/: Compact documentation
 9:  61577a3a =  9:  fc65b37e lib/, po/, src/: Rename stpeprintf() => seprintf()
10:  e1871ea6 = 10:  be7ff0d7 lib/string/: seprintf(), stpecpy(): Add missing const
11:  270352e0 = 11:  2a42dfff lib/string/strcpy/: strtcpy(): Set errno on error
12:  0e93a8b3 = 12:  7c80704b lib/string/strcpy/: stpecpy(): Use strtcpy() instead of its pattern
```
</details>

<details>
<summary>v14</summary>

-  Update lib/string/README.

```
$ git range-diff shadow/master gh/snprintf_ snprintf_ 
 1:  8600eac0 =  1:  8600eac0 lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  a2cd581f =  2:  a2cd581f lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
 3:  ca9556f5 =  3:  ca9556f5 lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  71bfbff6 =  4:  71bfbff6 lib/string/: Redesign stpecpy() and stpeprintf()
 5:  fae99350 !  5:  3ce59bb1 lib/, src/, tests/: Rename snprintf_() to stprintf()
    @@ lib/shell.c: int shell (const char *file, /*@null@*/const char *arg, char *const
        perror (arg0);
        return err;
     
    + ## lib/string/README ##
    +@@ lib/string/README: sprintf/ - Formatted string creation
    +   sprintf(3) variant that allocates.
    +   It has better interface than asprintf(3).
    + 
    +-    stprintf()  // Current name: snprintf_()
    ++    stprintf()
    +   snprintf(3) wrapper that reports truncation with -1.
    +   If you need more than one call to form a string,
    +   use seprintf() instead.
    +-    STPRINTF()  // Current name: SNPRINTF()
    ++    STPRINTF()
    +   Like stprintf(), but takes an array.
    + 
    +     seprintf()  // Current name: stpeprintf())
    +
      ## lib/string/sprintf/stpeprintf.h ##
     @@
      #include <stddef.h>
 6:  89b743c7 =  6:  f98cb2c1 lib/salt.c: Use stprintf() instead of snprintf(3)
 7:  a4ab9bda =  7:  bfdc216e lib/string/: Use [0] for end pointers
 8:  4cd166d7 =  8:  3d156c7b lib/string/: Compact documentation
 9:  fc65b37e !  9:  d3ea3a20 lib/, po/, src/: Rename stpeprintf() => seprintf()
    @@ lib/idmapping.c: void write_mapping(int proc_dir_fd, int ranges, const struct ma
        }
      
     
    + ## lib/string/README ##
    +@@ lib/string/README: sprintf/ - Formatted string creation
    +     STPRINTF()
    +   Like stprintf(), but takes an array.
    + 
    +-    seprintf()  // Current name: stpeprintf())
    ++    seprintf()
    +   Similar to stprintf(), but takes a pointer to the end instead of
    +   a size.  This makes it safer for chaining several calls.
    + 
    +
      ## lib/string/sprintf/seprintf.c (new) ##
     @@
     +// SPDX-FileCopyrightText: 2022-2025, Alejandro Colomar <alx@kernel.org>
10:  be7ff0d7 = 10:  1179595f lib/string/: seprintf(), stpecpy(): Add missing const
11:  2a42dfff = 11:  b7c4f1d3 lib/string/strcpy/: strtcpy(): Set errno on error
12:  7c80704b = 12:  d6297674 lib/string/strcpy/: stpecpy(): Use strtcpy() instead of its pattern
```
</details>

<details>
<summary>v14b</summary>

-  Fix signedness diagnostic.

```
$ git range-diff shadow/master gh/snprintf_ snprintf_ 
 1:  8600eac0 =  1:  8600eac0 lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  a2cd581f =  2:  a2cd581f lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
 3:  ca9556f5 =  3:  ca9556f5 lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  71bfbff6 =  4:  71bfbff6 lib/string/: Redesign stpecpy() and stpeprintf()
 5:  3ce59bb1 =  5:  3ce59bb1 lib/, src/, tests/: Rename snprintf_() to stprintf()
 6:  f98cb2c1 =  6:  f98cb2c1 lib/salt.c: Use stprintf() instead of snprintf(3)
 7:  bfdc216e =  7:  bfdc216e lib/string/: Use [0] for end pointers
 8:  3d156c7b =  8:  3d156c7b lib/string/: Compact documentation
 9:  d3ea3a20 =  9:  d3ea3a20 lib/, po/, src/: Rename stpeprintf() => seprintf()
10:  1179595f = 10:  1179595f lib/string/: seprintf(), stpecpy(): Add missing const
11:  b7c4f1d3 = 11:  b7c4f1d3 lib/string/strcpy/: strtcpy(): Set errno on error
12:  d6297674 ! 12:  29899e56 lib/string/strcpy/: stpecpy(): Use strtcpy() instead of its pattern
    @@ lib/string/strcpy/stpecpy.h: inline char *stpecpy(char *dst, const char end[0],
     -  bool    trunc;
     -  char    *p;
     -  size_t  dsize, dlen, slen;
    -+  size_t  dlen;
    ++  ssize_t  dlen;
      
        if (dst == NULL)
                return NULL;
```
</details>

<details>
<summary>v14c</summary>

-  Add missing include.

```
$ git range-diff shadow/master gh/snprintf_ snprintf_ 
 1:  8600eac0 =  1:  8600eac0 lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  a2cd581f =  2:  a2cd581f lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
 3:  ca9556f5 =  3:  ca9556f5 lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  71bfbff6 =  4:  71bfbff6 lib/string/: Redesign stpecpy() and stpeprintf()
 5:  3ce59bb1 =  5:  3ce59bb1 lib/, src/, tests/: Rename snprintf_() to stprintf()
 6:  f98cb2c1 =  6:  f98cb2c1 lib/salt.c: Use stprintf() instead of snprintf(3)
 7:  bfdc216e =  7:  bfdc216e lib/string/: Use [0] for end pointers
 8:  3d156c7b =  8:  3d156c7b lib/string/: Compact documentation
 9:  d3ea3a20 =  9:  d3ea3a20 lib/, po/, src/: Rename stpeprintf() => seprintf()
10:  1179595f = 10:  1179595f lib/string/: seprintf(), stpecpy(): Add missing const
11:  b7c4f1d3 ! 11:  8478ee96 lib/string/strcpy/: strtcpy(): Set errno on error
    @@ Commit message
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/string/strcpy/strtcpy.h ##
    +@@
    + 
    + #include "config.h"
    + 
    ++#include <errno.h>
    + #include <stdbool.h>
    + #include <stddef.h>
    + #include <string.h>
     @@ lib/string/strcpy/strtcpy.h: strtcpy(char *restrict dst, const char *restrict src, size_t dsize)
        bool    trunc;
        size_t  dlen, slen;
12:  29899e56 = 12:  51e04ae8 lib/string/strcpy/: stpecpy(): Use strtcpy() instead of its pattern
```
</details>

<details>
<summary>v14d</summary>

-  Rebase

```
$ git rd
 1:  8600eac0 =  1:  fb3e3490 lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  a2cd581f =  2:  2ad21e34 lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
 3:  ca9556f5 =  3:  9d283fa1 lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  71bfbff6 =  4:  adf162da lib/string/: Redesign stpecpy() and stpeprintf()
 5:  3ce59bb1 !  5:  9d551fdd lib/, src/, tests/: Rename snprintf_() to stprintf()
    @@ src/gpasswd.c: static void log_gpasswd_success_group (MAYBE_UNUSED void *arg)
     
      ## src/login.c ##
     @@
    - #include "pwauth.h"
    + #include "shadow/gshadow/endsgent.h"
      #include "shadowlog.h"
      #include "string/memset/memzero.h"
     -#include "string/sprintf/snprintf.h"
    @@ src/login.c: int main (int argc, char **argv)
     
      ## src/newgrp.c ##
     @@
    - #include "search/l/lsearch.h"
    - #include "shadow/grp/agetgroups.h"
    + #include "shadow/gshadow/getsgnam.h"
    + #include "shadow/gshadow/sgrp.h"
      #include "shadowlog.h"
     -#include "string/sprintf/snprintf.h"
     +#include "string/sprintf/stprintf.h"
    @@ src/newgrp.c: int main (int argc, char **argv)
     
      ## src/newusers.c ##
     @@
    - #endif                            /* ENABLE_SUBIDS */
    + #include "shadow/gshadow/sgrp.h"
      #include "shadowlog.h"
      #include "sssd.h"
     -#include "string/sprintf/snprintf.h"
 6:  f98cb2c1 =  6:  b06725e5 lib/salt.c: Use stprintf() instead of snprintf(3)
 7:  bfdc216e =  7:  738fa9ca lib/string/: Use [0] for end pointers
 8:  3d156c7b =  8:  9420b28b lib/string/: Compact documentation
 9:  d3ea3a20 !  9:  2b4d3d89 lib/, po/, src/: Rename stpeprintf() => seprintf()
    @@ src/chfn.c: int main (int argc, char **argv)
     
      ## src/groupmod.c ##
     @@
    - #endif
    + #include "shadow/gshadow/sgrp.h"
      #include "shadowlog.h"
      #include "sssd.h"
     -#include "string/sprintf/stpeprintf.h"
10:  1179595f = 10:  51adb280 lib/string/: seprintf(), stpecpy(): Add missing const
11:  8478ee96 = 11:  574f0db4 lib/string/strcpy/: strtcpy(): Set errno on error
12:  51e04ae8 = 12:  17a18628 lib/string/strcpy/: stpecpy(): Use strtcpy() instead of its pattern
```
</details>

<details>
<summary>v14e</summary>

-  Rebase

```
$ git rd 
 1:  fb3e3490 =  1:  dcc49a66 lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  2ad21e34 =  2:  6cac70db lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
 3:  9d283fa1 =  3:  0b9d3bca lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  adf162da =  4:  f27aa85e lib/string/: Redesign stpecpy() and stpeprintf()
 5:  9d551fdd !  5:  9f16c9b8 lib/, src/, tests/: Rename snprintf_() to stprintf()
    @@ lib/commonio.c: static void free_linked_list (struct commonio_db *db)
        db->setname = true;
        return 1;
      }
    -@@ lib/commonio.c: int commonio_unlock (struct commonio_db *db)
    +@@ lib/commonio.c: int commonio_unlock (struct commonio_db *db, bool process_selinux)
                 * then call ulckpwdf() (if used) on last unlock.
                 */
                db->locked = false;
    @@ lib/commonio.c: int commonio_unlock (struct commonio_db *db)
                unlink (lock);
                dec_lock_count ();
                return 1;
    -@@ lib/commonio.c: int commonio_close (struct commonio_db *db)
    +@@ lib/commonio.c: int commonio_close (struct commonio_db *db, bool process_selinux)
                /*
                 * Create backup file.
                 */
    @@ lib/commonio.c: int commonio_close (struct commonio_db *db)
                        (void) fclose (db->fp);
                        db->fp = NULL;
                        goto fail;
    -@@ lib/commonio.c: int commonio_close (struct commonio_db *db)
    +@@ lib/commonio.c: int commonio_close (struct commonio_db *db, bool process_selinux)
                sb.st_gid = db->st_gid;
        }
      
    @@ src/newusers.c
      #include "string/strcmp/streq.h"
      #include "string/strdup/xstrdup.h"
      #include "string/strtok/stpsep.h"
    -@@ src/newusers.c: static void process_flags (int argc, char **argv)
    +@@ src/newusers.c: static void process_flags (int argc, char **argv, struct option_flags *flags)
                if (freopen (argv[optind], "r", stdin) == NULL) {
                        char  buf[BUFSIZ];
      
     -                  SNPRINTF(buf, "%s: %s", Prog, argv[1]);
     +                  STPRINTF(buf, "%s: %s", Prog, argv[1]);
                        perror (buf);
    -                   fail_exit (EXIT_FAILURE);
    +                   fail_exit (EXIT_FAILURE, !flags->chroot);
                }
     
      ## src/su.c ##
    @@ src/vipw.c
      #include "string/sprintf/xaprintf.h"
      #include "string/strcmp/streq.h"
      
    -@@ src/vipw.c: vipwedit (const char *file, int (*file_lock) (void), int (*file_unlock) (void))
    +@@ src/vipw.c: vipwedit (const char *file, int (*file_lock) (void), int (*file_unlock) (bool))
        /* FIXME: the following should have variable sizes */
        char         filebackup[1024], fileedit[1024];
      
    @@ src/vipw.c: vipwedit (const char *file, int (*file_lock) (void), int (*file_unlo
      #ifdef WITH_TCB
        if (tcb_mode) {
                if (   (mkdir (TCB_DIR "/" SHADOWTCB_SCRATCHDIR, 0700) != 0)
    -@@ src/vipw.c: vipwedit (const char *file, int (*file_lock) (void), int (*file_unlock) (void))
    +@@ src/vipw.c: vipwedit (const char *file, int (*file_lock) (void), int (*file_unlock) (bool))
                if (shadowtcb_drop_priv () == SHADOWTCB_FAILURE) {
                        vipwexit (_("failed to drop privileges"), errno, 1);
                }
 6:  b06725e5 =  6:  3798cb15 lib/salt.c: Use stprintf() instead of snprintf(3)
 7:  738fa9ca =  7:  0125d026 lib/string/: Use [0] for end pointers
 8:  9420b28b =  8:  518afbfb lib/string/: Compact documentation
 9:  2b4d3d89 =  9:  9193a879 lib/, po/, src/: Rename stpeprintf() => seprintf()
10:  51adb280 = 10:  3e5ab353 lib/string/: seprintf(), stpecpy(): Add missing const
11:  574f0db4 = 11:  299e409b lib/string/strcpy/: strtcpy(): Set errno on error
12:  17a18628 = 12:  4c3583a6 lib/string/strcpy/: stpecpy(): Use strtcpy() instead of its pattern
```
</details>

<details>
<summary>v14f</summary>

-  Rebase

```
$ git rd 
 1:  dcc49a66 =  1:  59a936ba lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  6cac70db =  2:  aec0a88c lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
 3:  0b9d3bca =  3:  9607efe6 lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  f27aa85e =  4:  0dbb1ca8 lib/string/: Redesign stpecpy() and stpeprintf()
 5:  9f16c9b8 !  5:  4b275e35 lib/, src/, tests/: Rename snprintf_() to stprintf()
    @@ lib/user_busy.c
     -#include "string/sprintf/snprintf.h"
     +#include "string/sprintf/stprintf.h"
      #include "string/strcmp/streq.h"
    + #include "string/strcmp/strneq.h"
      #include "string/strcmp/strprefix.h"
    - 
     @@ lib/user_busy.c: static int different_namespace (const char *sname)
        char     path[41];
        char     buf[512], buf2[512];
    @@ src/login.c
     -#include "string/sprintf/snprintf.h"
     +#include "string/sprintf/stprintf.h"
      #include "string/strcmp/streq.h"
    + #include "string/strcmp/strneq.h"
      #include "string/strcmp/strprefix.h"
    - #include "string/strcpy/strtcpy.h"
     @@ src/login.c: int main (int argc, char **argv)
        }
      
 6:  3798cb15 =  6:  597ad90f lib/salt.c: Use stprintf() instead of snprintf(3)
 7:  0125d026 =  7:  ae146e9d lib/string/: Use [0] for end pointers
 8:  518afbfb =  8:  d8b8edb0 lib/string/: Compact documentation
 9:  9193a879 =  9:  3384763d lib/, po/, src/: Rename stpeprintf() => seprintf()
10:  3e5ab353 = 10:  e57b4696 lib/string/: seprintf(), stpecpy(): Add missing const
11:  299e409b = 11:  fb7cf351 lib/string/strcpy/: strtcpy(): Set errno on error
12:  4c3583a6 = 12:  7f8315d0 lib/string/strcpy/: stpecpy(): Use strtcpy() instead of its pattern
```
</details>

<details>
<summary>v14g</summary>

-  Rebase

```
$ git rd 
 1:  59a936ba =  1:  edb02ed8 lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  aec0a88c =  2:  0d71d8a3 lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
 3:  9607efe6 =  3:  373088de lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  0dbb1ca8 =  4:  95da878d lib/string/: Redesign stpecpy() and stpeprintf()
 5:  4b275e35 !  5:  492f5ac4 lib/, src/, tests/: Rename snprintf_() to stprintf()
    @@ lib/Makefile.am: libshadow_la_SOURCES = \
        string/sprintf/stpeprintf.h \
     +  string/sprintf/stprintf.c \
     +  string/sprintf/stprintf.h \
    -   string/sprintf/xaprintf.c \
    -   string/sprintf/xaprintf.h \
        string/strchr/strchrcnt.c \
    +   string/strchr/strchrcnt.h \
    +   string/strchr/strchrscnt.c \
     
      ## lib/audit_help.c ##
     @@
    @@ lib/commonio.c: int commonio_close (struct commonio_db *db, bool process_selinux
     
      ## lib/env.c ##
     @@
    - #include "prototypes.h"
      #include "defines.h"
      #include "shadowlog.h"
    + #include "string/sprintf/aprintf.h"
     -#include "string/sprintf/snprintf.h"
    +-#include "string/sprintf/aprintf.h"
     +#include "string/sprintf/stprintf.h"
    - #include "string/sprintf/xaprintf.h"
      #include "string/strcmp/strprefix.h"
    - #include "string/strdup/xstrdup.h"
    + #include "string/strdup/strdup.h"
    + 
     @@ lib/env.c: void set_env (int argc, char *const *argv)
      
                cp = strchr (*argv, '=');
    @@ src/chage.c
     +#include "string/sprintf/stprintf.h"
      #include "string/strcmp/streq.h"
      #include "string/strcpy/strtcpy.h"
    - #include "string/strdup/xstrdup.h"
    + #include "string/strdup/strdup.h"
     @@ src/chage.c: static int new_fields (void)
        (void) puts (_("Enter the new value, or press ENTER for the default"));
        (void) puts ("");
    @@ src/gpasswd.c
     +#include "string/sprintf/stprintf.h"
      #include "string/strcmp/streq.h"
      #include "string/strcpy/strtcpy.h"
    - #include "string/strdup/xstrdup.h"
    + #include "string/strdup/strdup.h"
     @@ src/gpasswd.c: static void log_gpasswd_failure_group (MAYBE_UNUSED void *arg)
      {
        char  buf[1024];
    @@ src/newgrp.c
     +#include "string/sprintf/stprintf.h"
      #include "string/strcmp/streq.h"
      #include "string/strcmp/strprefix.h"
    - #include "string/strdup/xstrdup.h"
    + #include "string/strdup/strdup.h"
     @@ src/newgrp.c: static void check_perms (const struct group *grp,
                if (streq(grp->gr_passwd, "") ||
                    !streq(grp->gr_passwd, cpasswd)) {
    @@ src/newusers.c
     -#include "string/sprintf/snprintf.h"
     +#include "string/sprintf/stprintf.h"
      #include "string/strcmp/streq.h"
    - #include "string/strdup/xstrdup.h"
    + #include "string/strdup/strdup.h"
      #include "string/strtok/stpsep.h"
     @@ src/newusers.c: static void process_flags (int argc, char **argv, struct option_flags *flags)
                if (freopen (argv[optind], "r", stdin) == NULL) {
    @@ src/newusers.c: static void process_flags (int argc, char **argv, struct option_
     
      ## src/su.c ##
     @@
    - #include "pwauth.h"
      #include "prototypes.h"
      #include "shadowlog.h"
    + #include "string/sprintf/aprintf.h"
     -#include "string/sprintf/snprintf.h"
     +#include "string/sprintf/stprintf.h"
    - #include "string/sprintf/xaprintf.h"
      #include "string/strcmp/streq.h"
      #include "string/strcmp/strprefix.h"
    + #include "string/strcpy/strtcpy.h"
     @@ src/su.c: static void prepare_pam_close_session (void)
                              stderr);
                (void) kill (-pid_child, caught);
    @@ src/useradd.c
      #include "string/sprintf/aprintf.h"
     -#include "string/sprintf/snprintf.h"
     +#include "string/sprintf/stprintf.h"
    - #include "string/sprintf/xaprintf.h"
      #include "string/strcmp/strcaseeq.h"
      #include "string/strcmp/streq.h"
    + #include "string/strcmp/strprefix.h"
     @@ src/useradd.c: set_defaults(void)
        /*
         * Rename the current default file to its backup name.
    @@ src/vipw.c
      #include "string/sprintf/aprintf.h"
     -#include "string/sprintf/snprintf.h"
     +#include "string/sprintf/stprintf.h"
    - #include "string/sprintf/xaprintf.h"
      #include "string/strcmp/streq.h"
      
    + 
     @@ src/vipw.c: vipwedit (const char *file, int (*file_lock) (void), int (*file_unlock) (bool))
        /* FIXME: the following should have variable sizes */
        char         filebackup[1024], fileedit[1024];
 6:  597ad90f =  6:  2588f6cd lib/salt.c: Use stprintf() instead of snprintf(3)
 7:  ae146e9d =  7:  b1c32d4c lib/string/: Use [0] for end pointers
 8:  d8b8edb0 =  8:  217c4b38 lib/string/: Compact documentation
 9:  3384763d !  9:  854f0327 lib/, po/, src/: Rename stpeprintf() => seprintf()
    @@ lib/Makefile.am: libshadow_la_SOURCES = \
     +  string/sprintf/seprintf.h \
        string/sprintf/stprintf.c \
        string/sprintf/stprintf.h \
    -   string/sprintf/xaprintf.c \
    +   string/strchr/strchrcnt.c \
     
      ## lib/idmapping.c ##
     @@
    @@ src/chfn.c
     +#include "string/sprintf/seprintf.h"
      #include "string/strcmp/streq.h"
      #include "string/strcpy/strtcpy.h"
    - #include "string/strdup/xstrdup.h"
    + #include "string/strdup/strdup.h"
     @@ src/chfn.c: int main (int argc, char **argv)
        /* Build the new GECOS field by plastering all the pieces together.  */
        p = new_gecos;
    @@ src/groupmod.c
     +#include "string/sprintf/seprintf.h"
      #include "string/strcmp/streq.h"
      #include "string/strcpy/stpecpy.h"
    - #include "string/strdup/xstrdup.h"
    + #include "string/strdup/strdup.h"
     @@ src/groupmod.c: static void prepare_failure_reports (void)
        info_passwd.audit_msg  = pw;
        pw_end                 = pw + 512;
10:  e57b4696 = 10:  f690a3cf lib/string/: seprintf(), stpecpy(): Add missing const
11:  fb7cf351 = 11:  10b7c4ec lib/string/strcpy/: strtcpy(): Set errno on error
12:  7f8315d0 = 12:  2f03513f lib/string/strcpy/: stpecpy(): Use strtcpy() instead of its pattern
```
</details>

<details>
<summary>v14h</summary>

-  Rebase

```
$ git rd 
 1:  edb02ed8d =  1:  1fb8ed24f lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  0d71d8a35 =  2:  1618378d0 lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
 3:  373088de1 =  3:  9f3843770 lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  95da878d0 =  4:  76bcef373 lib/string/: Redesign stpecpy() and stpeprintf()
 5:  492f5ac43 !  5:  44042b61b lib/, src/, tests/: Rename snprintf_() to stprintf()
    @@ lib/commonio.c
     +#include "string/sprintf/stprintf.h"
      #include "string/strcmp/streq.h"
      #include "string/strcmp/strprefix.h"
    - #include "string/strtok/stpsep.h"
    + #include "string/strerrno.h"
     @@ lib/commonio.c: static int do_lock_file (const char *file, const char *lock, bool log)
        }
      
    @@ lib/get_pid.c
      #include "prototypes.h"
     -#include "string/sprintf/snprintf.h"
     +#include "string/sprintf/stprintf.h"
    + #include "string/strerrno.h"
      
      
    - /*
     @@ lib/get_pid.c: int open_pidfd(const char *pidstr)
        if (get_pid(pidstr, &target) == -1)
                return -ENOENT;
    @@ lib/get_pid.c: int open_pidfd(const char *pidstr)
     -          fprintf(stderr, "snprintf of proc path failed for %d: %s\n",
     +  if (STPRINTF(proc_dir_name, "/proc/%d/", target) == -1) {
     +          fprintf(stderr, "stprintf of proc path failed for %d: %s\n",
    -                   target, strerror(errno));
    +                   target, strerrno());
                return -EINVAL;
        }
     
    @@ src/newusers.c
     +#include "string/sprintf/stprintf.h"
      #include "string/strcmp/streq.h"
      #include "string/strdup/strdup.h"
    - #include "string/strtok/stpsep.h"
    + #include "string/strerrno.h"
     @@ src/newusers.c: static void process_flags (int argc, char **argv, struct option_flags *flags)
                if (freopen (argv[optind], "r", stdin) == NULL) {
                        char  buf[BUFSIZ];
    @@ src/useradd.c: set_defaults(void)
     +  assert(STPRINTF(buf, "%s-", default_file) != -1);
        unlink (buf);
        if ((link (default_file, buf) != 0) && (ENOENT != errno)) {
    -           int err = errno;
    +           fprintf (stderr,
     
      ## src/vipw.c ##
     @@
    @@ src/vipw.c
     -#include "string/sprintf/snprintf.h"
     +#include "string/sprintf/stprintf.h"
      #include "string/strcmp/streq.h"
    - 
    + #include "string/strerrno.h"
      
     @@ src/vipw.c: vipwedit (const char *file, int (*file_lock) (void), int (*file_unlock) (bool))
        /* FIXME: the following should have variable sizes */
 6:  2588f6cd7 =  6:  8e338b1ed lib/salt.c: Use stprintf() instead of snprintf(3)
 7:  b1c32d4cf =  7:  c3569b5f8 lib/string/: Use [0] for end pointers
 8:  217c4b385 =  8:  fb65e5379 lib/string/: Compact documentation
 9:  854f03278 !  9:  051fef14c lib/, po/, src/: Rename stpeprintf() => seprintf()
    @@ lib/idmapping.c
     -#include "string/sprintf/stpeprintf.h"
     +#include "string/sprintf/seprintf.h"
      #include "string/strcmp/streq.h"
    - 
    + #include "string/strerrno.h"
      
     @@ lib/idmapping.c: void write_mapping(int proc_dir_fd, int ranges, const struct map_range *mappings
        mapping = mappings;
10:  f690a3cfd = 10:  fd6dbce94 lib/string/: seprintf(), stpecpy(): Add missing const
11:  10b7c4ec9 = 11:  f048418e6 lib/string/strcpy/: strtcpy(): Set errno on error
12:  2f03513fe = 12:  2f36b20a4 lib/string/strcpy/: stpecpy(): Use strtcpy() instead of its pattern
```
</details>

<details>
<summary>v14i</summary>

-  Rebase

```
$ git rd 
 1:  1fb8ed24f =  1:  156d72c80 lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  1618378d0 =  2:  b3a2eb5b8 lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
 3:  9f3843770 =  3:  1c38cbff6 lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  76bcef373 =  4:  01e609640 lib/string/: Redesign stpecpy() and stpeprintf()
 5:  44042b61b !  5:  953f60e18 lib/, src/, tests/: Rename snprintf_() to stprintf()
    @@ src/newgrp.c: static void check_perms (const struct group *grp,
     -                  SNPRINTF(audit_buf, "authentication new_gid=%lu",
     +                  STPRINTF(audit_buf, "authentication new_gid=%lu",
                                 (unsigned long) grp->gr_gid);
    -                   audit_logger (AUDIT_GRP_AUTH, Prog,
    +                   audit_logger (AUDIT_GRP_AUTH,
                                      audit_buf, NULL, getuid (), SHADOW_AUDIT_FAILURE);
     @@ src/newgrp.c: static void check_perms (const struct group *grp,
                        goto failure;
    @@ src/newgrp.c: static void check_perms (const struct group *grp,
     -          SNPRINTF(audit_buf, "authentication new_gid=%lu",
     +          STPRINTF(audit_buf, "authentication new_gid=%lu",
                         (unsigned long) grp->gr_gid);
    -           audit_logger (AUDIT_GRP_AUTH, Prog,
    +           audit_logger (AUDIT_GRP_AUTH,
                              audit_buf, NULL, getuid (), SHADOW_AUDIT_SUCCESS);
     @@ src/newgrp.c: int main (int argc, char **argv)
        if (setgid (gid) != 0) {
    @@ src/newgrp.c: int main (int argc, char **argv)
      #ifdef WITH_AUDIT
     -          SNPRINTF(audit_buf, "changing new_gid=%lu", (unsigned long) gid);
     +          STPRINTF(audit_buf, "changing new_gid=%lu", (unsigned long) gid);
    -           audit_logger (AUDIT_CHGRP_ID, Prog,
    +           audit_logger (AUDIT_CHGRP_ID,
                              audit_buf, NULL, getuid (), SHADOW_AUDIT_FAILURE);
      #endif
     @@ src/newgrp.c: int main (int argc, char **argv)
    @@ src/newgrp.c: int main (int argc, char **argv)
      #ifdef WITH_AUDIT
     -          SNPRINTF(audit_buf, "changing new_gid=%lu", (unsigned long) gid);
     +          STPRINTF(audit_buf, "changing new_gid=%lu", (unsigned long) gid);
    -           audit_logger (AUDIT_CHGRP_ID, Prog,
    +           audit_logger (AUDIT_CHGRP_ID,
                              audit_buf, NULL, getuid (), SHADOW_AUDIT_FAILURE);
      #endif
     @@ src/newgrp.c: int main (int argc, char **argv)
    @@ src/newgrp.c: int main (int argc, char **argv)
      #ifdef WITH_AUDIT
     -          SNPRINTF(audit_buf, "changing new_gid=%lu", (unsigned long) gid);
     +          STPRINTF(audit_buf, "changing new_gid=%lu", (unsigned long) gid);
    -           audit_logger (AUDIT_CHGRP_ID, Prog,
    +           audit_logger (AUDIT_CHGRP_ID,
                              audit_buf, NULL, getuid (), SHADOW_AUDIT_FAILURE);
      #endif
     @@ src/newgrp.c: int main (int argc, char **argv)
    @@ src/newgrp.c: int main (int argc, char **argv)
      #ifdef WITH_AUDIT
     -  SNPRINTF(audit_buf, "changing new_gid=%lu", (unsigned long) gid);
     +  STPRINTF(audit_buf, "changing new_gid=%lu", (unsigned long) gid);
    -   audit_logger (AUDIT_CHGRP_ID, Prog,
    +   audit_logger (AUDIT_CHGRP_ID,
                      audit_buf, NULL, getuid (), SHADOW_AUDIT_SUCCESS);
      #endif
     
 6:  8e338b1ed =  6:  ac5962f9c lib/salt.c: Use stprintf() instead of snprintf(3)
 7:  c3569b5f8 =  7:  f7b24d7b2 lib/string/: Use [0] for end pointers
 8:  fb65e5379 =  8:  38fff8b79 lib/string/: Compact documentation
 9:  051fef14c =  9:  2b8c6e8e5 lib/, po/, src/: Rename stpeprintf() => seprintf()
10:  fd6dbce94 = 10:  b056e72f1 lib/string/: seprintf(), stpecpy(): Add missing const
11:  f048418e6 = 11:  0b6611df7 lib/string/strcpy/: strtcpy(): Set errno on error
12:  2f36b20a4 = 12:  f705627d4 lib/string/strcpy/: stpecpy(): Use strtcpy() instead of its pattern
```
</details>

<details>
<summary>v15</summary>

-  Reorder commits.
-  Small changes to commit messages.
-  Small changes to comments.

<details>
<summary>interdiff</summary>

```diff
$ git diff f705627d4..1ccb20283
diff --git a/lib/string/sprintf/seprintf.h b/lib/string/sprintf/seprintf.h
index b755ff5f3..197aa6aa8 100644
--- a/lib/string/sprintf/seprintf.h
+++ b/lib/string/sprintf/seprintf.h
@@ -16,13 +16,11 @@
 
 
 #if !defined(HAVE_SEPRINTF)
-// string pointer-to-end print formatted
-// Like stpecpy(), but with a formatted string.
-// Report internal snprintf(3) errors with NULL and errno.
-// Calls to these functions can be chained with calls to stpecpy().
+// seprintf - string end-pointer print formatted
 format_attr(printf, 3, 4)
 inline char *seprintf(char *dst, const char end[0], const char *restrict fmt,
     ...);
+// vseprintf - va_list string end-pointer print formatted
 format_attr(printf, 3, 0)
 inline char *vseprintf(char *dst, const char end[0], const char *restrict fmt,
     va_list ap);
diff --git a/lib/string/strcpy/stpecpy.h b/lib/string/strcpy/stpecpy.h
index 6a0028462..7492f6e8f 100644
--- a/lib/string/strcpy/stpecpy.h
+++ b/lib/string/strcpy/stpecpy.h
@@ -18,16 +18,13 @@
 
 
 #if !defined(HAVE_STPECPY)
+// stpecpy - string offset-pointer end-pointer copy
 ATTR_STRING(3)
 inline char *stpecpy(char *dst, const char end[0], const char *restrict src);
 #endif
 
 
 #if !defined(HAVE_STPECPY)
-// string returns-pointer end-delimited copy
-// Report truncation with NULL and E2BIG.
-// Transparently pass through a NULL input.
-// Calls to this function can be chained with calls to [v]seprintf().
 inline char *
 stpecpy(char *dst, const char end[0], const char *restrict src)
 {
```
</details>

<details>
<summary>range-diff</summary>

```
$ git rd --creation-factor=99
 1:  156d72c80 =  1:  156d72c80 lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  b3a2eb5b8 !  2:  176c04ac1 lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/string/sprintf/snprintf.h: vsnprintf_(): Set errno = E2BIG on truncation
    +    lib/string/: vsnprintf_(), strtcpy(): Set errno = E2BIG on truncation
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    @@ lib/string/sprintf/snprintf.h: vsnprintf_(char *restrict s, size_t size, const c
      
        return len;
      }
    +
    + ## lib/string/strcpy/strtcpy.h ##
    +@@
    + 
    + #include "config.h"
    + 
    ++#include <errno.h>
    + #include <stdbool.h>
    + #include <stddef.h>
    + #include <string.h>
    +@@ lib/string/strcpy/strtcpy.h: strtcpy(char *restrict dst, const char *restrict src, size_t dsize)
    + 
    +   stpcpy(mempcpy(dst, src, dlen), "");
    + 
    +-  if (trunc)
    ++  if (trunc) {
    ++          errno = E2BIG;
    +           return -1;
    ++  }
    + 
    +   return slen;
    + }
 3:  1c38cbff6 =  3:  992e21e81 lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  01e609640 =  4:  4326914c7 lib/string/: Redesign stpecpy() and stpeprintf()
 8:  38fff8b79 !  5:  0069f6492 lib/string/: Compact documentation
    @@ Metadata
      ## Commit message ##
         lib/string/: Compact documentation
     
    -    These few lines are IMO more readable than the full-blown documentation.
    -
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/string/sprintf/stpeprintf.h ##
    @@ lib/string/sprintf/stpeprintf.h
      
      
      #if !defined(HAVE_STPEPRINTF)
    -+// string pointer-to-end print formatted
    -+// Like stpecpy(), but with a formatted string.
    -+// Report internal snprintf(3) errors with NULL and errno.
    -+// Calls to these functions can be chained with calls to stpecpy().
    ++// stpeprintf - string offset-pointer end-pointer print formatted
      format_attr(printf, 3, 4)
    - inline char *stpeprintf(char *dst, char end[0], const char *restrict fmt, ...);
    + inline char *stpeprintf(char *dst, char *end, const char *restrict fmt, ...);
    ++// vstpeprintf - va_list string offset-pointer end-pointer print formatted
      format_attr(printf, 3, 0)
    -@@ lib/string/sprintf/stpeprintf.h: inline char *vstpeprintf(char *dst, char end[0], const char *restrict fmt,
    + inline char *vstpeprintf(char *dst, char *end, const char *restrict fmt,
    +     va_list ap);
      #endif
      
      
    @@ lib/string/sprintf/stpeprintf.h: inline char *vstpeprintf(char *dst, char end[0]
     -
      #if !defined(HAVE_STPEPRINTF)
      inline char *
    - stpeprintf(char *dst, char end[0], const char *restrict fmt, ...)
    + stpeprintf(char *dst, char *end, const char *restrict fmt, ...)
     
      ## lib/string/strcpy/stpecpy.h ##
    -@@ lib/string/strcpy/stpecpy.h: inline char *stpecpy(char *dst, char end[0], const char *restrict src);
    +@@
    + 
    + 
    + #if !defined(HAVE_STPECPY)
    ++// stpecpy - string offset-pointer end-pointer copy
    + ATTR_STRING(3)
    + inline char *stpecpy(char *dst, char *end, const char *restrict src);
      #endif
      
      
    @@ lib/string/strcpy/stpecpy.h: inline char *stpecpy(char *dst, char end[0], const
     -
     -
      #if !defined(HAVE_STPECPY)
    -+// Like stpcpy(3), but use an 'end' pointer to truncate.
    -+// Report truncation with NULL and E2BIG.
    -+// Transparently pass through a NULL input.
    -+// Calls to this function can be chained with calls to [v]seprintf().
      inline char *
    - stpecpy(char *dst, char end[0], const char *restrict src)
    - {
    + stpecpy(char *dst, char *end, const char *restrict src)
 5:  953f60e18 !  6:  3edd6f0f4 lib/, src/, tests/: Rename snprintf_() to stprintf()
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/, src/, tests/: Rename snprintf_() to stprintf()
    +    lib/, src/, tests/: Rename snprintf_() => stprintf()
     
         For consistency with strTcpy(), call it sTprintf().
     
 9:  2b8c6e8e5 !  7:  4dfd68d2f lib/, po/, src/: Rename stpeprintf() => seprintf()
    @@ lib/string/sprintf/seprintf.c (new)
     +
     +
     +#if !defined(HAVE_SEPRINTF)
    -+extern inline char *seprintf(char *dst, char end[0], const char *restrict fmt,
    ++extern inline char *seprintf(char *dst, char *end, const char *restrict fmt,
     +    ...);
    -+extern inline char *vseprintf(char *dst, char end[0], const char *restrict fmt,
    ++extern inline char *vseprintf(char *dst, char *end, const char *restrict fmt,
     +    va_list ap);
     +#endif
     
    - ## lib/string/sprintf/stpeprintf.h => lib/string/sprintf/seprintf.h ##
    + ## lib/string/sprintf/seprintf.h (new) ##
     @@
    - // SPDX-License-Identifier: BSD-3-Clause
    - 
    - 
    --#ifndef SHADOW_INCLUDE_LIB_STRING_SPRINTF_STPEPRINTF_H_
    --#define SHADOW_INCLUDE_LIB_STRING_SPRINTF_STPEPRINTF_H_
    ++// SPDX-FileCopyrightText: 2022-2024, Alejandro Colomar <alx@kernel.org>
    ++// SPDX-License-Identifier: BSD-3-Clause
    ++
    ++
     +#ifndef SHADOW_INCLUDE_LIB_STRING_SPRINTF_SEPRINTF_H_
     +#define SHADOW_INCLUDE_LIB_STRING_SPRINTF_SEPRINTF_H_
    - 
    - 
    - #include "config.h"
    -@@
    - #include "string/sprintf/stprintf.h"
    - 
    - 
    --#if !defined(HAVE_STPEPRINTF)
    ++
    ++
    ++#include "config.h"
    ++
    ++#include <stdarg.h>
    ++#include <stddef.h>
    ++
    ++#include "attr.h"
    ++#include "string/sprintf/stprintf.h"
    ++
    ++
     +#if !defined(HAVE_SEPRINTF)
    - // string pointer-to-end print formatted
    - // Like stpecpy(), but with a formatted string.
    - // Report internal snprintf(3) errors with NULL and errno.
    - // Calls to these functions can be chained with calls to stpecpy().
    - format_attr(printf, 3, 4)
    --inline char *stpeprintf(char *dst, char end[0], const char *restrict fmt, ...);
    -+inline char *seprintf(char *dst, char end[0], const char *restrict fmt, ...);
    - format_attr(printf, 3, 0)
    --inline char *vstpeprintf(char *dst, char end[0], const char *restrict fmt,
    -+inline char *vseprintf(char *dst, char end[0], const char *restrict fmt,
    -     va_list ap);
    - #endif
    - 
    - 
    --#if !defined(HAVE_STPEPRINTF)
    ++// seprintf - string end-pointer print formatted
    ++format_attr(printf, 3, 4)
    ++inline char *seprintf(char *dst, char *end, const char *restrict fmt, ...);
    ++// vseprintf - va_list string end-pointer print formatted
    ++format_attr(printf, 3, 0)
    ++inline char *vseprintf(char *dst, char *end, const char *restrict fmt,
    ++    va_list ap);
    ++#endif
    ++
    ++
     +#if !defined(HAVE_SEPRINTF)
    - inline char *
    --stpeprintf(char *dst, char end[0], const char *restrict fmt, ...)
    -+seprintf(char *dst, char end[0], const char *restrict fmt, ...)
    - {
    -   char     *p;
    -   va_list  ap;
    - 
    -   va_start(ap, fmt);
    --  p = vstpeprintf(dst, end, fmt, ap);
    ++inline char *
    ++seprintf(char *dst, char *end, const char *restrict fmt, ...)
    ++{
    ++  char     *p;
    ++  va_list  ap;
    ++
    ++  va_start(ap, fmt);
     +  p = vseprintf(dst, end, fmt, ap);
    -   va_end(ap);
    - 
    -   return p;
    -@@ lib/string/sprintf/seprintf.h: stpeprintf(char *dst, char end[0], const char *restrict fmt, ...)
    - #endif
    - 
    - 
    --#if !defined(HAVE_STPEPRINTF)
    ++  va_end(ap);
    ++
    ++  return p;
    ++}
    ++#endif
    ++
    ++
     +#if !defined(HAVE_SEPRINTF)
    - inline char *
    --vstpeprintf(char *dst, char end[0], const char *restrict fmt, va_list ap)
    -+vseprintf(char *dst, char end[0], const char *restrict fmt, va_list ap)
    - {
    -   int        len;
    -   ptrdiff_t  size;
    ++inline char *
    ++vseprintf(char *dst, char *end, const char *restrict fmt, va_list ap)
    ++{
    ++  int        len;
    ++  ptrdiff_t  size;
    ++
    ++  if (dst == NULL)
    ++          return NULL;
    ++
    ++  size = end - dst;
    ++  len = vstprintf(dst, size, fmt, ap);
    ++  if (len == -1)
    ++          return NULL;
    ++
    ++  return dst + len;
    ++}
    ++#endif
    ++
    ++
    ++#endif  // include guard
     
      ## lib/string/sprintf/stpeprintf.c (deleted) ##
     @@
    --// SPDX-FileCopyrightText: 2022-2025, Alejandro Colomar <alx@kernel.org>
    +-// SPDX-FileCopyrightText: 2022-2024, Alejandro Colomar <alx@kernel.org>
     -// SPDX-License-Identifier: BSD-3-Clause
     -
     -
    @@ lib/string/sprintf/stpeprintf.c (deleted)
     -
     -
     -#if !defined(HAVE_STPEPRINTF)
    --extern inline char *stpeprintf(char *dst, char end[0], const char *restrict fmt,
    +-extern inline char *stpeprintf(char *dst, char *end, const char *restrict fmt,
     -    ...);
    --extern inline char *vstpeprintf(char *dst, char end[0], const char *restrict fmt,
    +-extern inline char *vstpeprintf(char *dst, char *end, const char *restrict fmt,
     -    va_list ap);
     -#endif
     
    + ## lib/string/sprintf/stpeprintf.h (deleted) ##
    +@@
    +-// SPDX-FileCopyrightText: 2022-2024, Alejandro Colomar <alx@kernel.org>
    +-// SPDX-License-Identifier: BSD-3-Clause
    +-
    +-
    +-#ifndef SHADOW_INCLUDE_LIB_STRING_SPRINTF_STPEPRINTF_H_
    +-#define SHADOW_INCLUDE_LIB_STRING_SPRINTF_STPEPRINTF_H_
    +-
    +-
    +-#include "config.h"
    +-
    +-#include <stdarg.h>
    +-#include <stddef.h>
    +-
    +-#include "attr.h"
    +-#include "string/sprintf/stprintf.h"
    +-
    +-
    +-#if !defined(HAVE_STPEPRINTF)
    +-// stpeprintf - string offset-pointer end-pointer print formatted
    +-format_attr(printf, 3, 4)
    +-inline char *stpeprintf(char *dst, char *end, const char *restrict fmt, ...);
    +-// vstpeprintf - va_list string offset-pointer end-pointer print formatted
    +-format_attr(printf, 3, 0)
    +-inline char *vstpeprintf(char *dst, char *end, const char *restrict fmt,
    +-    va_list ap);
    +-#endif
    +-
    +-
    +-#if !defined(HAVE_STPEPRINTF)
    +-inline char *
    +-stpeprintf(char *dst, char *end, const char *restrict fmt, ...)
    +-{
    +-  char     *p;
    +-  va_list  ap;
    +-
    +-  va_start(ap, fmt);
    +-  p = vstpeprintf(dst, end, fmt, ap);
    +-  va_end(ap);
    +-
    +-  return p;
    +-}
    +-#endif
    +-
    +-
    +-#if !defined(HAVE_STPEPRINTF)
    +-inline char *
    +-vstpeprintf(char *dst, char *end, const char *restrict fmt, va_list ap)
    +-{
    +-  int        len;
    +-  ptrdiff_t  size;
    +-
    +-  if (dst == NULL)
    +-          return NULL;
    +-
    +-  size = end - dst;
    +-  len = vstprintf(dst, size, fmt, ap);
    +-  if (len == -1)
    +-          return NULL;
    +-
    +-  return dst + len;
    +-}
    +-#endif
    +-
    +-
    +-#endif  // include guard
    +
      ## po/bs.po ##
     @@ po/bs.po: msgid "%s: Could not set caps\n"
      msgstr "%s: nepoznat član %s\n"
10:  b056e72f1 !  8:  3aa54b607 lib/string/: seprintf(), stpecpy(): Add missing const
    @@ lib/string/sprintf/seprintf.c
      
      
      #if !defined(HAVE_SEPRINTF)
    --extern inline char *seprintf(char *dst, char end[0], const char *restrict fmt,
    +-extern inline char *seprintf(char *dst, char *end, const char *restrict fmt,
     -    ...);
    --extern inline char *vseprintf(char *dst, char end[0], const char *restrict fmt,
    +-extern inline char *vseprintf(char *dst, char *end, const char *restrict fmt,
     -    va_list ap);
    -+extern inline char *seprintf(char *dst, const char end[0],
    ++extern inline char *seprintf(char *dst, const char *end,
     +    const char *restrict fmt, ...);
    -+extern inline char *vseprintf(char *dst, const char end[0],
    ++extern inline char *vseprintf(char *dst, const char *end,
     +    const char *restrict fmt, va_list ap);
      #endif
     
      ## lib/string/sprintf/seprintf.h ##
     @@
    - // Report internal snprintf(3) errors with NULL and errno.
    - // Calls to these functions can be chained with calls to stpecpy().
    + #if !defined(HAVE_SEPRINTF)
    + // seprintf - string end-pointer print formatted
      format_attr(printf, 3, 4)
    --inline char *seprintf(char *dst, char end[0], const char *restrict fmt, ...);
    -+inline char *seprintf(char *dst, const char end[0], const char *restrict fmt,
    +-inline char *seprintf(char *dst, char *end, const char *restrict fmt, ...);
    ++inline char *seprintf(char *dst, const char *end, const char *restrict fmt,
     +    ...);
    + // vseprintf - va_list string end-pointer print formatted
      format_attr(printf, 3, 0)
    --inline char *vseprintf(char *dst, char end[0], const char *restrict fmt,
    -+inline char *vseprintf(char *dst, const char end[0], const char *restrict fmt,
    +-inline char *vseprintf(char *dst, char *end, const char *restrict fmt,
    ++inline char *vseprintf(char *dst, const char *end, const char *restrict fmt,
          va_list ap);
      #endif
      
      
      #if !defined(HAVE_SEPRINTF)
      inline char *
    --seprintf(char *dst, char end[0], const char *restrict fmt, ...)
    -+seprintf(char *dst, const char end[0], const char *restrict fmt, ...)
    +-seprintf(char *dst, char *end, const char *restrict fmt, ...)
    ++seprintf(char *dst, const char *end, const char *restrict fmt, ...)
      {
        char     *p;
        va_list  ap;
    -@@ lib/string/sprintf/seprintf.h: seprintf(char *dst, char end[0], const char *restrict fmt, ...)
    +@@ lib/string/sprintf/seprintf.h: seprintf(char *dst, char *end, const char *restrict fmt, ...)
      
      #if !defined(HAVE_SEPRINTF)
      inline char *
    --vseprintf(char *dst, char end[0], const char *restrict fmt, va_list ap)
    -+vseprintf(char *dst, const char end[0], const char *restrict fmt, va_list ap)
    +-vseprintf(char *dst, char *end, const char *restrict fmt, va_list ap)
    ++vseprintf(char *dst, const char *end, const char *restrict fmt, va_list ap)
      {
        int        len;
        ptrdiff_t  size;
    @@ lib/string/strcpy/stpecpy.c
      
      
      #if !defined(HAVE_STPECPY)
    --extern inline char *stpecpy(char *dst, char end[0], const char *restrict src);
    -+extern inline char *stpecpy(char *dst, const char end[0],
    +-extern inline char *stpecpy(char *dst, char *end, const char *restrict src);
    ++extern inline char *stpecpy(char *dst, const char *end,
     +    const char *restrict src);
      #endif
     
      ## lib/string/strcpy/stpecpy.h ##
     @@
    - 
      #if !defined(HAVE_STPECPY)
    + // stpecpy - string offset-pointer end-pointer copy
      ATTR_STRING(3)
    --inline char *stpecpy(char *dst, char end[0], const char *restrict src);
    -+inline char *stpecpy(char *dst, const char end[0], const char *restrict src);
    +-inline char *stpecpy(char *dst, char *end, const char *restrict src);
    ++inline char *stpecpy(char *dst, const char *end, const char *restrict src);
      #endif
      
      
    -@@ lib/string/strcpy/stpecpy.h: inline char *stpecpy(char *dst, char end[0], const char *restrict src);
    - // Transparently pass through a NULL input.
    - // Calls to this function can be chained with calls to [v]seprintf().
    + #if !defined(HAVE_STPECPY)
      inline char *
    --stpecpy(char *dst, char end[0], const char *restrict src)
    -+stpecpy(char *dst, const char end[0], const char *restrict src)
    +-stpecpy(char *dst, char *end, const char *restrict src)
    ++stpecpy(char *dst, const char *end, const char *restrict src)
      {
        bool    trunc;
        char    *p;
11:  0b6611df7 !  9:  aeee5d9a6 lib/string/strcpy/: strtcpy(): Set errno on error
    @@ Commit message
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/string/strcpy/strtcpy.h ##
    -@@
    - 
    - #include "config.h"
    - 
    -+#include <errno.h>
    - #include <stdbool.h>
    - #include <stddef.h>
    - #include <string.h>
     @@ lib/string/strcpy/strtcpy.h: strtcpy(char *restrict dst, const char *restrict src, size_t dsize)
        bool    trunc;
        size_t  dlen, slen;
    @@ lib/string/strcpy/strtcpy.h: strtcpy(char *restrict dst, const char *restrict sr
      
        slen = strnlen(src, dsize);
        trunc = (slen == dsize);
    -@@ lib/string/strcpy/strtcpy.h: strtcpy(char *restrict dst, const char *restrict src, size_t dsize)
    - 
    -   stpcpy(mempcpy(dst, src, dlen), "");
    - 
    --  if (trunc)
    -+  if (trunc) {
    -+          errno = E2BIG;
    -           return -1;
    -+  }
    - 
    -   return slen;
    - }
 6:  ac5962f9c = 10:  a562e332a lib/salt.c: Use stprintf() instead of snprintf(3)
12:  f705627d4 ! 11:  ec5af084f lib/string/strcpy/: stpecpy(): Use strtcpy() instead of its pattern
    @@ lib/string/strcpy/stpecpy.h
      
      
      #if !defined(HAVE_STPECPY)
    -@@ lib/string/strcpy/stpecpy.h: inline char *stpecpy(char *dst, const char end[0], const char *restrict src);
    - 
    - 
    - #if !defined(HAVE_STPECPY)
    --// Like stpcpy(3), but use an 'end' pointer to truncate.
    -+// string returns-pointer end-delimited copy
    - // Report truncation with NULL and E2BIG.
    - // Transparently pass through a NULL input.
    - // Calls to this function can be chained with calls to [v]seprintf().
    +@@ lib/string/strcpy/stpecpy.h: inline char *stpecpy(char *dst, const char *end, const char *restrict src);
      inline char *
    - stpecpy(char *dst, const char end[0], const char *restrict src)
    + stpecpy(char *dst, const char *end, const char *restrict src)
      {
     -  bool    trunc;
     -  char    *p;
 7:  f7b24d7b2 ! 12:  1ccb20283 lib/string/: Use [0] for end pointers
    @@ Commit message
         Link: <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108036>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    - ## lib/string/sprintf/stpeprintf.c ##
    -@@
    --// SPDX-FileCopyrightText: 2022-2024, Alejandro Colomar <alx@kernel.org>
    -+// SPDX-FileCopyrightText: 2022-2025, Alejandro Colomar <alx@kernel.org>
    - // SPDX-License-Identifier: BSD-3-Clause
    - 
    - 
    + ## lib/string/sprintf/seprintf.c ##
     @@
      
      
    - #if !defined(HAVE_STPEPRINTF)
    --extern inline char *stpeprintf(char *dst, char *end, const char *restrict fmt,
    -+extern inline char *stpeprintf(char *dst, char end[0], const char *restrict fmt,
    -     ...);
    --extern inline char *vstpeprintf(char *dst, char *end, const char *restrict fmt,
    -+extern inline char *vstpeprintf(char *dst, char end[0], const char *restrict fmt,
    -     va_list ap);
    + #if !defined(HAVE_SEPRINTF)
    +-extern inline char *seprintf(char *dst, const char *end,
    ++extern inline char *seprintf(char *dst, const char end[0],
    +     const char *restrict fmt, ...);
    +-extern inline char *vseprintf(char *dst, const char *end,
    ++extern inline char *vseprintf(char *dst, const char end[0],
    +     const char *restrict fmt, va_list ap);
      #endif
     
    - ## lib/string/sprintf/stpeprintf.h ##
    + ## lib/string/sprintf/seprintf.h ##
     @@
     -// SPDX-FileCopyrightText: 2022-2024, Alejandro Colomar <alx@kernel.org>
     +// SPDX-FileCopyrightText: 2022-2025, Alejandro Colomar <alx@kernel.org>
    @@ lib/string/sprintf/stpeprintf.h
      
      
     @@
    - 
    - #if !defined(HAVE_STPEPRINTF)
    + #if !defined(HAVE_SEPRINTF)
    + // seprintf - string end-pointer print formatted
      format_attr(printf, 3, 4)
    --inline char *stpeprintf(char *dst, char *end, const char *restrict fmt, ...);
    -+inline char *stpeprintf(char *dst, char end[0], const char *restrict fmt, ...);
    +-inline char *seprintf(char *dst, const char *end, const char *restrict fmt,
    ++inline char *seprintf(char *dst, const char end[0], const char *restrict fmt,
    +     ...);
    + // vseprintf - va_list string end-pointer print formatted
      format_attr(printf, 3, 0)
    --inline char *vstpeprintf(char *dst, char *end, const char *restrict fmt,
    -+inline char *vstpeprintf(char *dst, char end[0], const char *restrict fmt,
    +-inline char *vseprintf(char *dst, const char *end, const char *restrict fmt,
    ++inline char *vseprintf(char *dst, const char end[0], const char *restrict fmt,
          va_list ap);
      #endif
      
    -@@ lib/string/sprintf/stpeprintf.h: inline char *vstpeprintf(char *dst, char *end, const char *restrict fmt,
      
    - #if !defined(HAVE_STPEPRINTF)
    + #if !defined(HAVE_SEPRINTF)
      inline char *
    --stpeprintf(char *dst, char *end, const char *restrict fmt, ...)
    -+stpeprintf(char *dst, char end[0], const char *restrict fmt, ...)
    +-seprintf(char *dst, const char *end, const char *restrict fmt, ...)
    ++seprintf(char *dst, const char end[0], const char *restrict fmt, ...)
      {
        char     *p;
        va_list  ap;
    -@@ lib/string/sprintf/stpeprintf.h: stpeprintf(char *dst, char *end, const char *restrict fmt, ...)
    +@@ lib/string/sprintf/seprintf.h: seprintf(char *dst, const char *end, const char *restrict fmt, ...)
      
    - #if !defined(HAVE_STPEPRINTF)
    + #if !defined(HAVE_SEPRINTF)
      inline char *
    --vstpeprintf(char *dst, char *end, const char *restrict fmt, va_list ap)
    -+vstpeprintf(char *dst, char end[0], const char *restrict fmt, va_list ap)
    +-vseprintf(char *dst, const char *end, const char *restrict fmt, va_list ap)
    ++vseprintf(char *dst, const char end[0], const char *restrict fmt, va_list ap)
      {
        int        len;
        ptrdiff_t  size;
    @@ lib/string/strcpy/stpecpy.c
      
      
      #if !defined(HAVE_STPECPY)
    --extern inline char *stpecpy(char *dst, char *end, const char *restrict src);
    -+extern inline char *stpecpy(char *dst, char end[0], const char *restrict src);
    +-extern inline char *stpecpy(char *dst, const char *end,
    ++extern inline char *stpecpy(char *dst, const char end[0],
    +     const char *restrict src);
      #endif
     
      ## lib/string/strcpy/stpecpy.h ##
    @@ lib/string/strcpy/stpecpy.h
      
      
     @@
    - 
      #if !defined(HAVE_STPECPY)
    + // stpecpy - string offset-pointer end-pointer copy
      ATTR_STRING(3)
    --inline char *stpecpy(char *dst, char *end, const char *restrict src);
    -+inline char *stpecpy(char *dst, char end[0], const char *restrict src);
    +-inline char *stpecpy(char *dst, const char *end, const char *restrict src);
    ++inline char *stpecpy(char *dst, const char end[0], const char *restrict src);
      #endif
      
      
    -@@ lib/string/strcpy/stpecpy.h: inline char *stpecpy(char *dst, char *end, const char *restrict src);
    - 
      #if !defined(HAVE_STPECPY)
      inline char *
    --stpecpy(char *dst, char *end, const char *restrict src)
    -+stpecpy(char *dst, char end[0], const char *restrict src)
    +-stpecpy(char *dst, const char *end, const char *restrict src)
    ++stpecpy(char *dst, const char end[0], const char *restrict src)
      {
    -   bool    trunc;
    -   char    *p;
    +   ssize_t  dlen;
    + 
```
</details>
</details>

<details>
<summary>v15b</summary>

-  Reorder commits.

```
$ git rd 
 1:  156d72c80 =  1:  156d72c80 lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  176c04ac1 =  2:  176c04ac1 lib/string/: vsnprintf_(), strtcpy(): Set errno = E2BIG on truncation
 3:  992e21e81 =  3:  992e21e81 lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  4326914c7 =  4:  4326914c7 lib/string/: Redesign stpecpy() and stpeprintf()
 5:  0069f6492 =  5:  0069f6492 lib/string/: Compact documentation
 6:  3edd6f0f4 =  6:  3edd6f0f4 lib/, src/, tests/: Rename snprintf_() => stprintf()
 7:  4dfd68d2f =  7:  4dfd68d2f lib/, po/, src/: Rename stpeprintf() => seprintf()
 8:  3aa54b607 =  8:  3aa54b607 lib/string/: seprintf(), stpecpy(): Add missing const
11:  ec5af084f =  9:  e3f80e1f5 lib/string/strcpy/: stpecpy(): Use strtcpy() instead of its pattern
10:  a562e332a = 10:  4ccc38585 lib/salt.c: Use stprintf() instead of snprintf(3)
 9:  aeee5d9a6 = 11:  4e6e69554 lib/string/strcpy/: strtcpy(): Set errno on error
12:  1ccb20283 = 12:  05e0cd871 lib/string/: Use [0] for end pointers
```
</details>

<details>
<summary>v16</summary>

-  Rebase on top of se2.

```
$ git range-diff shadow/master..gh/snprintf_ se..snprintf_ 
 1:  156d72c80 <  -:  --------- lib/subordinateio.c: get_owner_id(): Use snprintf_() instead of its pattern
 2:  176c04ac1 <  -:  --------- lib/string/: vsnprintf_(), strtcpy(): Set errno = E2BIG on truncation
 3:  992e21e81 <  -:  --------- lib/string/sprintf/: snprintf_(): Use int instead of size_t in $2
 4:  4326914c7 <  -:  --------- lib/string/: Redesign stpecpy() and stpeprintf()
 5:  0069f6492 <  -:  --------- lib/string/: Compact documentation
 6:  3edd6f0f4 <  -:  --------- lib/, src/, tests/: Rename snprintf_() => stprintf()
 7:  4dfd68d2f <  -:  --------- lib/, po/, src/: Rename stpeprintf() => seprintf()
 8:  3aa54b607 <  -:  --------- lib/string/: seprintf(), stpecpy(): Add missing const
 9:  e3f80e1f5 <  -:  --------- lib/string/strcpy/: stpecpy(): Use strtcpy() instead of its pattern
10:  4ccc38585 <  -:  --------- lib/salt.c: Use stprintf() instead of snprintf(3)
11:  4e6e69554 =  1:  639df75b0 lib/string/strcpy/: strtcpy(): Set errno on error
12:  05e0cd871 =  2:  dfbc2caf8 lib/string/: Use [0] for end pointers
```
</details>

<details>
<summary>v16b</summary>

-  Rebase

```
$ git range-diff gh/snprintf_^^..gh/snprintf_ se..snprintf_ 
1:  639df75b0 = 1:  d9b154b02 lib/string/strcpy/: strtcpy(): Set errno on error
2:  dfbc2caf8 = 2:  d120e2d76 lib/string/: Use [0] for end pointers
```
</details>

<details>
<summary>v17</summary>

-  Make stprintf() and strtcpy() more consistent, and set errno to EOVERFLOW on the same conditions.

```
$ git range-diff gh/se gh/snprintf_ snprintf_ 
1:  d9b154b02 ! 1:  137241aed lib/string/strcpy/: strtcpy(): Set errno on error
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/string/strcpy/: strtcpy(): Set errno on error
    +    lib/string/: strtcpy(), stprintf(): Set errno = EOVERFLOW if size == 0
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    + ## lib/string/sprintf/stprintf.h ##
    +@@ lib/string/sprintf/stprintf.h: vstprintf(char *restrict s, int size, const char *restrict fmt, va_list ap)
    + {
    +   int  len;
    + 
    ++  if (size == 0) {
    ++          errno = EOVERFLOW;
    ++          return -1;
    ++  }
    ++
    +   len = vsnprintf(s, size, fmt, ap);
    +   if (len == -1)
    +           return -1;
    +
      ## lib/string/strcpy/strtcpy.h ##
     @@ lib/string/strcpy/strtcpy.h: strtcpy(char *restrict dst, const char *restrict src, size_t dsize)
        bool    trunc;
2:  d120e2d76 = 2:  6975ad493 lib/string/: Use [0] for end pointers
```
</details>

<details>
<summary>v17b</summary>

-  Rebase

```
$ git range-diff gh/se..gh/snprintf_ se..snprintf_ 
1:  137241aed = 1:  5795f4bcc lib/string/: strtcpy(), stprintf(): Set errno = EOVERFLOW if size == 0
2:  6975ad493 = 2:  e189d5464 lib/string/: Use [0] for end pointers
```
</details>

<details>
<summary>v17c</summary>

-  Rebase

```
$ git range-diff gh/se..gh/snprintf_ se..snprintf_ 
1:  5795f4bcc = 1:  5bbf751b9 lib/string/: strtcpy(), stprintf(): Set errno = EOVERFLOW if size == 0
2:  e189d5464 = 2:  1fd8c666a lib/string/: Use [0] for end pointers
```
</details>

<details>
<summary>v17d</summary>

-  Rebase

```
$ git range-diff gh/se..gh/snprintf_ se..snprintf_ 
1:  5bbf751b9 = 1:  28a0f5aec lib/string/: strtcpy(), stprintf(): Set errno = EOVERFLOW if size == 0
2:  1fd8c666a = 2:  da5c1beac lib/string/: Use [0] for end pointers
```
</details>

<details>
<summary>v17e</summary>

-  Rebase

```
$ git range-diff gh/se..gh/snprintf_ se..snprintf_ 
1:  28a0f5aec < -:  --------- lib/string/: strtcpy(), stprintf(): Set errno = EOVERFLOW if size == 0
2:  da5c1beac = 1:  f1e215bab lib/string/: Use [0] for end pointers
```
</details>

<details>
<summary>v17f</summary>

-  Rebase

```
$ git range-diff gh/se..gh/snprintf_ se..snprintf_ 
1:  f1e215bab = 1:  84658b790 lib/string/: Use [0] for end pointers
```
</details>

<details>
<summary>v17g</summary>

-  Rebase

```
$ git range-diff gh/se..gh/snprintf_ se..snprintf_ 
1:  84658b790 = 1:  90962f7e9 lib/string/: Use [0] for end pointers
```
</details>

<details>
<summary>v17h</summary>

-  Rebase

```
$ git range-diff gh/se..gh/snprintf_ se..snprintf_ 
1:  90962f7e9 = 1:  377d3eb39 lib/string/: Use [0] for end pointers
```
</details>

<details>
<summary>v17i</summary>

-  Rebase

```
$ git range-diff gh/se..gh/snprintf_ se..snprintf_ 
1:  377d3eb39 = 1:  dc879ad29 lib/string/: Use [0] for end pointers
```
</details>

<details>
<summary>v17j</summary>

-  Rebase

```
$ git range-diff gh/se..gh/snprintf_ se..snprintf_ 
1:  dc879ad29 = 1:  c577e4168 lib/string/: Use [0] for end pointers
```
</details>

<details>
<summary>v17k</summary>

-  Rebase

```
$ git range-diff gh/se..gh/snprintf_ se..snprintf_ 
1:  c577e4168 = 1:  387c9e3d6 lib/string/: Use [0] for end pointers
```
</details>

<details>
<summary>v17l</summary>

-  Rebase

```
$ git range-diff gh/se..gh/snprintf_ se..snprintf_ 
1:  387c9e3d6 = 1:  2aebeacbb lib/string/: Use [0] for end pointers
```
</details>

<details>
<summary>v17m</summary>

-  Rebase

```
$ git range-diff gh/se gh/snprintf_ snprintf_ 
1:  2aebeacbb = 1:  56bf6aaa7 lib/string/: Use [0] for end pointers
```
</details>

<details>
<summary>v17n</summary>

-  Rebase

```
$ git range-diff gh/se..gh/snprintf_ se..snprintf_ 
1:  56bf6aaa7 = 1:  e1a9b3b89 lib/string/: Use [0] for end pointers
```
</details>

<details>
<summary>v17o</summary>

-  Rebase

```
$ git range-diff gh/se..gh/snprintf_ se..snprintf_ 
1:  e1a9b3b89 = 1:  7af19f834 lib/string/: Use [0] for end pointers
```
</details>

<details>
<summary>v17p</summary>

-  Rebase

```
$ git range-diff gh/se..gh/snprintf_ se..snprintf_ 
1:  7af19f8347fe = 1:  2812ecb595c8 lib/string/: Use [0] for end pointers
```
</details> 

<details>
<summary>v17q</summary>

-  Rebase

```
$ git range-diff gh/se..gh/snprintf_ se..snprintf_ 
1:  2812ecb595c8 = 1:  cf7dedc82ef3 lib/string/: Use [0] for end pointers
```
</details>

<details>
<summary>v17r</summary>

-  Rebase

```
$ git range-diff gh/se..gh/snprintf_ se..snprintf_ 
1:  cf7dedc82ef3 = 1:  ff0018592db0 lib/string/: Use [0] for end pointers
```
</details>

<details>
<summary>v17s</summary>

-  Rebase

```
$ git range-diff gh/se..gh/snprintf_ se..snprintf_ 
1:  ff001859 = 1:  5064a374 lib/string/: Use [0] for end pointers
```
</details>

<details>
<summary>v17t</summary>

-  Rebase

```
$ git range-diff gh/se..gh/snprintf_ se..snprintf_ 
1:  5064a374 = 1:  040cbb41 lib/string/: Use [0] for end pointers
```
</details>

<details>
<summary>v17u</summary>

-  Rebase

```
$ git range-diff gh/se..gh/snprintf_ se..snprintf_ 
1:  040cbb41 = 1:  65fa64cf lib/string/: Use [0] for end pointers
```
</details>

<details>
<summary>v18</summary>

-  Rebase (#1387 has been merged already).

```
$ git rd 
 1:  c959c7dd <  -:  -------- lib/string/: vsnprintf_(), strtcpy(): Set errno = E2BIG on truncation
 2:  e3e1ee7f <  -:  -------- lib/string/sprintf/: snprintf_(): Use ssize_t instead of size_t in $2
 3:  2438c99a <  -:  -------- lib/string/: vsnprintf_(), strtcpy(): abort() if size==0
 4:  088136be <  -:  -------- lib/string/: Redesign stpecpy() and stpeprintf()
 5:  2339f5dd <  -:  -------- lib/string/: Compact documentation
 6:  a3725c9b <  -:  -------- lib/, src/, tests/: Rename snprintf_() => stprintf()
 7:  d5bdfe85 <  -:  -------- lib/, po/, src/: Rename stpeprintf() => seprintf()
 8:  fba5ab1e <  -:  -------- lib/string/: seprintf(), stpecpy(): Add missing const
 9:  893d3302 <  -:  -------- lib/string/strcpy/: stpecpy(): Use strtcpy() instead of its pattern
10:  784c370a <  -:  -------- lib/salt.c: Use stprintf() instead of snprintf(3)
11:  65fa64cf =  1:  d33beebb lib/string/: Use [0] for end pointers
```
</details>

<details>
<summary>v18b</summary>

-  Rebase

```
$ git rd 
1:  d33beebb89f2 = 1:  9f180262f09b lib/string/: Use [0] for end pointers
```
</details>

<details>
<summary>v18c</summary>

-  Rebase

```
$ git rd 
1:  9f180262f09b = 1:  27ff2d956c02 lib/string/: Use [0] for end pointers
```
</details>