### PR TITLE
lib/string/strdup/: STRNDUPA(): Reimplement in terms of strndupa(3)

### DIFF
--- a/lib/string/strdup/strndupa.h
+++ b/lib/string/strdup/strndupa.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-FileCopyrightText: 2024-2025, Alejandro Colomar <alx@kernel.org>
 // SPDX-License-Identifier: BSD-3-Clause
 
 
@@ -12,7 +12,6 @@
 #include <string.h>
 
 #include "sizeof.h"
-#include "string/strcpy/strncat.h"
 
 
 // string n-bounded-read duplicate using-alloca(3)
@@ -21,11 +20,7 @@
 #endif
 
 
-// Similar to strndupa(3), but ensure that 's' is an array.
-#define STRNDUPA(s)                                                           \
-(                                                                             \
-	STRNCAT(strcpy(alloca(strnlen(s, NITEMS(s)) + 1), ""), s)             \
-)
+#define STRNDUPA(s)  strndupa(s, NITEMS(s))
 
 
 #endif  // include guard

--- a/lib/string/strdup/strndupa.h
+++ b/lib/string/strdup/strndupa.h
@@ -15,6 +15,12 @@
 #include "string/strcpy/strncat.h"
 
 
+// string n-bounded-read duplicate using-alloca(3)
+#ifndef  strndupa
+# define strndupa(s, n)  strncat(strcpy(alloca(n + 1), ""), s, n)
+#endif
+
+
 // Similar to strndupa(3), but ensure that 's' is an array.
 #define STRNDUPA(s)                                                           \
 (                                                                             \


### PR DESCRIPTION
Cc: @chqrlie


---

Revisions:

<details>
<summary>v2</summary>

-  Implement STRDUPA() instead of a macro that checks if the argument is a string literal.  This is what we want in the first place.

```
$ git range-diff master gh/sl sl 
1:  76257601 < -:  -------- lib/typetraits.h: is_string_literal(): Add macro
-:  -------- > 1:  dd4fa7bb lib/strdup/: STRDUPA(): Add macro
```
</details>

<details>
<summary>v2b</summary>

-  Fix commit message

```
$ git range-diff master gh/sl sl 
1:  dd4fa7bb ! 1:  6cc16778 lib/strdup/: STRDUPA(): Add macro
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/strdup/: STRDUPA(): Add macro
    +    lib/string/strdup/: STRDUPA(): Add macro
     
         This is like strdupa(3), but we make sure that the argument is a string
         literal, which makes sure that we won't have a stack overflow.
```
</details>

<details>
<summary>v3</summary>

-  Simplify STRNDUPA().
-  Make comment consistent with the one in STRNDUPA().

```
$ git range-diff master gh/sl sl 
1:  6cc16778 ! 1:  1838660c lib/string/strdup/: STRDUPA(): Add macro
    @@ lib/string/strdup/strdupa.h (new)
     +#include <string.h>
     +
     +
    -+// strdupa(3), but make sure that the argument is a string literal.
    ++// strdupa(3), but ensure that 's' is a string literal.
     +#define STRDUPA(s)  strdupa("" s "")
     +
     +
-:  -------- > 2:  9a4b3426 lib/string/strdup/strndupa.h: STRNDUPA(): Simplify implementation
```
</details>

<details>
<summary>v4</summary>

-  Implement strndupa(3), for musl.

```
$ git range-diff shadow/master gh/sl sl 
1:  1838660c = 1:  1838660c lib/string/strdup/: STRDUPA(): Add macro
-:  -------- > 2:  0e95f992 lib/string/strdup/strndupa.h: Add strndupa(3)
2:  9a4b3426 ! 3:  9227a343 lib/string/strdup/strndupa.h: STRNDUPA(): Simplify implementation
    @@ Metadata
      ## Commit message ##
         lib/string/strdup/strndupa.h: STRNDUPA(): Simplify implementation
     
    -    I don't know why I implemented it so complicated.  :|
    -
    -    Probably, I had implemented XSTRNDUP() recently, and I just had that
    -    too recent in memory.
    -
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/string/strdup/strndupa.h ##
    @@ lib/string/strdup/strndupa.h
      
      
     @@
    - 
    - #include <config.h>
    - 
    --#include <alloca.h>
      #include <string.h>
      
      #include "sizeof.h"
     -#include "string/strcpy/strncat.h"
      
      
    - // Similar to strndupa(3), but ensure that 's' is an array.
    + #ifndef  strndupa
    +@@
    + #endif
    + 
    + 
    +-// Similar to strndupa(3), but ensure that 's' is an array.
     -#define STRNDUPA(s)                                                           \
     -(                                                                             \
     -  STRNCAT(strcpy(alloca(strnlen(s, NITEMS(s)) + 1), ""), s)             \
     -)
    -+#define STRNDUPA(s)  strndupa(s, NITEMS(s))
    ++// strndupa(3), but ensure that 's' is an array.
    ++#define STRNDUPA(s)      strndupa(s, NITEMS(s))
      
      
      #endif  // include guard
```
</details>

<details>
<summary>v4b</summary>

-  Fix commit message.

```
$ git range-diff master gh/sl sl 
1:  1838660c = 1:  1838660c lib/string/strdup/: STRDUPA(): Add macro
2:  0e95f992 ! 2:  8a584bb3 lib/string/strdup/strndupa.h: Add strndupa(3)
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/string/strdup/strndupa.h: Add strndupa(3)
    +    lib/string/strdup/strndupa.h: strndupa(3): Add macro
     
         musl doesn't provide strndupa(3).
     
3:  9227a343 = 3:  f848a85d lib/string/strdup/strndupa.h: STRNDUPA(): Simplify implementation
```
</details>

<details>
<summary>v4c</summary>

-  Remove superfluous comment.  Now after the simplification it's obvious.

```
$ git range-diff master gh/sl sl 
1:  1838660c = 1:  1838660c lib/string/strdup/: STRDUPA(): Add macro
2:  8a584bb3 = 2:  8a584bb3 lib/string/strdup/strndupa.h: strndupa(3): Add macro
3:  f848a85d ! 3:  3bece290 lib/string/strdup/strndupa.h: STRNDUPA(): Simplify implementation
    @@ lib/string/strdup/strndupa.h
     -(                                                                             \
     -  STRNCAT(strcpy(alloca(strnlen(s, NITEMS(s)) + 1), ""), s)             \
     -)
    -+// strndupa(3), but ensure that 's' is an array.
     +#define STRNDUPA(s)      strndupa(s, NITEMS(s))
      
      
```
</details>

<details>
<summary>v5</summary>

-  Drop STRDUPA(), since the PR that needs it might actually not need it.
-  Use 2 spaces.

```
$ git range-diff master gh/sl sl 
1:  1838660c < -:  -------- lib/string/strdup/: STRDUPA(): Add macro
2:  8a584bb3 = 1:  4ec34e64 lib/string/strdup/strndupa.h: strndupa(3): Add macro
3:  3bece290 ! 2:  f8f938a8 lib/string/strdup/strndupa.h: STRNDUPA(): Simplify implementation
    @@ lib/string/strdup/strndupa.h
     -(                                                                             \
     -  STRNCAT(strcpy(alloca(strnlen(s, NITEMS(s)) + 1), ""), s)             \
     -)
    -+#define STRNDUPA(s)      strndupa(s, NITEMS(s))
    ++#define STRNDUPA(s)  strndupa(s, NITEMS(s))
      
      
      #endif  // include guard
```
</details>

<details>
<summary>v5b</summary>

-  Rebase

```
$ git range-diff master..gh/sl shadow/master..sl 
1:  4ec34e64 = 1:  6bd994fb lib/string/strdup/strndupa.h: strndupa(3): Add macro
2:  f8f938a8 = 2:  c53ca575 lib/string/strdup/strndupa.h: STRNDUPA(): Simplify implementation
```
</details>

<details>
<summary>v5c</summary>

-  Rebase

```
$ git range-diff master..gh/sl shadow/master..sl 
1:  6bd994fb = 1:  23537073 lib/string/strdup/strndupa.h: strndupa(3): Add macro
2:  c53ca575 = 2:  5d509cc5 lib/string/strdup/strndupa.h: STRNDUPA(): Simplify implementation
```
</details>

<details>
<summary>v5d</summary>

-  Rebase

```
$ git range-diff master..gh/sl shadow/master..sl 
1:  23537073 = 1:  cae4ad3f lib/string/strdup/strndupa.h: strndupa(3): Add macro
2:  5d509cc5 = 2:  403db33b lib/string/strdup/strndupa.h: STRNDUPA(): Simplify implementation
```
</details>

<details>
<summary>v6</summary>

-  Add comment explaining the meaning of the letter-soup API names.  [@hallyn]

```
$ git range-diff shadow/master gh/sl sl 
1:  cae4ad3f ! 1:  8ee0c312 lib/string/strdup/strndupa.h: strndupa(3): Add macro
    @@ lib/string/strdup/strndupa.h
      #include "string/strcpy/strncat.h"
      
      
    ++// string n-bounded-read duplicate using-alloca(3)
     +#ifndef  strndupa
     +# define strndupa(s, n)  strncat(strcpy(alloca(n + 1), ""), s, n)
     +#endif
2:  403db33b ! 2:  6cc386b6 lib/string/strdup/strndupa.h: STRNDUPA(): Simplify implementation
    @@ lib/string/strdup/strndupa.h
     -#include "string/strcpy/strncat.h"
      
      
    - #ifndef  strndupa
    + // string n-bounded-read duplicate using-alloca(3)
     @@
      #endif
      
```
</details>

<details>
<summary>v6b</summary>

-  Rebase

```
$ git range-diff master..gh/sl shadow/master..sl 
1:  8ee0c312 = 1:  44c21490 lib/string/strdup/strndupa.h: strndupa(3): Add macro
2:  6cc386b6 = 2:  cc0b829e lib/string/strdup/strndupa.h: STRNDUPA(): Simplify implementation
```
</details>

<details>
<summary>v6c</summary>

-  Rebase

```
$ git range-diff master..gh/sl shadow/master..sl
1:  44c21490 = 1:  646810b0 lib/string/strdup/strndupa.h: strndupa(3): Add macro
2:  cc0b829e = 2:  8c590f96 lib/string/strdup/strndupa.h: STRNDUPA(): Simplify implementation
```
</details>

<details>
<summary>v6d</summary>

-  Rebase

```
$ git range-diff master..gh/sl shadow/master..sl
1:  646810b0 = 1:  e8c3de31 lib/string/strdup/strndupa.h: strndupa(3): Add macro
2:  8c590f96 = 2:  83d17cd0 lib/string/strdup/strndupa.h: STRNDUPA(): Simplify implementation
```
</details>

<details>
<summary>v6e</summary>

-  Rebase

```
$ git rd
1:  e8c3de31 = 1:  9c56cb1d lib/string/strdup/strndupa.h: strndupa(3): Add macro
2:  83d17cd0 = 2:  c6daec68 lib/string/strdup/strndupa.h: STRNDUPA(): Simplify implementation
```
</details>

<details>
<summary>v6f</summary>

-  Rebase

```
$ git rd
1:  9c56cb1d = 1:  6629e354 lib/string/strdup/strndupa.h: strndupa(3): Add macro
2:  c6daec68 = 2:  9ba9737f lib/string/strdup/strndupa.h: STRNDUPA(): Simplify implementation
```
</details>

<details>
<summary>v6g</summary>

-  Rebase

```
$ git rd
1:  6629e354 = 1:  c2ad0ba7 lib/string/strdup/strndupa.h: strndupa(3): Add macro
2:  9ba9737f = 2:  9dcf865e lib/string/strdup/strndupa.h: STRNDUPA(): Simplify implementation
```
</details>