### PR TITLE
login: Fix no-pam authorization regression

### DIFF
--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -171,7 +171,7 @@ list_match(char *list, const char *item, bool (*match_fn)(char *, const char*))
 		while (   (NULL != (tok = strsep(&list, sep)))
 		       && (strcasecmp (tok, "EXCEPT") != 0))
 			/* VOID */ ;
-		if (tok == NULL || !list_match(NULL, item, match_fn)) {
+		if (tok == NULL || !list_match(list, item, match_fn)) {
 			return (match);
 		}
 	}


### PR DESCRIPTION
A regression in `/etc/login.access` parsing could allow or deny more users than configured. It affects shadow 4.17.x.

The regression takes place in `login` tool if compiled without PAM support. Basically all distributions ship either with PAM support or use util-linux login, so this affects rather few systems, let alone it requires the `EXCEPT` keyword in `/etc/login.access`. Affected right now:

- Linux From Scratch

And these distributions could be affected depending on compile configuration, but have older unaffected versions:

- Gentoo
- NixOS

The `list_match` function handles `EXCEPT` entries in `/etc/login.access` through recursive calls. It calls itself with `NULL`, which was then passed to `strtok` so parsing continued at current position.

Replacing `strtok` with `strsep`, this means that `EXCEPT` entries never match, because `strsep(NULL, ...)` always returns `NULL`, i.e. the code treats everything after `EXCEPT` as non-existing.

Fix this by passing current list pointer to recursive call.

Proof of Concept:

1. Compile shadow without PAM support, i.e. use `--without-libpam`, no need to install login into system
2. Create this `/etc/login.access` file (replace `myuser` with a user which is okay if access is denied):
```
# Allow everyone explicitly (first matching rule wins) except myuser
+:ALL EXCEPT myuser:ALL
# Explicitly deny myuser
-:myuser:ALL
```
3. Run compiled login program
```
sudo ./src/login
```

If you try to log in as denied user, you can actually log in. This happens because the first rule matches `myuser` because EXCEPT handling is broken. With this patch, `myuser` is correctly blocked because the first rule does not match, but the second.

Fixes: 90afe61003ef (2024-07-04; "lib/, src/: Use strsep(3) instead of strtok(3)")
