### PR TITLE
man/: Install suauth.5 only if feature exists

### DIFF
--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -39,7 +39,6 @@ man_MANS = \
 	man1/sg.1 \
 	man3/shadow.3 \
 	man5/shadow.5 \
-	man5/suauth.5 \
 	man8/useradd.8 \
 	man8/userdel.8 \
 	man8/usermod.8 \
@@ -57,6 +56,7 @@ man_nopam = \
 
 if WITH_SU
 man_MANS += man1/su.1
+man_nopam += man5/suauth.5
 endif
 
 if !USE_PAM


### PR DESCRIPTION
Support for `/etc/suauth` only exists if su is installed without PAM support. If su is not installed (--without-su) or if PAM support is enabled (default), do not install suauth.5 manual page.