### PR TITLE
Restore the original terminal pgrp after editing

### DIFF
--- a/src/vipw.c
+++ b/src/vipw.c
@@ -372,8 +372,14 @@ vipwedit (const char *file, int (*file_lock) (void), int (*file_unlock) (void))
 		}
 	}
 
-	if (orig_pgrp != -1)
+	if (orig_pgrp != -1) {
+		 /* Restore terminal pgrp after editing. */
+		if (tcsetpgrp(STDIN_FILENO, orig_pgrp) == -1) {
+			fprintf(stderr, "%s: %s: %s", Prog,
+			        "tcsetpgrp", strerror(errno));
+		}
 		sigprocmask(SIG_SETMASK, &omask, NULL);
+	}
 
 	if (-1 == pid) {
 		vipwexit (editor, 1, 1);


### PR DESCRIPTION
This fixes a problem when the shell is not in monitor mode (job control enabled) which resulted in the terminal pgrp being set to an invalid value once vipw exited.  Fixes #1194.