### PR TITLE
lib/attr.h: use C23 attributes only with gcc >= 10

### DIFF
--- a/lib/attr.h
+++ b/lib/attr.h
@@ -5,7 +5,7 @@
 #include "config.h"
 
 
-#if defined(__GNUC__)
+#if (__GNUC__ >= 10)
 # define MAYBE_UNUSED                [[gnu::unused]]
 # define NORETURN                    [[gnu::__noreturn__]]
 # define format_attr(type, fmt, va)  [[gnu::format(type, fmt, va)]]


### PR DESCRIPTION
These are not available on earlier versions and builds break there.