### PR TITLE
Revert "lib/, src/: Use local time for human-readable dates"

### DIFF
--- a/lib/time/day_to_str.h
+++ b/lib/time/day_to_str.h
@@ -38,7 +38,7 @@ day_to_str(size_t size, char buf[size], long day)
 		return;
 	}
 
-	if (localtime_r(&date, &tm) == NULL) {
+	if (gmtime_r(&date, &tm) == NULL) {
 		strtcpy(buf, "future", size);
 		return;
 	}

--- a/src/chage.c
+++ b/src/chage.c
@@ -238,7 +238,7 @@ print_day_as_date(long day)
 		return;
 	}
 
-	if (localtime_r(&date, &tm) == NULL) {
+	if (gmtime_r(&date, &tm) == NULL) {
 		puts(_("future"));
 		return;
 	}


### PR DESCRIPTION
This reverts commit 3f5b4b56268269fefed55aa106f382037297d663.

The dates are stored as UTC, and are stored as a number of days since Epoch.  We don't have enough precision to translate it into local time. Using local time has caused endless issues in users.

This patch is not enough for fixing this issue completely, since printing a date without time-zone information means that the date is a local date, but what we're printing is a UTC date.  A future patch should add time-zone information to the date.

For now, let's revert this change that has caused so many issues.

Fixes: 3f5b4b562682 (2024-08-01; "lib/, src/: Use local time for human-readable dates")
Link: <https://github.com/ansible/ansible/blob/devel/test/integration/targets/user/tasks/test_expires.yml#L2-L20>
Link: <https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1095430>
Link: <https://lists.iana.org/hyperkitty/list/tz@iana.org/message/ENE5IFV3GAH6WK22UJ6YU57D6TQINSP5/>
Link: <https://github.com/shadow-maint/shadow/issues/1202>
Link: <https://github.com/shadow-maint/shadow/issues/1057>
Link: <https://github.com/shadow-maint/shadow/issues/939>
Link: <https://github.com/shadow-maint/shadow/pull/1058>
Link: <https://github.com/shadow-maint/shadow/pull/1059#issuecomment-2309888519>
Link: <https://github.com/shadow-maint/shadow/pull/952>
Link: <https://github.com/shadow-maint/shadow/pull/942>
Reported-by: @zeha 
Reported-by: @kenion
Reported-by: @alejandro-colomar 
Reported-by: @jubalh
Reported-by: @leegarrett
Cc: @eggert
Cc: @timparenti
Cc: @ikerexxe 
Cc: @hallyn 
Cc: @BrianInglis

---

Here goes the first round of changes.  This reverts back to the old behavior.

---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git range-diff alx/master..gh/t shadow/master..t
1:  0f13c140 = 1:  e49f4a57 Revert "lib/, src/: Use local time for human-readable dates"
```
</details>

<details>
<summary>v1c</summary>

-  Reviewed-by @ikerexxe 

```
$ git range-diff master gh/t t 
1:  e49f4a57 ! 1:  a0c5dbd6 Revert "lib/, src/: Use local time for human-readable dates"
    @@ Commit message
         Reported-by: Lee Garrett <lgarrett@rocketjump.eu>
         Cc: Paul Eggert <eggert@cs.ucla.edu>
         Cc: Tim Parenti <tim@timtimeonline.com>
    -    Cc: Iker Pedrosa <ipedrosa@redhat.com>
         Cc: "Serge E. Hallyn" <serge@hallyn.com>
         Cc: Brian Inglis <Brian.Inglis@SystematicSW.ab.ca>
    +    Reviewed-by: Iker Pedrosa <ipedrosa@redhat.com>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/time/day_to_str.h ##
```
</details>