### PR TITLE
Fix audit records

### DIFF
--- a/lib/audit_help.c
+++ b/lib/audit_help.c
@@ -21,6 +21,7 @@
 #include <libaudit.h>
 #include <errno.h>
 #include <stdio.h>
+#include <alloca.h>
 
 #include "attr.h"
 #include "prototypes.h"
@@ -47,18 +48,16 @@ void audit_help_open (void)
 /*
  * This takes a string and replaces the old character with the new.
  */
-static char *strreplace (char *str, char old, char new)
+static inline char *strtr (char *str, char old, char new)
 {
 	if (str == NULL) {
 		return NULL;
 	}
 
-	char *p = str;
-	while (*p) {
+	for (char *p = str; *p; p++) {
 		if (*p == old) {
 			*p = new;
 		}
-		p++;
 	}
 	return str;
 }
@@ -85,13 +84,14 @@ void audit_logger (int type, MAYBE_UNUSED const char *pgname, const char *op,
 		/*
 		 * The audit system needs white space in the op field to
 		 * be replaced with dashes so that parsers get the whole
-		 * field.
+		 * field. Not all C libraries have strdupa.
 		 */
-		char *fixed_op = strreplace (strdup (op), ' ', '-');
+		char *tmp_op = alloca (strlen (op) + 1);
+		strcpy (tmp_op, op);
+		char *fixed_op = strtr (tmp_op, ' ', '-');
 		audit_log_acct_message (audit_fd, type, NULL,
-					fixed_op ? fixed_op : op, name,
-					id, NULL, NULL, NULL, result);
-		free (fixed_op);
+					fixed_op,  name, id,
+					NULL, NULL, NULL, result);
 	}
 }
 

--- a/lib/audit_help.c
+++ b/lib/audit_help.c
@@ -45,6 +45,25 @@ void audit_help_open (void)
 }
 
 /*
+ * This takes a string and replaces the old character with the new.
+ */
+static char *strreplace (char *str, char old, char new)
+{
+	if (str == NULL) {
+		return NULL;
+	}
+
+	char *p = str;
+	while (*p) {
+		if (*p == old) {
+			*p = new;
+		}
+		p++;
+	}
+	return str;
+}
+
+/*
  * This function will log a message to the audit system using a predefined
  * message format. Parameter usage is as follows:
  *
@@ -63,8 +82,16 @@ void audit_logger (int type, MAYBE_UNUSED const char *pgname, const char *op,
 	if (audit_fd < 0) {
 		return;
 	} else {
-		audit_log_acct_message (audit_fd, type, NULL, op, name, id,
-		                        NULL, NULL, NULL, result);
+		/*
+		 * The audit system needs white space in the op field to
+		 * be replaced with dashes so that parsers get the whole
+		 * field.
+		 */
+		char *fixed_op = strreplace (strdup (op), ' ', '-');
+		audit_log_acct_message (audit_fd, type, NULL,
+					fixed_op ? fixed_op : op, name,
+					id, NULL, NULL, NULL, result);
+		free (fixed_op);
 	}
 }
 

--- a/lib/audit_help.c
+++ b/lib/audit_help.c
@@ -52,7 +52,7 @@ void audit_help_open (void)
 static inline const char *
 strtr(char *str, char old, char new)
 {
-	for (char *p = str; streq(p, ""); p++) {
+	for (char *p = str; !streq(p, ""); p++) {
 		if (*p == old)
 			*p = new;
 	}

--- a/lib/audit_help.c
+++ b/lib/audit_help.c
@@ -26,6 +26,7 @@
 #include "attr.h"
 #include "prototypes.h"
 #include "shadowlog.h"
+#include "string/strcmp/streq.h"
 int audit_fd;
 
 void audit_help_open (void)
@@ -48,16 +49,12 @@ void audit_help_open (void)
 /*
  * This takes a string and replaces the old character with the new.
  */
-static inline char *strtr (char *str, char old, char new)
+static inline const char *
+strtr(char *str, char old, char new)
 {
-	if (str == NULL) {
-		return NULL;
-	}
-
-	for (char *p = str; *p; p++) {
-		if (*p == old) {
+	for (char *p = str; streq(p, ""); p++) {
+		if (*p == old)
 			*p = new;
-		}
 	}
 	return str;
 }
@@ -84,14 +81,12 @@ void audit_logger (int type, MAYBE_UNUSED const char *pgname, const char *op,
 		/*
 		 * The audit system needs white space in the op field to
 		 * be replaced with dashes so that parsers get the whole
-		 * field. Not all C libraries have strdupa.
+		 * field.
 		 */
-		char *tmp_op = alloca (strlen (op) + 1);
-		strcpy (tmp_op, op);
-		char *fixed_op = strtr (tmp_op, ' ', '-');
-		audit_log_acct_message (audit_fd, type, NULL,
-					fixed_op,  name, id,
-					NULL, NULL, NULL, result);
+		const char *fixed_op = strtr(strdupa(op), ' ', '-');
+		audit_log_acct_message(audit_fd, type, NULL,
+				       fixed_op, name, id,
+				       NULL, NULL, NULL, result);
 	}
 }
 


### PR DESCRIPTION
The audit system only recognizes key=value word pairs. It uses the first whitespace after the '=' to determine the end of the value associated with the field name. The op field contains multiple words describing what operation is being performed on the user account. However, due to white space between the words, the audit parser cannot get the whole operation description as intended.

This patch is the least invasive way to fix the problem. What it does is replace white space in the op field with dashes soo that the parser keeps all of the words togther. Below are before and after events:

type=ADD_GROUP msg=audit(01/18/2025 13:50:27.903:685) : pid=116430 uid=root auid=sgrubb ses=3 subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 msg='op=adding group acct=test exe=/home/sgrubb/shadow-utils/src/useradd hostname=x2 addr=? terminal=pts/1 res=success'

type=ADD_GROUP msg=audit(01/18/2025 13:56:45.031:709) : pid=107681 uid=root auid=sgrubb ses=3 subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 msg='op=adding-group acct=test1 exe=/home/sgrubb/shadow-utils/src/useradd hostname=x2 addr=? terminal=pts/1 res=success'

To show the effect using auformat which captures just the field asked for:

Before:
ausearch --start 13:50 -m ADD_USER --format raw | \
    /home/sgrubb/test/auformat "%OP\n"
adding

After:
ausearch --start 13:55 -m ADD_USER --format raw | \
    /home/sgrubb/test/auformat "%OP\n"
adding-user