### PR TITLE
src/login_nopam.c: Use iterative list_match

### DIFF
--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -161,8 +161,8 @@ list_match(char *list, const char *item, bool (*match_fn)(char *, const char*))
 		if (strcasecmp (tok, "EXCEPT") == 0) {	/* EXCEPT: give up */
 			break;
 		}
-		match = (*match_fn) (tok, item);
-		if (match) {
+		if ((*match_fn)(tok, item)) {
+			match = true;
 			break;
 		}
 	}

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -149,7 +149,6 @@ list_match(char *list, const char *item, bool (*match_fn)(char *, const char*))
 	static const char  sep[] = ", \t";
 
 	char *tok;
-	bool match = false;
 
 	/*
 	 * Process tokens one at a time. We have exhausted all possible matches
@@ -162,20 +161,16 @@ list_match(char *list, const char *item, bool (*match_fn)(char *, const char*))
 			break;
 
 		} else if ((*match_fn)(tok, item)) {
-			match = true;
+			while (   (NULL != (tok = strsep(&list, sep)))
+			       && (strcasecmp (tok, "EXCEPT") != 0))
+				/* VOID */ ;
+			if (tok == NULL || !list_match(list, item, match_fn)) {
+				return true;
+			}
 			break;
 		}
 	}
 
-	/* Process exceptions to matches. */
-	if (match) {
-		while (   (NULL != (tok = strsep(&list, sep)))
-		       && (strcasecmp (tok, "EXCEPT") != 0))
-			/* VOID */ ;
-		if (tok == NULL || !list_match(list, item, match_fn)) {
-			return true;
-		}
-	}
 	return false;
 }
 

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -160,8 +160,8 @@ list_match(char *list, const char *item, bool (*match_fn)(char *, const char*))
 	while (NULL != (tok = strsep(&list, sep))) {
 		if (strcasecmp (tok, "EXCEPT") == 0) {	/* EXCEPT: give up */
 			break;
-		}
-		if ((*match_fn)(tok, item)) {
+
+		} else if ((*match_fn)(tok, item)) {
 			match = true;
 			break;
 		}

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -146,8 +146,6 @@ login_access(const char *user, const char *from)
 static bool
 list_match(char *list, const char *item, bool (*match_fn)(char *, const char*))
 {
-	static const char  sep[] = ", \t";
-
 	char *tok;
 
 	/*
@@ -156,12 +154,12 @@ list_match(char *list, const char *item, bool (*match_fn)(char *, const char*))
 	 * a match, look for an "EXCEPT" list and recurse to determine whether
 	 * the match is affected by any exceptions.
 	 */
-	while (NULL != (tok = strsep(&list, sep))) {
+	while (NULL != (tok = strsep(&list, ", \t"))) {
 		if (strcasecmp (tok, "EXCEPT") == 0) {	/* EXCEPT: give up */
 			break;
 
 		} else if ((*match_fn)(tok, item)) {
-			while (   (NULL != (tok = strsep(&list, sep)))
+			while (   (NULL != (tok = strsep(&list, ", \t")))
 			       && (strcasecmp (tok, "EXCEPT") != 0))
 				/* VOID */ ;
 			if (tok == NULL || !list_match(list, item, match_fn)) {

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -173,7 +173,7 @@ list_match(char *list, const char *item, bool (*match_fn)(char *, const char*))
 		       && (strcasecmp (tok, "EXCEPT") != 0))
 			/* VOID */ ;
 		if (tok == NULL || !list_match(list, item, match_fn)) {
-			return (match);
+			return true;
 		}
 	}
 	return false;


### PR DESCRIPTION
The recursive nature of list_match triggered regression during refactoring. In Linux-PAM, the same code exists which could lead to stack overflow because access.conf could be arbitrarily long.

Use an iterative approach for easier refactoring, to support long lines in the future and to stay in sync with Linux-PAM.

Please see https://github.com/linux-pam/linux-pam/pull/871 for more details since Linux-PAM could at least be affected on a very weird system configuration. Definitely not a security issue, but let's stay in sync and be prepared for a switch from fgets to getline.