### PR TITLE
Add some wrappers for usual loops around strsep(3)

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -243,6 +243,8 @@ libshadow_la_SOURCES = \
 	string/strspn/strrspn.h \
 	string/strtok/stpsep.c \
 	string/strtok/stpsep.h \
+	string/strtok/astrsep2ls.c \
+	string/strtok/astrsep2ls.h \
 	string/strtok/strsep2arr.c \
 	string/strtok/strsep2arr.h \
 	string/strtok/strsep2ls.c \

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -249,6 +249,8 @@ libshadow_la_SOURCES = \
 	string/strtok/strsep2arr.h \
 	string/strtok/strsep2ls.c \
 	string/strtok/strsep2ls.h \
+	string/strtok/xastrsep2ls.c \
+	string/strtok/xastrsep2ls.h \
 	strtoday.c \
 	sub.c \
 	subordinateio.h \

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -243,6 +243,8 @@ libshadow_la_SOURCES = \
 	string/strspn/strrspn.h \
 	string/strtok/stpsep.c \
 	string/strtok/stpsep.h \
+	string/strtok/strsep2arr.c \
+	string/strtok/strsep2arr.h \
 	strtoday.c \
 	sub.c \
 	subordinateio.h \

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -245,6 +245,8 @@ libshadow_la_SOURCES = \
 	string/strtok/stpsep.h \
 	string/strtok/strsep2arr.c \
 	string/strtok/strsep2arr.h \
+	string/strtok/strsep2ls.c \
+	string/strtok/strsep2ls.h \
 	strtoday.c \
 	sub.c \
 	subordinateio.h \

--- a/lib/gshadow.c
+++ b/lib/gshadow.c
@@ -26,12 +26,11 @@
 #include "string/strchr/strchrcnt.h"
 #include "string/strcmp/streq.h"
 #include "string/strtok/stpsep.h"
+#include "string/strtok/strsep2arr.h"
 
 
 static /*@null@*/FILE *shadow;
 static struct sgrp  sgroup = {};
-
-#define	FIELDS	4
 
 
 static /*@null@*/char **
@@ -73,9 +72,7 @@ sgetsgent(const char *s)
 {
 	static char  *dup = NULL;
 
-	char  *fields[FIELDS];
-	char *cp;
-	int i;
+	char  *fields[4];
 
 	free(dup);
 	dup = strdup(s);
@@ -84,20 +81,7 @@ sgetsgent(const char *s)
 
 	stpsep(dup, "\n");
 
-	/*
-	 * There should be exactly 4 colon separated fields.  Find
-	 * all 4 of them and save the starting addresses in fields[].
-	 */
-
-	for (cp = dup, i = 0; (i < FIELDS) && (NULL != cp); i++)
-		fields[i] = strsep(&cp, ":");
-
-	/*
-	 * If there was an extra field somehow, or perhaps not enough,
-	 * the line is invalid.
-	 */
-
-	if (NULL != cp || i != FIELDS)
+	if (STRSEP2ARR(dup, ":", fields) == -1)
 		return NULL;
 
 	sgroup.sg_namp = fields[0];

--- a/lib/gshadow.c
+++ b/lib/gshadow.c
@@ -20,13 +20,12 @@
 
 #include "alloc/malloc.h"
 #include "alloc/realloc.h"
-#include "alloc/x/xmalloc.h"
 #include "defines.h"
 #include "prototypes.h"
-#include "string/strchr/strchrcnt.h"
 #include "string/strcmp/streq.h"
 #include "string/strtok/stpsep.h"
 #include "string/strtok/strsep2arr.h"
+#include "string/strtok/xastrsep2ls.h"
 
 
 static /*@null@*/FILE *shadow;
@@ -37,14 +36,12 @@ static /*@null@*/char **
 build_list(char *s)
 {
 	char    **l;
-	size_t  i;
+	size_t  n;
 
-	l = XMALLOC(strchrcnt(s, ',') + 2, char *);
+	l = xastrsep2ls(s, ",", &n);
 
-	for (i = 0; s != NULL && !streq(s, ""); i++)
-		l[i] = strsep(&s, ",");
-
-	l[i] = NULL;
+	if (streq(l[n-1], ""))
+		l[n-1] = NULL;
 
 	return l;
 }

--- a/lib/list.c
+++ b/lib/list.c
@@ -18,6 +18,7 @@
 #include "string/strchr/strchrcnt.h"
 #include "string/strcmp/streq.h"
 #include "string/strdup/xstrdup.h"
+#include "string/strtok/strsep2ls.h"
 
 
 /*
@@ -186,9 +187,7 @@ comma_to_list(const char *comma)
 {
 	char *members;
 	char **array;
-	int i;
-	char *cp;
-	char *cp2;
+	size_t  n;
 
 	assert (NULL != comma);
 
@@ -203,7 +202,8 @@ comma_to_list(const char *comma)
 	 * n: number of delimiters + last element + NULL
 	 */
 
-	array = XMALLOC(strchrcnt(members, ',') + 2, char *);
+	n = strchrcnt(members, ',') + 2;
+	array = XMALLOC(n, char *);
 
 	/*
 	 * Empty list is special - 0 members, not 1 empty member.  --marekm
@@ -215,18 +215,7 @@ comma_to_list(const char *comma)
 		return array;
 	}
 
-	/*
-	 * Now go walk that list all over again, this time building the
-	 * array of pointers.
-	 */
-
-	for (cp = members, i = 0; cp != NULL; i++)
-		array[i] = strsep(&cp, ",");
-	array[i] = NULL;
-
-	/*
-	 * Return the new array of pointers
-	 */
+	strsep2ls(members, ",", n, array);
 
 	return array;
 }

--- a/lib/port.c
+++ b/lib/port.c
@@ -22,6 +22,7 @@
 #include "string/strcmp/streq.h"
 #include "string/strcmp/strprefix.h"
 #include "string/strtok/stpsep.h"
+#include "string/strtok/strsep2ls.h"
 
 
 static FILE *ports;
@@ -160,13 +161,7 @@ next:
 		goto next;
 
 	port.pt_names = ttys;
-	for (j = 0; j < PORT_TTY; j++) {
-		port.pt_names[j] = strsep(&cp, ",");
-		if (cp == NULL)
-			break;
-	}
-	port.pt_names[j] = NULL;
-	if (cp != NULL)
+	if (STRSEP2LS(cp, ",", ttys) == -1)
 		goto next;
 
 	/*
@@ -181,13 +176,7 @@ next:
 		goto next;
 
 	port.pt_users = users;
-	for (j = 0; j < PORT_IDS; j++) {
-		port.pt_users[j] = strsep(&cp, ",");
-		if (cp == NULL)
-			break;
-	}
-	port.pt_users[j] = NULL;
-	if (cp != NULL)
+	if (STRSEP2LS(cp, ",", users) == -1)
 		goto next;
 
 	/*

--- a/lib/port.c
+++ b/lib/port.c
@@ -103,7 +103,8 @@ getportent(void)
 	int   dtime;
 	int   i, j;
 	int   saveerr;
-	char  *cp, *field;
+	char  *cp;
+	char  *fields[3];
 
 	static char            buf[BUFSIZ];
 	static char            *ttys[PORT_TTY + 1];
@@ -147,7 +148,8 @@ next:
 
 	stpsep(buf, "\n");
 
-	field = buf;
+	if (STRSEP2ARR(buf, ":", fields) == -1)
+		goto next;
 
 	/*
 	 * Get the name of the TTY device.  It is the first colon
@@ -155,13 +157,8 @@ next:
 	 * leading "/dev".  The entry '*' is used to specify all
 	 * TTY devices.
 	 */
-
-	cp = strsep(&field, ":");
-	if (field == NULL)
-		goto next;
-
 	port.pt_names = ttys;
-	if (STRSEP2LS(cp, ",", ttys) == -1)
+	if (STRSEP2LS(fields[0], ",", ttys) == -1)
 		goto next;
 
 	/*
@@ -170,13 +167,8 @@ next:
 	 * names.  The entry '*' is used to specify all usernames.
 	 * The last entry in the list is a NULL pointer.
 	 */
-
-	cp = strsep(&field, ":");
-	if (field == NULL)
-		goto next;
-
 	port.pt_users = users;
-	if (STRSEP2LS(cp, ",", users) == -1)
+	if (STRSEP2LS(fields[1], ",", users) == -1)
 		goto next;
 
 	/*
@@ -192,7 +184,7 @@ next:
 	 * the starting time.  Days are presumed to wrap at 0000.
 	 */
 
-	cp = field;
+	cp = fields[2];
 
 	if (streq(cp, "")) {
 		port.pt_times = NULL;

--- a/lib/sgetgrent.c
+++ b/lib/sgetgrent.c
@@ -24,9 +24,8 @@
 #include "prototypes.h"
 #include "string/strcmp/streq.h"
 #include "string/strtok/stpsep.h"
+#include "string/strtok/strsep2arr.h"
 
-
-#define	NFIELDS	4
 
 /*
  * list - turn a comma-separated string into an array of (char *)'s
@@ -71,9 +70,7 @@ sgetgrent(const char *s)
 	static char         *dup = NULL;
 	static struct group grent;
 
-	int i;
-	char *cp;
-	char  *fields[NFIELDS];
+	char  *fields[4];
 
 	free(dup);
 	dup = strdup(s);
@@ -82,12 +79,12 @@ sgetgrent(const char *s)
 
 	stpsep(dup, "\n");
 
-	for (cp = dup, i = 0; (i < NFIELDS) && (NULL != cp); i++)
-		fields[i] = strsep(&cp, ":");
-
-	if (i < NFIELDS || streq(fields[2], "") || cp != NULL) {
+	if (STRSEP2ARR(dup, ":", fields) == -1)
 		return NULL;
-	}
+
+	if (streq(fields[2], ""))
+		return NULL;
+
 	grent.gr_name = fields[0];
 	grent.gr_passwd = fields[1];
 	if (get_gid(fields[2], &grent.gr_gid) == -1) {

--- a/lib/sgetgrent.c
+++ b/lib/sgetgrent.c
@@ -43,6 +43,9 @@ list(char *s)
 	static size_t size = 0;	/* max members + 1 */
 	size_t i;
 
+	free(members);
+	members = NULL;
+
 	i = 0;
 	for (;;) {
 		/* check if there is room for another pointer (to a group

--- a/lib/sgetgrent.c
+++ b/lib/sgetgrent.c
@@ -18,13 +18,13 @@
 #include <sys/types.h>
 
 #include "alloc/malloc.h"
-#include "alloc/reallocf.h"
 #include "atoi/getnum.h"
 #include "defines.h"
 #include "prototypes.h"
 #include "string/strcmp/streq.h"
 #include "string/strtok/stpsep.h"
 #include "string/strtok/strsep2arr.h"
+#include "string/strtok/astrsep2ls.h"
 
 
 /*
@@ -40,29 +40,18 @@ static char **
 list(char *s)
 {
 	static char **members = NULL;
-	static size_t size = 0;	/* max members + 1 */
-	size_t i;
+
+	size_t  n;
 
 	free(members);
-	members = NULL;
 
-	i = 0;
-	for (;;) {
-		/* check if there is room for another pointer (to a group
-		   member name, or terminating NULL).  */
-		if (i >= size) {
-			size = i + 100;	/* at least: i + 1 */
-			members = REALLOCF(members, size, char *);
-			if (!members) {
-				size = 0;
-				return NULL;
-			}
-		}
-		if (!s || streq(s, ""))
-			break;
-		members[i++] = strsep(&s, ",");
-	}
-	members[i] = NULL;
+	members = astrsep2ls(s, ",", &n);
+	if (members == NULL)
+		return NULL;
+
+	if (streq(members[n-1], ""))
+		members[n-1] = NULL;
+
 	return members;
 }
 

--- a/lib/sgetpwent.c
+++ b/lib/sgetpwent.c
@@ -23,9 +23,8 @@
 #include "shadowlog_internal.h"
 #include "string/strcmp/streq.h"
 #include "string/strtok/stpsep.h"
+#include "string/strtok/strsep2arr.h"
 
-
-#define	NFIELDS	7
 
 /*
  * sgetpwent - convert a string to a (struct passwd)
@@ -45,9 +44,7 @@ sgetpwent(const char *s)
 	static char          *dup = NULL;
 	static struct passwd pwent;
 
-	int i;
-	char *cp;
-	char  *fields[NFIELDS];
+	char  *fields[7];
 
 	free(dup);
 	dup = strdup(s);
@@ -56,26 +53,12 @@ sgetpwent(const char *s)
 
 	stpsep(dup, "\n");
 
-	/*
-	 * Save a pointer to the start of each colon separated
-	 * field.  The fields are converted into NUL terminated strings.
-	 */
-
-	for (cp = dup, i = 0; (i < NFIELDS) && (NULL != cp); i++)
-		fields[i] = strsep(&cp, ":");
-
-	/* something at the end, columns over shot */
-	if ( cp != NULL ) {
-		return( NULL );
-	}
-
-	/*
-	 * There must be exactly NFIELDS colon separated fields or
-	 * the entry is invalid.  Also, the UID and GID must be non-blank.
-	 */
-
-	if (i != NFIELDS)
+	if (STRSEP2ARR(dup, ":", fields) == -1)
 		return NULL;
+
+	/*
+	 * The UID and GID must be non-blank.
+	 */
 	if (streq(fields[2], ""))
 		return NULL;
 	if (streq(fields[3], ""))

--- a/lib/sgetspent.c
+++ b/lib/sgetspent.c
@@ -25,8 +25,10 @@
 #include "defines.h"
 #include "prototypes.h"
 #include "shadowlog_internal.h"
+#include "sizeof.h"
 #include "string/strcmp/streq.h"
 #include "string/strtok/stpsep.h"
+#include "string/strtok/strsep2arr.h"
 
 
 #define	FIELDS	9
@@ -43,8 +45,7 @@ sgetspent(const char *s)
 	static struct spwd spwd;
 
 	char *fields[FIELDS];
-	char *cp;
-	int i;
+	size_t  i;
 
 	free(dup);
 	dup = strdup(s);
@@ -53,18 +54,10 @@ sgetspent(const char *s)
 
 	stpsep(dup, "\n");
 
-	/*
-	 * Tokenize the string into colon separated fields.  Allow up to
-	 * FIELDS different fields.
-	 */
-
-	for (cp = dup, i = 0; cp != NULL && i < FIELDS; i++)
-		fields[i] = strsep(&cp, ":");
-
-	if (i == (FIELDS - 1))
+	i = strsep2arr(dup, ":", countof(fields), fields);
+	if (i == countof(fields) - 1)
 		fields[i++] = "";
-
-	if (cp != NULL || (i != FIELDS && i != OFIELDS))
+	if (i != countof(fields) && i != OFIELDS)
 		return NULL;
 
 	/*

--- a/lib/string/strtok/astrsep2ls.c
+++ b/lib/string/strtok/astrsep2ls.c
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#include <config.h>
+
+#include "string/strtok/astrsep2ls.h"
+
+#include <stddef.h>
+
+
+extern inline char **astrsep2ls(char *restrict s, const char *restrict delim,
+    size_t *restrict np);

--- a/lib/string/strtok/astrsep2ls.h
+++ b/lib/string/strtok/astrsep2ls.h
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#ifndef SHADOW_INCLUDE_LIB_STRING_STRTOK_ASTRSEP2LS_H_
+#define SHADOW_INCLUDE_LIB_STRING_STRTOK_ASTRSEP2LS_H_
+
+
+#include <config.h>
+
+#include <stddef.h>
+
+#include "alloc/malloc.h"
+#include "attr.h"
+#include "string/strchr/strchrscnt.h"
+#include "string/strtok/strsep2ls.h"
+
+
+ATTR_ACCESS(read_write, 1) ATTR_ACCESS(write_only, 3)
+ATTR_STRING(1) ATTR_STRING(2)
+inline char **astrsep2ls(char *restrict s, const char *restrict delim,
+    size_t *restrict np);
+
+
+// allocate string separate to list-of-strings
+// Like strsep2ls(), but allocate the list array.
+inline char **
+astrsep2ls(char *s, const char *restrict delim, size_t *restrict np)
+{
+	char     **ls;
+	ssize_t  n;
+
+	n = strchrscnt(s, delim) + 2;
+
+	ls = MALLOC(n, char *);
+	if (ls == NULL)
+		return NULL;
+
+	n = strsep2ls(s, delim, n, ls);
+	if (n == -1) {
+		free(ls);
+		return NULL;
+	}
+
+	if (np != NULL)
+		*np = n;
+
+	return ls;
+}
+
+
+#endif  // include guard

--- a/lib/string/strtok/strsep2arr.c
+++ b/lib/string/strtok/strsep2arr.c
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#include <config.h>
+
+#include "string/strtok/strsep2arr.h"
+
+#include <stddef.h>
+#include <sys/types.h>
+
+
+extern inline ssize_t strsep2arr(char *s, const char *restrict delim,
+    size_t n, char *a[restrict n]);

--- a/lib/string/strtok/strsep2arr.h
+++ b/lib/string/strtok/strsep2arr.h
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#ifndef SHADOW_INCLUDE_LIB_STRING_STRTOK_STRSEP2ARR_H_
+#define SHADOW_INCLUDE_LIB_STRING_STRTOK_STRSEP2ARR_H_
+
+
+#include <config.h>
+
+#include <errno.h>
+#include <stddef.h>
+#include <string.h>
+#include <sys/types.h>
+
+#include "attr.h"
+#include "sizeof.h"
+
+
+#define STRSEP2ARR(s, delim, a)                                       \
+(                                                                     \
+	strsep2arr(s, delim, countof(a), a) == countof(a) ? 0 : -1    \
+)
+
+
+ATTR_ACCESS(read_write, 1) ATTR_ACCESS(write_only, 4, 3)
+ATTR_STRING(1) ATTR_STRING(2)
+inline ssize_t strsep2arr(char *s, const char *restrict delim,
+    size_t n, char *a[restrict n]);
+
+
+// string separate to array-of-strings
+// strsep(3) a string into an array of strings.
+// Return the number of fields in the string, or -1 on error.
+inline ssize_t
+strsep2arr(char *s, const char *restrict delim, size_t n, char *a[restrict n])
+{
+	size_t  i;
+
+	for (i = 0; i < n && s != NULL; i++)
+		a[i] = strsep(&s, delim);
+
+	if (s != NULL) {
+		errno = E2BIG;
+		return -1;
+	}
+
+	return i;
+}
+
+
+#endif  // include guard

--- a/lib/string/strtok/strsep2ls.c
+++ b/lib/string/strtok/strsep2ls.c
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#include <config.h>
+
+#include "string/strtok/strsep2ls.h"
+
+#include <stddef.h>
+#include <sys/types.h>
+
+
+extern inline ssize_t strsep2ls(char *s, const char *restrict delim,
+    size_t n, char *ls[restrict n]);

--- a/lib/string/strtok/strsep2ls.h
+++ b/lib/string/strtok/strsep2ls.h
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#ifndef SHADOW_INCLUDE_LIB_STRING_STRTOK_STRSEP2LS_H_
+#define SHADOW_INCLUDE_LIB_STRING_STRTOK_STRSEP2LS_H_
+
+
+#include <config.h>
+
+#include <errno.h>
+#include <stddef.h>
+#include <sys/types.h>
+
+#include "attr.h"
+#include "sizeof.h"
+#include "string/strtok/strsep2arr.h"
+
+
+#define STRSEP2LS(s, delim, ls)  strsep2ls(s, delim, countof(ls), ls)
+
+
+ATTR_ACCESS(read_write, 1) ATTR_ACCESS(write_only, 4, 3)
+ATTR_STRING(1) ATTR_STRING(2)
+inline ssize_t strsep2ls(char *s, const char *restrict delim,
+    size_t n, char *ls[restrict n]);
+
+
+// string separate to list-of-strings
+// Like strsep2arr(), but add a NULL terminator.
+inline ssize_t
+strsep2ls(char *s, const char *restrict delim, size_t n, char *ls[restrict n])
+{
+	size_t  i;
+
+	i = strsep2arr(s, delim, n, ls);
+	if (i >= n) {
+		errno = E2BIG;
+		return -1;
+	}
+
+	ls[i] = NULL;
+
+	return i;
+}
+
+
+#endif  // include guard

--- a/lib/string/strtok/xastrsep2ls.c
+++ b/lib/string/strtok/xastrsep2ls.c
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#include <config.h>
+
+#include "string/strtok/xastrsep2ls.h"
+
+#include <stddef.h>
+
+
+extern inline char **xastrsep2ls(char *restrict s, const char *restrict delim,
+    size_t *restrict np);

--- a/lib/string/strtok/xastrsep2ls.h
+++ b/lib/string/strtok/xastrsep2ls.h
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#ifndef SHADOW_INCLUDE_LIB_STRING_STRTOK_XASTRSEP2LS_H_
+#define SHADOW_INCLUDE_LIB_STRING_STRTOK_XASTRSEP2LS_H_
+
+
+#include <config.h>
+
+#include <errno.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "attr.h"
+#include "shadowlog.h"
+#include "string/strtok/astrsep2ls.h"
+
+
+ATTR_ACCESS(read_write, 1) ATTR_ACCESS(write_only, 3)
+ATTR_STRING(1) ATTR_STRING(2)
+inline char **xastrsep2ls(char *restrict s, const char *restrict delim,
+    size_t *restrict np);
+
+
+// exit-on-error allocate string separate to list-of-strings
+inline char **
+xastrsep2ls(char *s, const char *restrict delim, size_t *restrict np)
+{
+	char     **ls;
+
+	ls = astrsep2ls(s, delim, np);
+	if (ls == NULL)
+		goto x;
+
+	return ls;
+x:
+	fprintf(log_get_logfd(), "%s: %s\n",
+	        log_get_progname(), strerror(errno));
+	exit(13);
+}
+
+
+#endif  // include guard

--- a/lib/subordinateio.c
+++ b/lib/subordinateio.c
@@ -25,6 +25,7 @@
 #include "string/ctype/strisascii/strisdigit.h"
 #include "string/sprintf/snprintf.h"
 #include "string/strcmp/streq.h"
+#include "string/strtok/strsep2arr.h"
 
 
 #define ID_SIZE 31
@@ -85,8 +86,6 @@ subordinate_parse(const char *line)
 {
 	static struct subordinate_range range;
 	static char rangebuf[1024];
-	int i;
-	char *cp;
 	char *fields[SUBID_NFIELDS];
 
 	/*
@@ -97,20 +96,9 @@ subordinate_parse(const char *line)
 		return NULL;	/* fail if too long */
 	strcpy (rangebuf, line);
 
-	/*
-	 * Save a pointer to the start of each colon separated
-	 * field.  The fields are converted into NUL terminated strings.
-	 */
-
-	for (cp = rangebuf, i = 0; (i < SUBID_NFIELDS) && (NULL != cp); i++)
-		fields[i] = strsep(&cp, ":");
-
-	/*
-	 * There must be exactly SUBID_NFIELDS colon separated fields or
-	 * the entry is invalid.  Also, fields must be non-blank.
-	 */
-	if (i != SUBID_NFIELDS)
+	if (STRSEP2ARR(rangebuf, ":", fields) == -1)
 		return NULL;
+
 	if (streq(fields[0], ""))
 		return NULL;
 	if (streq(fields[1], ""))

--- a/src/newusers.c
+++ b/src/newusers.c
@@ -58,6 +58,7 @@
 #include "string/strcmp/streq.h"
 #include "string/strdup/xstrdup.h"
 #include "string/strtok/stpsep.h"
+#include "string/strtok/strsep2arr.h"
 
 
 /*
@@ -1060,8 +1061,6 @@ int main (int argc, char **argv)
 {
 	char buf[BUFSIZ];
 	char *fields[7];
-	int nfields;
-	char *cp;
 	const struct passwd *pw;
 	struct passwd newpw;
 	intmax_t line = 0;
@@ -1119,17 +1118,7 @@ int main (int argc, char **argv)
 			fail_exit (EXIT_FAILURE);
 		}
 
-		/*
-		 * Break the string into fields and screw around with them.
-		 * There MUST be 7 colon separated fields, although the
-		 * values aren't that particular.
-		 */
-		for (cp = buf, nfields = 0; nfields < 7; nfields++) {
-			fields[nfields] = strsep(&cp, ":");
-			if (cp == NULL)
-				break;
-		}
-		if (nfields != 6) {
+		if (STRSEP2ARR(buf, ":", fields) == -1) {
 			fprintf (stderr, _("%s: line %jd: invalid line\n"),
 			         Prog, line);
 			fail_exit (EXIT_FAILURE);


### PR DESCRIPTION
Suggested-by: @hallyn 

---

Revisions:

<details>
<summary>v2</summary>

-  Workaround two GCC bugs [@uecker , @pinskia]
   <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=118044>
   <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=118043>


```
$ git range-diff master gh/astrsep2ls astrsep2ls 
 1:  ad66293e !  1:  ccee0abc lib/string/strtok/: strsep2arr(), STRSEP2ARR(): Add APIs
    @@ lib/string/strtok/strsep2arr.h (new)
     +)
     +
     +
    -+ATTR_ACCESS(read_write, 1) ATTR_ACCESS(write_only, 4)
    ++ATTR_ACCESS(read_write, 1) ATTR_ACCESS(write_only, 4, 3)
     +ATTR_STRING(1) ATTR_STRING(2)
     +inline ssize_t strsep2arr(char *s, const char *restrict delim,
     +    size_t n, char *a[restrict n]);
 2:  5f98de6e !  2:  95f4a921 lib/string/strtok/: strsep2ls(), STRSEP2LS(): Add APIs
    @@ lib/string/strtok/strsep2ls.h (new)
     +#define STRSEP2LS(s, delim, ls)  strsep2ls(s, delim, NITEMS(ls), ls)
     +
     +
    -+ATTR_ACCESS(read_write, 1) ATTR_ACCESS(write_only, 4)
    ++ATTR_ACCESS(read_write, 1) ATTR_ACCESS(write_only, 4, 3)
     +ATTR_STRING(1) ATTR_STRING(2)
     +inline ssize_t strsep2ls(char *s, const char *restrict delim,
     +    size_t n, char *ls[restrict n]);
 3:  a5390a9c =  3:  ab168394 lib/: Use STRSEP2LS() instead of its pattern
 4:  4f29f5e7 =  4:  411dd0be lib/port.c: getportent(): Use STRSEP2ARR() instead of its pattern
 5:  519fc865 =  5:  dc232372 lib/: Use strsep2arr() instead of its pattern
 6:  57f481b4 =  6:  a2dd29c8 lib/: Use STRSEP2ARR() instead of its pattern
 7:  70f747cc =  7:  884f9611 lib/string/strtok/: astrsep2ls(): Add function
 8:  3b908118 =  8:  abcaf9ed lib/sgetgrent.c: list(): Explicitly free(3) at the start of the function
 9:  28366e31 =  9:  60a02867 lib/string/strtok/: xastrsep2ls(): Add function
10:  8b6cac14 = 10:  040a7acf lib/: Use xastrsep2ls() instead of its pattern
```
</details>

<details>
<summary>v2b</summary>

-  Rebase

```
$ git range-diff alx/master..gh/astrsep2ls master..astrsep2ls 
 1:  ccee0abc =  1:  060db63c lib/string/strtok/: strsep2arr(), STRSEP2ARR(): Add APIs
 2:  95f4a921 =  2:  2858fb22 lib/string/strtok/: strsep2ls(), STRSEP2LS(): Add APIs
 3:  ab168394 =  3:  e2f2c2ed lib/: Use STRSEP2LS() instead of its pattern
 4:  411dd0be =  4:  a707b113 lib/port.c: getportent(): Use STRSEP2ARR() instead of its pattern
 5:  dc232372 =  5:  d7fdde21 lib/: Use strsep2arr() instead of its pattern
 6:  a2dd29c8 =  6:  b708da45 lib/: Use STRSEP2ARR() instead of its pattern
 7:  884f9611 =  7:  051e32e2 lib/string/strtok/: astrsep2ls(): Add function
 8:  abcaf9ed =  8:  9f3f560f lib/sgetgrent.c: list(): Explicitly free(3) at the start of the function
 9:  60a02867 =  9:  5f22734d lib/string/strtok/: xastrsep2ls(): Add function
10:  040a7acf = 10:  729949bd lib/: Use xastrsep2ls() instead of its pattern
```
</details>

<details>
<summary>v2c</summary>

-  Rebase

```
$ git range-diff alx/master..gh/astrsep2ls master..astrsep2ls 
 1:  060db63c =  1:  8f864f1c lib/string/strtok/: strsep2arr(), STRSEP2ARR(): Add APIs
 2:  2858fb22 =  2:  2ed11b13 lib/string/strtok/: strsep2ls(), STRSEP2LS(): Add APIs
 3:  e2f2c2ed =  3:  d246f9fe lib/: Use STRSEP2LS() instead of its pattern
 4:  a707b113 =  4:  06bff0e2 lib/port.c: getportent(): Use STRSEP2ARR() instead of its pattern
 5:  d7fdde21 =  5:  96e71394 lib/: Use strsep2arr() instead of its pattern
 6:  b708da45 !  6:  7fe618f2 lib/: Use STRSEP2ARR() instead of its pattern
    @@ src/newusers.c: int main (int argc, char **argv)
     -  char *cp;
        const struct passwd *pw;
        struct passwd newpw;
    -   int line = 0;
    +   intmax_t line = 0;
     @@ src/newusers.c: int main (int argc, char **argv)
                        fail_exit (EXIT_FAILURE);
                }
    @@ src/newusers.c: int main (int argc, char **argv)
     -          }
     -          if (nfields != 6) {
     +          if (STRSEP2ARR(buf, ":", fields) == -1) {
    -                   fprintf (stderr, _("%s: line %d: invalid line\n"),
    +                   fprintf (stderr, _("%s: line %jd: invalid line\n"),
                                 Prog, line);
                        fail_exit (EXIT_FAILURE);
 7:  051e32e2 =  7:  6b9865ad lib/string/strtok/: astrsep2ls(): Add function
 8:  9f3f560f =  8:  fa61d4da lib/sgetgrent.c: list(): Explicitly free(3) at the start of the function
 9:  5f22734d =  9:  faa72acd lib/string/strtok/: xastrsep2ls(): Add function
10:  729949bd = 10:  b4ce84cc lib/: Use xastrsep2ls() instead of its pattern
```
</details>

<details>
<summary>v2d</summary>

-  Rebase

```
$ git range-diff master..gh/astrsep2ls shadow/master..astrsep2ls 
 1:  8f864f1c =  1:  c553fb99 lib/string/strtok/: strsep2arr(), STRSEP2ARR(): Add APIs
 2:  2ed11b13 =  2:  2aa3acd1 lib/string/strtok/: strsep2ls(), STRSEP2LS(): Add APIs
 3:  d246f9fe =  3:  6af902d9 lib/: Use STRSEP2LS() instead of its pattern
 4:  06bff0e2 =  4:  7e4fe7d1 lib/port.c: getportent(): Use STRSEP2ARR() instead of its pattern
 5:  96e71394 =  5:  2203576f lib/: Use strsep2arr() instead of its pattern
 6:  7fe618f2 !  6:  806e7a74 lib/: Use STRSEP2ARR() instead of its pattern
    @@ lib/gshadow.c: sgetsgent(const char *string)
     +  if (STRSEP2ARR(sgrbuf, ":", fields) == -1)
                return NULL;
      
    -   sgroup.sg_name = fields[0];
    +   sgroup.sg_namp = fields[0];
     
      ## lib/sgetgrent.c ##
     @@
 7:  6b9865ad =  7:  9cc51b54 lib/string/strtok/: astrsep2ls(): Add function
 8:  fa61d4da =  8:  fe87cd70 lib/sgetgrent.c: list(): Explicitly free(3) at the start of the function
 9:  faa72acd =  9:  e3dd7f24 lib/string/strtok/: xastrsep2ls(): Add function
10:  b4ce84cc = 10:  0413de0a lib/: Use xastrsep2ls() instead of its pattern
```
</details>

<details>
<summary>v2e</summary>

-  Rebase

```
$ git range-diff master..gh/astrsep2ls shadow/master..astrsep2ls 
 1:  c553fb99 =  1:  268cb83d lib/string/strtok/: strsep2arr(), STRSEP2ARR(): Add APIs
 2:  2aa3acd1 =  2:  b5ea7e1b lib/string/strtok/: strsep2ls(), STRSEP2LS(): Add APIs
 3:  6af902d9 =  3:  c210ec07 lib/: Use STRSEP2LS() instead of its pattern
 4:  7e4fe7d1 =  4:  fa169f67 lib/port.c: getportent(): Use STRSEP2ARR() instead of its pattern
 5:  2203576f =  5:  34a8c828 lib/: Use strsep2arr() instead of its pattern
 6:  806e7a74 =  6:  203a400f lib/: Use STRSEP2ARR() instead of its pattern
 7:  9cc51b54 =  7:  ed1dc8c3 lib/string/strtok/: astrsep2ls(): Add function
 8:  fe87cd70 =  8:  c3f46d42 lib/sgetgrent.c: list(): Explicitly free(3) at the start of the function
 9:  e3dd7f24 =  9:  fcc1d8e9 lib/string/strtok/: xastrsep2ls(): Add function
10:  0413de0a = 10:  b93cc4d4 lib/: Use xastrsep2ls() instead of its pattern
```
</details>

<details>
<summary>v3</summary>

-  Use strsep2ls() instead of STRSEP2LS() with non-array input.

```
$ git range-diff shadow/master gh/astrsep2ls astrsep2ls 
 1:  268cb83d =  1:  268cb83d lib/string/strtok/: strsep2arr(), STRSEP2ARR(): Add APIs
 2:  b5ea7e1b =  2:  b5ea7e1b lib/string/strtok/: strsep2ls(), STRSEP2LS(): Add APIs
 -:  -------- >  3:  7b0faaf6 lib/list.c: Use strsep2ls() instead of its pattern
 3:  c210ec07 !  4:  fdd8c924 lib/: Use STRSEP2LS() instead of its pattern
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/: Use STRSEP2LS() instead of its pattern
    +    lib/port.c: Use STRSEP2LS() instead of its pattern
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    - ## lib/list.c ##
    -@@
    - #include "string/strchr/strchrcnt.h"
    - #include "string/strcmp/streq.h"
    - #include "string/strdup/xstrdup.h"
    -+#include "string/strtok/strsep2ls.h"
    - 
    - 
    - /*
    -@@ lib/list.c: comma_to_list(const char *comma)
    - {
    -   char *members;
    -   char **array;
    --  int i;
    --  char *cp;
    --  char *cp2;
    - 
    -   assert (NULL != comma);
    - 
    -@@ lib/list.c: comma_to_list(const char *comma)
    -           return array;
    -   }
    - 
    --  /*
    --   * Now go walk that list all over again, this time building the
    --   * array of pointers.
    --   */
    --
    --  for (cp = members, i = 0; cp != NULL; i++)
    --          array[i] = strsep(&cp, ",");
    --  array[i] = NULL;
    --
    --  /*
    --   * Return the new array of pointers
    --   */
    -+  STRSEP2LS(members, ",", array);
    - 
    -   return array;
    - }
    -
      ## lib/port.c ##
     @@
      #include "prototypes.h"
 4:  fa169f67 =  5:  5904aff5 lib/port.c: getportent(): Use STRSEP2ARR() instead of its pattern
 5:  34a8c828 =  6:  034175ba lib/: Use strsep2arr() instead of its pattern
 6:  203a400f =  7:  efbdb4a6 lib/: Use STRSEP2ARR() instead of its pattern
 7:  ed1dc8c3 =  8:  ca4c4959 lib/string/strtok/: astrsep2ls(): Add function
 8:  c3f46d42 =  9:  fafb2f36 lib/sgetgrent.c: list(): Explicitly free(3) at the start of the function
 9:  fcc1d8e9 = 10:  bf24bd3e lib/string/strtok/: xastrsep2ls(): Add function
10:  b93cc4d4 = 11:  2e6ef4b0 lib/: Use xastrsep2ls() instead of its pattern
```
</details>

<details>
<summary>v4</summary>

-  Fix a few typos.

```
$ git range-diff shadow/master gh/astrsep2ls astrsep2ls 
 1:  268cb83d =  1:  268cb83d lib/string/strtok/: strsep2arr(), STRSEP2ARR(): Add APIs
 2:  b5ea7e1b =  2:  b5ea7e1b lib/string/strtok/: strsep2ls(), STRSEP2LS(): Add APIs
 3:  7b0faaf6 =  3:  7b0faaf6 lib/list.c: Use strsep2ls() instead of its pattern
 4:  fdd8c924 =  4:  fdd8c924 lib/port.c: Use STRSEP2LS() instead of its pattern
 5:  5904aff5 !  5:  d0e9086e lib/port.c: getportent(): Use STRSEP2ARR() instead of its pattern
    @@ lib/port.c: getportent(void)
        int   saveerr;
     -  char  *cp, *field;
     +  char  *cp;
    -+  char  fields[3];
    ++  char  *fields[3];
      
        static char            buf[BUFSIZ];
        static char            *ttys[PORT_TTY + 1];
 6:  034175ba =  6:  8493aeb5 lib/: Use strsep2arr() instead of its pattern
 7:  efbdb4a6 !  7:  a9dafec7 lib/: Use STRSEP2ARR() instead of its pattern
    @@ lib/subordinateio.c: subordinate_parse(const char *line)
     -   * the entry is invalid.  Also, fields must be non-blank.
     -   */
     -  if (i != SUBID_NFIELDS)
    -+  if (STRSEP2ARR(rangebuff, ":", fields) == -1)
    ++  if (STRSEP2ARR(rangebuf, ":", fields) == -1)
                return NULL;
     +
        if (streq(fields[0], ""))
 8:  ca4c4959 =  8:  d43aac97 lib/string/strtok/: astrsep2ls(): Add function
 9:  fafb2f36 =  9:  3cbeb393 lib/sgetgrent.c: list(): Explicitly free(3) at the start of the function
10:  bf24bd3e = 10:  df12d7eb lib/string/strtok/: xastrsep2ls(): Add function
11:  2e6ef4b0 = 11:  de41126e lib/: Use xastrsep2ls() instead of its pattern
```
</details>

<details>
<summary>v4b</summary>

-  Rebase

```
$ git range-diff master..gh/astrsep2ls shadow/master..astrsep2ls 
 1:  268cb83d =  1:  aecd18a4 lib/string/strtok/: strsep2arr(), STRSEP2ARR(): Add APIs
 2:  b5ea7e1b =  2:  b84de158 lib/string/strtok/: strsep2ls(), STRSEP2LS(): Add APIs
 3:  7b0faaf6 =  3:  ea06f0db lib/list.c: Use strsep2ls() instead of its pattern
 4:  fdd8c924 =  4:  5ac90f5d lib/port.c: Use STRSEP2LS() instead of its pattern
 5:  d0e9086e =  5:  6387fa80 lib/port.c: getportent(): Use STRSEP2ARR() instead of its pattern
 6:  8493aeb5 =  6:  4357ac55 lib/: Use strsep2arr() instead of its pattern
 7:  a9dafec7 =  7:  d82cccfa lib/: Use STRSEP2ARR() instead of its pattern
 8:  d43aac97 =  8:  d934164b lib/string/strtok/: astrsep2ls(): Add function
 9:  3cbeb393 =  9:  f6ed9958 lib/sgetgrent.c: list(): Explicitly free(3) at the start of the function
10:  df12d7eb = 10:  9cd4d325 lib/string/strtok/: xastrsep2ls(): Add function
11:  de41126e = 11:  0430e0bd lib/: Use xastrsep2ls() instead of its pattern
```
</details>

<details>
<summary>v5</summary>

-  In function definitions, put the return type on a line of its own.
-  Add comments spelling out the meaning of the letter-soup API names.  [@hallyn]

```
$ git range-diff shadow/master gh/astrsep2ls astrsep2ls 
 1:  aecd18a4 !  1:  6b8d8482 lib/string/strtok/: strsep2arr(), STRSEP2ARR(): Add APIs
    @@ lib/string/strtok/strsep2arr.h (new)
     +    size_t n, char *a[restrict n]);
     +
     +
    ++// string separate to array-of-strings
     +// strsep(3) a string into an array of strings.
     +// Return the number of fields in the string, or -1 on error.
    -+inline ssize_t strsep2arr(char *s, const char *restrict delim,
    -+    size_t n, char *a[restrict n])
    ++inline ssize_t
    ++strsep2arr(char *s, const char *restrict delim, size_t n, char *a[restrict n])
     +{
     +  size_t  i;
     +
 2:  b84de158 !  2:  b8c2f8f1 lib/string/strtok/: strsep2ls(), STRSEP2LS(): Add APIs
    @@ lib/string/strtok/strsep2ls.h (new)
     +    size_t n, char *ls[restrict n]);
     +
     +
    ++// string separate to list-of-strings
     +// Like strsep2arr(), but add a NULL terminator.
    -+inline ssize_t strsep2ls(char *s, const char *restrict delim,
    -+    size_t n, char *ls[restrict n])
    ++inline ssize_t
    ++strsep2ls(char *s, const char *restrict delim, size_t n, char *ls[restrict n])
     +{
     +  size_t  i;
     +
 3:  ea06f0db =  3:  5123cd78 lib/list.c: Use strsep2ls() instead of its pattern
 4:  5ac90f5d =  4:  03cf076e lib/port.c: Use STRSEP2LS() instead of its pattern
 5:  6387fa80 =  5:  33f6b3bc lib/port.c: getportent(): Use STRSEP2ARR() instead of its pattern
 6:  4357ac55 =  6:  b5d71210 lib/: Use strsep2arr() instead of its pattern
 7:  d82cccfa =  7:  5f03ea0e lib/: Use STRSEP2ARR() instead of its pattern
 8:  d934164b !  8:  0009294f lib/string/strtok/: astrsep2ls(): Add function
    @@ lib/string/strtok/astrsep2ls.h (new)
     +    size_t *restrict np);
     +
     +
    ++// allocate string separate to list-of-strings
     +// Like strsep2ls(), but allocate the list array.
    -+inline char **astrsep2ls(char *s, const char *restrict delim,
    -+    size_t *restrict np)
    ++inline char **
    ++astrsep2ls(char *s, const char *restrict delim, size_t *restrict np)
     +{
     +  char     **ls;
     +  ssize_t  n;
 9:  f6ed9958 =  9:  bbe3d126 lib/sgetgrent.c: list(): Explicitly free(3) at the start of the function
10:  9cd4d325 ! 10:  6c38440b lib/string/strtok/: xastrsep2ls(): Add function
    @@ lib/string/strtok/xastrsep2ls.h (new)
     +    size_t *restrict np);
     +
     +
    -+inline char **xastrsep2ls(char *s, const char *restrict delim,
    -+    size_t *restrict np)
    ++// exit-on-error allocate string separate to list-of-strings
    ++inline char **
    ++xastrsep2ls(char *s, const char *restrict delim, size_t *restrict np)
     +{
     +  char     **ls;
     +
11:  0430e0bd = 11:  62d4348d lib/: Use xastrsep2ls() instead of its pattern
```
</details>

<details>
<summary>v5b</summary>

-  Rebase

```
$ git range-diff master..gh/astrsep2ls shadow/master..astrsep2ls 
 1:  6b8d8482 !  1:  5ae71be9 lib/string/strtok/: strsep2arr(), STRSEP2ARR(): Add APIs
    @@ Commit message
     
      ## lib/Makefile.am ##
     @@ lib/Makefile.am: libshadow_la_SOURCES = \
    -   string/strftime.h \
    +   string/strspn/strrspn.h \
        string/strtok/stpsep.c \
        string/strtok/stpsep.h \
     +  string/strtok/strsep2arr.c \
 2:  b8c2f8f1 =  2:  d3c5cccb lib/string/strtok/: strsep2ls(), STRSEP2LS(): Add APIs
 3:  5123cd78 =  3:  6f92964e lib/list.c: Use strsep2ls() instead of its pattern
 4:  03cf076e =  4:  f919b470 lib/port.c: Use STRSEP2LS() instead of its pattern
 5:  33f6b3bc =  5:  51e52f8e lib/port.c: getportent(): Use STRSEP2ARR() instead of its pattern
 6:  b5d71210 =  6:  84274eeb lib/: Use strsep2arr() instead of its pattern
 7:  5f03ea0e =  7:  094f8c13 lib/: Use STRSEP2ARR() instead of its pattern
 8:  0009294f !  8:  dbfd45b0 lib/string/strtok/: astrsep2ls(): Add function
    @@ Commit message
     
      ## lib/Makefile.am ##
     @@ lib/Makefile.am: libshadow_la_SOURCES = \
    -   string/strftime.h \
    +   string/strspn/strrspn.h \
        string/strtok/stpsep.c \
        string/strtok/stpsep.h \
     +  string/strtok/astrsep2ls.c \
 9:  bbe3d126 =  9:  7d95317f lib/sgetgrent.c: list(): Explicitly free(3) at the start of the function
10:  6c38440b = 10:  acdd17da lib/string/strtok/: xastrsep2ls(): Add function
11:  62d4348d = 11:  7f723f5f lib/: Use xastrsep2ls() instead of its pattern
```
</details>

<details>
<summary>v5c</summary>

-  Rebase

```
$ git range-diff master..gh/astrsep2ls shadow/master..astrsep2ls 
 1:  5ae71be9 =  1:  7296bb71 lib/string/strtok/: strsep2arr(), STRSEP2ARR(): Add APIs
 2:  d3c5cccb =  2:  1013737d lib/string/strtok/: strsep2ls(), STRSEP2LS(): Add APIs
 3:  6f92964e =  3:  19d4b8a0 lib/list.c: Use strsep2ls() instead of its pattern
 4:  f919b470 =  4:  725f450b lib/port.c: Use STRSEP2LS() instead of its pattern
 5:  51e52f8e =  5:  68168f2e lib/port.c: getportent(): Use STRSEP2ARR() instead of its pattern
 6:  84274eeb =  6:  4376c10b lib/: Use strsep2arr() instead of its pattern
 7:  094f8c13 !  7:  fe6697fa lib/: Use STRSEP2ARR() instead of its pattern
    @@ lib/sgetpwent.c: sgetpwent(const char *buf)
     
      ## lib/subordinateio.c ##
     @@
    - #include "atoi/str2i/str2u.h"
    + #include "string/ctype/strisascii/strisdigit.h"
      #include "string/sprintf/snprintf.h"
      #include "string/strcmp/streq.h"
     +#include "string/strtok/strsep2arr.h"
 8:  dbfd45b0 =  8:  ec9c9dd8 lib/string/strtok/: astrsep2ls(): Add function
 9:  7d95317f =  9:  161ba558 lib/sgetgrent.c: list(): Explicitly free(3) at the start of the function
10:  acdd17da = 10:  a6a4f8a0 lib/string/strtok/: xastrsep2ls(): Add function
11:  7f723f5f = 11:  b53790c5 lib/: Use xastrsep2ls() instead of its pattern
```
</details>

<details>
<summary>v5d</summary>

-  Rebase

```
$ git range-diff master..gh/astrsep2ls shadow/master..astrsep2ls 
 1:  7296bb71 =  1:  46316135 lib/string/strtok/: strsep2arr(), STRSEP2ARR(): Add APIs
 2:  1013737d =  2:  95473371 lib/string/strtok/: strsep2ls(), STRSEP2LS(): Add APIs
 3:  19d4b8a0 =  3:  49d0d7f4 lib/list.c: Use strsep2ls() instead of its pattern
 4:  725f450b =  4:  472f8937 lib/port.c: Use STRSEP2LS() instead of its pattern
 5:  68168f2e =  5:  02eb448a lib/port.c: getportent(): Use STRSEP2ARR() instead of its pattern
 6:  4376c10b =  6:  0cb74f80 lib/: Use strsep2arr() instead of its pattern
 7:  fe6697fa =  7:  f544508d lib/: Use STRSEP2ARR() instead of its pattern
 8:  ec9c9dd8 =  8:  57968091 lib/string/strtok/: astrsep2ls(): Add function
 9:  161ba558 =  9:  ff5d3838 lib/sgetgrent.c: list(): Explicitly free(3) at the start of the function
10:  a6a4f8a0 = 10:  6abcc1fa lib/string/strtok/: xastrsep2ls(): Add function
11:  b53790c5 = 11:  be9ecea5 lib/: Use xastrsep2ls() instead of its pattern
```
</details>

<details>
<summary>v5e</summary>

-  Rebase

```
$ git range-diff db/master..gh/astrsep2ls shadow/master..astrsep2ls 
 1:  46316135 =  1:  227d17b5 lib/string/strtok/: strsep2arr(), STRSEP2ARR(): Add APIs
 2:  95473371 =  2:  10032e7c lib/string/strtok/: strsep2ls(), STRSEP2LS(): Add APIs
 3:  49d0d7f4 =  3:  d3176f7a lib/list.c: Use strsep2ls() instead of its pattern
 4:  472f8937 =  4:  eebaf09e lib/port.c: Use STRSEP2LS() instead of its pattern
 5:  02eb448a =  5:  7c60fda5 lib/port.c: getportent(): Use STRSEP2ARR() instead of its pattern
 6:  0cb74f80 =  6:  ba036072 lib/: Use strsep2arr() instead of its pattern
 7:  f544508d =  7:  8a17b2b5 lib/: Use STRSEP2ARR() instead of its pattern
 8:  57968091 =  8:  1fff4252 lib/string/strtok/: astrsep2ls(): Add function
 9:  ff5d3838 =  9:  661fd94b lib/sgetgrent.c: list(): Explicitly free(3) at the start of the function
10:  6abcc1fa = 10:  4c6573b7 lib/string/strtok/: xastrsep2ls(): Add function
11:  be9ecea5 = 11:  e1386929 lib/: Use xastrsep2ls() instead of its pattern
```
</details>

<details>
<summary>v5f</summary>

-  Rebase

```
$ git rd 
 1:  227d17b5 =  1:  00950f0a lib/string/strtok/: strsep2arr(), STRSEP2ARR(): Add APIs
 2:  10032e7c =  2:  725d3709 lib/string/strtok/: strsep2ls(), STRSEP2LS(): Add APIs
 3:  d3176f7a =  3:  f2ac06bc lib/list.c: Use strsep2ls() instead of its pattern
 4:  eebaf09e =  4:  345bab52 lib/port.c: Use STRSEP2LS() instead of its pattern
 5:  7c60fda5 =  5:  835086b2 lib/port.c: getportent(): Use STRSEP2ARR() instead of its pattern
 6:  ba036072 =  6:  fa1fe897 lib/: Use strsep2arr() instead of its pattern
 7:  8a17b2b5 =  7:  45de48c2 lib/: Use STRSEP2ARR() instead of its pattern
 8:  1fff4252 =  8:  ed63a937 lib/string/strtok/: astrsep2ls(): Add function
 9:  661fd94b =  9:  1d2a44af lib/sgetgrent.c: list(): Explicitly free(3) at the start of the function
10:  4c6573b7 = 10:  8d678288 lib/string/strtok/: xastrsep2ls(): Add function
11:  e1386929 = 11:  14df6eb8 lib/: Use xastrsep2ls() instead of its pattern
```
</details>

<details>
<summary>v5g</summary>

-  Rebase

```
$ git rd
 1:  00950f0a =  1:  289acff1 lib/string/strtok/: strsep2arr(), STRSEP2ARR(): Add APIs
 2:  725d3709 =  2:  b240c896 lib/string/strtok/: strsep2ls(), STRSEP2LS(): Add APIs
 3:  f2ac06bc =  3:  2b6fbcc0 lib/list.c: Use strsep2ls() instead of its pattern
 4:  345bab52 !  4:  ad1e3360 lib/port.c: Use STRSEP2LS() instead of its pattern
    @@ Commit message
     
      ## lib/port.c ##
     @@
    - #include "prototypes.h"
      #include "string/strcmp/streq.h"
    + #include "string/strcmp/strprefix.h"
      #include "string/strtok/stpsep.h"
     +#include "string/strtok/strsep2ls.h"
      
 5:  835086b2 =  5:  72166697 lib/port.c: getportent(): Use STRSEP2ARR() instead of its pattern
 6:  fa1fe897 =  6:  a1855359 lib/: Use strsep2arr() instead of its pattern
 7:  45de48c2 =  7:  41ed1f5d lib/: Use STRSEP2ARR() instead of its pattern
 8:  ed63a937 =  8:  1d208c91 lib/string/strtok/: astrsep2ls(): Add function
 9:  1d2a44af =  9:  d96be7af lib/sgetgrent.c: list(): Explicitly free(3) at the start of the function
10:  8d678288 = 10:  9f95b266 lib/string/strtok/: xastrsep2ls(): Add function
11:  14df6eb8 = 11:  46d4fc8c lib/: Use xastrsep2ls() instead of its pattern
```
</details>

<details>
<summary>v5h</summary>

-  Rebase

```
$ git rd
 1:  289acff1 =  1:  6c463b50 lib/string/strtok/: strsep2arr(), STRSEP2ARR(): Add APIs
 2:  b240c896 =  2:  34b951bc lib/string/strtok/: strsep2ls(), STRSEP2LS(): Add APIs
 3:  2b6fbcc0 =  3:  54f53e88 lib/list.c: Use strsep2ls() instead of its pattern
 4:  ad1e3360 =  4:  46ba0773 lib/port.c: Use STRSEP2LS() instead of its pattern
 5:  72166697 =  5:  3585339c lib/port.c: getportent(): Use STRSEP2ARR() instead of its pattern
 6:  a1855359 =  6:  09f11ff1 lib/: Use strsep2arr() instead of its pattern
 7:  41ed1f5d =  7:  3fda6c44 lib/: Use STRSEP2ARR() instead of its pattern
 8:  1d208c91 =  8:  122ca305 lib/string/strtok/: astrsep2ls(): Add function
 9:  d96be7af =  9:  794ebf91 lib/sgetgrent.c: list(): Explicitly free(3) at the start of the function
10:  9f95b266 = 10:  21d6b6c0 lib/string/strtok/: xastrsep2ls(): Add function
11:  46d4fc8c = 11:  56740a56 lib/: Use xastrsep2ls() instead of its pattern
```
</details>

<details>
<summary>v6</summary>

-  Rebase

```
$ git rd
 1:  6c463b50 =  1:  0f9c14ce lib/string/strtok/: strsep2arr(), STRSEP2ARR(): Add APIs
 2:  34b951bc =  2:  fce85e83 lib/string/strtok/: strsep2ls(), STRSEP2LS(): Add APIs
 3:  54f53e88 =  3:  1c203f4f lib/list.c: Use strsep2ls() instead of its pattern
 4:  46ba0773 =  4:  078e7e0e lib/port.c: Use STRSEP2LS() instead of its pattern
 5:  3585339c =  5:  7ac821a7 lib/port.c: getportent(): Use STRSEP2ARR() instead of its pattern
 6:  09f11ff1 !  6:  378b3fbf lib/: Use strsep2arr() instead of its pattern
    @@ lib/sgetspent.c
      
      
      #define   FIELDS  9
    -@@ lib/sgetspent.c: sgetspent(const char *string)
    -   static char spwbuf[PASSWD_ENTRY_MAX_LENGTH];
    +@@ lib/sgetspent.c: sgetspent(const char *s)
    +   static char        *dup = NULL;
        static struct spwd spwd;
        char *fields[FIELDS];
     -  char *cp;
     -  int i;
     +  size_t  i;
      
    -   /*
    -    * Copy string to local buffer.  It has to be tokenized and we
    -@@ lib/sgetspent.c: sgetspent(const char *string)
    -   strcpy (spwbuf, string);
    -   stpsep(spwbuf, "\n");
    +   free(dup);
    +   dup = strdup(s);
    +@@ lib/sgetspent.c: sgetspent(const char *s)
    + 
    +   stpsep(dup, "\n");
      
     -  /*
     -   * Tokenize the string into colon separated fields.  Allow up to
     -   * FIELDS different fields.
     -   */
     -
    --  for (cp = spwbuf, i = 0; cp != NULL && i < FIELDS; i++)
    +-  for (cp = dup, i = 0; cp != NULL && i < FIELDS; i++)
     -          fields[i] = strsep(&cp, ":");
     -
     -  if (i == (FIELDS - 1))
    -+  i = strsep2arr(spwbuf, ":", NITEMS(fields), fields);
    ++  i = strsep2arr(dup, ":", NITEMS(fields), fields);
     +  if (i == NITEMS(fields) - 1)
                fields[i++] = "";
     -
 7:  3fda6c44 !  7:  b5f0f29d lib/: Use STRSEP2ARR() instead of its pattern
    @@ lib/gshadow.c
      
      static /*@null@*/char **
      build_list(char *s)
    -@@ lib/gshadow.c: sgetsgent(const char *string)
    -   static char *sgrbuf = NULL;
    -   static size_t sgrbuflen = 0;
    +@@ lib/gshadow.c: sgetsgent(const char *s)
    + {
    +   static char  *dup = NULL;
      
     -  char *fields[FIELDS];
     -  char *cp;
     -  int i;
     +  char  *fields[4];
    -   size_t len = strlen (string) + 1;
      
    -   if (len > sgrbuflen) {
    -@@ lib/gshadow.c: sgetsgent(const char *string)
    -   strcpy (sgrbuf, string);
    -   stpsep(sgrbuf, "\n");
    +   free(dup);
    +   dup = strdup(s);
    +@@ lib/gshadow.c: sgetsgent(const char *s)
    + 
    +   stpsep(dup, "\n");
      
     -  /*
     -   * There should be exactly 4 colon separated fields.  Find
     -   * all 4 of them and save the starting addresses in fields[].
     -   */
     -
    --  for (cp = sgrbuf, i = 0; (i < FIELDS) && (NULL != cp); i++)
    +-  for (cp = dup, i = 0; (i < FIELDS) && (NULL != cp); i++)
     -          fields[i] = strsep(&cp, ":");
     -
     -  /*
    @@ lib/gshadow.c: sgetsgent(const char *string)
     -   */
     -
     -  if (NULL != cp || i != FIELDS)
    -+  if (STRSEP2ARR(sgrbuf, ":", fields) == -1)
    ++  if (STRSEP2ARR(dup, ":", fields) == -1)
                return NULL;
      
        sgroup.sg_namp = fields[0];
    @@ lib/sgetgrent.c
      /*
       * list - turn a comma-separated string into an array of (char *)'s
       *
    -@@ lib/sgetgrent.c: list(char *s)
    - struct group *sgetgrent (const char *buf)
    +@@ lib/sgetgrent.c: struct group *
    + sgetgrent(const char *s)
      {
    -   static char *grpbuf = NULL;
    -+  static char   *grpfields[4];
    -   static size_t size = 0;
    +   static char         *dup = NULL;
     -  static char *grpfields[NFIELDS];
    ++  static char         *grpfields[4];
        static struct group grent;
     -  int i;
     -  char *cp;
      
    -   if (strlen (buf) + 1 > size) {
    -           /* no need to use realloc() here - just free it and
    -@@ lib/sgetgrent.c: struct group *sgetgrent (const char *buf)
    -   strcpy (grpbuf, buf);
    -   stpsep(grpbuf, "\n");
    +   free(dup);
    +   dup = strdup(s);
    +   if (dup == NULL)
    +           return NULL;
      
    --  for (cp = grpbuf, i = 0; (i < NFIELDS) && (NULL != cp); i++)
    +-  stpsep(dup, "\n");
    +-
    +-  for (cp = dup, i = 0; (i < NFIELDS) && (NULL != cp); i++)
     -          grpfields[i] = strsep(&cp, ":");
     -
     -  if (i < NFIELDS || streq(grpfields[2], "") || cp != NULL) {
    -+  if (STRSEP2ARR(grpbuf, ":", grpfields) == -1)
    ++  if (STRSEP2ARR(dup, ":", grpfields) == -1)
                return NULL;
     -  }
     +
    @@ lib/sgetgrent.c: struct group *sgetgrent (const char *buf)
     
      ## lib/sgetpwent.c ##
     @@
    - #include "prototypes.h"
      #include "shadowlog_internal.h"
      #include "string/strcmp/streq.h"
    + #include "string/strtok/stpsep.h"
     +#include "string/strtok/strsep2arr.h"
      
      
    @@ lib/sgetpwent.c
      /*
       * sgetpwent - convert a string to a (struct passwd)
       *
    -@@ lib/sgetpwent.c: sgetpwent(const char *buf)
    +@@ lib/sgetpwent.c: sgetpwent(const char *s)
      {
    +   static char          *dup = NULL;
        static struct passwd pwent;
    -   static char pwdbuf[PASSWD_ENTRY_MAX_LENGTH];
     -  int i;
     -  char *cp;
     -  char *fields[NFIELDS];
     +
     +  char  *fields[7];
      
    -   /*
    -    * Copy the string to a static buffer so the pointers into
    -@@ lib/sgetpwent.c: sgetpwent(const char *buf)
    -   }
    -   strcpy (pwdbuf, buf);
    +   free(dup);
    +   dup = strdup(s);
    +@@ lib/sgetpwent.c: sgetpwent(const char *s)
    + 
    +   stpsep(dup, "\n");
      
     -  /*
     -   * Save a pointer to the start of each colon separated
     -   * field.  The fields are converted into NUL terminated strings.
     -   */
     -
    --  for (cp = pwdbuf, i = 0; (i < NFIELDS) && (NULL != cp); i++)
    +-  for (cp = dup, i = 0; (i < NFIELDS) && (NULL != cp); i++)
     -          fields[i] = strsep(&cp, ":");
     -
     -  /* something at the end, columns over shot */
    @@ lib/sgetpwent.c: sgetpwent(const char *buf)
     -   */
     -
     -  if (i != NFIELDS)
    -+  if (STRSEP2ARR(pwdbuf, ":", fields) == -1)
    ++  if (STRSEP2ARR(dup, ":", fields) == -1)
                return NULL;
     +
     +  /*
 8:  122ca305 =  8:  f6cbcdd3 lib/string/strtok/: astrsep2ls(): Add function
 9:  794ebf91 =  9:  e1db6f1c lib/sgetgrent.c: list(): Explicitly free(3) at the start of the function
10:  21d6b6c0 = 10:  aa2b8b8b lib/string/strtok/: xastrsep2ls(): Add function
11:  56740a56 ! 11:  97a6bcbd lib/: Use xastrsep2ls() instead of its pattern
    @@ lib/gshadow.c: static /*@null@*/char **
     
      ## lib/sgetgrent.c ##
     @@
    - #include <string.h>
    + #include <sys/types.h>
      
      #include "alloc/malloc.h"
     -#include "alloc/reallocf.h"
```
</details>

<details>
<summary>v7</summary>

-  Rebase

```
$ git rd
 1:  0f9c14ce =  1:  05c71335 lib/string/strtok/: strsep2arr(), STRSEP2ARR(): Add APIs
 2:  fce85e83 =  2:  1960225a lib/string/strtok/: strsep2ls(), STRSEP2LS(): Add APIs
 3:  1c203f4f =  3:  94c35b40 lib/list.c: Use strsep2ls() instead of its pattern
 4:  078e7e0e =  4:  aa0744db lib/port.c: Use STRSEP2LS() instead of its pattern
 5:  7ac821a7 =  5:  9e4b7bc5 lib/port.c: getportent(): Use STRSEP2ARR() instead of its pattern
 6:  378b3fbf !  6:  36444318 lib/: Use strsep2arr() instead of its pattern
    @@ lib/sgetspent.c
      
      #define   FIELDS  9
     @@ lib/sgetspent.c: sgetspent(const char *s)
    -   static char        *dup = NULL;
        static struct spwd spwd;
    + 
        char *fields[FIELDS];
     -  char *cp;
     -  int i;
 7:  b5f0f29d !  7:  cafbf392 lib/: Use STRSEP2ARR() instead of its pattern
    @@ lib/gshadow.c: sgetsgent(const char *s)
      {
        static char  *dup = NULL;
      
    --  char *fields[FIELDS];
    +-  char  *fields[FIELDS];
     -  char *cp;
     -  int i;
     +  char  *fields[4];
    @@ lib/sgetgrent.c
      /*
       * list - turn a comma-separated string into an array of (char *)'s
       *
    -@@ lib/sgetgrent.c: struct group *
    - sgetgrent(const char *s)
    - {
    +@@ lib/sgetgrent.c: sgetgrent(const char *s)
        static char         *dup = NULL;
    --  static char *grpfields[NFIELDS];
    -+  static char         *grpfields[4];
        static struct group grent;
    + 
     -  int i;
     -  char *cp;
    +-  char  *fields[NFIELDS];
    ++  char  *fields[4];
      
        free(dup);
        dup = strdup(s);
    -   if (dup == NULL)
    -           return NULL;
    +@@ lib/sgetgrent.c: sgetgrent(const char *s)
    + 
    +   stpsep(dup, "\n");
      
    --  stpsep(dup, "\n");
    --
     -  for (cp = dup, i = 0; (i < NFIELDS) && (NULL != cp); i++)
    --          grpfields[i] = strsep(&cp, ":");
    +-          fields[i] = strsep(&cp, ":");
     -
    --  if (i < NFIELDS || streq(grpfields[2], "") || cp != NULL) {
    -+  if (STRSEP2ARR(dup, ":", grpfields) == -1)
    +-  if (i < NFIELDS || streq(fields[2], "") || cp != NULL) {
    ++  if (STRSEP2ARR(dup, ":", fields) == -1)
                return NULL;
     -  }
     +
    -+  if (streq(grpfields[2], ""))
    ++  if (streq(fields[2], ""))
     +          return NULL;
     +
    -   grent.gr_name = grpfields[0];
    -   grent.gr_passwd = grpfields[1];
    -   if (get_gid(grpfields[2], &grent.gr_gid) == -1) {
    +   grent.gr_name = fields[0];
    +   grent.gr_passwd = fields[1];
    +   if (get_gid(fields[2], &grent.gr_gid) == -1) {
     
      ## lib/sgetpwent.c ##
     @@
    @@ lib/sgetpwent.c
       * sgetpwent - convert a string to a (struct passwd)
       *
     @@ lib/sgetpwent.c: sgetpwent(const char *s)
    - {
        static char          *dup = NULL;
        static struct passwd pwent;
    + 
     -  int i;
     -  char *cp;
    --  char *fields[NFIELDS];
    -+
    +-  char  *fields[NFIELDS];
     +  char  *fields[7];
      
        free(dup);
 8:  f6cbcdd3 =  8:  08be50cc lib/string/strtok/: astrsep2ls(): Add function
 9:  e1db6f1c =  9:  000eedf2 lib/sgetgrent.c: list(): Explicitly free(3) at the start of the function
10:  aa2b8b8b = 10:  ee3e3080 lib/string/strtok/: xastrsep2ls(): Add function
11:  97a6bcbd = 11:  eeed3c66 lib/: Use xastrsep2ls() instead of its pattern
```
</details>

<details>
<summary>v7b</summary>

-  Rebase

```
$ git rd
 1:  05c71335 =  1:  5e072d61 lib/string/strtok/: strsep2arr(), STRSEP2ARR(): Add APIs
 2:  1960225a =  2:  8a17b3b4 lib/string/strtok/: strsep2ls(), STRSEP2LS(): Add APIs
 3:  94c35b40 =  3:  17939bea lib/list.c: Use strsep2ls() instead of its pattern
 4:  aa0744db =  4:  5f02ab4d lib/port.c: Use STRSEP2LS() instead of its pattern
 5:  9e4b7bc5 =  5:  561246fe lib/port.c: getportent(): Use STRSEP2ARR() instead of its pattern
 6:  36444318 =  6:  fb263462 lib/: Use strsep2arr() instead of its pattern
 7:  cafbf392 =  7:  c68012c6 lib/: Use STRSEP2ARR() instead of its pattern
 8:  08be50cc =  8:  65b1daa8 lib/string/strtok/: astrsep2ls(): Add function
 9:  000eedf2 =  9:  eb614bf9 lib/sgetgrent.c: list(): Explicitly free(3) at the start of the function
10:  ee3e3080 = 10:  6cac7bdf lib/string/strtok/: xastrsep2ls(): Add function
11:  eeed3c66 = 11:  9d3ce192 lib/: Use xastrsep2ls() instead of its pattern
```
</details>

<details>
<summary>v7c</summary>

-  Rebase

```
$ git rd
 1:  5e072d61 =  1:  b8cfe714 lib/string/strtok/: strsep2arr(), STRSEP2ARR(): Add APIs
 2:  8a17b3b4 =  2:  79014af5 lib/string/strtok/: strsep2ls(), STRSEP2LS(): Add APIs
 3:  17939bea =  3:  59af142f lib/list.c: Use strsep2ls() instead of its pattern
 4:  5f02ab4d =  4:  c590f720 lib/port.c: Use STRSEP2LS() instead of its pattern
 5:  561246fe =  5:  272e2254 lib/port.c: getportent(): Use STRSEP2ARR() instead of its pattern
 6:  fb263462 =  6:  7673f320 lib/: Use strsep2arr() instead of its pattern
 7:  c68012c6 =  7:  8f147494 lib/: Use STRSEP2ARR() instead of its pattern
 8:  65b1daa8 =  8:  679eb63f lib/string/strtok/: astrsep2ls(): Add function
 9:  eb614bf9 =  9:  3c93e1af lib/sgetgrent.c: list(): Explicitly free(3) at the start of the function
10:  6cac7bdf = 10:  0fc9164f lib/string/strtok/: xastrsep2ls(): Add function
11:  9d3ce192 = 11:  18055c2b lib/: Use xastrsep2ls() instead of its pattern
```
</details>

<details>
<summary>v7d</summary>

-  Rebase

```
$ git rd 
 1:  b8cfe714 =  1:  e9843f35 lib/string/strtok/: strsep2arr(), STRSEP2ARR(): Add APIs
 2:  79014af5 =  2:  505726e8 lib/string/strtok/: strsep2ls(), STRSEP2LS(): Add APIs
 3:  59af142f =  3:  01f41f4a lib/list.c: Use strsep2ls() instead of its pattern
 4:  c590f720 =  4:  4d5a8ea0 lib/port.c: Use STRSEP2LS() instead of its pattern
 5:  272e2254 =  5:  c8a85385 lib/port.c: getportent(): Use STRSEP2ARR() instead of its pattern
 6:  7673f320 =  6:  07f6e908 lib/: Use strsep2arr() instead of its pattern
 7:  8f147494 =  7:  c52836dc lib/: Use STRSEP2ARR() instead of its pattern
 8:  679eb63f =  8:  7412d72f lib/string/strtok/: astrsep2ls(): Add function
 9:  3c93e1af =  9:  b05a4410 lib/sgetgrent.c: list(): Explicitly free(3) at the start of the function
10:  0fc9164f = 10:  ade7482c lib/string/strtok/: xastrsep2ls(): Add function
11:  18055c2b = 11:  9fcbc6d3 lib/: Use xastrsep2ls() instead of its pattern
```
</details>

<details>
<summary>v7e</summary>

-  Rebase

```
$ git rd
 1:  e9843f35 =  1:  f5e42b2d lib/string/strtok/: strsep2arr(), STRSEP2ARR(): Add APIs
 2:  505726e8 =  2:  7302bd36 lib/string/strtok/: strsep2ls(), STRSEP2LS(): Add APIs
 3:  01f41f4a =  3:  629625bc lib/list.c: Use strsep2ls() instead of its pattern
 4:  4d5a8ea0 =  4:  b426cae1 lib/port.c: Use STRSEP2LS() instead of its pattern
 5:  c8a85385 =  5:  a3453b7d lib/port.c: getportent(): Use STRSEP2ARR() instead of its pattern
 6:  07f6e908 =  6:  e90343f7 lib/: Use strsep2arr() instead of its pattern
 7:  c52836dc =  7:  64bb5409 lib/: Use STRSEP2ARR() instead of its pattern
 8:  7412d72f =  8:  8ab5dfd8 lib/string/strtok/: astrsep2ls(): Add function
 9:  b05a4410 =  9:  694a0ebd lib/sgetgrent.c: list(): Explicitly free(3) at the start of the function
10:  ade7482c = 10:  c1b80efb lib/string/strtok/: xastrsep2ls(): Add function
11:  9fcbc6d3 = 11:  7907741c lib/: Use xastrsep2ls() instead of its pattern
```
</details>

<details>
<summary>v7f</summary>

-  Use countof instead of NITEMS().

```
$ git range-diff shadow/master gh/astrsep2ls astrsep2ls 
 1:  f5e42b2d !  1:  9592b402 lib/string/strtok/: strsep2arr(), STRSEP2ARR(): Add APIs
    @@ lib/string/strtok/strsep2arr.h (new)
     +
     +#define STRSEP2ARR(s, delim, a)                                       \
     +(                                                                     \
    -+  strsep2arr(s, delim, NITEMS(a), a) == NITEMS(a) ? 0 : -1      \
    ++  strsep2arr(s, delim, countof(a), a) == countof(a) ? 0 : -1    \
     +)
     +
     +
 2:  7302bd36 !  2:  5d643151 lib/string/strtok/: strsep2ls(), STRSEP2LS(): Add APIs
    @@ lib/string/strtok/strsep2ls.h (new)
     +#include "string/strtok/strsep2arr.h"
     +
     +
    -+#define STRSEP2LS(s, delim, ls)  strsep2ls(s, delim, NITEMS(ls), ls)
    ++#define STRSEP2LS(s, delim, ls)  strsep2ls(s, delim, countof(ls), ls)
     +
     +
     +ATTR_ACCESS(read_write, 1) ATTR_ACCESS(write_only, 4, 3)
 3:  629625bc =  3:  2deadda9 lib/list.c: Use strsep2ls() instead of its pattern
 4:  b426cae1 =  4:  6ad775e0 lib/port.c: Use STRSEP2LS() instead of its pattern
 5:  a3453b7d =  5:  859b9906 lib/port.c: getportent(): Use STRSEP2ARR() instead of its pattern
 6:  e90343f7 !  6:  ab9a16e9 lib/: Use strsep2arr() instead of its pattern
    @@ lib/sgetspent.c: sgetspent(const char *s)
     -          fields[i] = strsep(&cp, ":");
     -
     -  if (i == (FIELDS - 1))
    -+  i = strsep2arr(dup, ":", NITEMS(fields), fields);
    -+  if (i == NITEMS(fields) - 1)
    ++  i = strsep2arr(dup, ":", countof(fields), fields);
    ++  if (i == countof(fields) - 1)
                fields[i++] = "";
     -
     -  if (cp != NULL || (i != FIELDS && i != OFIELDS))
    -+  if (i != NITEMS(fields) && i != OFIELDS)
    ++  if (i != countof(fields) && i != OFIELDS)
                return NULL;
      
        /*
 7:  64bb5409 =  7:  bad087e5 lib/: Use STRSEP2ARR() instead of its pattern
 8:  8ab5dfd8 =  8:  ade89c5f lib/string/strtok/: astrsep2ls(): Add function
 9:  694a0ebd =  9:  fda889ec lib/sgetgrent.c: list(): Explicitly free(3) at the start of the function
10:  c1b80efb = 10:  ca9040b6 lib/string/strtok/: xastrsep2ls(): Add function
11:  7907741c = 11:  848e778c lib/: Use xastrsep2ls() instead of its pattern
```
</details>

<details>
<summary>v8</summary>

-  Rebase on top of #1265 , which fixes several off-by-one bugs.  [@hallyn ]
-  Fix memory leak.  [@hallyn ]

```
$ git range-diff shadow/master..gh/astrsep2ls gh/fields678..astrsep2ls 
 1:  9592b402 =  1:  2c6f4569 lib/string/strtok/: strsep2arr(), STRSEP2ARR(): Add APIs
 2:  5d643151 =  2:  63fd9412 lib/string/strtok/: strsep2ls(), STRSEP2LS(): Add APIs
 3:  2deadda9 =  3:  de75187b lib/list.c: Use strsep2ls() instead of its pattern
 4:  6ad775e0 =  4:  0ea7cda7 lib/port.c: Use STRSEP2LS() instead of its pattern
 5:  859b9906 =  5:  097ce9f1 lib/port.c: getportent(): Use STRSEP2ARR() instead of its pattern
 6:  ab9a16e9 =  6:  4a3d37da lib/: Use strsep2arr() instead of its pattern
 7:  bad087e5 !  7:  b203d199 lib/: Use STRSEP2ARR() instead of its pattern
    @@ src/newusers.c
     @@ src/newusers.c: int main (int argc, char **argv)
      {
        char buf[BUFSIZ];
    -   char *fields[8];
    +   char *fields[6];
     -  int nfields;
     -  char *cp;
        const struct passwd *pw;
    @@ src/newusers.c: int main (int argc, char **argv)
      
     -          /*
     -           * Break the string into fields and screw around with them.
    --           * There MUST be 7 colon separated fields, although the
    --           * values aren't that particular.
    +-           * The values aren't that particular.
     -           */
    --          for (cp = buf, nfields = 0; nfields < 7; nfields++) {
    +-          for (cp = buf, nfields = 0; nfields < 6 && cp != NULL; nfields++) {
     -                  fields[nfields] = strsep(&cp, ":");
    --                  if (cp == NULL)
    --                          break;
     -          }
    --          if (nfields != 6) {
    +-          if (nfields != 6 || cp != NULL) {
     +          if (STRSEP2ARR(buf, ":", fields) == -1) {
                        fprintf (stderr, _("%s: line %jd: invalid line\n"),
                                 Prog, line);
 8:  ade89c5f !  8:  50af3a10 lib/string/strtok/: astrsep2ls(): Add function
    @@ lib/string/strtok/astrsep2ls.h (new)
     +          return NULL;
     +
     +  n = strsep2ls(s, delim, n, ls);
    -+  if (n == -1)
    ++  if (n == -1) {
    ++          free(ls);
     +          return NULL;
    ++  }
     +
     +  if (np != NULL)
     +          *np = n;
 9:  fda889ec =  9:  01d8d143 lib/sgetgrent.c: list(): Explicitly free(3) at the start of the function
10:  ca9040b6 = 10:  b4e0f6be lib/string/strtok/: xastrsep2ls(): Add function
11:  848e778c = 11:  08ea2bfc lib/: Use xastrsep2ls() instead of its pattern
```
</details>

<details>
<summary>v9</summary>

-  Rebase on top of #1266 

```
$ git range-diff 2c6f45697cc1^..gh/astrsep2ls gh/fields8..astrsep2ls 
 1:  2c6f4569 =  1:  9488a0f9 lib/string/strtok/: strsep2arr(), STRSEP2ARR(): Add APIs
 2:  63fd9412 =  2:  09bc72ea lib/string/strtok/: strsep2ls(), STRSEP2LS(): Add APIs
 3:  de75187b =  3:  2679eaab lib/list.c: Use strsep2ls() instead of its pattern
 4:  0ea7cda7 =  4:  300f488b lib/port.c: Use STRSEP2LS() instead of its pattern
 5:  097ce9f1 =  5:  a594936a lib/port.c: getportent(): Use STRSEP2ARR() instead of its pattern
 6:  4a3d37da =  6:  83dfa17c lib/: Use strsep2arr() instead of its pattern
 7:  b203d199 !  7:  a185070d lib/: Use STRSEP2ARR() instead of its pattern
    @@ src/newusers.c
     @@ src/newusers.c: int main (int argc, char **argv)
      {
        char buf[BUFSIZ];
    -   char *fields[6];
    +   char *fields[7];
     -  int nfields;
     -  char *cp;
        const struct passwd *pw;
    @@ src/newusers.c: int main (int argc, char **argv)
      
     -          /*
     -           * Break the string into fields and screw around with them.
    --           * The values aren't that particular.
    +-           * There MUST be 7 colon separated fields, although the
    +-           * values aren't that particular.
     -           */
    --          for (cp = buf, nfields = 0; nfields < 6 && cp != NULL; nfields++) {
    +-          for (cp = buf, nfields = 0; nfields < 7; nfields++) {
     -                  fields[nfields] = strsep(&cp, ":");
    +-                  if (cp == NULL)
    +-                          break;
     -          }
    --          if (nfields != 6 || cp != NULL) {
    +-          if (nfields != 6) {
     +          if (STRSEP2ARR(buf, ":", fields) == -1) {
                        fprintf (stderr, _("%s: line %jd: invalid line\n"),
                                 Prog, line);
 8:  50af3a10 =  8:  96fd6aa5 lib/string/strtok/: astrsep2ls(): Add function
 9:  01d8d143 =  9:  df5a3d50 lib/sgetgrent.c: list(): Explicitly free(3) at the start of the function
10:  b4e0f6be = 10:  ca2f6413 lib/string/strtok/: xastrsep2ls(): Add function
11:  08ea2bfc = 11:  534cb2a1 lib/: Use xastrsep2ls() instead of its pattern
```
</details>

<details>
<summary>v9b</summary>

-  Rebase

```
$ git range-diff 9488a0f9e2ae^..gh/astrsep2ls shadow/master..astrsep2ls 
 1:  9488a0f9 =  1:  eb7b2953 lib/string/strtok/: strsep2arr(), STRSEP2ARR(): Add APIs
 2:  09bc72ea =  2:  475ca898 lib/string/strtok/: strsep2ls(), STRSEP2LS(): Add APIs
 3:  2679eaab =  3:  8988f78a lib/list.c: Use strsep2ls() instead of its pattern
 4:  300f488b =  4:  30de20c5 lib/port.c: Use STRSEP2LS() instead of its pattern
 5:  a594936a =  5:  f7c7ce3e lib/port.c: getportent(): Use STRSEP2ARR() instead of its pattern
 6:  83dfa17c =  6:  48e6eec7 lib/: Use strsep2arr() instead of its pattern
 7:  a185070d =  7:  5b0cbf76 lib/: Use STRSEP2ARR() instead of its pattern
 8:  96fd6aa5 =  8:  46dbb91e lib/string/strtok/: astrsep2ls(): Add function
 9:  df5a3d50 =  9:  f6bf3e1a lib/sgetgrent.c: list(): Explicitly free(3) at the start of the function
10:  ca2f6413 = 10:  725d9a39 lib/string/strtok/: xastrsep2ls(): Add function
11:  534cb2a1 = 11:  01bed8a3 lib/: Use xastrsep2ls() instead of its pattern
```
</details>