### PR TITLE
Use HTTPS in link to Wikipedia article on password strength

### DIFF
--- a/man/passwd.1.xml
+++ b/man/passwd.1.xml
@@ -137,7 +137,7 @@
 
       <para>
 	You can find advice on how to choose a strong password on
-	http://en.wikipedia.org/wiki/Password_strength
+	https://en.wikipedia.org/wiki/Password_strength
       </para>
     </refsect2>
   </refsect1>


### PR DESCRIPTION
The link to the Wikipedia article was added here in 2008, and Wikipedia went HTTPS-only in 2015. (https://diff.wikimedia.org/2015/06/12/securing-wikimedia-sites-with-https/)