### PR TITLE
Add strisdigit(), and use it instead of its pattern

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -186,6 +186,8 @@ libshadow_la_SOURCES = \
 	spawn.c \
 	sssd.c \
 	sssd.h \
+	string/ctype/strisascii/strisdigit.c \
+	string/ctype/strisascii/strisdigit.h \
 	string/memset/memzero.c \
 	string/memset/memzero.h \
 	string/sprintf/snprintf.c \

--- a/lib/chkname.c
+++ b/lib/chkname.c
@@ -31,6 +31,7 @@
 
 #include "defines.h"
 #include "chkname.h"
+#include "string/ctype/strisascii/strisdigit.h"
 #include "string/strcmp/streq.h"
 
 
@@ -71,7 +72,11 @@ is_valid_name(const char *name)
          *
          * Also do not allow fully numeric names or just "." or "..".
          */
-	int numeric;
+
+	if (strisdigit(name)) {
+		errno = EINVAL;
+		return false;
+	}
 
 	if (streq(name, "") ||
 	    streq(name, ".") ||
@@ -86,8 +91,6 @@ is_valid_name(const char *name)
 		return false;
 	}
 
-	numeric = isdigit(*name);
-
 	while (!streq(++name, "")) {
 		if (!((*name >= 'a' && *name <= 'z') ||
 		      (*name >= 'A' && *name <= 'Z') ||
@@ -101,12 +104,6 @@ is_valid_name(const char *name)
 			errno = EINVAL;
 			return false;
 		}
-		numeric &= isdigit(*name);
-	}
-
-	if (numeric) {
-		errno = EINVAL;
-		return false;
 	}
 
 	return true;

--- a/lib/string/ctype/strisascii/strisdigit.c
+++ b/lib/string/ctype/strisascii/strisdigit.c
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#include <config.h>
+
+#include "string/ctype/strisascii/strisdigit.h"
+
+#include <stdbool.h>
+
+
+extern inline bool strisdigit(const char *s);

--- a/lib/string/ctype/strisascii/strisdigit.h
+++ b/lib/string/ctype/strisascii/strisdigit.h
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#ifndef SHADOW_INCLUDE_LIB_STRING_CTYPE_STRISASCII_STRISDIGIT_H_
+#define SHADOW_INCLUDE_LIB_STRING_CTYPE_STRISASCII_STRISDIGIT_H_
+
+
+#include <config.h>
+
+#include <stdbool.h>
+
+#include "string/strcmp/streq.h"
+#include "string/strspn/stpspn.h"
+
+
+inline bool strisdigit(const char *s);
+
+
+// string is [:digit:]
+// Like isdigit(3), but check all characters in the string.
+inline bool
+strisdigit(const char *s)
+{
+	if (streq(s, ""))
+		return false;
+
+	return streq(stpspn(s, "0123456789"), "");
+}
+
+
+#endif  // include guard

--- a/lib/strtoday.c
+++ b/lib/strtoday.c
@@ -14,6 +14,7 @@
 #include "atoi/str2i/str2s.h"
 #include "getdate.h"
 #include "prototypes.h"
+#include "string/ctype/strisascii/strisdigit.h"
 #include "string/strcmp/streq.h"
 #include "string/strspn/stpspn.h"
 
@@ -35,7 +36,6 @@
 long strtoday (const char *str)
 {
 	time_t t;
-	bool isnum = true;
 	const char *s = str;
 
 	/*
@@ -54,14 +54,9 @@ long strtoday (const char *str)
 		s++;
 	}
 	s = stpspn(s, " ");
-	while (isnum && !streq(s, "")) {
-		if (!isdigit (*s)) {
-			isnum = false;
-		}
-		s++;
-	}
-	if (isnum) {
+	if (strisdigit(s)) {
 		long retdate;
+
 		if (str2sl(&retdate, str) == -1)
 			return -2;
 		return retdate;

--- a/lib/subordinateio.c
+++ b/lib/subordinateio.c
@@ -22,6 +22,7 @@
 #include "alloc/realloc.h"
 #include "alloc/reallocf.h"
 #include "atoi/str2i/str2u.h"
+#include "string/ctype/strisascii/strisdigit.h"
 #include "string/sprintf/snprintf.h"
 #include "string/strcmp/streq.h"
 
@@ -926,22 +927,12 @@ out:
 	return count;
 }
 
-static bool all_digits(const char *str)
-{
-	int i;
-
-	for (i = 0; str[i] != '\0'; i++)
-		if (!isdigit(str[i]))
-			return false;
-	return true;
-}
-
 static int append_uids(uid_t **uids, const char *owner, int n)
 {
 	int    i;
 	uid_t  owner_uid;
 
-	if (all_digits(owner)) {
+	if (strisdigit(owner)) {
 		i = sscanf(owner, "%d", &owner_uid);
 		if (i != 1) {
 			// should not happen


### PR DESCRIPTION
---

Revisions:

<details>
<summary>v2</summary>

-  Add strisdigit() and use it instead of open-coding it.
-  Add note about empty strings in commit message.

```
$ git range-diff master gh/alldigits alldigits 
-:  -------- > 1:  40c9035b lib/string/ctype/: strisdigit(): Add function
1:  a349dfd3 ! 2:  24335081 lib/: Reimplement all_digits() in terms of streq(stpspn()), and open-code it
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/: Reimplement all_digits() in terms of streq(stpspn()), and open-code it
    +    lib/: Use strisdigit() instead of its pattern
    +
    +    Note that the old code in
    +
    +            (1)  lib/strtoday.c:strtoday()
    +            (2)  lib/subordinateio.c:append_uids()
    +
    +    was considering an empty string as if it were a number.
    +    strisdigit() does not consider an empty string to be numeric.
    +
    +    I think it will not affect the behavior in either case, as they should
    +    sooner or later result in an error somewhere.  And it seems (IMO)
    +    surprising to treat empty strings as numeric strings, so let's not do
    +    it.
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    @@ lib/chkname.c
      
      #include "defines.h"
      #include "chkname.h"
    -+#include "string/strchr/stpspn.h"
    ++#include "string/ctype/strisdigit.h"
      #include "string/strcmp/streq.h"
      
      
    @@ lib/chkname.c: is_valid_name(const char *name)
               */
     -  int numeric;
     +
    -+  if (streq(stpspn(name, "0123456789"), "")) {
    ++  if (strisdigit(name)) {
     +          errno = EINVAL;
     +          return false;
     +  }
    @@ lib/chkname.c: is_valid_name(const char *name)
        return true;
     
      ## lib/strtoday.c ##
    +@@
    + #include "atoi/str2i/str2s.h"
    + #include "getdate.h"
    + #include "prototypes.h"
    ++#include "string/ctype/strisdigit.h"
    + #include "string/strchr/stpspn.h"
    + #include "string/strcmp/streq.h"
    + 
     @@
      long strtoday (const char *str)
      {
    @@ lib/strtoday.c: long strtoday (const char *str)
     -          s++;
     -  }
     -  if (isnum) {
    -+  if (streq(stpspn(s, "0123456789"), "")) {
    ++  if (strisdigit(s)) {
                long retdate;
     +
                if (str2sl(&retdate, str) == -1)
    @@ lib/strtoday.c: long strtoday (const char *str)
     
      ## lib/subordinateio.c ##
     @@
    + #include "alloc/realloc.h"
      #include "alloc/reallocf.h"
      #include "atoi/str2i/str2u.h"
    ++#include "string/ctype/strisdigit.h"
      #include "string/sprintf/snprintf.h"
    -+#include "string/strchr/stpspn.h"
      #include "string/strcmp/streq.h"
      
    - 
     @@ lib/subordinateio.c: out:
        return count;
      }
    @@ lib/subordinateio.c: out:
        uid_t  owner_uid;
      
     -  if (all_digits(owner)) {
    -+  if (streq(stpspn(owner, "0123456789"), "")) {
    ++  if (strisdigit(owner)) {
                i = sscanf(owner, "%d", &owner_uid);
                if (i != 1) {
                        // should not happen
```
</details>

<details>
<summary>v3</summary>

-  Clarify that this API works with the C locale.

```
$ git range-diff master gh/alldigits alldigits 
1:  40c9035b ! 1:  6183a653 lib/string/ctype/: strisdigit(): Add function
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/string/ctype/: strisdigit(): Add function
    +    lib/string/ctype/: strisdigit_c(): Add function
    +
    +    The "_c" clarifies that is considers the digits from the C locale.
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    @@ lib/Makefile.am: libshadow_la_SOURCES = \
        spawn.c \
        sssd.c \
        sssd.h \
    -+  string/ctype/strisdigit.c \
    -+  string/ctype/strisdigit.h \
    ++  string/ctype/strisdigit_c.c \
    ++  string/ctype/strisdigit_c.h \
        string/memset/memzero.c \
        string/memset/memzero.h \
        string/sprintf/snprintf.c \
     
    - ## lib/string/ctype/strisdigit.c (new) ##
    + ## lib/string/ctype/strisdigit_c.c (new) ##
     @@
     +// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
     +// SPDX-License-Identifier: BSD-3-Clause
    @@ lib/string/ctype/strisdigit.c (new)
     +
     +#include <config.h>
     +
    -+#include "string/ctype/strisdigit.h"
    ++#include "string/ctype/strisdigit_c.h"
     +
     +#include <stdbool.h>
     +
     +
    -+extern inline bool strisdigit(const char *s);
    ++extern inline bool strisdigit_c(const char *s);
     
    - ## lib/string/ctype/strisdigit.h (new) ##
    + ## lib/string/ctype/strisdigit_c.h (new) ##
     @@
     +// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
     +// SPDX-License-Identifier: BSD-3-Clause
     +
     +
    -+#ifndef SHADOW_INCLUDE_LIB_STRING_CTYPE_STRISDIGIT_H_
    -+#define SHADOW_INCLUDE_LIB_STRING_CTYPE_STRISDIGIT_H_
    ++#ifndef SHADOW_INCLUDE_LIB_STRING_CTYPE_STRISDIGIT_C_H_
    ++#define SHADOW_INCLUDE_LIB_STRING_CTYPE_STRISDIGIT_C_H_
     +
     +
     +#include <config.h>
    @@ lib/string/ctype/strisdigit.h (new)
     +#include "string/strcmp/streq.h"
     +
     +
    -+inline bool strisdigit(const char *s);
    ++inline bool strisdigit_c(const char *s);
     +
     +
    -+// Like isdigit(3), but check all characters in the string
    ++// Like isdigit(3),
    ++// but check all characters in the string, and use the C locale.
     +inline bool
    -+strisdigit(const char *s)
    ++strisdigit_c(const char *s)
     +{
     +  if (streq(s, ""))
     +          return false;
2:  24335081 ! 2:  b9da40df lib/: Use strisdigit() instead of its pattern
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/: Use strisdigit() instead of its pattern
    +    lib/: Use strisdigit_c() instead of its pattern
     
         Note that the old code in
     
    @@ Commit message
                 (2)  lib/subordinateio.c:append_uids()
     
         was considering an empty string as if it were a number.
    -    strisdigit() does not consider an empty string to be numeric.
    +    strisdigit_c() does not consider an empty string to be numeric.
     
         I think it will not affect the behavior in either case, as they should
         sooner or later result in an error somewhere.  And it seems (IMO)
    @@ lib/chkname.c
      
      #include "defines.h"
      #include "chkname.h"
    -+#include "string/ctype/strisdigit.h"
    ++#include "string/ctype/strisdigit_c.h"
      #include "string/strcmp/streq.h"
      
      
    @@ lib/chkname.c: is_valid_name(const char *name)
               */
     -  int numeric;
     +
    -+  if (strisdigit(name)) {
    ++  if (strisdigit_c(name)) {
     +          errno = EINVAL;
     +          return false;
     +  }
    @@ lib/strtoday.c
      #include "atoi/str2i/str2s.h"
      #include "getdate.h"
      #include "prototypes.h"
    -+#include "string/ctype/strisdigit.h"
    ++#include "string/ctype/strisdigit_c.h"
      #include "string/strchr/stpspn.h"
      #include "string/strcmp/streq.h"
      
    @@ lib/strtoday.c: long strtoday (const char *str)
     -          s++;
     -  }
     -  if (isnum) {
    -+  if (strisdigit(s)) {
    ++  if (strisdigit_c(s)) {
                long retdate;
     +
                if (str2sl(&retdate, str) == -1)
    @@ lib/subordinateio.c
      #include "alloc/realloc.h"
      #include "alloc/reallocf.h"
      #include "atoi/str2i/str2u.h"
    -+#include "string/ctype/strisdigit.h"
    ++#include "string/ctype/strisdigit_c.h"
      #include "string/sprintf/snprintf.h"
      #include "string/strcmp/streq.h"
      
    @@ lib/subordinateio.c: out:
        uid_t  owner_uid;
      
     -  if (all_digits(owner)) {
    -+  if (strisdigit(owner)) {
    ++  if (strisdigit_c(owner)) {
                i = sscanf(owner, "%d", &owner_uid);
                if (i != 1) {
                        // should not happen
```
</details>

<details>
<summary>v4</summary>

-  Move files into subdirectory.

```
$ git range-diff master gh/alldigits alldigits 
1:  6183a653 ! 1:  e25769be lib/string/ctype/: strisdigit_c(): Add function
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/string/ctype/: strisdigit_c(): Add function
    +    lib/string/ctype/strisascii_c/: strisdigit_c(): Add function
     
    -    The "_c" clarifies that is considers the digits from the C locale.
    +    The "_c" means that it considers the digits from the C locale.
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    @@ lib/Makefile.am: libshadow_la_SOURCES = \
        spawn.c \
        sssd.c \
        sssd.h \
    -+  string/ctype/strisdigit_c.c \
    -+  string/ctype/strisdigit_c.h \
    ++  string/ctype/strisascii_c/strisdigit_c.c \
    ++  string/ctype/strisascii_c/strisdigit_c.h \
        string/memset/memzero.c \
        string/memset/memzero.h \
        string/sprintf/snprintf.c \
     
    - ## lib/string/ctype/strisdigit_c.c (new) ##
    + ## lib/string/ctype/strisascii_c/strisdigit_c.c (new) ##
     @@
     +// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
     +// SPDX-License-Identifier: BSD-3-Clause
    @@ lib/string/ctype/strisdigit_c.c (new)
     +
     +extern inline bool strisdigit_c(const char *s);
     
    - ## lib/string/ctype/strisdigit_c.h (new) ##
    + ## lib/string/ctype/strisascii_c/strisdigit_c.h (new) ##
     @@
     +// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
     +// SPDX-License-Identifier: BSD-3-Clause
2:  b9da40df ! 2:  418486c1 lib/: Use strisdigit_c() instead of its pattern
    @@ lib/chkname.c
      
      #include "defines.h"
      #include "chkname.h"
    -+#include "string/ctype/strisdigit_c.h"
    ++#include "string/ctype/strisascii_c/strisdigit_c.h"
      #include "string/strcmp/streq.h"
      
      
    @@ lib/strtoday.c
      #include "atoi/str2i/str2s.h"
      #include "getdate.h"
      #include "prototypes.h"
    -+#include "string/ctype/strisdigit_c.h"
    ++#include "string/ctype/strisascii_c/strisdigit_c.h"
      #include "string/strchr/stpspn.h"
      #include "string/strcmp/streq.h"
      
    @@ lib/subordinateio.c
      #include "alloc/realloc.h"
      #include "alloc/reallocf.h"
      #include "atoi/str2i/str2u.h"
    -+#include "string/ctype/strisdigit_c.h"
    ++#include "string/ctype/strisascii_c/strisdigit_c.h"
      #include "string/sprintf/snprintf.h"
      #include "string/strcmp/streq.h"
      
```
</details>

<details>
<summary>v4b</summary>

-  Fix include guard and include path.

```
$ git range-diff master gh/alldigits alldigits 
1:  e25769be ! 1:  d160bacc lib/string/ctype/strisascii_c/: strisdigit_c(): Add function
    @@ lib/string/ctype/strisascii_c/strisdigit_c.c (new)
     +
     +#include <config.h>
     +
    -+#include "string/ctype/strisdigit_c.h"
    ++#include "string/ctype/strisascii_c/strisdigit_c.h"
     +
     +#include <stdbool.h>
     +
    @@ lib/string/ctype/strisascii_c/strisdigit_c.h (new)
     +// SPDX-License-Identifier: BSD-3-Clause
     +
     +
    -+#ifndef SHADOW_INCLUDE_LIB_STRING_CTYPE_STRISDIGIT_C_H_
    -+#define SHADOW_INCLUDE_LIB_STRING_CTYPE_STRISDIGIT_C_H_
    ++#ifndef SHADOW_INCLUDE_LIB_STRING_CTYPE_STRISASCII_C_STRISDIGIT_C_H_
    ++#define SHADOW_INCLUDE_LIB_STRING_CTYPE_STRISASCII_C_STRISDIGIT_C_H_
     +
     +
     +#include <config.h>
2:  418486c1 = 2:  04c1c1b1 lib/: Use strisdigit_c() instead of its pattern
```
</details>

<details>
<summary>v5</summary>

-  Simplify name (character encodings are a mess, anyway).

```
$ git range-diff master gh/alldigits alldigits 
1:  d160bacc ! 1:  d5fb6c45 lib/string/ctype/strisascii_c/: strisdigit_c(): Add function
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/string/ctype/strisascii_c/: strisdigit_c(): Add function
    -
    -    The "_c" means that it considers the digits from the C locale.
    +    lib/string/ctype/strisascii/: strisdigit(): Add function
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    @@ lib/Makefile.am: libshadow_la_SOURCES = \
        spawn.c \
        sssd.c \
        sssd.h \
    -+  string/ctype/strisascii_c/strisdigit_c.c \
    -+  string/ctype/strisascii_c/strisdigit_c.h \
    ++  string/ctype/strisascii/strisdigit.c \
    ++  string/ctype/strisascii/strisdigit.h \
        string/memset/memzero.c \
        string/memset/memzero.h \
        string/sprintf/snprintf.c \
     
    - ## lib/string/ctype/strisascii_c/strisdigit_c.c (new) ##
    + ## lib/string/ctype/strisascii/strisdigit.c (new) ##
     @@
     +// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
     +// SPDX-License-Identifier: BSD-3-Clause
    @@ lib/string/ctype/strisascii_c/strisdigit_c.c (new)
     +
     +#include <config.h>
     +
    -+#include "string/ctype/strisascii_c/strisdigit_c.h"
    ++#include "string/ctype/strisascii/strisdigit.h"
     +
     +#include <stdbool.h>
     +
     +
    -+extern inline bool strisdigit_c(const char *s);
    ++extern inline bool strisdigit(const char *s);
     
    - ## lib/string/ctype/strisascii_c/strisdigit_c.h (new) ##
    + ## lib/string/ctype/strisascii/strisdigit.h (new) ##
     @@
     +// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
     +// SPDX-License-Identifier: BSD-3-Clause
     +
     +
    -+#ifndef SHADOW_INCLUDE_LIB_STRING_CTYPE_STRISASCII_C_STRISDIGIT_C_H_
    -+#define SHADOW_INCLUDE_LIB_STRING_CTYPE_STRISASCII_C_STRISDIGIT_C_H_
    ++#ifndef SHADOW_INCLUDE_LIB_STRING_CTYPE_STRISASCII_STRISDIGIT_H_
    ++#define SHADOW_INCLUDE_LIB_STRING_CTYPE_STRISASCII_STRISDIGIT_H_
     +
     +
     +#include <config.h>
    @@ lib/string/ctype/strisascii_c/strisdigit_c.h (new)
     +#include "string/strcmp/streq.h"
     +
     +
    -+inline bool strisdigit_c(const char *s);
    ++inline bool strisdigit(const char *s);
     +
     +
    -+// Like isdigit(3),
    -+// but check all characters in the string, and use the C locale.
    ++// Like isdigit(3), but check all characters in the string.
     +inline bool
    -+strisdigit_c(const char *s)
    ++strisdigit(const char *s)
     +{
     +  if (streq(s, ""))
     +          return false;
2:  04c1c1b1 ! 2:  e22bf379 lib/: Use strisdigit_c() instead of its pattern
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/: Use strisdigit_c() instead of its pattern
    +    lib/: Use strisdigit() instead of its pattern
     
         Note that the old code in
     
    @@ Commit message
                 (2)  lib/subordinateio.c:append_uids()
     
         was considering an empty string as if it were a number.
    -    strisdigit_c() does not consider an empty string to be numeric.
    +    strisdigit() does not consider an empty string to be numeric.
     
         I think it will not affect the behavior in either case, as they should
         sooner or later result in an error somewhere.  And it seems (IMO)
    @@ lib/chkname.c
      
      #include "defines.h"
      #include "chkname.h"
    -+#include "string/ctype/strisascii_c/strisdigit_c.h"
    ++#include "string/ctype/strisascii/strisdigit.h"
      #include "string/strcmp/streq.h"
      
      
    @@ lib/chkname.c: is_valid_name(const char *name)
               */
     -  int numeric;
     +
    -+  if (strisdigit_c(name)) {
    ++  if (strisdigit(name)) {
     +          errno = EINVAL;
     +          return false;
     +  }
    @@ lib/strtoday.c
      #include "atoi/str2i/str2s.h"
      #include "getdate.h"
      #include "prototypes.h"
    -+#include "string/ctype/strisascii_c/strisdigit_c.h"
    ++#include "string/ctype/strisascii/strisdigit.h"
      #include "string/strchr/stpspn.h"
      #include "string/strcmp/streq.h"
      
    @@ lib/strtoday.c: long strtoday (const char *str)
     -          s++;
     -  }
     -  if (isnum) {
    -+  if (strisdigit_c(s)) {
    ++  if (strisdigit(s)) {
                long retdate;
     +
                if (str2sl(&retdate, str) == -1)
    @@ lib/subordinateio.c
      #include "alloc/realloc.h"
      #include "alloc/reallocf.h"
      #include "atoi/str2i/str2u.h"
    -+#include "string/ctype/strisascii_c/strisdigit_c.h"
    ++#include "string/ctype/strisascii/strisdigit.h"
      #include "string/sprintf/snprintf.h"
      #include "string/strcmp/streq.h"
      
    @@ lib/subordinateio.c: out:
        uid_t  owner_uid;
      
     -  if (all_digits(owner)) {
    -+  if (strisdigit_c(owner)) {
    ++  if (strisdigit(owner)) {
                i = sscanf(owner, "%d", &owner_uid);
                if (i != 1) {
                        // should not happen
```
</details>

<details>
<summary>v5b</summary>

-  Rebase

```
$ git range-diff alx/master..gh/alldigits master..alldigits 
1:  d5fb6c45 = 1:  eb0bf9e2 lib/string/ctype/strisascii/: strisdigit(): Add function
2:  e22bf379 = 2:  d549476d lib/: Use strisdigit() instead of its pattern
```
</details>

<details>
<summary>v5c</summary>

-  Rebase

```
$ git range-diff alx/master..gh/alldigits master..alldigits 
1:  eb0bf9e2 = 1:  f67e5ea0 lib/string/ctype/strisascii/: strisdigit(): Add function
2:  d549476d = 2:  2e145013 lib/: Use strisdigit() instead of its pattern
```
</details>

<details>
<summary>v5d</summary>

-  Rebase

```
$ git range-diff master..gh/alldigits shadow/master..alldigits 
1:  f67e5ea0 = 1:  b3d890b8 lib/string/ctype/strisascii/: strisdigit(): Add function
2:  2e145013 = 2:  39e47ac9 lib/: Use strisdigit() instead of its pattern
```
</details>

<details>
<summary>v5e</summary>

-  Rebase

```
$ git range-diff master..gh/alldigits shadow/master..alldigits 
1:  b3d890b8 = 1:  005f71a1 lib/string/ctype/strisascii/: strisdigit(): Add function
2:  39e47ac9 ! 2:  c8a57136 lib/: Use strisdigit() instead of its pattern
    @@ lib/chkname.c: is_valid_name(const char *name)
     +          return false;
     +  }
      
    -   if ('\0' == *name ||
    -       ('.' == *name && (('.' == name[1] && '\0' == name[2]) ||
    +   if (streq(name, "") ||
    +       streq(name, ".") ||
     @@ lib/chkname.c: is_valid_name(const char *name)
                return false;
        }
```
</details>

<details>
<summary>v5f</summary>

-  Rebase

```
$ git range-diff master..gh/alldigits shadow/master..alldigits 
1:  005f71a1 = 1:  a99f3d54 lib/string/ctype/strisascii/: strisdigit(): Add function
2:  c8a57136 = 2:  8b969321 lib/: Use strisdigit() instead of its pattern
```
</details>

<details>
<summary>v6</summary>

-  Add comment spelling out the meaning of the letter-soup API names.  [@hallyn ]

```
$ git range-diff master gh/alldigits alldigits 
1:  a99f3d54 ! 1:  7a12a0fa lib/string/ctype/strisascii/: strisdigit(): Add function
    @@ lib/string/ctype/strisascii/strisdigit.h (new)
     +inline bool strisdigit(const char *s);
     +
     +
    ++// string is [:digit:]
     +// Like isdigit(3), but check all characters in the string.
     +inline bool
     +strisdigit(const char *s)
2:  8b969321 = 2:  edf0994c lib/: Use strisdigit() instead of its pattern
```
</details>

<details>
<summary>v6b</summary>

-  Rebase
-  Reviewed-by @hallyn 

```
$ git range-diff master..gh/alldigits shadow/master..alldigits 
1:  7a12a0fa ! 1:  b54bb7e9 lib/string/ctype/strisascii/: strisdigit(): Add function
    @@ Metadata
      ## Commit message ##
         lib/string/ctype/strisascii/: strisdigit(): Add function
     
    +    Reviewed-by: Serge Hallyn <serge@hallyn.com>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/Makefile.am ##
2:  edf0994c ! 2:  7388c365 lib/: Use strisdigit() instead of its pattern
    @@ Commit message
         surprising to treat empty strings as numeric strings, so let's not do
         it.
     
    +    Reviewed-by: Serge Hallyn <serge@hallyn.com>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/chkname.c ##
    @@ lib/strtoday.c
      #include "getdate.h"
      #include "prototypes.h"
     +#include "string/ctype/strisascii/strisdigit.h"
    - #include "string/strchr/stpspn.h"
      #include "string/strcmp/streq.h"
    + #include "string/strspn/stpspn.h"
      
     @@
      long strtoday (const char *str)
```
</details>

<details>
<summary>v6c</summary>

-  Fix include path after rebase

```
$ git range-diff shadow/master gh/alldigits alldigits 
1:  b54bb7e9 ! 1:  ceef9e1a lib/string/ctype/strisascii/: strisdigit(): Add function
    @@ lib/string/ctype/strisascii/strisdigit.h (new)
     +
     +#include <stdbool.h>
     +
    -+#include "string/strchr/stpspn.h"
     +#include "string/strcmp/streq.h"
    ++#include "string/strspn/stpspn.h"
     +
     +
     +inline bool strisdigit(const char *s);
2:  7388c365 = 2:  b9e6bf2c lib/: Use strisdigit() instead of its pattern
```
</details>