### PR TITLE
Clear plaintext passwords in more error cases

### DIFF
--- a/lib/encrypt.c
+++ b/lib/encrypt.c
@@ -65,7 +65,8 @@
 		(void) fprintf (shadow_logfd,
 		                _("crypt method not supported by libcrypt? (%s)\n"),
 		                method);
-		exit (EXIT_FAILURE);
+		errno = EINVAL;
+		return NULL;
 	}
 
 	if (strlen (cp) != 13) {

--- a/src/gpasswd.c
+++ b/src/gpasswd.c
@@ -864,13 +864,13 @@ static void change_passwd (struct group *gr)
 
 	salt = crypt_make_salt (NULL, NULL);
 	cp = pw_encrypt (pass, salt);
+	MEMZERO(pass);
 	if (NULL == cp) {
 		fprintf (stderr,
 		         _("%s: failed to crypt password with salt '%s': %s\n"),
 		         Prog, salt, strerror (errno));
 		exit (1);
 	}
-	MEMZERO(pass);
 #ifdef SHADOWGRP
 	if (is_shadowgrp) {
 		gr->gr_passwd = SHADOW_PASSWD_STRING;

--- a/src/gpasswd.c
+++ b/src/gpasswd.c
@@ -818,7 +818,7 @@ static void change_passwd (struct group *gr)
 #endif
 {
 	char *cp;
-	static char pass[BUFSIZ];
+	static char pass[PASS_MAX + 1];
 	int retries;
 	const char *salt;
 


### PR DESCRIPTION
Most code paths make sure that a plaintext password, if not read from stdin or a file, is properly cleared.

This is not true for all `pw_encrypt` error cases. If the salt itself is considered "unknown", then `exit` is called. Let `pw_encrypt` return an error code so the program logic can clear passwords properly before handling the error.

One such example is musl. If passwd compiled for musl tries to encrypt a password with SHA512 which is longer than 256 characters, it fails. But this can be easily the valid password on the system, because glibc has no such problem. So, just wipe it.

Example output with this patch (passwd linked with musl):
```
$ passwd
Changing password for user
Old password:
crypt method not supported by libcrypt? (SHA512)
passwd: failed to crypt password with previous salt: Invalid argument
The password for user is unchanged.
```

While at it, fixed missing clearing in gpasswd and adjusted a preprocessor definition usage.