### PR TITLE
Add cheap defense mechanisms

### DIFF
--- a/lib/gshadow.c
+++ b/lib/gshadow.c
@@ -55,7 +55,7 @@ void setsgent (void)
 	if (NULL != shadow) {
 		rewind (shadow);
 	} else {
-		shadow = fopen (SGROUP_FILE, "r");
+		shadow = fopen (SGROUP_FILE, "re");
 	}
 }
 

--- a/lib/run_part.c
+++ b/lib/run_part.c
@@ -32,7 +32,7 @@ static int run_part(char *script_path, const char *name, const char *action)
 		setenv("SUBJECT",name,1);
 		execv(script_path,args);
 		fprintf(shadow_logfd, "execv: %s\n", strerror(errno));
-		exit(1);
+		_exit(1);
 	}
 
 	pid_status = wait(&wait_status);

--- a/lib/shadow.c
+++ b/lib/shadow.c
@@ -41,7 +41,7 @@ void setspent (void)
 	if (NULL != shadow) {
 		rewind (shadow);
 	}else {
-		shadow = fopen (SHADOW_FILE, "r");
+		shadow = fopen (SHADOW_FILE, "re");
 	}
 }
 

--- a/lib/spawn.c
+++ b/lib/spawn.c
@@ -35,11 +35,11 @@ run_command(const char *cmd, const char *argv[],
 		(void) execve (cmd, (char * const *) argv,
 		               (char * const *) envp);
 		if (ENOENT == errno) {
-			exit (E_CMD_NOTFOUND);
+			_exit (E_CMD_NOTFOUND);
 		}
 		fprintf (shadow_logfd, "%s: cannot execute %s: %s\n",
 		         shadow_progname, cmd, strerror (errno));
-		exit (E_CMD_NOEXEC);
+		_exit (E_CMD_NOEXEC);
 	} else if ((pid_t)-1 == pid) {
 		fprintf (shadow_logfd, "%s: cannot execute %s: %s\n",
 		         shadow_progname, cmd, strerror (errno));


### PR DESCRIPTION
Before you read any further: No reachable issues exist in current code base (as far as I can tell)

But these defense mechanisms would have made reviewing easier because I could have skipped a few searches:

1. Use `_exit` instead of `exit` after execution errors

After a fork and a failing exec, calling `exit` is not the best choice. Use `_exit` instead because tools like `groupmod` etc. use `add_cleanup` to clean up when `exit` is called. If the child, which inherits these instructions, calls `exit` by itself, these cleanup routines could release passwd/group locks too early. Again: Does not happen, because the code launches sub processes only after these cleanup routines have been already released again. Yet, better be safe than sorry.

2. Set close on exec on critical file descriptors

Even though `fopen` is used in lib/gshadow.c and lib/shadow.c, we can add the "e" mode to trigger O_CLOEXEC for systems which support this glibc extension. The file descriptor which keeps /etc/gshadow or /etc/shadow open is then guaranteed to not be passed down to a sub process. Again: Does not happen. The code carefully closes these file descriptors through dedicated function calls before sub processes are launched. Yet, better be safe than sorry again.