### PR TITLE
lib/chkname.c: Put limits for LOGIN_NAME_MAX and sysconf(_SC_LOGIN_NAME_MAX)

### DIFF
--- a/lib/chkname.c
+++ b/lib/chkname.c
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 1996-2000, Marek Michałkiewicz
 // SPDX-FileCopyrightText: 2001-2005, Tomasz Kłoczko
 // SPDX-FileCopyrightText: 2005-2008, Nicolas François
-// SPDX-FileCopyrightText: 2023-2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-FileCopyrightText: 2023-2025, Alejandro Colomar <alx@kernel.org>
 // SPDX-License-Identifier: BSD-3-Clause
 
 
@@ -27,13 +27,16 @@
 #include <limits.h>
 #include <stdbool.h>
 #include <stddef.h>
-#include <stdint.h>
-#include <sys/param.h>
 #include <unistd.h>
 
 #include "defines.h"
 #include "chkname.h"
 #include "string/strcmp/streq.h"
+
+
+#ifndef  LOGIN_NAME_MAX
+# define LOGIN_NAME_MAX  256
+#endif
 
 
 int allow_bad_names = false;
@@ -44,12 +47,11 @@ login_name_max_size(void)
 {
 	long  conf;
 
-	errno = 0;
 	conf = sysconf(_SC_LOGIN_NAME_MAX);
-	if (conf == -1 && errno != 0)
+	if (conf == -1)
 		return LOGIN_NAME_MAX;
 
-	return MIN(conf, PTRDIFF_MAX);
+	return conf;
 }
 
 


### PR DESCRIPTION
```
GNU Hurd recommends having no system limits.  When a program needs a
limit, because it needs to validate user input, it is recommended that
each program defines its own limit macros.  The rationale is that this
avoids hard-coded limits in ABIs, which cannot be modified ever.

However, that doesn't mean that programs should have no limits at all.
We use this limit for validating user input, and so we shouldn't allow
anything just because the system doesn't want to set a limit.

So, when sysconf(2) returns -1, either due to an error or due to a claim
for no limits, we must fall back to the LOGIN_NAME_MAX value.  And if
the system doesn't define that value, we must define it ourselves (we're
more or less free to choose any value, so let's pick the one that glibc
provides nowadays).
```

Fixes: 6a1f45d932c8 (2024-02-04: "lib/chkname.c: Support unlimited user name lengths")
Closes: <https://github.com/shadow-maint/shadow/issues/1166>
Cc: @zeha
Cc: @stoeckmann
Cc: @sthibaul


---

Revisions:

<details>
<summary>v1b</summary>

-  Remove credits to @zeha 
-  Update copyright.
-  Mention in commit message explicitly that GNU Hurd doesn't define LOGIN_NAME_MAX.  [@zeha]

```
$ git range-diff shadow/master gh/hurd hurd 
1:  1d87e944 ! 1:  f2698953 lib/chkname.c: login_name_max_size(): Put limits for LOGIN_NAME_MAX and sysconf(_SC_LOGIN_NAME_MAX)
    @@ Metadata
      ## Commit message ##
         lib/chkname.c: login_name_max_size(): Put limits for LOGIN_NAME_MAX and sysconf(_SC_LOGIN_NAME_MAX)
     
    -    GNU Hurd recommends having no system limits.  When a program needs a
    -    limit, because it needs to validate user input, it is recommended that
    -    each program defines its own limit macros.  The rationale is that this
    -    avoids hard-coded limits in ABIs, which cannot be modified ever.
    +    GNU Hurd doesn't define LOGIN_NAME_MAX.  GNU Hurd recommends having no
    +    system limits.  When a program needs a limit, because it needs to
    +    validate user input, it is recommended that each program defines its own
    +    limit macros.  The rationale is that this avoids hard-coded limits in
    +    ABIs, which cannot be modified ever.
     
         However, that doesn't mean that programs should have no limits at all.
         We use this limit for validating user input, and so we shouldn't allow
    @@ Commit message
     
         Fixes: 6a1f45d932c8 (2024-02-04; "lib/chkname.c: Support unlimited user name lengths")
         Closes: <https://github.com/shadow-maint/shadow/issues/1166>
    -    Co-developed-by: Chris Hofstaedtler <zeha@debian.org>
    +    Cc: Chris Hofstaedtler <zeha@debian.org>
         Cc: Tobias Stoeckmann <tobias@stoeckmann.org>
         Cc: Samuel Thibault <samuel.thibault@ens-lyon.org>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/chkname.c ##
    +@@
    + // SPDX-FileCopyrightText: 1996-2000, Marek Michałkiewicz
    + // SPDX-FileCopyrightText: 2001-2005, Tomasz Kłoczko
    + // SPDX-FileCopyrightText: 2005-2008, Nicolas François
    +-// SPDX-FileCopyrightText: 2023-2024, Alejandro Colomar <alx@kernel.org>
    ++// SPDX-FileCopyrightText: 2023-2025, Alejandro Colomar <alx@kernel.org>
    + // SPDX-License-Identifier: BSD-3-Clause
    + 
    + 
     @@
      #include <limits.h>
      #include <stdbool.h>
```
</details>

<details>
<summary>v1c</summary>

-  Reviewed-by: @sthibaul , @stoeckmann , @ikerexxe 

```
$ git range-diff shadow/master gh/hurd hurd 
1:  f2698953 ! 1:  87b8f5a3 lib/chkname.c: login_name_max_size(): Put limits for LOGIN_NAME_MAX and sysconf(_SC_LOGIN_NAME_MAX)
    @@ Commit message
         Fixes: 6a1f45d932c8 (2024-02-04; "lib/chkname.c: Support unlimited user name lengths")
         Closes: <https://github.com/shadow-maint/shadow/issues/1166>
         Cc: Chris Hofstaedtler <zeha@debian.org>
    -    Cc: Tobias Stoeckmann <tobias@stoeckmann.org>
    -    Cc: Samuel Thibault <samuel.thibault@ens-lyon.org>
    +    Reviewed-by: Samuel Thibault <samuel.thibault@ens-lyon.org>
    +    Reviewed-by: Tobias Stoeckmann <tobias@stoeckmann.org>
    +    Reviewed-by: Iker Pedrosa <ipedrosa@redhat.com>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/chkname.c ##
```
</details>