### PR TITLE
man/passwd.1.xml: -P disables PAM support

### DIFF
--- a/man/passwd.1.xml
+++ b/man/passwd.1.xml
@@ -292,8 +292,7 @@
 	    found under the directory <replaceable>PREFIX_DIR</replaceable>.
 	    This option does not chroot and is intended for preparing a cross-compilation
 	    target.  Some limitations: NIS and LDAP users/groups are
-	    not verified.  PAM authentication is using the host files.
-	    No SELINUX support.
+	    not verified.  No PAM support.  No SELINUX support.
 	  </para>
 	</listitem>
       </varlistentry>


### PR DESCRIPTION
If passwd is called with -P, then PAM handling is disabled ([src/passwd.c line 749](https://github.com/shadow-maint/shadow/blob/master/src/passwd.c#L746-L751)). The manual page claims that host files would be used, which is not true.