### PR TITLE
src/: Make line number overflows less likely

### DIFF
--- a/src/chgpasswd.c
+++ b/src/chgpasswd.c
@@ -14,6 +14,7 @@
 #include <fcntl.h>
 #include <getopt.h>
 #include <pwd.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -426,7 +427,7 @@ int main (int argc, char **argv)
 	const struct group *gr;
 	struct group newgr;
 	int errors = 0;
-	int line = 0;
+	intmax_t line = 0;
 
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
@@ -463,7 +464,7 @@ int main (int argc, char **argv)
 	while (fgets (buf, (int) sizeof buf, stdin) != NULL) {
 		line++;
 		if (stpsep(buf, "\n") == NULL) {
-			fprintf (stderr, _("%s: line %d: line too long\n"),
+			fprintf (stderr, _("%s: line %jd: line too long\n"),
 			         Prog, line);
 			errors++;
 			continue;
@@ -482,7 +483,7 @@ int main (int argc, char **argv)
 		cp = stpsep(name, ":");
 		if (cp == NULL) {
 			fprintf (stderr,
-			         _("%s: line %d: missing new password\n"),
+			         _("%s: line %jd: missing new password\n"),
 			         Prog, line);
 			errors++;
 			continue;
@@ -533,7 +534,7 @@ int main (int argc, char **argv)
 		gr = gr_locate (name);
 		if (NULL == gr) {
 			fprintf (stderr,
-			         _("%s: line %d: group '%s' does not exist\n"), Prog,
+			         _("%s: line %jd: group '%s' does not exist\n"), Prog,
 			         line, name);
 			errors++;
 			continue;
@@ -593,7 +594,7 @@ int main (int argc, char **argv)
 		if (NULL != sg) {
 			if (sgr_update (&newsg) == 0) {
 				fprintf (stderr,
-				         _("%s: line %d: failed to prepare the new %s entry '%s'\n"),
+				         _("%s: line %jd: failed to prepare the new %s entry '%s'\n"),
 				         Prog, line, sgr_dbname (), newsg.sg_name);
 				errors++;
 				continue;
@@ -605,7 +606,7 @@ int main (int argc, char **argv)
 		{
 			if (gr_update (&newgr) == 0) {
 				fprintf (stderr,
-				         _("%s: line %d: failed to prepare the new %s entry '%s'\n"),
+				         _("%s: line %jd: failed to prepare the new %s entry '%s'\n"),
 				         Prog, line, gr_dbname (), newgr.gr_name);
 				errors++;
 				continue;

--- a/src/chpasswd.c
+++ b/src/chpasswd.c
@@ -14,6 +14,7 @@
 #include <fcntl.h>
 #include <getopt.h>
 #include <pwd.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -453,7 +454,7 @@ int main (int argc, char **argv)
 #endif				/* USE_PAM */
 
 	int errors = 0;
-	int line = 0;
+	intmax_t line = 0;
 
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
@@ -514,7 +515,7 @@ int main (int argc, char **argv)
 				}
 
 				fprintf (stderr,
-				         _("%s: line %d: line too long\n"),
+				         _("%s: line %jd: line too long\n"),
 				         Prog, line);
 				errors++;
 				continue;
@@ -534,7 +535,7 @@ int main (int argc, char **argv)
 		cp = stpsep(name, ":");
 		if (cp == NULL) {
 			fprintf (stderr,
-			         _("%s: line %d: missing new password\n"),
+			         _("%s: line %jd: missing new password\n"),
 			         Prog, line);
 			errors++;
 			continue;
@@ -545,7 +546,7 @@ int main (int argc, char **argv)
 		if (use_pam) {
 			if (do_pam_passwd_non_interactive (Prog, name, newpwd) != 0) {
 				fprintf (stderr,
-				         _("%s: (line %d, user %s) password not changed\n"),
+				         _("%s: (line %jd, user %s) password not changed\n"),
 				         Prog, line, name);
 				errors++;
 			}
@@ -574,7 +575,7 @@ int main (int argc, char **argv)
 		pw = pw_locate (name);
 		if (NULL == pw) {
 			fprintf (stderr,
-			         _("%s: line %d: user '%s' does not exist\n"), Prog,
+			         _("%s: line %jd: user '%s' does not exist\n"), Prog,
 			         line, name);
 			errors++;
 			continue;
@@ -640,7 +641,7 @@ int main (int argc, char **argv)
 		if (NULL != sp) {
 			if (spw_update (&newsp) == 0) {
 				fprintf (stderr,
-				         _("%s: line %d: failed to prepare the new %s entry '%s'\n"),
+				         _("%s: line %jd: failed to prepare the new %s entry '%s'\n"),
 				         Prog, line, spw_dbname (), newsp.sp_namp);
 				errors++;
 				continue;
@@ -650,7 +651,7 @@ int main (int argc, char **argv)
 		    || !streq(pw->pw_passwd, SHADOW_PASSWD_STRING)) {
 			if (pw_update (&newpw) == 0) {
 				fprintf (stderr,
-				         _("%s: line %d: failed to prepare the new %s entry '%s'\n"),
+				         _("%s: line %jd: failed to prepare the new %s entry '%s'\n"),
 				         Prog, line, pw_dbname (), newpw.pw_name);
 				errors++;
 				continue;

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -47,6 +47,7 @@
 #include <pwd.h>
 #endif
 #include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -94,7 +95,7 @@ login_access(const char *user, const char *from)
 	 */
 	fp = fopen (TABLE, "r");
 	if (NULL != fp) {
-		int lineno = 0;	/* for diagnostics */
+		intmax_t lineno = 0;	/* for diagnostics */
 		while (   !match
 		       && (fgets (line, sizeof (line), fp) == line))
 		{
@@ -103,7 +104,7 @@ login_access(const char *user, const char *from)
 			lineno++;
 			if (stpsep(line, "\n") == NULL) {
 				SYSLOG ((LOG_ERR,
-					 "%s: line %d: missing newline or line too long",
+					 "%s: line %jd: missing newline or line too long",
 					 TABLE, lineno));
 				continue;
 			}
@@ -120,13 +121,13 @@ login_access(const char *user, const char *from)
 			froms = strsep(&p, ":");
 			if (froms == NULL || p != NULL) {
 				SYSLOG ((LOG_ERR,
-					 "%s: line %d: bad field count",
+					 "%s: line %jd: bad field count",
 					 TABLE, lineno));
 				continue;
 			}
 			if (perm[0] != '+' && perm[0] != '-') {
 				SYSLOG ((LOG_ERR,
-					 "%s: line %d: bad first field",
+					 "%s: line %jd: bad first field",
 					 TABLE, lineno));
 				continue;
 			}

--- a/src/newusers.c
+++ b/src/newusers.c
@@ -28,6 +28,7 @@
 #include <getopt.h>
 #include <ctype.h>
 #include <errno.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <string.h>
 
@@ -1070,7 +1071,7 @@ int main (int argc, char **argv)
 	intmax_t *lines = NULL;
 	char **usernames = NULL;
 	char **passwords = NULL;
-	unsigned int nusers = 0;
+	size_t nusers = 0;
 #endif				/* USE_PAM */
 
 	log_set_progname(Prog);
@@ -1334,9 +1335,8 @@ int main (int argc, char **argv)
 	sssd_flush_cache (SSSD_DB_PASSWD | SSSD_DB_GROUP);
 
 #ifdef USE_PAM
-	unsigned int i;
 	/* Now update the passwords using PAM */
-	for (i = 0; i < nusers; i++) {
+	for (size_t i = 0; i < nusers; i++) {
 		if (do_pam_passwd_non_interactive ("newusers", usernames[i], passwords[i]) != 0) {
 			fprintf (stderr,
 			         _("%s: (line %jd, user %s) password not changed\n"),

--- a/src/suauth.c
+++ b/src/suauth.c
@@ -12,6 +12,7 @@
 #include <errno.h>
 #include <grp.h>
 #include <pwd.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/types.h>
@@ -42,7 +43,7 @@ static int applies (const char *, char *);
 
 static int isgrp (const char *, const char *);
 
-static int lines = 0;
+static intmax_t lines = 0;
 
 
 int
@@ -78,7 +79,7 @@ check_su_auth(const char *actual_id, const char *wanted_id, bool su_to_root)
 
 		if (stpsep(temp, "\n") == NULL) {
 			SYSLOG ((LOG_ERR,
-				 "%s, line %d: line too long or missing newline",
+				 "%s, line %jd: line too long or missing newline",
 				 SUAUTHFILE, lines));
 			continue;
 		}
@@ -94,7 +95,7 @@ check_su_auth(const char *actual_id, const char *wanted_id, bool su_to_root)
 		action = strsep(&p, ":");
 		if (action == NULL || p != NULL) {
 			SYSLOG ((LOG_ERR,
-				 "%s, line %d. Bad number of fields.\n",
+				 "%s, line %jd. Bad number of fields.\n",
 				 SUAUTHFILE, lines));
 			continue;
 		}
@@ -128,7 +129,7 @@ check_su_auth(const char *actual_id, const char *wanted_id, bool su_to_root)
 			return OWNPWORD;
 		} else {
 			SYSLOG ((LOG_ERR,
-				 "%s, line %d: unrecognized action!\n",
+				 "%s, line %jd: unrecognized action!\n",
 				 SUAUTHFILE, lines));
 		}
 	}
@@ -148,7 +149,7 @@ applies(const char *single, char *list)
 		if (streq(tok, "ALL")) {
 			if (state != 0) {
 				SYSLOG ((LOG_ERR,
-					 "%s, line %d: ALL in bad place\n",
+					 "%s, line %jd: ALL in bad place\n",
 					 SUAUTHFILE, lines));
 				return 0;
 			}
@@ -156,7 +157,7 @@ applies(const char *single, char *list)
 		} else if (streq(tok, "EXCEPT")) {
 			if (state != 1) {
 				SYSLOG ((LOG_ERR,
-					 "%s, line %d: EXCEPT in bas place\n",
+					 "%s, line %jd: EXCEPT in bas place\n",
 					 SUAUTHFILE, lines));
 				return 0;
 			}
@@ -164,7 +165,7 @@ applies(const char *single, char *list)
 		} else if (streq(tok, "GROUP")) {
 			if ((state != 0) && (state != 2)) {
 				SYSLOG ((LOG_ERR,
-					 "%s, line %d: GROUP in bad place\n",
+					 "%s, line %jd: GROUP in bad place\n",
 					 SUAUTHFILE, lines));
 				return 0;
 			}
@@ -177,7 +178,7 @@ applies(const char *single, char *list)
 				break;
 			case 1:	/* An all */
 				SYSLOG ((LOG_ERR,
-					 "%s, line %d: expect another token after ALL\n",
+					 "%s, line %jd: expect another token after ALL\n",
 					 SUAUTHFILE, lines));
 				return 0;
 			case 2:	/* All except */


### PR DESCRIPTION
First pull request based on current work of refactoring login_nopam.c:

Huge files could trigger signed integer overflows if enough lines are within the file. Use intmax_t which is at least 64 bit to move this event far into the future. I don't see a need to handle THAT case in any more effort.

Also turn a variable from unsigned int to size_t just to make sure that even systems with huge amount of memory cannot trigger an out of boundary access.