### PR TITLE
su: Fix su - regression

### DIFF
--- a/src/su.c
+++ b/src/su.c
@@ -1212,6 +1212,7 @@ int main (int argc, char **argv)
 		}
 
 		xasprintf(&arg0, "-%s", cp);
+		cp = arg0;
 	} else {
 		cp = Basename (shellstr);
 	}


### PR DESCRIPTION
Launch a login shell again if requested through "su -" or "su -l".

Fixes: d9923431eb38 ("src/: Use xasprintf() instead of its pattern")
Closes: <https://github.com/shadow-maint/shadow/issues/1160>