### PR TITLE
lib/chkname.c, src/: Strictly disallow really bad names

### DIFF
--- a/lib/chkname.c
+++ b/lib/chkname.c
@@ -55,7 +55,7 @@ is_valid_name(const char *name)
 	 || streq(name, ".")
 	 || streq(name, "..")
 	 || strspn(name, "-")
-	 || strpbrk(name, " \"#',/:;")
+	 || strpbrk(name, " !\"#'&*+,/:;@|~")
 	 || strchriscntrl_c(name)
 	 || strisdigit_c(name))
 	{


### PR DESCRIPTION
    Some names are bad, and some names are really bad.  '--badname' should
    only allow the mildly bad ones, which we can handle.  Some names are too
    bad, and it's not possible to deal with them.  Reject them
    unconditionally.
    
Cc: @zeha, @zugschlus, @ikerexxe , @hallyn , @uecker 

---

Revisions:

<details>
<summary>v1b</summary>

-  Acked-by: @zeha 

```
$ git range-diff streq gh/reallybadnames reallybadnames 
1:  1c5acb5f ! 1:  9af4a680 lib/chkname.c, src/: Strictly disallow really bad names
    @@ Commit message
         bad, and it's not possible to deal with them.  Reject them
         unconditionally.
     
    -    Cc: Chris Hofstaedtler <zeha@debian.org>
    +    Acked-by: Chris Hofstaedtler <zeha@debian.org>
         Cc: Marc 'Zugschlus' Haber <mh+githubvisible@zugschlus.de>
         Cc: Iker Pedrosa <ipedrosa@redhat.com>
         Cc: Serge Hallyn <serge@hallyn.com>
```
</details>

<details>
<summary>v2</summary>

-  Reject a leading hyphen-minus unconditionally. So many tools would not be able to handle this; probably including ourselves.

```
$ git range-diff streq 9af4a680 reallybadnames 
1:  9af4a680 ! 1:  8a17ba49 lib/chkname.c, src/: Strictly disallow really bad names
    @@ lib/chkname.c
     +#include "string/ctype/strchrisascii/strchriscntrl.h"
     +#include "string/ctype/strisascii/strisdigit.h"
      #include "string/strcmp/streq.h"
    ++#include "string/strcmp/strprefix.h"
      
      
    + int allow_bad_names = false;
     @@ lib/chkname.c: login_name_max_size(void)
      static bool
      is_valid_name(const char *name)
    @@ lib/chkname.c: login_name_max_size(void)
     +   || streq(name, ".")
     +   || streq(name, "..")
     +   || strpbrk(name, ",:")
    ++   || strprefix(name, "-")
     +   || strchriscntrl(name)
     +   || strisdigit(name))
     +  {
```
</details>

<details>
<summary>v3</summary>

-  Reject spaces unconditionally.  [@zeha ]
   Spaces are used as structuring characters in several programs (e.g., id(1)).  Don't mess with them.

```
$ git range-diff streq gh/reallybadnames reallybadnames 
1:  8a17ba49 ! 1:  5369182a lib/chkname.c, src/: Strictly disallow really bad names
    @@ lib/chkname.c: login_name_max_size(void)
     +  if (streq(name, "")
     +   || streq(name, ".")
     +   || streq(name, "..")
    -+   || strpbrk(name, ",:")
    ++   || strpbrk(name, ",: ")
     +   || strprefix(name, "-")
     +   || strchriscntrl(name)
     +   || strisdigit(name))
```
</details>

<details>
<summary>v4</summary>

-  Add `/` to the ban.  [@Zugschlus ]

```
$ git range-diff gh/streq gh/reallybadnames reallybadnames 
1:  5369182a ! 1:  810bc45c lib/chkname.c, src/: Strictly disallow really bad names
    @@ lib/chkname.c: login_name_max_size(void)
     +  if (streq(name, "")
     +   || streq(name, ".")
     +   || streq(name, "..")
    -+   || strpbrk(name, ",: ")
    ++   || strpbrk(name, ",: /")
     +   || strprefix(name, "-")
     +   || strchriscntrl(name)
     +   || strisdigit(name))
```
</details>
<details>
<summary>v4b</summary>

-  Rebase

```
$ git range-diff alx/master..gh/reallybadnames master..reallybadnames 
1:  4aee5e06 = 1:  95b045d3 lib/chkname.c: is_valid_name(): Use streq() instead of its pattern
2:  dda02b8b = 2:  d2f54847 src/useradd.c: create_home(): Use !streq() instead of its pattern
3:  810bc45c ! 3:  5ddbdca8 lib/chkname.c, src/: Strictly disallow really bad names
    @@ lib/chkname.c
     +#include "string/strcmp/strprefix.h"
      
      
    - int allow_bad_names = false;
    + #ifndef  LOGIN_NAME_MAX
     @@ lib/chkname.c: login_name_max_size(void)
      static bool
      is_valid_name(const char *name)
```

Whoops, it seems this was supposed to be based after the streq branch.
</details>

<details>
<summary>v4c</summary>

-  Rebase

```
$ git range-diff alx/master..gh/reallybadnames master..reallybadnames 
1:  95b045d3 = 1:  8aae1eed lib/chkname.c: is_valid_name(): Use streq() instead of its pattern
2:  d2f54847 = 2:  ddc631e5 src/useradd.c: create_home(): Use !streq() instead of its pattern
3:  5ddbdca8 = 3:  8be46b32 lib/chkname.c, src/: Strictly disallow really bad names
```
</details>

<details>
<summary>v4d</summary>

-  Rebase

```
$ git range-diff master..gh/reallybadnames shadow/master..reallybadnames 
1:  8aae1eed = 1:  f7c83692 lib/chkname.c: is_valid_name(): Use streq() instead of its pattern
2:  ddc631e5 = 2:  d1d2263b src/useradd.c: create_home(): Use !streq() instead of its pattern
3:  8be46b32 ! 3:  0716561b lib/chkname.c, src/: Strictly disallow really bad names
    @@ src/newusers.c: static int add_user (const char *name, uid_t uid, gid_t gid)
                                Prog, name);
     
      ## src/pwck.c ##
    -@@ src/pwck.c: static void check_pw_file (int *errors, bool *changed)
    +@@ src/pwck.c: static void check_pw_file (bool *errors, bool *changed)
                 */
      
                if (!is_valid_user_name(pwd->pw_name)) {
```
</details>

<details>
<summary>v5</summary>

-  Also disallow `"`.  This is so that we don't need to call audit_value_needs_encoding(3) and audit_encode_value(3).

```
$ git range-diff master gh/reallybadnames reallybadnames 
1:  f7c83692 = 1:  f7c83692 lib/chkname.c: is_valid_name(): Use streq() instead of its pattern
2:  d1d2263b = 2:  d1d2263b src/useradd.c: create_home(): Use !streq() instead of its pattern
3:  0716561b ! 3:  74b54226 lib/chkname.c, src/: Strictly disallow really bad names
    @@ lib/chkname.c: login_name_max_size(void)
     +  if (streq(name, "")
     +   || streq(name, ".")
     +   || streq(name, "..")
    -+   || strpbrk(name, ",: /")
    ++   || strpbrk(name, ",: /\"")
     +   || strprefix(name, "-")
     +   || strchriscntrl(name)
     +   || strisdigit(name))
```
</details>

<details>
<summary>v6</summary>

-  Disallow character `@`, and disallow a few case-insensitive names: `none`, `all`, and `except`.  [@stoeckmann ]

```
$ git range-diff alx/master gh/reallybadnames reallybadnames 
1:  f7c83692 = 1:  f7c83692 lib/chkname.c: is_valid_name(): Use streq() instead of its pattern
2:  d1d2263b = 2:  d1d2263b src/useradd.c: create_home(): Use !streq() instead of its pattern
-:  -------- > 3:  f4b64e1e lib/string/strcmp/: strcaseeq(): Add function
3:  74b54226 ! 4:  831b11b1 lib/chkname.c, src/: Strictly disallow really bad names
    @@ lib/chkname.c
     +#include "string/ctype/strchrisascii/strchriscntrl.h"
     +#include "string/ctype/strisascii/strisdigit.h"
      #include "string/strcmp/streq.h"
    ++#include "string/strcmp/strcaseeq.h"
     +#include "string/strcmp/strprefix.h"
      
      
    @@ lib/chkname.c: login_name_max_size(void)
     +  if (streq(name, "")
     +   || streq(name, ".")
     +   || streq(name, "..")
    -+   || strpbrk(name, ",: /\"")
    ++   || strcaseeq(name, "none")
    ++   || strcaseeq(name, "all")
    ++   || strcaseeq(name, "except")
     +   || strprefix(name, "-")
    ++   || strpbrk(name, ",: /@\"")
     +   || strchriscntrl(name)
     +   || strisdigit(name))
     +  {
```
</details>

<details>
<summary>v7</summary>

-  Reorder characters by ASCII code.
-  Add `#` to the ban.  [@stoeckmann ]

```
$ git range-diff alx/master gh/reallybadnames reallybadnames 
1:  f7c83692 = 1:  f7c83692 lib/chkname.c: is_valid_name(): Use streq() instead of its pattern
2:  d1d2263b = 2:  d1d2263b src/useradd.c: create_home(): Use !streq() instead of its pattern
3:  f4b64e1e = 3:  f4b64e1e lib/string/strcmp/: strcaseeq(): Add function
4:  831b11b1 ! 4:  2e6ba45e lib/chkname.c, src/: Strictly disallow really bad names
    @@ lib/chkname.c: login_name_max_size(void)
     +   || strcaseeq(name, "all")
     +   || strcaseeq(name, "except")
     +   || strprefix(name, "-")
    -+   || strpbrk(name, ",: /@\"")
    ++   || strpbrk(name, " \"#,/:@")
     +   || strchriscntrl(name)
     +   || strisdigit(name))
     +  {
```
</details>

<details>
<summary>v8</summary>

-  Add to the ban: `|`, `&`, `;`, `+`, `*`, `!`

```
$ git range-diff alx/master gh/reallybadnames reallybadnames 
1:  f7c83692 = 1:  f7c83692 lib/chkname.c: is_valid_name(): Use streq() instead of its pattern
2:  d1d2263b = 2:  d1d2263b src/useradd.c: create_home(): Use !streq() instead of its pattern
3:  f4b64e1e = 3:  f4b64e1e lib/string/strcmp/: strcaseeq(): Add function
4:  2e6ba45e ! 4:  a1159f6b lib/chkname.c, src/: Strictly disallow really bad names
    @@ lib/chkname.c: login_name_max_size(void)
     +   || strcaseeq(name, "all")
     +   || strcaseeq(name, "except")
     +   || strprefix(name, "-")
    -+   || strpbrk(name, " \"#,/:@")
    ++   || strpbrk(name, " !\"#&*+,/:;@|")
     +   || strchriscntrl(name)
     +   || strisdigit(name))
     +  {
```
</details>

<details>
<summary>v8b</summary>

-  Rebase

```
$ git range-diff master..gh/reallybadnames shadow/master..reallybadnames 
1:  f7c83692 < -:  -------- lib/chkname.c: is_valid_name(): Use streq() instead of its pattern
2:  d1d2263b < -:  -------- src/useradd.c: create_home(): Use !streq() instead of its pattern
3:  f4b64e1e = 1:  4eb2c509 lib/string/strcmp/: strcaseeq(): Add function
4:  a1159f6b = 2:  4be5a599 lib/chkname.c, src/: Strictly disallow really bad names
```
</details>

<details>
<summary>v9</summary>

-  Rebase.  `strcaseeq()` is already available in `master`.

```
$ git range-diff master..gh/reallybadnames shadow/master..reallybadnames 
1:  4eb2c509 < -:  -------- lib/string/strcmp/: strcaseeq(): Add function
2:  4be5a599 = 1:  a1c47e47 lib/chkname.c, src/: Strictly disallow really bad names
```
</details>

<details>
<summary>v9b</summary>

-  Rebase

```
$ git range-diff master..gh/reallybadnames shadow/master..reallybadnames 
1:  a1c47e47 = 1:  50087342 lib/chkname.c, src/: Strictly disallow really bad names
```
</details>

<details>
<summary>v10</summary>

-  Rebase.  strisdigit() is now available.

```
$ git range-diff master..gh/reallybadnames shadow/master..reallybadnames 
1:  50087342 ! 1:  4ececc33 lib/chkname.c, src/: Strictly disallow really bad names
    @@ lib/chkname.c
      #include "defines.h"
      #include "chkname.h"
     +#include "string/ctype/strchrisascii/strchriscntrl.h"
    -+#include "string/ctype/strisascii/strisdigit.h"
    + #include "string/ctype/strisascii/strisdigit.h"
      #include "string/strcmp/streq.h"
     +#include "string/strcmp/strcaseeq.h"
     +#include "string/strcmp/strprefix.h"
    @@ lib/chkname.c: is_valid_name(const char *name)
     -         *
     -         * Also do not allow fully numeric names or just "." or "..".
               */
    --  int numeric;
      
    +-  if (strisdigit(name)) {
    +-          errno = EINVAL;
    +-          return false;
    +-  }
    +-
     -  if (streq(name, "") ||
     -      streq(name, ".") ||
     -      streq(name, "..") ||
    @@ lib/chkname.c: is_valid_name(const char *name)
                return false;
        }
      
    --  numeric = isdigit(*name);
    --
    -   while (!streq(++name, "")) {
    -           if (!((*name >= 'a' && *name <= 'z') ||
    -                 (*name >= 'A' && *name <= 'Z') ||
     @@ lib/chkname.c: is_valid_name(const char *name)
                      streq(name, "$")
                     ))
    @@ lib/chkname.c: is_valid_name(const char *name)
     +                  errno = EILSEQ;
                        return false;
                }
    --          numeric &= isdigit(*name);
    --  }
    --
    --  if (numeric) {
    --          errno = EINVAL;
    --          return false;
        }
    - 
    -   return true;
     
      ## src/newusers.c ##
     @@ src/newusers.c: static int add_user (const char *name, uid_t uid, gid_t gid)
```
</details>

<details>
<summary>v11</summary>

-  Add `~` to the ban list.  (Debian forbid that character for a long time.)

```
$ git range-diff master gh/reallybadnames reallybadnames 
1:  4ececc33 ! 1:  02a2bb2b lib/chkname.c, src/: Strictly disallow really bad names
    @@ lib/chkname.c: login_name_max_size(void)
     +   || strcaseeq(name, "all")
     +   || strcaseeq(name, "except")
     +   || strprefix(name, "-")
    -+   || strpbrk(name, " !\"#&*+,/:;@|")
    ++   || strpbrk(name, " !\"#&*+,/:;@|~")
     +   || strchriscntrl(name)
     +   || strisdigit(name))
     +  {
```
</details>

<details>
<summary>v11b</summary>

-  Rebase

```
$ git range-diff master..gh/reallybadnames shadow/master..reallybadnames 
1:  02a2bb2b = 1:  50485f7b lib/chkname.c, src/: Strictly disallow really bad names
```
</details>

<details>
<summary>v11c</summary>

-  Rebase

```
$ git rd
1:  50485f7b = 1:  5c3f1784 lib/chkname.c, src/: Strictly disallow really bad names
```
</details>

<details>
<summary>v11d</summary>

-  Rebase

```
$ git rd 
1:  5c3f1784 = 1:  db8d0a1b lib/chkname.c, src/: Strictly disallow really bad names
```
</details>

<details>
<summary>v11e</summary>

-  Rebase

```
$ git rd
1:  db8d0a1b = 1:  d19eba6d lib/chkname.c, src/: Strictly disallow really bad names
```
</details>

<details>
<summary>v11f</summary>

-  Rebase

```
$ git rd 
1:  d19eba6d = 1:  a5886986 lib/chkname.c, src/: Strictly disallow really bad names
```
</details>

<details>
<summary>v11g</summary>

-  Rebase

```
$ git rd
1:  a5886986 = 1:  5f9b7879 lib/chkname.c, src/: Strictly disallow really bad names
```
</details>

<details>
<summary>v11h</summary>

-  Rebase

```
$ git rd 
1:  5f9b7879 = 1:  06985d54 lib/chkname.c, src/: Strictly disallow really bad names
```
</details>

<details>
<summary>v11i</summary>

-  Rebase

```
$ git rd 
1:  06985d54 = 1:  566cea5c lib/chkname.c, src/: Strictly disallow really bad names
```
</details>

<details>
<summary>v11j</summary>

-  Rebase

```
$ git rd 
1:  566cea5c = 1:  ca200b77 lib/chkname.c, src/: Strictly disallow really bad names
```
</details>

<details>
<summary>v11k</summary>

-  Rebase

```
$ git rd 
1:  ca200b77 = 1:  538ddfbf lib/chkname.c, src/: Strictly disallow really bad names
```
</details>

<details>
<summary>v11l</summary>

-  Rebase

```
$ git rd 
1:  538ddfbf = 1:  2e1a85e3 lib/chkname.c, src/: Strictly disallow really bad names
```
</details>

<details>
<summary>v11m</summary>

-  Rebase

```
$ git rd 
1:  2e1a85e3 = 1:  a77c6672 lib/chkname.c, src/: Strictly disallow really bad names
```
</details>

<details>
<summary>v11n</summary>

-  Rebase

```
$ git rd 
1:  a77c6672 = 1:  4c606cdd lib/chkname.c, src/: Strictly disallow really bad names
```
</details>

<details>
<summary>v11o</summary>

-  Rebase

```
$ git rd 
1:  4c606cdd = 1:  3881973b lib/chkname.c, src/: Strictly disallow really bad names
```
</details>

<details>
<summary>v11p</summary>

-  Rebase

```
$ git rd 
1:  3881973b = 1:  b6fe5b47 lib/chkname.c, src/: Strictly disallow really bad names
```
</details>

<details>
<summary>v11q</summary>

-  Rebase

```
$ git rd 
1:  b6fe5b47 = 1:  cc7e081f lib/chkname.c, src/: Strictly disallow really bad names
```
</details>

<details>
<summary>v11r</summary>

-  Rebase

```
$ git rd 
1:  cc7e081f ! 1:  f34485e7 lib/chkname.c, src/: Strictly disallow really bad names
    @@ src/newusers.c: static int add_user (const char *name, uid_t uid, gid_t gid)
                                Prog, name);
     
      ## src/pwck.c ##
    -@@ src/pwck.c: static void check_pw_file (bool *errors, bool *changed)
    +@@ src/pwck.c: static void check_pw_file (bool *errors, bool *changed, struct option_flags *fla
                 */
      
                if (!is_valid_user_name(pwd->pw_name)) {
    @@ src/pwck.c: static void check_pw_file (bool *errors, bool *changed)
                        } else {
     
      ## src/useradd.c ##
    -@@ src/useradd.c: static void process_flags (int argc, char **argv)
    +@@ src/useradd.c: static void process_flags (int argc, char **argv, struct option_flags *flags)
      
                user_name = argv[optind];
                if (!is_valid_user_name(user_name)) {
    @@ src/useradd.c: static void process_flags (int argc, char **argv)
                                        Prog, user_name);
     
      ## src/usermod.c ##
    -@@ src/usermod.c: process_flags(int argc, char **argv)
    +@@ src/usermod.c: process_flags(int argc, char **argv, struct option_flags *flags)
                                /*@notreached@*/break;
                        case 'l':
                                if (!is_valid_user_name(optarg)) {
```
</details>

<details>
<summary>v11s</summary>

-  Add comments.  [@zeha ]

```
$ git range-diff shadow/master gh/reallybadnames reallybadnames 
1:  f34485e7 ! 1:  7dae722c lib/chkname.c, src/: Strictly disallow really bad names
    @@ lib/chkname.c: login_name_max_size(void)
     +  if (streq(name, "")
     +   || streq(name, ".")
     +   || streq(name, "..")
    -+   || strcaseeq(name, "none")
    -+   || strcaseeq(name, "all")
    -+   || strcaseeq(name, "except")
    ++   || strcaseeq(name, "none")  // access.conf(5)
    ++   || strcaseeq(name, "all")  // access.conf(5)
    ++   || strcaseeq(name, "except")  // access.conf(5)
     +   || strprefix(name, "-")
     +   || strpbrk(name, " !\"#&*+,/:;@|~")
     +   || strchriscntrl(name)
```
</details>

<details>
<summary>v11t</summary>

-  Sort access.conf(5) stuff alphabetically.  [@stoeckmann ]
-  Acked-by: @stoeckmann 

```
$ git range-diff shadow/master gh/reallybadnames reallybadnames 
1:  7dae722c ! 1:  a1344ae8 lib/chkname.c, src/: Strictly disallow really bad names
    @@ Commit message
         unconditionally.
     
         Acked-by: Chris Hofstaedtler <zeha@debian.org>
    +    Acked-by: Tobias Stoeckmann <tobias@stoeckmann.org>
         Cc: Marc 'Zugschlus' Haber <mh+githubvisible@zugschlus.de>
         Cc: Iker Pedrosa <ipedrosa@redhat.com>
         Cc: Serge Hallyn <serge@hallyn.com>
    @@ lib/chkname.c: login_name_max_size(void)
     +  if (streq(name, "")
     +   || streq(name, ".")
     +   || streq(name, "..")
    -+   || strcaseeq(name, "none")  // access.conf(5)
    -+   || strcaseeq(name, "all")  // access.conf(5)
    ++   || strcaseeq(name, "all")     // access.conf(5)
     +   || strcaseeq(name, "except")  // access.conf(5)
    ++   || strcaseeq(name, "none")    // access.conf(5)
     +   || strprefix(name, "-")
     +   || strpbrk(name, " !\"#&*+,/:;@|~")
     +   || strchriscntrl(name)
```
</details>

<details>
<summary>v11u</summary>

-  Rebase

```
$ git rd
1:  a1344ae89 = 1:  5f87a82ab lib/chkname.c, src/: Strictly disallow really bad names
```
</details>

<details>
<summary>v12</summary>

-  Use strspn(3) instead of strprefix().  Both are fine, and strspn(3) is standard.  It's also more useful when more than one leading characters are of interest, which is quite common (see <https://github.com/shadow-maint/shadow/pull/1369>).

```
$ git rd 
1:  5f87a82ab ! 1:  1dea42b9e lib/chkname.c, src/: Strictly disallow really bad names
    @@ lib/chkname.c
       */
      
     @@
    + #include <limits.h>
    + #include <stdbool.h>
    + #include <stddef.h>
    ++#include <string.h>
    + #include <unistd.h>
      
      #include "defines.h"
      #include "chkname.h"
    @@ lib/chkname.c
      #include "string/ctype/strisascii/strisdigit.h"
      #include "string/strcmp/streq.h"
     +#include "string/strcmp/strcaseeq.h"
    -+#include "string/strcmp/strprefix.h"
      
      
      #ifndef  LOGIN_NAME_MAX
    @@ lib/chkname.c: login_name_max_size(void)
     +   || strcaseeq(name, "all")     // access.conf(5)
     +   || strcaseeq(name, "except")  // access.conf(5)
     +   || strcaseeq(name, "none")    // access.conf(5)
    -+   || strprefix(name, "-")
    ++   || strspn(name, "-")
     +   || strpbrk(name, " !\"#&*+,/:;@|~")
     +   || strchriscntrl(name)
     +   || strisdigit(name))
```
</details>

<details>
<summary>v12b</summary>

-  Rebase

```
$ git rd 
1:  1dea42b9e = 1:  429bdbed7 lib/chkname.c, src/: Strictly disallow really bad names
```
</details>

<details>
<summary>v12c</summary>

-  Rebase

```
$ git rd 
1:  429bdbed7 = 1:  39cc733c0 lib/chkname.c, src/: Strictly disallow really bad names
```
</details>

<details>
<summary>v13</summary>

-  Don't disallow all,except,none.  [@hallyn]

```
$ git rd 
1:  39cc733c0 ! 1:  d333a6fa5 lib/chkname.c, src/: Strictly disallow really bad names
    @@ lib/chkname.c: login_name_max_size(void)
     +  if (streq(name, "")
     +   || streq(name, ".")
     +   || streq(name, "..")
    -+   || strcaseeq(name, "all")     // access.conf(5)
    -+   || strcaseeq(name, "except")  // access.conf(5)
    -+   || strcaseeq(name, "none")    // access.conf(5)
     +   || strspn(name, "-")
     +   || strpbrk(name, " !\"#&*+,/:;@|~")
     +   || strchriscntrl(name)
```
</details>

<details>
<summary>v13b</summary>

-  Rebase

```
$ git rd 
1:  d333a6fa5 = 1:  235e72aed lib/chkname.c, src/: Strictly disallow really bad names
```
</details>

<details>
<summary>v13c</summary>

-  Rebase

```
$ git rd 
1:  235e72aed ! 1:  58f4dc970 lib/chkname.c, src/: Strictly disallow really bad names
    @@ src/newusers.c: static int add_user (const char *name, uid_t uid, gid_t gid)
                                Prog, name);
     
      ## src/pwck.c ##
    -@@ src/pwck.c: static void check_pw_file (bool *errors, bool *changed, struct option_flags *fla
    +@@ src/pwck.c: static void check_pw_file(bool *errors, bool *changed, const struct option_flags
                 */
      
                if (!is_valid_user_name(pwd->pw_name)) {
```
</details>

<details>
<summary>v14</summary>

-  Split into two commits.

```
alx@devuan:~/src/shadow/shadow/master$ git diff gh/reallybadnames 
alx@devuan:~/src/shadow/shadow/master$ git rd 
1:  58f4dc970 ! 1:  1d2c5ea5e lib/chkname.c, src/: Strictly disallow really bad names
    @@ Commit message
         bad, and it's not possible to deal with them.  Reject them
         unconditionally.
     
    +    -  A leading '-' is too dangerous.  It breaks things like execve(2), and
    +       almost every command.
    +
    +    -  Spaces are used for delimiting lists of users and groups.
    +
    +    -  '"' is special in many languages, including the shell.  Having it in
    +       user names would be unnecessarily dangerous.
    +
    +    -  '#' is used for delimiting comments in several of our config files.
    +       Having it in usernames could result in incorrect configuration files.
    +
    +    -  ',' is used for delimiting lists of users and groups.
    +
    +    -  '/' is used for delimiting files, and thus could result in incorrect
    +       handling of users and groups.
    +
    +    -  ':' is the main delimiter in /etc/shadow and /etc/passwd.
    +
    +    -  ';' is special in many languages, including the shell.  Having it in
    +       user names would be unnecessarily dangerous.
    +
    +    There are other characters that we should disallow, but they need more
    +    research to make sure we don't introduce regressions.  This set should
    +    be less problematic.
    +
         Acked-by: Chris Hofstaedtler <zeha@debian.org>
         Acked-by: Tobias Stoeckmann <tobias@stoeckmann.org>
         Cc: Marc 'Zugschlus' Haber <mh+githubvisible@zugschlus.de>
    @@ lib/chkname.c: login_name_max_size(void)
     +   || streq(name, ".")
     +   || streq(name, "..")
     +   || strspn(name, "-")
    -+   || strpbrk(name, " !\"#&*+,/:;@|~")
    ++   || strpbrk(name, " \"#,/:;")
     +   || strchriscntrl(name)
     +   || strisdigit(name))
     +  {
-:  --------- > 2:  3b4d01e48 lib/chkname.c, src/: Strictly disallow really bad names
```
</details>

<details>
<summary>v14b</summary>

-  Rebase

```
$ git rd 
1:  1d2c5ea5e ! 1:  41026bcca lib/chkname.c, src/: Strictly disallow really bad names
    @@ lib/chkname.c: login_name_max_size(void)
                return true;
        }
     @@ lib/chkname.c: is_valid_name(const char *name)
    -          *
    -          * as a non-POSIX, extension, allow "$" as the last char for
    -          * sake of Samba 3.x "add machine script"
    --         *
    --         * Also do not allow fully numeric names or just "." or "..".
    -          */
    +    *
    +    * as a non-POSIX, extension, allow "$" as the last char for
    +    * sake of Samba 3.x "add machine script"
    +-   *
    +-   * Also do not allow fully numeric names or just "." or "..".
    +    */
      
     -  if (strisdigit(name)) {
     -          errno = EINVAL;
2:  3b4d01e48 = 2:  a93bdde27 lib/chkname.c, src/: Strictly disallow really bad names
```
</details>

<details>
<summary>v15</summary>

-  Rebase

```
$ git rd 
1:  41026bcca < -:  --------- lib/chkname.c, src/: Strictly disallow really bad names
2:  a93bdde27 ! 1:  a9ab6921f lib/chkname.c, src/: Strictly disallow really bad names
    @@ lib/chkname.c: is_valid_name(const char *name)
         || streq(name, ".")
         || streq(name, "..")
         || strspn(name, "-")
    --   || strpbrk(name, " \"#,/:;")
    -+   || strpbrk(name, " !\"#&*+,/:;@|~")
    +-   || strpbrk(name, " \"#',/:;")
    ++   || strpbrk(name, " !\"#'&*+,/:;@|~")
         || strchriscntrl(name)
         || strisdigit(name))
        {
```
</details>

<details>
<summary>v15b</summary>

-  Rebase

```
$ git rd 
1:  a9ab6921f = 1:  d6f767229 lib/chkname.c, src/: Strictly disallow really bad names
```
</details>

<details>
<summary>v15c</summary>

-  Rebase

```
$ git rd 
1:  d6f7672291cb = 1:  a753c444a08e lib/chkname.c, src/: Strictly disallow really bad names
```
</details>

<details>
<summary>v15d</summary>

-  Rebase

```
$ git rd 
1:  a753c444 = 1:  2c147bd0 lib/chkname.c, src/: Strictly disallow really bad names
```
</details>

<details>
<summary>v15e</summary>

-  Rebase

```
$ git rd 
1:  2c147bd0a8da ! 1:  770a08bc117c lib/chkname.c, src/: Strictly disallow really bad names
    @@ lib/chkname.c: is_valid_name(const char *name)
         || strspn(name, "-")
     -   || strpbrk(name, " \"#',/:;")
     +   || strpbrk(name, " !\"#'&*+,/:;@|~")
    -    || strchriscntrl(name)
    -    || strisdigit(name))
    +    || strchriscntrl_c(name)
    +    || strisdigit_c(name))
        {
```
</details>