### PR TITLE
src/: Simplify, using strpbrk(3)

### DIFF
--- a/lib/fields.c
+++ b/lib/fields.c
@@ -43,7 +43,7 @@ int valid_field (const char *field, const char *illegal)
 
 	/* For each character of field, search if it appears in the list
 	 * of illegal characters. */
-	if (illegal && NULL != strpbrk (field, illegal)) {
+	if (illegal && strpbrk(field, illegal)) {
 		return -1;
 	}
 

--- a/lib/setupenv.c
+++ b/lib/setupenv.c
@@ -73,7 +73,7 @@ static void read_env_file (const char *filename)
 		val = stpsep(cp, "=");
 		if (val == NULL)
 			continue;
-		if (strpbrk(name, " \t") != NULL)
+		if (strpbrk(name, " \t"))
 			continue;
 #if 0				/* XXX untested, and needs rewrite with fewer goto's :-) */
 /*

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -111,7 +111,7 @@ static const char *def_log_init = "yes";
 static long def_inactive = -1;
 static const char *def_expire = "";
 
-#define	VALID(s)	(strcspn (s, ":\n") == strlen (s))
+#define VALID(s)  (!strpbrk(s, ":\n"))
 
 static const char *user_name = "";
 static const char *user_pass = "!";

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -94,7 +94,7 @@
 #define E_SUB_GID_UPDATE 18	/* can't update the subordinate gid file */
 #endif				/* ENABLE_SUBIDS */
 
-#define	VALID(s)	(strcspn (s, ":\n") == strlen (s))
+#define VALID(s)  (!strpbrk(s, ":\n"))
 
 /*
  * Global variables


### PR DESCRIPTION
    Checking a boolean (actually, a boolean-like pointer) is more readable
    than comparing against a length.
    
    This removes the only uses of strcspn(3) in this project.
    
    strpbrk(3) is a simpler call, even though it has a weird name.  It's
    just like strchr(3) but searches for several characters.  I'd have named
    it strchrs().


---

@hallyn   Oh well, this is your fault for mentioning that.  :D

---

Revisions:

<details>
<summary>v2</summary>

-  Since strpbrk(3) is like strchr(3), use it similarly.  That is, treat it as a boolean, with the meaning "the characters were found".  Act as if it was called strchrs().

-  Use spaces instead of tabs.

```
$ git range-diff shadow/master gh/strpbrk strpbrk 
1:  878792c7 ! 1:  72823449 src/: Simplify, using strpbrk(3)
    @@ Metadata
      ## Commit message ##
         src/: Simplify, using strpbrk(3)
     
    -    Comparing against NULL is more readable than comparing against a length.
    +    Checking a boolean (actually, a boolean-like pointer) is more readable
    +    than comparing against a length.
     
    -    This removes the only uses of strcspn(3) in this project.  strpbrk(3) is
    -    a simpler call, even though it has a weird name.  It's just like
    -    strchr(3) but searches for several characters.  I'd have named it
    -    strchrs().
    +    This removes the only uses of strcspn(3) in this project.
    +
    +    strpbrk(3) is a simpler call, even though it has a weird name.  It's
    +    just like strchr(3) but searches for several characters.  I'd have named
    +    it strchrs().
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    @@ src/useradd.c: static const char *def_log_init = "yes";
      static const char *def_expire = "";
      
     -#define   VALID(s)        (strcspn (s, ":\n") == strlen (s))
    -+#define   VALID(s)        (strpbrk(s, ":\n") == NULL)
    ++#define VALID(s)  (!strpbrk(s, ":\n"))
      
      static const char *user_name = "";
      static const char *user_pass = "!";
    @@ src/usermod.c
      #endif                            /* ENABLE_SUBIDS */
      
     -#define   VALID(s)        (strcspn (s, ":\n") == strlen (s))
    -+#define   VALID(s)        (strpbrk(s, ":\n") == NULL)
    ++#define VALID(s)  (!strpbrk(s, ":\n"))
      
      /*
       * Global variables
```
</details>

<details>
<summary>v3</summary>

-  Treat strpbrk(3) as a boolean everywhere.

```
$ git range-diff shadow/master gh/strpbrk strpbrk 
1:  72823449 = 1:  72823449 src/: Simplify, using strpbrk(3)
-:  -------- > 2:  258e9e29 lib/: Treat strpbrk(3)'s return value as a boolean
```
</details>

<details>
<summary>v3b</summary>

-  Rebase

```
$ git range-diff 4.17.1..gh/strpbrk master..strpbrk 
1:  72823449 = 1:  44e9c6ac src/: Simplify, using strpbrk(3)
2:  258e9e29 = 2:  c534aa67 lib/: Treat strpbrk(3)'s return value as a boolean
```
</details>

<details>
<summary>v3c</summary>

-  Rebase

```
$ git range-diff master..gh/strpbrk shadow/master..strpbrk 
1:  f6b53605 = 1:  8a3145a2 src/: Simplify, using strpbrk(3)
2:  e7a56050 = 2:  412d4daf lib/: Treat strpbrk(3)'s return value as a boolean
```
</details>

<details>
<summary>v3d</summary>

-  Rebase

```
$ git range-diff master..gh/strpbrk shadow/master..strpbrk 
1:  8a3145a2 = 1:  e7591047 src/: Simplify, using strpbrk(3)
2:  412d4daf = 2:  77bc9e92 lib/: Treat strpbrk(3)'s return value as a boolean
```
</details>

<details>
<summary>v3e</summary>

-  Rebase

```
$ git range-diff master..gh/strpbrk shadow/master..strpbrk 
1:  e7591047 = 1:  7ee7ee10 src/: Simplify, using strpbrk(3)
2:  77bc9e92 = 2:  6d49f866 lib/: Treat strpbrk(3)'s return value as a boolean
```
</details>

<details>
<summary>v3f</summary>

-  Rebase

```
$ git range-diff master..gh/strpbrk shadow/master..strpbrk 
1:  7ee7ee10 = 1:  dba6cd9c src/: Simplify, using strpbrk(3)
2:  6d49f866 = 2:  97e9e54f lib/: Treat strpbrk(3)'s return value as a boolean
```
</details>

<details>
<summary>v3g</summary>

-  Rebase

```
$ git range-diff master..gh/strpbrk shadow/master..strpbrk 
1:  dba6cd9c = 1:  915f7fc0 src/: Simplify, using strpbrk(3)
2:  97e9e54f = 2:  37771da3 lib/: Treat strpbrk(3)'s return value as a boolean
```
</details>

<details>
<summary>v3h</summary>

-  Rebase

```
$ git range-diff master..gh/strpbrk shadow/master..strpbrk 
1:  915f7fc0 = 1:  514789e0 src/: Simplify, using strpbrk(3)
2:  37771da3 = 2:  23bd7cf0 lib/: Treat strpbrk(3)'s return value as a boolean
```
</details>

<details>
<summary>v3i</summary>

-  Rebase

```
$ git rd
1:  514789e0 = 1:  d38a7d78 src/: Simplify, using strpbrk(3)
2:  23bd7cf0 = 2:  5d1ed05f lib/: Treat strpbrk(3)'s return value as a boolean
```
</details>

<details>
<summary>v3j</summary>

-  Rebase

```
$ git rd 
1:  d38a7d78 = 1:  d03c69a6 src/: Simplify, using strpbrk(3)
2:  5d1ed05f = 2:  10051c02 lib/: Treat strpbrk(3)'s return value as a boolean
```
</details>

<details>
<summary>v3k</summary>

-  Rebase

```
$ git rd
1:  d03c69a6 = 1:  47d740d4 src/: Simplify, using strpbrk(3)
2:  10051c02 = 2:  5a7cfa9f lib/: Treat strpbrk(3)'s return value as a boolean
```
</details>