### PR TITLE
src/: Prefer return over exit in main function

### DIFF
--- a/src/chage.c
+++ b/src/chage.c
@@ -749,7 +749,7 @@ int main (int argc, char **argv)
 		         Prog);
 		SYSLOG ((LOG_WARN, "can't find the shadow password file"));
 		closelog ();
-		exit (E_SHADOW_NOTFOUND);
+		return E_SHADOW_NOTFOUND;
 	}
 
 	open_files (lflg);
@@ -856,6 +856,6 @@ int main (int argc, char **argv)
 	SYSLOG ((LOG_INFO, "changed password expiry for %s", user_name));
 
 	closelog ();
-	exit (E_SUCCESS);
+	return E_SUCCESS;
 }
 

--- a/src/check_subid_range.c
+++ b/src/check_subid_range.c
@@ -36,20 +36,20 @@ main(int argc, char **argv)
 	log_set_logfd(stderr);
 
 	if (argc != 5)
-		exit(1);
+		return 1;
 
 	owner = argv[1];
 	check_uids = argv[2][0] == 'u';
 	if (get_uid(argv[3], &start) == -1)
-		exit(1);
+		return 1;
 	if (str2ul(&count, argv[4]) == -1)
-		exit(1);
+		return 1;
 	if (check_uids) {
 		if (have_sub_uids(owner, start, count))
 			exit(0);
-		exit(1);
+		return 1;
 	}
 	if (have_sub_gids(owner, start, count))
-		exit(0);
-	exit(1);
+		return 0;
+	return 1;
 }

--- a/src/chfn.c
+++ b/src/chfn.c
@@ -713,6 +713,6 @@ int main (int argc, char **argv)
 	sssd_flush_cache (SSSD_DB_PASSWD);
 
 	closelog ();
-	exit (E_SUCCESS);
+	return E_SUCCESS;
 }
 

--- a/src/chsh.c
+++ b/src/chsh.c
@@ -581,6 +581,6 @@ int main (int argc, char **argv)
 	sssd_flush_cache (SSSD_DB_PASSWD);
 
 	closelog ();
-	exit (E_SUCCESS);
+	return E_SUCCESS;
 }
 

--- a/src/expiry.c
+++ b/src/expiry.c
@@ -160,7 +160,7 @@ int main (int argc, char **argv)
 		         Prog);
 		SYSLOG ((LOG_WARN, "Cannot determine the user name of the caller (UID %lu)",
 		         (unsigned long) getuid ()));
-		exit (10);
+		return 10;
 	}
 	spwd = getspnam (pwd->pw_name); /* !USE_PAM, No need for xgetspnam */
 
@@ -176,7 +176,7 @@ int main (int argc, char **argv)
 		/*
 		 * Exit with status indicating state of account.
 		 */
-		exit (isexpired (pwd, spwd));
+		return isexpired (pwd, spwd);
 	}
 
 	/*

--- a/src/faillog.c
+++ b/src/faillog.c
@@ -551,7 +551,7 @@ int main (int argc, char **argv)
 					fprintf (stderr,
 					         _("%s: invalid numeric argument '%s'\n"),
 					         Prog, optarg);
-					exit (E_BAD_ARG);
+					return E_BAD_ARG;
 				}
 				lflg = true;
 				break;
@@ -561,7 +561,7 @@ int main (int argc, char **argv)
 					fprintf (stderr,
 					         _("%s: invalid numeric argument '%s'\n"),
 					         Prog, optarg);
-					exit (E_BAD_ARG);
+					return E_BAD_ARG;
 				}
 				mflg = true;
 				break;
@@ -576,7 +576,7 @@ int main (int argc, char **argv)
 					fprintf (stderr,
 					         _("%s: invalid numeric argument '%s'\n"),
 					         Prog, optarg);
-					exit (E_BAD_ARG);
+					return E_BAD_ARG;
 				}
 				seconds = (time_t) days * DAY;
 				tflg = true;
@@ -607,7 +607,7 @@ int main (int argc, char **argv)
 						fprintf (stderr,
 						         _("%s: Unknown user or range: %s\n"),
 						         Prog, optarg);
-						exit (E_BAD_ARG);
+						return E_BAD_ARG;
 					}
 				}
 
@@ -639,7 +639,7 @@ int main (int argc, char **argv)
 		fprintf (stderr,
 		         _("%s: Cannot open %s: %s\n"),
 		         Prog, FAILLOG_FILE, strerror (errno));
-		exit (E_NOPERM);
+		return E_NOPERM;
 	}
 
 	/* Get the size of the faillog */
@@ -647,7 +647,7 @@ int main (int argc, char **argv)
 		fprintf (stderr,
 		         _("%s: Cannot get the size of %s: %s\n"),
 		         Prog, FAILLOG_FILE, strerror (errno));
-		exit (E_NOPERM);
+		return E_NOPERM;
 	}
 
 	if (lflg) {
@@ -681,6 +681,6 @@ int main (int argc, char **argv)
 		(void) fclose (fail);
 	}
 
-	exit (errors ? E_NOPERM : E_SUCCESS);
+	return errors ? E_NOPERM : E_SUCCESS;
 }
 

--- a/src/free_subid_range.c
+++ b/src/free_subid_range.c
@@ -51,7 +51,7 @@ int main(int argc, char *argv[])
 
 	if (!ok) {
 		fprintf(stderr, "Failed freeing id range\n");
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 	}
 
 	return 0;

--- a/src/get_subid_owners.c
+++ b/src/get_subid_owners.c
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
 	}
 	if (n < 0) {
 		fprintf(stderr, "No owners found\n");
-		exit(1);
+		return 1;
 	}
 	for (i = 0; i < n; i++) {
 		printf("%d\n", uids[i]);

--- a/src/getsubids.c
+++ b/src/getsubids.c
@@ -40,7 +40,7 @@ int main(int argc, char *argv[])
 	}
 	if (!ranges) {
 		fprintf(stderr, "Error fetching ranges\n");
-		exit(1);
+		return 1;
 	}
 	for (i = 0; i < count; i++) {
 		printf("%d: %s %lu %lu\n", i, owner,

--- a/src/gpasswd.c
+++ b/src/gpasswd.c
@@ -938,7 +938,7 @@ int main (int argc, char **argv)
 		SYSLOG ((LOG_WARN,
 		         "Cannot determine the user name of the caller (UID %lu)",
 		         (unsigned long) getuid ()));
-		exit (E_NOPERM);
+		return E_NOPERM;
 	}
 	myname = xstrdup (pw->pw_name);
 
@@ -948,7 +948,7 @@ int main (int argc, char **argv)
 	 */
 	if (atexit (do_cleanups) != 0) {
 		fprintf(stderr, "%s: cannot set exit function\n", Prog);
-		exit (1);
+		return 1;
 	}
 
 	/* Parse the options */
@@ -1044,7 +1044,7 @@ int main (int argc, char **argv)
 			fprintf (stderr,
 			         _("%s: user '%s' is not a member of '%s'\n"),
 			         Prog, user, group);
-			exit (E_BAD_ARG);
+			return E_BAD_ARG;
 		}
 		goto output;
 	}
@@ -1082,7 +1082,7 @@ int main (int argc, char **argv)
 	 */
 	if ((isatty (0) == 0) || (isatty (1) == 0)) {
 		fprintf (stderr, _("%s: Not a tty\n"), Prog);
-		exit (E_NOPERM);
+		return E_NOPERM;
 	}
 
 	catch_signals (0);	/* save tty modes */
@@ -1111,7 +1111,7 @@ int main (int argc, char **argv)
 		fputs (_("Cannot change ID to root.\n"), stderr);
 		SYSLOG ((LOG_ERR, "can't setuid(0)"));
 		closelog ();
-		exit (E_NOPERM);
+		return E_NOPERM;
 	}
 	pwd_init ();
 
@@ -1135,6 +1135,6 @@ int main (int argc, char **argv)
 	}
 #endif
 	free(grent.gr_mem);
-	exit (E_SUCCESS);
+	return E_SUCCESS;
 }
 

--- a/src/groupadd.c
+++ b/src/groupadd.c
@@ -597,7 +597,7 @@ int main (int argc, char **argv)
 		fprintf (stderr,
 		         _("%s: Cannot setup cleanup service.\n"),
 		         Prog);
-		exit (1);
+		return 1;
 	}
 
 	/*
@@ -609,7 +609,7 @@ int main (int argc, char **argv)
 
 	if (run_parts ("/etc/shadow-maint/groupadd-pre.d", group_name,
 			Prog)) {
-		exit(1);
+		return 1;
 	}
 
 #ifdef SHADOWGRP
@@ -624,7 +624,7 @@ int main (int argc, char **argv)
 
 	if (!gflg) {
 		if (find_new_gid (rflg, &group_id, NULL) < 0) {
-			exit (E_GID_IN_USE);
+			return E_GID_IN_USE;
 		}
 	}
 
@@ -632,7 +632,7 @@ int main (int argc, char **argv)
 	close_files ();
 	if (run_parts ("/etc/shadow-maint/groupadd-post.d", group_name,
 			Prog)) {
-		exit(1);
+		return 1;
 	}
 
 

--- a/src/groupdel.c
+++ b/src/groupdel.c
@@ -368,7 +368,7 @@ int main (int argc, char **argv)
 		fprintf (stderr,
 		         _("%s: Cannot setup cleanup service.\n"),
 		         Prog);
-		exit (1);
+		return 1;
 	}
 
 	process_flags (argc, argv);
@@ -382,7 +382,7 @@ int main (int argc, char **argv)
 			fprintf (stderr,
 			         _("%s: Cannot determine your user name.\n"),
 			         Prog);
-			exit (1);
+			return 1;
 		}
 
 		retval = pam_start (Prog, pampw->pw_name, &conv, &pamh);
@@ -403,7 +403,7 @@ int main (int argc, char **argv)
 		if (NULL != pamh) {
 			(void) pam_end (pamh, retval);
 		}
-		exit (1);
+		return 1;
 	}
 	(void) pam_end (pamh, retval);
 #endif				/* USE_PAM */
@@ -438,7 +438,7 @@ int main (int argc, char **argv)
 
 	if (run_parts ("/etc/shadow-maint/groupdel-pre.d", group_name,
 			Prog)) {
-		exit(1);
+		return 1;
 	}
 
 	/*
@@ -453,7 +453,7 @@ int main (int argc, char **argv)
 
 	if (run_parts ("/etc/shadow-maint/groupdel-post.d", group_name,
 			Prog)) {
-		exit(1);
+		return 1;
 	}
 
 	nscd_flush_cache ("group");

--- a/src/groupmems.c
+++ b/src/groupmems.c
@@ -614,6 +614,6 @@ int main (int argc, char **argv)
 
 	close_files ();
 
-	exit (EXIT_SUCCESS);
+	return EXIT_SUCCESS;
 }
 

--- a/src/groupmod.c
+++ b/src/groupmod.c
@@ -784,7 +784,7 @@ int main (int argc, char **argv)
 		fprintf (stderr,
 		         _("%s: Cannot setup cleanup service.\n"),
 		         Prog);
-		exit (E_CLEANUP_SERVICE);
+		return E_CLEANUP_SERVICE;
 	}
 
 	process_flags (argc, argv);
@@ -798,7 +798,7 @@ int main (int argc, char **argv)
 			fprintf (stderr,
 			         _("%s: Cannot determine your user name.\n"),
 			         Prog);
-			exit (E_PAM_USERNAME);
+			return E_PAM_USERNAME;
 		}
 
 		retval = pam_start (Prog, pampw->pw_name, &conv, &pamh);
@@ -819,7 +819,7 @@ int main (int argc, char **argv)
 		if (NULL != pamh) {
 			(void) pam_end (pamh, retval);
 		}
-		exit (E_PAM_ERROR);
+		return E_PAM_ERROR;
 	}
 	(void) pam_end (pamh, retval);
 #endif				/* USE_PAM */
@@ -838,7 +838,7 @@ int main (int argc, char **argv)
 			fprintf (stderr,
 			         _("%s: group '%s' does not exist\n"),
 			         Prog, group_name);
-			exit (E_NOTFOUND);
+			return E_NOTFOUND;
 		} else {
 			group_id = grp->gr_gid;
 		}

--- a/src/grpconv.c
+++ b/src/grpconv.c
@@ -269,7 +269,7 @@ int main (MAYBE_UNUSED int argc, char **argv)
 {
 	fprintf (stderr,
 		 "%s: not configured for shadow group support.\n", argv[0]);
-	exit (1);
+	return 1;
 }
 #endif				/* !SHADOWGRP */
 

--- a/src/grpunconv.c
+++ b/src/grpunconv.c
@@ -142,7 +142,7 @@ int main (int argc, char **argv)
 	process_flags (argc, argv);
 
 	if (sgr_file_present () == 0) {
-		exit (0);	/* no /etc/gshadow, nothing to do */
+		return 0;	/* no /etc/gshadow, nothing to do */
 	}
 
 	if (gr_lock () == 0) {
@@ -231,7 +231,7 @@ int main (MAYBE_UNUSED int argc, char **argv)
 {
 	fprintf (stderr,
 		 "%s: not configured for shadow group support.\n", argv[0]);
-	exit (1);
+	return 1;
 }
 #endif				/* !SHADOWGRP */
 

--- a/src/lastlog.c
+++ b/src/lastlog.c
@@ -397,7 +397,7 @@ int main (int argc, char **argv)
 						fprintf (stderr,
 						         _("%s: Unknown user or range: %s\n"),
 						         Prog, optarg);
-						exit (EXIT_FAILURE);
+						return EXIT_FAILURE;
 					}
 				}
 				break;
@@ -435,7 +435,7 @@ int main (int argc, char **argv)
 	lastlogfile = fopen (LASTLOG_FILE, (Cflg || Sflg)?"r+":"r");
 	if (NULL == lastlogfile) {
 		perror (LASTLOG_FILE);
-		exit (EXIT_FAILURE);
+		return EXIT_FAILURE;
 	}
 
 	/* Get the lastlog size */
@@ -443,7 +443,7 @@ int main (int argc, char **argv)
 		fprintf (stderr,
 		         _("%s: Cannot get the size of %s: %s\n"),
 		         Prog, LASTLOG_FILE, strerror (errno));
-		exit (EXIT_FAILURE);
+		return EXIT_FAILURE;
 	}
 
 	if (Cflg || Sflg)

--- a/src/login.c
+++ b/src/login.c
@@ -495,13 +495,13 @@ int main (int argc, char **argv)
 
 	if (geteuid() != 0) {
 		fprintf (stderr, _("%s: Cannot possibly work without effective root\n"), Prog);
-		exit (1);
+		return 1;
 	}
 
 	process_flags (argc, argv);
 
 	if ((isatty (0) == 0) || (isatty (1) == 0) || (isatty (2) == 0)) {
-		exit (1);	/* must be a terminal */
+		return 1;	/* must be a terminal */
 	}
 
 	err = get_session_host(&host);
@@ -513,7 +513,7 @@ int main (int argc, char **argv)
 		SYSLOG ((LOG_ERR,
 				 "No session entry, error %d.  You must exec \"login\" from the lowest level \"sh\"",
 				 err));
-		exit (1);
+		return 1;
 	}
 
 	tmptty = ttyname (0);
@@ -623,7 +623,7 @@ int main (int argc, char **argv)
 		         pam_strerror (pamh, retcode));
 		SYSLOG ((LOG_ERR, "Couldn't initialize PAM: %s",
 		         pam_strerror (pamh, retcode)));
-		exit (99);
+		return 99;
 	}
 
 	/*
@@ -699,13 +699,13 @@ int main (int argc, char **argv)
 				         _("Maximum number of tries exceeded (%u)\n"),
 				         failcount);
 				PAM_END;
-				exit(0);
+				return 0;
 			} else if (retcode == PAM_ABORT) {
 				/* Serious problems, quit now */
 				(void) fputs (_("login: abort requested by PAM\n"), stderr);
 				SYSLOG ((LOG_ERR,"PAM_ABORT returned from pam_authenticate()"));
 				PAM_END;
-				exit(99);
+				return 99;
 			} else if (retcode != PAM_SUCCESS) {
 				SYSLOG ((LOG_NOTICE,"FAILED LOGIN (%u)%s FOR '%s', %s",
 				         failcount, fromhost, failent_user,
@@ -743,7 +743,7 @@ int main (int argc, char **argv)
 				         _("Maximum number of tries exceeded (%u)\n"),
 				         failcount);
 				PAM_END;
-				exit(0);
+				return 0;
 			}
 
 			/*
@@ -788,7 +788,7 @@ int main (int argc, char **argv)
 		fprintf (stderr,
 		         _("Cannot find user (%s)\n"),
 		         username);
-		exit (1);
+		return 1;
 	}
 
 	/* This set up the process credential (group) and initialize the
@@ -796,7 +796,7 @@ int main (int argc, char **argv)
 	 * This has to be done before pam_setcred
 	 */
 	if (setup_groups (pwd) != 0) {
-		exit (1);
+		return 1;
 	}
 
 	retcode = pam_setcred (pamh, PAM_ESTABLISH_CRED);
@@ -832,7 +832,7 @@ int main (int argc, char **argv)
 			max_size = login_name_max_size();
 			if (subroot) {
 				closelog ();
-				exit (1);
+				return 1;
 			}
 			preauth_flag = false;
 			username = XMALLOC(max_size, char);
@@ -988,7 +988,7 @@ int main (int argc, char **argv)
 		/* allow only one attempt with -f */
 		if (fflg || (retries <= 0)) {
 			closelog ();
-			exit (1);
+			return 1;
 		}
 	}			/* while (true) */
 #endif				/* ! USE_PAM */
@@ -1009,7 +1009,7 @@ int main (int argc, char **argv)
 		         username, fromhost));
 		closelog ();
 		bad_time_notify ();
-		exit (1);
+		return 1;
 	}
 
 	check_nologin (pwd->pw_uid == 0);
@@ -1076,7 +1076,7 @@ int main (int argc, char **argv)
 				SYSLOG ((LOG_ERR,
 				         "cannot find user %s after update of expired password",
 				         username));
-				exit (1);
+				return 1;
 			}
 			spw_free (spwd);
 			spwd = xgetspnam (username);
@@ -1098,7 +1098,7 @@ int main (int argc, char **argv)
 		fprintf (stderr, _("%s: failure forking: %s"),
 		         Prog, strerror (errno));
 		PAM_END;
-		exit (0);
+		return 0;
 	} else if (child != 0) {
 		/*
 		 * parent - wait for child to finish, then cleanup
@@ -1106,7 +1106,7 @@ int main (int argc, char **argv)
 		 */
 		wait (NULL);
 		PAM_END;
-		exit (0);
+		return 0;
 	}
 	/* child */
 #endif
@@ -1151,7 +1151,7 @@ int main (int argc, char **argv)
 	if (change_uid (pwd))
 #endif
 	{
-		exit (1);
+		return 1;
 	}
 
 	setup_env (pwd);	/* set env vars, cd to the home dir */

--- a/src/logoutd.c
+++ b/src/logoutd.c
@@ -137,11 +137,11 @@ main(int argc, char **argv)
 	pid = fork ();
 	if (pid > 0) {
 		/* parent */
-		exit (EXIT_SUCCESS);
+		return EXIT_SUCCESS;
 	} else if (pid < 0) {
 		/* error */
 		perror ("fork");
-		exit (EXIT_FAILURE);
+		return EXIT_FAILURE;
 	}
 #endif				/* !DEBUG */
 

--- a/src/new_subid_range.c
+++ b/src/new_subid_range.c
@@ -56,7 +56,7 @@ int main(int argc, char *argv[])
 
 	if (!ok) {
 		fprintf(stderr, "Failed creating new id range\n");
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 	}
 	printf("Subuid range %lu:%lu\n", range.start, range.count);
 

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -452,7 +452,7 @@ int main (int argc, char **argv)
 		SYSLOG ((LOG_WARN, "Cannot determine the user name of the caller (UID %lu)",
 		         (unsigned long) getuid ()));
 		closelog ();
-		exit (EXIT_FAILURE);
+		return EXIT_FAILURE;
 	}
 	name = pwd->pw_name;
 
@@ -498,7 +498,7 @@ int main (int argc, char **argv)
 		} else {
 			usage ();
 			closelog ();
-			exit (EXIT_FAILURE);
+			return EXIT_FAILURE;
 		}
 		if (argc > 0) {
 
@@ -571,7 +571,7 @@ int main (int argc, char **argv)
 				     "changing", NULL, getuid(), 0);
 		}
 #endif
-		exit(EXIT_FAILURE);
+		return EXIT_FAILURE;
 	}
 
 	/*
@@ -708,7 +708,7 @@ int main (int argc, char **argv)
 		audit_logger (AUDIT_CHGRP_ID, Prog,
 		              audit_buf, NULL, getuid (), 0);
 #endif
-		exit (EXIT_FAILURE);
+		return EXIT_FAILURE;
 	}
 
 	if (setuid (getuid ()) != 0) {
@@ -718,7 +718,7 @@ int main (int argc, char **argv)
 		audit_logger (AUDIT_CHGRP_ID, Prog,
 		              audit_buf, NULL, getuid (), 0);
 #endif
-		exit (EXIT_FAILURE);
+		return EXIT_FAILURE;
 	}
 
 	/*
@@ -734,7 +734,7 @@ int main (int argc, char **argv)
 		              audit_buf, NULL, getuid (), 0);
 #endif
 		perror (SHELL);
-		exit ((errno == ENOENT) ? E_CMD_NOTFOUND : E_CMD_NOEXEC);
+		return (errno == ENOENT) ? E_CMD_NOTFOUND : E_CMD_NOEXEC;
 	}
 
 	/*
@@ -804,7 +804,7 @@ int main (int argc, char **argv)
 	 * the previous environment which should be the user's login shell.
 	 */
 	err = shell (prog, initflag ? NULL : progbase, newenvp);
-	exit ((err == ENOENT) ? E_CMD_NOTFOUND : E_CMD_NOEXEC);
+	return (err == ENOENT) ? E_CMD_NOTFOUND : E_CMD_NOEXEC;
 	/*@notreached@*/
       failure:
 
@@ -829,6 +829,6 @@ int main (int argc, char **argv)
 		              "changing", NULL, getuid (), 0);
 	}
 #endif
-	exit (EXIT_FAILURE);
+	return EXIT_FAILURE;
 }
 

--- a/src/newusers.c
+++ b/src/newusers.c
@@ -1341,11 +1341,11 @@ int main (int argc, char **argv)
 			fprintf (stderr,
 			         _("%s: (line %jd, user %s) password not changed\n"),
 			         Prog, lines[i], usernames[i]);
-			exit (EXIT_FAILURE);
+			return EXIT_FAILURE;
 		}
 	}
 #endif				/* USE_PAM */
 
-	exit (EXIT_SUCCESS);
+	return EXIT_SUCCESS;
 }
 

--- a/src/passwd.c
+++ b/src/passwd.c
@@ -843,7 +843,7 @@ main(int argc, char **argv)
 					fprintf (stderr,
 					         _("%s: repository %s not supported\n"),
 						 Prog, optarg);
-					exit (E_BAD_ARG);
+					return E_BAD_ARG;
 				}
 				break;
 			case 'R': /* no-op, handled in process_root_flag () */
@@ -908,7 +908,7 @@ main(int argc, char **argv)
 		                Prog);
 		SYSLOG ((LOG_WARN, "Cannot determine the user name of the caller (UID %lu)",
 		         (unsigned long) getuid ()));
-		exit (E_NOPERM);
+		return E_NOPERM;
 	}
 	myname = xstrdup (pw->pw_name);
 	if (optind < argc) {
@@ -940,7 +940,7 @@ main(int argc, char **argv)
 			(void) fprintf (stderr,
 			                _("%s: Permission denied.\n"),
 			                Prog);
-			exit (E_NOPERM);
+			return E_NOPERM;
 		}
 		prefix_setpwent ();
 		while ( (pw = prefix_getpwent ()) != NULL ) {
@@ -980,7 +980,7 @@ main(int argc, char **argv)
 
 	if (anyflag && !amroot) {
 		(void) fprintf (stderr, _("%s: Permission denied.\n"), Prog);
-		exit (E_NOPERM);
+		return E_NOPERM;
 	}
 
 	pw = xprefix_getpwnam (name);
@@ -988,7 +988,7 @@ main(int argc, char **argv)
 		(void) fprintf (stderr,
 		                _("%s: user '%s' does not exist\n"),
 		                Prog, name);
-		exit (E_NOPERM);
+		return E_NOPERM;
 	}
 #ifdef WITH_SELINUX
 	/* only do this check when getuid()==0 because it's a pre-condition for
@@ -1000,7 +1000,7 @@ main(int argc, char **argv)
 		(void) fprintf(stderr,
 		               _("%s: root is not authorized by SELinux to change the password of %s\n"),
 		               Prog, name);
-		exit (E_NOPERM);
+		return E_NOPERM;
 	}
 #endif				/* WITH_SELINUX */
 
@@ -1016,12 +1016,12 @@ main(int argc, char **argv)
 		         "can't view or modify password information for %s",
 		         name));
 		closelog ();
-		exit (E_NOPERM);
+		return E_NOPERM;
 	}
 
 	if (Sflg) {
 		print_status (pw);
-		exit (E_SUCCESS);
+		return E_SUCCESS;
 	}
 	if (!use_pam)
 	{
@@ -1034,7 +1034,7 @@ main(int argc, char **argv)
 				(void) fprintf (stderr,
 				                _("%s: Permission denied.\n"),
 				                Prog);
-				exit (E_NOPERM);
+				return E_NOPERM;
 			}
 			sp = pwd_to_spwd (pw);
 		}
@@ -1065,7 +1065,7 @@ main(int argc, char **argv)
 				                _("The password for %s is unchanged.\n"),
 				                name);
 				closelog ();
-				exit (E_NOPERM);
+				return E_NOPERM;
 			}
 			do_update_pwd = true;
 			do_update_age = true;
@@ -1095,14 +1095,14 @@ main(int argc, char **argv)
 		} else {
 			do_pam_passwd (name, qflg, kflg);
 		}
-		exit (E_SUCCESS);
+		return E_SUCCESS;
 	}
 #endif				/* USE_PAM */
 	if (setuid (0) != 0) {
 		(void) fputs (_("Cannot change ID to root.\n"), stderr);
 		SYSLOG ((LOG_ERR, "can't setuid(0)"));
 		closelog ();
-		exit (E_NOPERM);
+		return E_NOPERM;
 	}
 	if (spw_file_present ()) {
 		update_shadow ();

--- a/src/pwconv.c
+++ b/src/pwconv.c
@@ -173,7 +173,7 @@ int main (int argc, char **argv)
 #ifdef WITH_TCB
 	if (getdef_bool("USE_TCB")) {
 		fprintf (stderr, _("%s: can't work with tcb enabled\n"), Prog);
-		exit (E_FAILURE);
+		return E_FAILURE;
 	}
 #endif				/* WITH_TCB */
 

--- a/src/pwunconv.c
+++ b/src/pwunconv.c
@@ -134,13 +134,13 @@ int main (int argc, char **argv)
 #ifdef WITH_TCB
 	if (getdef_bool("USE_TCB")) {
 		fprintf (stderr, _("%s: can't work with tcb enabled\n"), Prog);
-		exit (1);
+		return 1;
 	}
 #endif				/* WITH_TCB */
 
 	if (!spw_file_present ()) {
 		/* shadow not installed, do nothing */
-		exit (0);
+		return 0;
 	}
 
 	if (pw_lock () == 0) {

--- a/src/su.c
+++ b/src/su.c
@@ -1034,7 +1034,7 @@ int main (int argc, char **argv)
 		fprintf (stderr,
 		         _("%s: pam_start: error %d\n"),
 		         Prog, ret));
-		exit (1);
+		return 1;
 	}
 
 	ret = pam_set_item (pamh, PAM_TTY, caller_tty);
@@ -1046,7 +1046,7 @@ int main (int argc, char **argv)
 		         pam_strerror (pamh, ret)));
 		fprintf (stderr, _("%s: %s\n"), Prog, pam_strerror (pamh, ret));
 		pam_end (pamh, ret);
-		exit (1);
+		return 1;
 	}
 #endif				/* USE_PAM */
 
@@ -1095,7 +1095,7 @@ int main (int argc, char **argv)
 	/* set primary group id and supplementary groups */
 	if (setup_groups (pw) != 0) {
 		pam_end (pamh, PAM_ABORT);
-		exit (1);
+		return 1;
 	}
 
 	/*
@@ -1107,7 +1107,7 @@ int main (int argc, char **argv)
 		SYSLOG ((LOG_ERR, "pam_setcred: %s", pam_strerror (pamh, ret)));
 		fprintf (stderr, _("%s: %s\n"), Prog, pam_strerror (pamh, ret));
 		(void) pam_end (pamh, ret);
-		exit (1);
+		return 1;
 	}
 
 	ret = pam_open_session (pamh, 0);
@@ -1117,14 +1117,14 @@ int main (int argc, char **argv)
 		fprintf (stderr, _("%s: %s\n"), Prog, pam_strerror (pamh, ret));
 		pam_setcred (pamh, PAM_DELETE_CRED);
 		(void) pam_end (pamh, ret);
-		exit (1);
+		return 1;
 	}
 
 	prepare_pam_close_session ();
 
 	/* become the new user */
 	if (change_uid (pw) != 0) {
-		exit (1);
+		return 1;
 	}
 #else				/* !USE_PAM */
 	/* no limits if su from root (unless su must fake login's behavior) */
@@ -1133,7 +1133,7 @@ int main (int argc, char **argv)
 	}
 
 	if (setup_uid_gid (pw, caller_on_console) != 0) {
-		exit (1);
+		return 1;
 	}
 #endif				/* !USE_PAM */
 
@@ -1180,7 +1180,7 @@ int main (int argc, char **argv)
 			(void) fprintf (stderr,
 			                _("%s: Cannot drop the controlling terminal\n"),
 			                Prog);
-			exit (1);
+			return 1;
 		}
 	}
 

--- a/src/sulogin.c
+++ b/src/sulogin.c
@@ -92,15 +92,15 @@ main(int argc, char *argv[])
 	}
 	if (access (PASSWD_FILE, F_OK) == -1) {	/* must be a password file! */
 		(void) puts (_("No password file"));
-		exit (1);
+		return 1;
 	}
 #if !defined(DEBUG) && defined(SULOGIN_ONLY_INIT)
 	if (getppid () != 1) {	/* parent must be INIT */
-		exit (1);
+		return 1;
 	}
 #endif
 	if ((isatty (0) == 0) || (isatty (1) == 0) || (isatty (2) == 0)) {
-		exit (1);	/* must be a terminal */
+		return 1;	/* must be a terminal */
 	}
 	/* If we were init, we need to start a new session */
 	if (getppid() == 1) {
@@ -135,7 +135,7 @@ main(int argc, char *argv[])
 			 * Fail secure
 			 */
 			(void) puts(_("No password entry for 'root'"));
-			exit(1);
+			return 1;
 		}
 
 		/*
@@ -160,7 +160,7 @@ main(int argc, char *argv[])
 #ifdef	TELINIT
 			execl (PATH_TELINIT, "telinit", RUNLEVEL, (char *) NULL);
 #endif
-			exit (0);
+			return 0;
 		}
 
 		done = valid(pass, &pwent);

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -2514,7 +2514,7 @@ int main (int argc, char **argv)
 
 	if (run_parts ("/etc/shadow-maint/useradd-pre.d", user_name,
 			"useradd")) {
-		exit(1);
+		return 1;
 	}
 
 #ifdef ACCT_TOOLS_SETUID
@@ -2559,11 +2559,11 @@ int main (int argc, char **argv)
 	 */
 	if (Dflg) {
 		if (gflg || bflg || fflg || eflg || sflg) {
-			exit ((set_defaults () != 0) ? 1 : 0);
+			return (set_defaults () != 0) ? 1 : 0;
 		}
 
 		show_defaults ();
-		exit (E_SUCCESS);
+		return E_SUCCESS;
 	}
 
 	/*
@@ -2739,7 +2739,7 @@ int main (int argc, char **argv)
 
 	if (run_parts ("/etc/shadow-maint/useradd-post.d", user_name,
 			"useradd")) {
-		exit(1);
+		return 1;
 	}
 
 	return E_SUCCESS;

--- a/src/userdel.c
+++ b/src/userdel.c
@@ -1019,7 +1019,7 @@ int main (int argc, char **argv)
 					fprintf (stderr,
 					         _("%s: -Z cannot be used with --prefix\n"),
 					         Prog);
-					exit (E_BAD_ARG);
+					return E_BAD_ARG;
 				}
 				if (is_selinux_enabled () > 0) {
 					Zflg = true;
@@ -1028,7 +1028,7 @@ int main (int argc, char **argv)
 					         _("%s: -Z requires SELinux enabled kernel\n"),
 					         Prog);
 
-					exit (E_BAD_ARG);
+					return E_BAD_ARG;
 				}
 				break;
 #endif				/* WITH_SELINUX */
@@ -1051,7 +1051,7 @@ int main (int argc, char **argv)
 			fprintf (stderr,
 			         _("%s: Cannot determine your user name.\n"),
 			         Prog);
-			exit (E_PW_UPDATE);
+			return E_PW_UPDATE;
 		}
 
 		retval = pam_start (Prog, pampw->pw_name, &conv, &pamh);
@@ -1072,7 +1072,7 @@ int main (int argc, char **argv)
 		if (NULL != pamh) {
 			(void) pam_end (pamh, retval);
 		}
-		exit (E_PW_UPDATE);
+		return E_PW_UPDATE;
 	}
 	(void) pam_end (pamh, retval);
 #endif				/* USE_PAM */
@@ -1096,7 +1096,7 @@ int main (int argc, char **argv)
 
 		if (run_parts ("/etc/shadow-maint/userdel-pre.d", user_name,
 				"userdel")) {
-			exit(1);
+			return 1;
 		}
 		pw_open(O_RDONLY);
 		pwd = pw_locate (user_name); /* we care only about local users */
@@ -1110,7 +1110,7 @@ int main (int argc, char **argv)
 			              user_name, AUDIT_NO_ID,
 			              SHADOW_AUDIT_FAILURE);
 #endif				/* WITH_AUDIT */
-			exit (E_NOTFOUND);
+			return E_NOTFOUND;
 		}
 		user_id = pwd->pw_uid;
 		user_gid = pwd->pw_gid;
@@ -1124,7 +1124,7 @@ int main (int argc, char **argv)
 	}
 #ifdef WITH_TCB
 	if (shadowtcb_set_user (user_name) == SHADOWTCB_FAILURE) {
-		exit (E_NOTFOUND);
+		return E_NOTFOUND;
 	}
 #endif				/* WITH_TCB */
 	/*
@@ -1140,7 +1140,7 @@ int main (int argc, char **argv)
 			              user_name, AUDIT_NO_ID,
 			              SHADOW_AUDIT_FAILURE);
 #endif				/* WITH_AUDIT */
-			exit (E_USER_BUSY);
+			return E_USER_BUSY;
 		}
 	}
 
@@ -1272,7 +1272,7 @@ int main (int argc, char **argv)
 	close_files ();
 
 	if (run_parts ("/etc/shadow-maint/userdel-post.d", user_name, "userdel")) {
-		exit(1);
+		return 1;
 	}
 
 #ifdef WITH_TCB

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -2192,7 +2192,7 @@ int main (int argc, char **argv)
 #endif				/* ENABLE_SUBIDS */
 	       )
 	    && (user_busy (user_name, user_id) != 0)) {
-		exit (E_USER_BUSY);
+		return E_USER_BUSY;
 	}
 
 #ifdef ACCT_TOOLS_SETUID
@@ -2204,7 +2204,7 @@ int main (int argc, char **argv)
 			fprintf (stderr,
 			         _("%s: Cannot determine your user name.\n"),
 			         Prog);
-			exit (1);
+			return 1;
 		}
 
 		retval = pam_start (Prog, pampw->pw_name, &conv, &pamh);
@@ -2225,7 +2225,7 @@ int main (int argc, char **argv)
 		if (NULL != pamh) {
 			(void) pam_end (pamh, retval);
 		}
-		exit (1);
+		return 1;
 	}
 	(void) pam_end (pamh, retval);
 #endif				/* USE_PAM */
@@ -2233,7 +2233,7 @@ int main (int argc, char **argv)
 
 #ifdef WITH_TCB
 	if (shadowtcb_set_user (user_name) == SHADOWTCB_FAILURE) {
-		exit (E_PW_UPDATE);
+		return E_PW_UPDATE;
 	}
 #endif
 
@@ -2324,7 +2324,7 @@ int main (int argc, char **argv)
 #ifdef WITH_TCB
 	if (   (lflg || uflg)
 	    && (shadowtcb_move (user_newname, user_newid) == SHADOWTCB_FAILURE) ) {
-		exit (E_PW_UPDATE);
+		return E_PW_UPDATE;
 	}
 #endif
 


### PR DESCRIPTION
Argued with myself about creating this PR or not, so here are my pro and contra arguments:

### return over exit
- Allows the stack protector of main function to work

### exit over return
- Prevents copy&paste errors if code is moved from main into another function
- Counter argument to stack protector: Writing far enough behind the end of stack could modify the stack protector behavior itself
- If no stack protector is compiled in, this change actually enables stack attacks in main function

### Either/or
- Unifies the code base a bit more

### Keep as is
- Every change has potential of failure
- Counter argument to stack protector: Pretty much every error handling with exit in a function circumvents the protector

Since I created the PR, I see benefits in allowing the stack protector to work and unification process is always nice.

But let's not rush this. Small benefit anyway.