### PR TITLE
[deadbeef] Remove dead code

### DIFF
--- a/doc/HOWTO
+++ b/doc/HOWTO
@@ -1751,7 +1751,7 @@
       }
   #ifdef HAS_SHADOW
       if ((pw->pw_passwd && pw->pw_passwd[0] == '@'
-           && pw_auth (pw->pw_passwd+1, pw->pw_name, PW_LOGIN))
+           && pw_auth(pw->pw_passwd+1, pw->pw_name))
           || !valid (passwd, pw)) {
           return (UPAP_AUTHNAK);
       }

--- a/doc/HOWTO
+++ b/doc/HOWTO
@@ -1751,7 +1751,7 @@
       }
   #ifdef HAS_SHADOW
       if ((pw->pw_passwd && pw->pw_passwd[0] == '@'
-           && pw_auth (pw->pw_passwd+1, pw->pw_name, PW_LOGIN, NULL))
+           && pw_auth (pw->pw_passwd+1, pw->pw_name, PW_LOGIN))
           || !valid (passwd, pw)) {
           return (UPAP_AUTHNAK);
       }

--- a/lib/pwauth.c
+++ b/lib/pwauth.c
@@ -48,9 +48,8 @@ static const char *PROMPT = gettext_noop ("%s's Password: ");
  *	compared.
  */
 
-int pw_auth (const char *cipher,
-             const char *user,
-             int reason)
+int
+pw_auth(const char *cipher, const char *user)
 {
 	int          retval;
 	char         prompt[1024];

--- a/lib/pwauth.c
+++ b/lib/pwauth.c
@@ -54,37 +54,16 @@ int pw_auth (const char *cipher,
 {
 	int          retval;
 	char         prompt[1024];
-	char         *clear = NULL;
+	char         *clear;
 	const char   *cp;
 	const char   *encrypted;
-	const char   *input = NULL;
+	const char   *input;
 
 #ifdef	SKEY
 	bool         use_skey = false;
 	char         challenge_info[40];
 	struct skey  skey;
 #endif
-
-	/*
-	 * There are programs for adding and deleting authentication data.
-	 */
-
-	if ((PW_ADD == reason) || (PW_DELETE == reason)) {
-		return 0;
-	}
-
-	/*
-	 * WARNING:
-	 *
-	 * When we change a password and we are root, we don't prompt.
-	 * This is so root can change any password without having to
-	 * know it.  This is a policy decision that might have to be
-	 * revisited.
-	 */
-
-	if ((PW_CHANGE == reason) && (getuid () == 0)) {
-		return 0;
-	}
 
 	/*
 	 * WARNING:
@@ -120,25 +99,22 @@ int pw_auth (const char *cipher,
 #endif
 
 	/*
-	 * Prompt for the password as required.  FTPD and REXECD both
-	 * get the cleartext password for us.
+	 * Prompt for the password as required.
 	 */
 
-	if ((PW_FTP != reason) && (PW_REXEC != reason)) {
-		cp = getdef_str ("LOGIN_STRING");
-		if (NULL == cp) {
-			cp = _(PROMPT);
-		}
+	cp = getdef_str ("LOGIN_STRING");
+	if (NULL == cp) {
+		cp = _(PROMPT);
+	}
 #ifdef	SKEY
-		if (use_skey) {
-			printf ("[%s]\n", challenge_info);
-		}
+	if (use_skey) {
+		printf ("[%s]\n", challenge_info);
+	}
 #endif
 
-		SNPRINTF(prompt, cp, user);
-		clear = agetpass(prompt);
-		input = (clear == NULL) ? "" : clear;
-	}
+	SNPRINTF(prompt, cp, user);
+	clear = agetpass(prompt);
+	input = (clear == NULL) ? "" : clear;
 
 	/*
 	 * Convert the cleartext password into a ciphertext string.

--- a/lib/pwauth.c
+++ b/lib/pwauth.c
@@ -50,14 +50,14 @@ static const char *PROMPT = gettext_noop ("%s's Password: ");
 
 int pw_auth (const char *cipher,
              const char *user,
-             int reason,
-             /*@null@*/const char *input)
+             int reason)
 {
 	int          retval;
 	char         prompt[1024];
 	char         *clear = NULL;
 	const char   *cp;
 	const char   *encrypted;
+	const char   *input = NULL;
 
 #ifdef	SKEY
 	bool         use_skey = false;
@@ -70,14 +70,6 @@ int pw_auth (const char *cipher,
 	 */
 
 	if ((PW_ADD == reason) || (PW_DELETE == reason)) {
-		return 0;
-	}
-
-	/*
-	 * There are even programs for changing the user name ...
-	 */
-
-	if ((PW_CHANGE == reason) && (NULL != input)) {
 		return 0;
 	}
 
@@ -132,7 +124,7 @@ int pw_auth (const char *cipher,
 	 * get the cleartext password for us.
 	 */
 
-	if ((PW_FTP != reason) && (PW_REXEC != reason) && (NULL == input)) {
+	if ((PW_FTP != reason) && (PW_REXEC != reason)) {
 		cp = getdef_str ("LOGIN_STRING");
 		if (NULL == cp) {
 			cp = _(PROMPT);

--- a/lib/pwauth.h
+++ b/lib/pwauth.h
@@ -17,8 +17,7 @@
 #ifndef USE_PAM
 int pw_auth (const char *cipher,
              const char *user,
-             int flag,
-             /*@null@*/const char *input);
+             int flag);
 #endif				/* !USE_PAM */
 
 /*

--- a/lib/pwauth.h
+++ b/lib/pwauth.h
@@ -28,20 +28,10 @@ int pw_auth (const char *cipher,
 #define	PW_LOGIN	2
 
 /*
- * Administrative functions
- */
-
-#define	PW_ADD		101
-#define	PW_CHANGE	102
-#define	PW_DELETE	103
-
-/*
  * Network access
  */
 
 #define	PW_TELNET	201
 #define	PW_RLOGIN	202
-#define	PW_FTP		203
-#define	PW_REXEC	204
 
 #endif /* _PWAUTH_H */

--- a/lib/pwauth.h
+++ b/lib/pwauth.h
@@ -7,31 +7,11 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-/*
- *	$Id$
- */
-
 #ifndef _PWAUTH_H
 #define _PWAUTH_H
 
 #ifndef USE_PAM
-int pw_auth (const char *cipher,
-             const char *user,
-             int flag);
+int pw_auth(const char *cipher, const char *user);
 #endif				/* !USE_PAM */
-
-/*
- * Local access
- */
-
-#define	PW_SU		1
-#define	PW_LOGIN	2
-
-/*
- * Network access
- */
-
-#define	PW_TELNET	201
-#define	PW_RLOGIN	202
 
 #endif /* _PWAUTH_H */

--- a/lib/pwdcheck.c
+++ b/lib/pwdcheck.c
@@ -28,7 +28,7 @@ void passwd_check (const char *user, const char *passwd, MAYBE_UNUSED const char
 	if (NULL != sp) {
 		passwd = sp->sp_pwdp;
 	}
-	if (pw_auth(passwd, user, PW_LOGIN) != 0) {
+	if (pw_auth(passwd, user) != 0) {
 		SYSLOG ((LOG_WARN, "incorrect password for `%s'", user));
 		(void) sleep (1);
 		fprintf (log_get_logfd(), _("Incorrect password for %s.\n"), user);

--- a/lib/pwdcheck.c
+++ b/lib/pwdcheck.c
@@ -28,7 +28,7 @@ void passwd_check (const char *user, const char *passwd, MAYBE_UNUSED const char
 	if (NULL != sp) {
 		passwd = sp->sp_pwdp;
 	}
-	if (pw_auth (passwd, user, PW_LOGIN, NULL) != 0) {
+	if (pw_auth(passwd, user, PW_LOGIN) != 0) {
 		SYSLOG ((LOG_WARN, "incorrect password for `%s'", user));
 		(void) sleep (1);
 		fprintf (log_get_logfd(), _("Incorrect password for %s.\n"), user);

--- a/src/login.c
+++ b/src/login.c
@@ -77,7 +77,6 @@ static const char Prog[] = "login";
 
 static const char *hostname = "";
 static /*@null@*/ /*@only@*/char *username = NULL;
-static int reason = PW_LOGIN;
 
 #ifndef USE_PAM
 #ifdef ENABLE_LASTLOG
@@ -289,7 +288,6 @@ static void process_flags (int argc, char *const *argv)
 		case 'h':
 			hflg = true;
 			hostname = optarg;
-			reason = PW_TELNET;
 			break;
 		case 'p':
 			pflg = true;
@@ -535,9 +533,6 @@ int main (int argc, char **argv)
 	}
 	if (fflg) {
 		preauth_flag = true;
-	}
-	if (hflg) {
-		reason = PW_RLOGIN;
 	}
 
 	OPENLOG (Prog);
@@ -903,7 +898,7 @@ int main (int argc, char **argv)
 			goto auth_ok;
 		}
 
-		if (pw_auth(user_passwd, username, reason) == 0) {
+		if (pw_auth(user_passwd, username) == 0) {
 			goto auth_ok;
 		}
 
@@ -964,7 +959,7 @@ int main (int argc, char **argv)
 		 * all).  --marekm
 		 */
 		if (streq(user_passwd, "")) {
-			pw_auth("!", username, reason);
+			pw_auth("!", username);
 		}
 
 		/*

--- a/src/login.c
+++ b/src/login.c
@@ -903,7 +903,7 @@ int main (int argc, char **argv)
 			goto auth_ok;
 		}
 
-		if (pw_auth (user_passwd, username, reason, NULL) == 0) {
+		if (pw_auth(user_passwd, username, reason) == 0) {
 			goto auth_ok;
 		}
 
@@ -964,7 +964,7 @@ int main (int argc, char **argv)
 		 * all).  --marekm
 		 */
 		if (streq(user_passwd, "")) {
-			pw_auth ("!", username, reason, NULL);
+			pw_auth("!", username, reason);
 		}
 
 		/*

--- a/src/su.c
+++ b/src/su.c
@@ -590,7 +590,7 @@ static void check_perms_nopam (const struct passwd *pw)
 	 * The first character of an administrator defined method is an '@'
 	 * character.
 	 */
-	if (pw_auth (password, name, PW_SU, NULL) != 0) {
+	if (pw_auth(password, name, PW_SU) != 0) {
 		SYSLOG (((pw->pw_uid != 0)? LOG_NOTICE : LOG_WARN,
 		         "Authentication failed for %s", name));
 		fprintf(stderr, _("%s: Authentication failure\n"), Prog);

--- a/src/su.c
+++ b/src/su.c
@@ -590,7 +590,7 @@ static void check_perms_nopam (const struct passwd *pw)
 	 * The first character of an administrator defined method is an '@'
 	 * character.
 	 */
-	if (pw_auth(password, name, PW_SU) != 0) {
+	if (pw_auth(password, name) != 0) {
 		SYSLOG (((pw->pw_uid != 0)? LOG_NOTICE : LOG_WARN,
 		         "Authentication failed for %s", name));
 		fprintf(stderr, _("%s: Authentication failure\n"), Prog);


### PR DESCRIPTION
One of the benefits of rewriting a lot of code, is finding dead code that can be removed.  :-)

Cc: @thesamesam

---

Revisions:

<details>
<summary>v2</summary>

-  Delete another round of dead code.

```
$ git range-diff master gh/deadbeef deadbeef 
1:  28a46878 = 1:  28a46878 lib/, src/, doc/: Remove dead code
2:  5064c6b4 = 2:  5064c6b4 lib/pwauth.*: PW_{ADD,CHANGE,DELETE,FTP,REXEC}: Remove dead code
-:  -------- > 3:  17e7da68 lib/, src/, doc/: Remove pw_auth()'s  as dead code
```
</details>

<details>
<summary>v2b</summary>

-  tfix in commit message

```
$ git range-diff master gh/deadbeef deadbeef 
1:  28a46878 = 1:  28a46878 lib/, src/, doc/: Remove dead code
2:  5064c6b4 = 2:  5064c6b4 lib/pwauth.*: PW_{ADD,CHANGE,DELETE,FTP,REXEC}: Remove dead code
3:  17e7da68 ! 3:  a66b4a9c lib/, src/, doc/: Remove pw_auth()'s  as dead code
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/, src/, doc/: Remove pw_auth()'s  as dead code
    +    lib/, src/, doc/: Remove pw_auth()'s $3 as dead code
     
         We don't read the parameter at all.  Remove it.
     
````
</details>