### PR TITLE
valid_field(): Improve readability

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -94,6 +94,7 @@ libshadow_la_SOURCES = \
 	failure.h \
 	fd.c \
 	fields.c \
+	fields.h \
 	find_new_gid.c \
 	find_new_uid.c \
 	find_new_sub_gids.c \

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -179,6 +179,8 @@ libshadow_la_SOURCES = \
 	spawn.c \
 	sssd.c \
 	sssd.h \
+	string/ctype/strchrisascii/strchriscntrl.c \
+	string/ctype/strchrisascii/strchriscntrl.h \
 	string/ctype/strisascii/strisdigit.c \
 	string/ctype/strisascii/strisdigit.h \
 	string/ctype/strisascii/strisprint.c \

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -181,6 +181,8 @@ libshadow_la_SOURCES = \
 	sssd.h \
 	string/ctype/strisascii/strisdigit.c \
 	string/ctype/strisascii/strisdigit.h \
+	string/ctype/strisascii/strisprint.c \
+	string/ctype/strisascii/strisprint.h \
 	string/ctype/strtoascii/strtolower.c \
 	string/ctype/strtoascii/strtolower.h \
 	string/memset/memzero.c \

--- a/lib/fields.c
+++ b/lib/fields.c
@@ -27,19 +27,16 @@
 /*
  * valid_field - insure that a field contains all legal characters
  *
- * The supplied field is scanned for non-printable and other illegal
- * characters.
- *  + -1 is returned if an illegal or control character is present.
- *  +  1 is returned if no illegal or control characters are present,
- *       but the field contains a non-printable character.
- *  +  0 is returned otherwise.
+ * Return:
+ *	-1	Illegal or control characters are present.
+ *	1	Non-ASCII characters are present.
+ *	0	All chatacters are legal and ASCII.
  */
 int
 valid_field_(const char *field, const char *illegal)
 {
-	if (NULL == field) {
+	if (NULL == field)
 		return -1;
-	}
 
 	if (strpbrk(field, illegal))
 		return -1;
@@ -50,7 +47,7 @@ valid_field_(const char *field, const char *illegal)
 	if (streq(field, ""))
 		return 0;
 
-	return 1;
+	return 1;  // !ASCII
 }
 
 /*

--- a/lib/fields.c
+++ b/lib/fields.c
@@ -9,7 +9,7 @@
 
 #include <config.h>
 
-#ident "$Id$"
+#include "fields.h"
 
 #include <ctype.h>
 #include <string.h>

--- a/lib/fields.c
+++ b/lib/fields.c
@@ -48,12 +48,10 @@ valid_field_(const char *field, const char *illegal)
 	/* Search if there are non-printable or control characters */
 	for (cp = field; !streq(cp, ""); cp++) {
 		unsigned char c = *cp;
+		if (iscntrl(c))
+			return -1;
 		if (!isprint (c)) {
 			err = 1;
-		}
-		if (iscntrl (c)) {
-			err = -1;
-			break;
 		}
 	}
 

--- a/lib/fields.c
+++ b/lib/fields.c
@@ -32,7 +32,8 @@
  *       but the field contains a non-printable character.
  *  +  0 is returned otherwise.
  */
-int valid_field (const char *field, const char *illegal)
+int
+valid_field_(const char *field, const char *illegal)
 {
 	const char *cp;
 	int err = 0;

--- a/lib/fields.c
+++ b/lib/fields.c
@@ -42,11 +42,8 @@ valid_field_(const char *field, const char *illegal)
 		return -1;
 	}
 
-	/* For each character of field, search if it appears in the list
-	 * of illegal characters. */
-	if (illegal && strpbrk(field, illegal)) {
+	if (strpbrk(field, illegal))
 		return -1;
-	}
 
 	/* Search if there are non-printable or control characters */
 	for (cp = field; !streq(cp, ""); cp++) {

--- a/lib/fields.c
+++ b/lib/fields.c
@@ -16,6 +16,7 @@
 #include <stdio.h>
 
 #include "prototypes.h"
+#include "string/ctype/strisascii/strisprint.h"
 #include "string/strcmp/streq.h"
 #include "string/strspn/stpspn.h"
 #include "string/strspn/stprspn.h"
@@ -36,7 +37,6 @@ int
 valid_field_(const char *field, const char *illegal)
 {
 	const char *cp;
-	int err = 0;
 
 	if (NULL == field) {
 		return -1;
@@ -50,12 +50,14 @@ valid_field_(const char *field, const char *illegal)
 		unsigned char c = *cp;
 		if (iscntrl(c))
 			return -1;
-		if (!isprint (c)) {
-			err = 1;
-		}
 	}
 
-	return err;
+	if (strisprint(field))
+		return 0;
+	if (streq(field, ""))
+		return 0;
+
+	return 1;
 }
 
 /*

--- a/lib/fields.c
+++ b/lib/fields.c
@@ -17,6 +17,7 @@
 
 #include "prototypes.h"
 #include "string/ctype/strisascii/strisprint.h"
+#include "string/ctype/strchrisascii/strchriscntrl.h"
 #include "string/strcmp/streq.h"
 #include "string/strspn/stpspn.h"
 #include "string/strspn/stprspn.h"
@@ -36,22 +37,14 @@
 int
 valid_field_(const char *field, const char *illegal)
 {
-	const char *cp;
-
 	if (NULL == field) {
 		return -1;
 	}
 
 	if (strpbrk(field, illegal))
 		return -1;
-
-	/* Search if there are non-printable or control characters */
-	for (cp = field; !streq(cp, ""); cp++) {
-		unsigned char c = *cp;
-		if (iscntrl(c))
-			return -1;
-	}
-
+	if (strchriscntrl(field))
+		return -1;
 	if (strisprint(field))
 		return 0;
 	if (streq(field, ""))

--- a/lib/fields.h
+++ b/lib/fields.h
@@ -10,7 +10,10 @@
 #include <stddef.h>
 
 
-int valid_field(const char *field, const char *illegal);
+#define valid_field(field, illegal)  valid_field_(field, "" illegal "")
+
+
+int valid_field_(const char *field, const char *illegal);
 void change_field(char *buf, size_t maxsize, const char *prompt);
 
 

--- a/lib/fields.h
+++ b/lib/fields.h
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef _SHADOW_INCLUDE_LIB_FIELDS_H_
+#define _SHADOW_INCLUDE_LIB_FIELDS_H_
+
+
+#include <config.h>
+
+#include <stddef.h>
+
+
+int valid_field(const char *field, const char *illegal);
+void change_field(char *buf, size_t maxsize, const char *prompt);
+
+
+#endif  // include guard

--- a/lib/groupio.c
+++ b/lib/groupio.c
@@ -19,6 +19,7 @@
 #include "alloc/malloc.h"
 #include "commonio.h"
 #include "defines.h"
+#include "fields.h"
 #include "getdef.h"
 #include "groupio.h"
 #include "prototypes.h"

--- a/lib/prototypes.h
+++ b/lib/prototypes.h
@@ -120,10 +120,6 @@ extern void sanitize_env (void);
 /* fd.c */
 extern void check_fds (void);
 
-/* fields.c */
-extern void change_field (char *, size_t, const char *);
-extern int valid_field (const char *, const char *);
-
 /* find_new_gid.c */
 extern int find_new_gid (bool sys_group,
                          gid_t *gid,

--- a/lib/pwio.c
+++ b/lib/pwio.c
@@ -10,13 +10,13 @@
 
 #include <config.h>
 
-#ident "$Id$"
-
-#include "prototypes.h"
-#include "defines.h"
 #include <pwd.h>
 #include <stdio.h>
+
 #include "commonio.h"
+#include "defines.h"
+#include "fields.h"
+#include "prototypes.h"
 #include "pwio.h"
 
 static /*@null@*/ /*@only@*/void *passwd_dup (const void *ent)

--- a/lib/sgroupio.c
+++ b/lib/sgroupio.c
@@ -19,6 +19,7 @@
 #include "prototypes.h"
 #include "defines.h"
 #include "commonio.h"
+#include "fields.h"
 #include "getdef.h"
 #include "sgroupio.h"
 #include "string/memset/memzero.h"

--- a/lib/shadowio.c
+++ b/lib/shadowio.c
@@ -10,19 +10,21 @@
 
 #include <config.h>
 
-#ident "$Id$"
-
-#include "prototypes.h"
-#include "defines.h"
 #include <shadow.h>
 #include <stdio.h>
+
 #include "commonio.h"
+#include "defines.h"
+#include "fields.h"
 #include "getdef.h"
+#include "prototypes.h"
 #include "shadowio.h"
+
 #ifdef WITH_TCB
 #include <tcb.h>
 #include "tcbfuncs.h"
 #endif				/* WITH_TCB */
+
 
 static /*@null@*/ /*@only@*/void *shadow_dup (const void *ent)
 {

--- a/lib/string/ctype/strchrisascii/strchriscntrl.c
+++ b/lib/string/ctype/strchrisascii/strchriscntrl.c
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#include <config.h>
+
+#include "string/ctype/strchrisascii/strchriscntrl.h"
+
+#include <stdbool.h>
+
+
+extern inline bool strchriscntrl(const char *s);

--- a/lib/string/ctype/strchrisascii/strchriscntrl.h
+++ b/lib/string/ctype/strchrisascii/strchriscntrl.h
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2024-2025, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#ifndef SHADOW_INCLUDE_LIB_STRING_CTYPE_STRCHRISASCII_STRCHRISCNTRL_H_
+#define SHADOW_INCLUDE_LIB_STRING_CTYPE_STRCHRISASCII_STRCHRISCNTRL_H_
+
+
+#include <config.h>
+
+#include <ctype.h>
+#include <stdbool.h>
+
+#include "string/strcmp/streq.h"
+
+
+inline bool strchriscntrl(const char *s);
+
+
+// string character is [:cntrl:]
+// Return true if any iscntrl(3) character is found in the string.
+inline bool
+strchriscntrl(const char *s)
+{
+	for (; !streq(s, ""); s++) {
+		unsigned char  c = *s;
+
+		if (iscntrl(c))
+			return true;
+	}
+
+	return false;
+}
+
+
+#endif  // include guard

--- a/lib/string/ctype/strisascii/strisprint.c
+++ b/lib/string/ctype/strisascii/strisprint.c
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#include <config.h>
+
+#include "string/ctype/strisascii/strisprint.h"
+
+#include <stdbool.h>
+
+
+extern inline bool strisprint(const char *s);

--- a/lib/string/ctype/strisascii/strisprint.h
+++ b/lib/string/ctype/strisascii/strisprint.h
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2024-2025, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#ifndef SHADOW_INCLUDE_LIB_STRING_CTYPE_STRISASCII_STRISPRINT_H_
+#define SHADOW_INCLUDE_LIB_STRING_CTYPE_STRISASCII_STRISPRINT_H_
+
+
+#include <config.h>
+
+#include <ctype.h>
+#include <stdbool.h>
+
+#include "string/strcmp/streq.h"
+
+
+inline bool strisprint(const char *s);
+
+
+// string is [:print:]
+// Like isprint(3), but check all characters in the string.
+inline bool
+strisprint(const char *s)
+{
+	if (streq(s, ""))
+		return false;
+
+	for (; !streq(s, ""); s++) {
+		unsigned char  c = *s;
+
+		if (!isprint(c))
+			return false;
+	}
+
+	return true;
+}
+
+
+#endif  // include guard

--- a/src/chage.c
+++ b/src/chage.c
@@ -23,6 +23,7 @@
 
 #include "atoi/a2i/a2s.h"
 #include "defines.h"
+#include "fields.h"
 #include "prototypes.h"
 #include "pwio.h"
 #include "shadowio.h"

--- a/src/chfn.c
+++ b/src/chfn.c
@@ -22,6 +22,7 @@
 #include "defines.h"
 /*@-exitarg@*/
 #include "exitcodes.h"
+#include "fields.h"
 #include "getdef.h"
 #include "nscd.h"
 #ifdef USE_PAM

--- a/src/chsh.c
+++ b/src/chsh.c
@@ -21,6 +21,7 @@
 #include "defines.h"
 /*@-exitarg@*/
 #include "exitcodes.h"
+#include "fields.h"
 #include "getdef.h"
 #include "nscd.h"
 #include "prototypes.h"


### PR DESCRIPTION
This adds `strisprint()` and `strchriscntrl()`.

---

Revisions:

<details>
<summary>v2</summary>

-  Rewrite the for loops in strisprint() and strchriscntrl().
-  Add comment desoupifying API names.

```
$ git range-diff shadow/master gh/vf vf 
1:  8561e822 ! 1:  9d2d0f66 lib/string/ctype/strisascii/: strisprint(): Add function
    @@ lib/string/ctype/strisascii/strisprint.c (new)
     
      ## lib/string/ctype/strisascii/strisprint.h (new) ##
     @@
    -+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
    ++// SPDX-FileCopyrightText: 2024-2025, Alejandro Colomar <alx@kernel.org>
     +// SPDX-License-Identifier: BSD-3-Clause
     +
     +
    @@ lib/string/ctype/strisascii/strisprint.h (new)
     +  if (streq(s, ""))
     +          return false;
     +
    -+  for (unsigned char c = *s; !streq(s, ""); c = *s++) {
    ++  for (; !streq(s, ""); s++) {
    ++          unsigned char  c = *s;
    ++
     +          if (!isprint(c))
     +                  return false;
     +  }
2:  e0404e20 ! 2:  83feb72a lib/string/ctype/strchrisascii/: strchriscntrl(): Add function
    @@ lib/string/ctype/strchrisascii/strchriscntrl.c (new)
     
      ## lib/string/ctype/strchrisascii/strchriscntrl.h (new) ##
     @@
    -+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
    ++// SPDX-FileCopyrightText: 2024-2025, Alejandro Colomar <alx@kernel.org>
     +// SPDX-License-Identifier: BSD-3-Clause
     +
     +
    @@ lib/string/ctype/strchrisascii/strchriscntrl.h (new)
     +inline bool strchriscntrl(const char *s);
     +
     +
    ++// string character is [:cntrl:]
     +// Return true if any iscntrl(3) character is found in the string.
     +inline bool
     +strchriscntrl(const char *s)
     +{
    -+  for (unsigned char c = *s; !streq(s, ""); c = *s++) {
    ++  for (; !streq(s, ""); s++) {
    ++          unsigned char  c = *s;
    ++
     +          if (iscntrl(c))
     +                  return true;
     +  }
3:  3bf69d20 = 3:  cb7ac416 lib/fields.c: valid_field(): Remove useless check
4:  dd9dcf99 = 4:  2633c872 lib/fields.c: valid_field(): Return early on error
5:  8c894903 = 5:  40bdb529 lib/fields.c: valid_field(): Use strisprint() instead of its pattern
6:  179652c2 = 6:  a47c6de7 lib/fields.c: valid_field(): Use strchriscntrl() instead of its pattern
7:  8032894a = 7:  fdee80fc lib/fields.c: valid_field(): Clarify comments
```
</details>

<details>
<summary>v2b</summary>

-  Rebase

```
$ git range-diff master..gh/vf shadow/master..vf 
1:  9d2d0f66 = 1:  793e5089 lib/string/ctype/strisascii/: strisprint(): Add function
2:  83feb72a = 2:  3cd6275c lib/string/ctype/strchrisascii/: strchriscntrl(): Add function
3:  cb7ac416 = 3:  ad633f26 lib/fields.c: valid_field(): Remove useless check
4:  2633c872 = 4:  4fe506c8 lib/fields.c: valid_field(): Return early on error
5:  40bdb529 = 5:  2ebb6672 lib/fields.c: valid_field(): Use strisprint() instead of its pattern
6:  a47c6de7 = 6:  316c8984 lib/fields.c: valid_field(): Use strchriscntrl() instead of its pattern
7:  fdee80fc = 7:  819f6ca0 lib/fields.c: valid_field(): Clarify comments
```
</details>

<details>
<summary>v2c</summary>

-  Rebase

```
$ git rd
1:  793e5089 = 1:  3c9ff60a lib/string/ctype/strisascii/: strisprint(): Add function
2:  3cd6275c = 2:  3935b6cb lib/string/ctype/strchrisascii/: strchriscntrl(): Add function
3:  ad633f26 = 3:  f7483326 lib/fields.c: valid_field(): Remove useless check
4:  4fe506c8 = 4:  e25096ae lib/fields.c: valid_field(): Return early on error
5:  2ebb6672 = 5:  923429ee lib/fields.c: valid_field(): Use strisprint() instead of its pattern
6:  316c8984 = 6:  9f9e7fa8 lib/fields.c: valid_field(): Use strchriscntrl() instead of its pattern
7:  819f6ca0 = 7:  dddb1d8e lib/fields.c: valid_field(): Clarify comments
```
</details>

<details>
<summary>v2d</summary>

-  Rebase

```
$ git rd
1:  3c9ff60a = 1:  26be5ef8 lib/string/ctype/strisascii/: strisprint(): Add function
2:  3935b6cb = 2:  dc105439 lib/string/ctype/strchrisascii/: strchriscntrl(): Add function
3:  f7483326 = 3:  e33796f0 lib/fields.c: valid_field(): Remove useless check
4:  e25096ae = 4:  0ccd7fc4 lib/fields.c: valid_field(): Return early on error
5:  923429ee = 5:  3857b4cd lib/fields.c: valid_field(): Use strisprint() instead of its pattern
6:  9f9e7fa8 = 6:  6875eb30 lib/fields.c: valid_field(): Use strchriscntrl() instead of its pattern
7:  dddb1d8e = 7:  1a6344c3 lib/fields.c: valid_field(): Clarify comments
```
</details>

<details>
<summary>v2e</summary>

-  Rebase

```
$ git rd
1:  26be5ef8 = 1:  4feaa04e lib/string/ctype/strisascii/: strisprint(): Add function
2:  dc105439 = 2:  80d6e2ad lib/string/ctype/strchrisascii/: strchriscntrl(): Add function
3:  e33796f0 = 3:  9b924437 lib/fields.c: valid_field(): Remove useless check
4:  0ccd7fc4 = 4:  699b0f7e lib/fields.c: valid_field(): Return early on error
5:  3857b4cd = 5:  3cae4b3a lib/fields.c: valid_field(): Use strisprint() instead of its pattern
6:  6875eb30 = 6:  c6ccbf77 lib/fields.c: valid_field(): Use strchriscntrl() instead of its pattern
7:  1a6344c3 = 7:  09291f44 lib/fields.c: valid_field(): Clarify comments
```
</details>

<details>
<summary>v2f</summary>

-  Rebase

```
$ git rd
1:  4feaa04e = 1:  e51e4c69 lib/string/ctype/strisascii/: strisprint(): Add function
2:  80d6e2ad = 2:  7789cb48 lib/string/ctype/strchrisascii/: strchriscntrl(): Add function
3:  9b924437 ! 3:  95c966d0 lib/fields.c: valid_field(): Remove useless check
    @@ lib/fields.c: int valid_field (const char *field, const char *illegal)
      
     -  /* For each character of field, search if it appears in the list
     -   * of illegal characters. */
    --  if (illegal && NULL != strpbrk (field, illegal)) {
    -+  if (NULL != strpbrk(field, illegal))
    +-  if (illegal && strpbrk(field, illegal)) {
    ++  if (strpbrk(field, illegal))
                return -1;
     -  }
      
4:  699b0f7e = 4:  76905a72 lib/fields.c: valid_field(): Return early on error
5:  3cae4b3a = 5:  88f683d3 lib/fields.c: valid_field(): Use strisprint() instead of its pattern
6:  c6ccbf77 ! 6:  a92b7c4b lib/fields.c: valid_field(): Use strchriscntrl() instead of its pattern
    @@ lib/fields.c
                return -1;
        }
      
    -   if (NULL != strpbrk(field, illegal))
    +   if (strpbrk(field, illegal))
                return -1;
     -
     -  /* Search if there are non-printable or control characters */
7:  09291f44 ! 7:  cedcbb3a lib/fields.c: valid_field(): Clarify comments
    @@ lib/fields.c
                return -1;
     -  }
      
    -   if (NULL != strpbrk(field, illegal))
    +   if (strpbrk(field, illegal))
                return -1;
     @@ lib/fields.c: int valid_field (const char *field, const char *illegal)
        if (streq(field, ""))
```
</details>

<details>
<summary>v2g</summary>

-  Rebase

```
$ git rd
1:  e51e4c69 ! 1:  1e5df9ee lib/string/ctype/strisascii/: strisprint(): Add function
    @@ lib/Makefile.am: libshadow_la_SOURCES = \
        string/ctype/strisascii/strisdigit.h \
     +  string/ctype/strisascii/strisprint.c \
     +  string/ctype/strisascii/strisprint.h \
    +   string/ctype/strtoascii/strtolower.c \
    +   string/ctype/strtoascii/strtolower.h \
        string/memset/memzero.c \
    -   string/memset/memzero.h \
    -   string/sprintf/snprintf.c \
     
      ## lib/string/ctype/strisascii/strisprint.c (new) ##
     @@
2:  7789cb48 ! 2:  0e235f86 lib/string/ctype/strchrisascii/: strchriscntrl(): Add function
    @@ Commit message
     
      ## lib/Makefile.am ##
     @@ lib/Makefile.am: libshadow_la_SOURCES = \
    -   string/ctype/strisascii/strisdigit.h \
    -   string/ctype/strisascii/strisprint.c \
    -   string/ctype/strisascii/strisprint.h \
    +   spawn.c \
    +   sssd.c \
    +   sssd.h \
     +  string/ctype/strchrisascii/strchriscntrl.c \
     +  string/ctype/strchrisascii/strchriscntrl.h \
    -   string/memset/memzero.c \
    -   string/memset/memzero.h \
    -   string/sprintf/snprintf.c \
    +   string/ctype/strisascii/strisdigit.c \
    +   string/ctype/strisascii/strisdigit.h \
    +   string/ctype/strisascii/strisprint.c \
     
      ## lib/string/ctype/strchrisascii/strchriscntrl.c (new) ##
     @@
3:  95c966d0 = 3:  09b8078b lib/fields.c: valid_field(): Remove useless check
4:  76905a72 = 4:  04c04996 lib/fields.c: valid_field(): Return early on error
5:  88f683d3 = 5:  8e8c0d1d lib/fields.c: valid_field(): Use strisprint() instead of its pattern
6:  a92b7c4b = 6:  a1a8d8dd lib/fields.c: valid_field(): Use strchriscntrl() instead of its pattern
7:  cedcbb3a = 7:  1c932329 lib/fields.c: valid_field(): Clarify comments
```
</details>

<details>
<summary>v2h</summary>

-  Rebase

```
$ git rd
1:  1e5df9ee = 1:  584e35d3 lib/string/ctype/strisascii/: strisprint(): Add function
2:  0e235f86 = 2:  6b215fb3 lib/string/ctype/strchrisascii/: strchriscntrl(): Add function
3:  09b8078b = 3:  f257fbd8 lib/fields.c: valid_field(): Remove useless check
4:  04c04996 = 4:  9adee2e0 lib/fields.c: valid_field(): Return early on error
5:  8e8c0d1d = 5:  bddb8418 lib/fields.c: valid_field(): Use strisprint() instead of its pattern
6:  a1a8d8dd = 6:  7b1a9c8a lib/fields.c: valid_field(): Use strchriscntrl() instead of its pattern
7:  1c932329 = 7:  44c20f7d lib/fields.c: valid_field(): Clarify comments
```
</details>

<details>
<summary>v3</summary>

-  Add guarantees that $2 is a string literal.  [@hallyn ]

```
$ git rd
 1:  584e35d3 =  1:  584e35d3 lib/string/ctype/strisascii/: strisprint(): Add function
 2:  6b215fb3 =  2:  6b215fb3 lib/string/ctype/strchrisascii/: strchriscntrl(): Add function
 -:  -------- >  3:  8d92cee2 lib/, src/: Move prototypes of "lib/fields.c" to "lib/fields.h"
 -:  -------- >  4:  8786de13 lib/fields.*: valid_field: Make sure that $2 is a string literal
 3:  f257fbd8 !  5:  2924cf8c lib/fields.c: valid_field(): Remove useless check
    @@ Commit message
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/fields.c ##
    -@@ lib/fields.c: int valid_field (const char *field, const char *illegal)
    +@@ lib/fields.c: valid_field_(const char *field, const char *illegal)
                return -1;
        }
      
 4:  9adee2e0 !  6:  8caca9ca lib/fields.c: valid_field(): Return early on error
    @@ Commit message
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/fields.c ##
    -@@ lib/fields.c: int valid_field (const char *field, const char *illegal)
    +@@ lib/fields.c: valid_field_(const char *field, const char *illegal)
        /* Search if there are non-printable or control characters */
        for (cp = field; !streq(cp, ""); cp++) {
                unsigned char c = *cp;
 5:  bddb8418 !  7:  57031a30 lib/fields.c: valid_field(): Use strisprint() instead of its pattern
    @@ lib/fields.c
      #include "string/strcmp/streq.h"
      #include "string/strspn/stpspn.h"
      #include "string/strspn/stprspn.h"
    -@@
    - int valid_field (const char *field, const char *illegal)
    +@@ lib/fields.c: int
    + valid_field_(const char *field, const char *illegal)
      {
        const char *cp;
     -  int err = 0;
      
        if (NULL == field) {
                return -1;
    -@@ lib/fields.c: int valid_field (const char *field, const char *illegal)
    +@@ lib/fields.c: valid_field_(const char *field, const char *illegal)
                unsigned char c = *cp;
                if (iscntrl(c))
                        return -1;
 6:  7b1a9c8a !  8:  fc43aaba lib/fields.c: valid_field(): Use strchriscntrl() instead of its pattern
    @@ lib/fields.c
      #include "string/strspn/stpspn.h"
      #include "string/strspn/stprspn.h"
     @@
    -  */
    - int valid_field (const char *field, const char *illegal)
    + int
    + valid_field_(const char *field, const char *illegal)
      {
     -  const char *cp;
     -
 7:  44c20f7d !  9:  edcad794 lib/fields.c: valid_field(): Clarify comments
    @@ lib/fields.c
     + *        1       Non-ASCII characters are present.
     + *        0       All chatacters are legal and ASCII.
       */
    --int valid_field (const char *field, const char *illegal)
    -+int
    -+valid_field(const char *field, const char *illegal)
    + int
    + valid_field_(const char *field, const char *illegal)
      {
     -  if (NULL == field) {
     +  if (NULL == field)
    @@ lib/fields.c
      
        if (strpbrk(field, illegal))
                return -1;
    -@@ lib/fields.c: int valid_field (const char *field, const char *illegal)
    +@@ lib/fields.c: valid_field_(const char *field, const char *illegal)
        if (streq(field, ""))
                return 0;
      
```
</details>

<details>
<summary>v3b</summary>

-  Fix sorting of includes.

```
$ git rd
 1:  584e35d3 =  1:  584e35d3 lib/string/ctype/strisascii/: strisprint(): Add function
 2:  6b215fb3 =  2:  6b215fb3 lib/string/ctype/strchrisascii/: strchriscntrl(): Add function
 3:  8d92cee2 !  3:  c8011b63 lib/, src/: Move prototypes of "lib/fields.c" to "lib/fields.h"
    @@ lib/pwio.c
      #include <pwd.h>
      #include <stdio.h>
     +
    -+#include "prototypes.h"
      #include "commonio.h"
     +#include "defines.h"
     +#include "fields.h"
    ++#include "prototypes.h"
      #include "pwio.h"
      
      static /*@null@*/ /*@only@*/void *passwd_dup (const void *ent)
    @@ lib/shadowio.c
      #include <shadow.h>
      #include <stdio.h>
     +
    -+#include "prototypes.h"
      #include "commonio.h"
     +#include "defines.h"
     +#include "fields.h"
      #include "getdef.h"
    ++#include "prototypes.h"
      #include "shadowio.h"
     +
      #ifdef WITH_TCB
 4:  8786de13 =  4:  c21f9ce3 lib/fields.*: valid_field: Make sure that $2 is a string literal
 5:  2924cf8c =  5:  804c0f3b lib/fields.c: valid_field(): Remove useless check
 6:  8caca9ca =  6:  a486b062 lib/fields.c: valid_field(): Return early on error
 7:  57031a30 =  7:  98346110 lib/fields.c: valid_field(): Use strisprint() instead of its pattern
 8:  fc43aaba =  8:  548f2c0c lib/fields.c: valid_field(): Use strchriscntrl() instead of its pattern
 9:  edcad794 =  9:  9789471c lib/fields.c: valid_field(): Clarify comments
```
</details>

<details>
<summary>v3c</summary>

-  Rebase

```
$ git rd 
 1:  584e35d3 =  1:  f0de212a lib/string/ctype/strisascii/: strisprint(): Add function
 2:  6b215fb3 =  2:  dbe1f1e7 lib/string/ctype/strchrisascii/: strchriscntrl(): Add function
 3:  c8011b63 =  3:  e53ce352 lib/, src/: Move prototypes of "lib/fields.c" to "lib/fields.h"
 4:  c21f9ce3 =  4:  53fdda71 lib/fields.*: valid_field: Make sure that $2 is a string literal
 5:  804c0f3b =  5:  0629ddc2 lib/fields.c: valid_field(): Remove useless check
 6:  a486b062 =  6:  0fd492ca lib/fields.c: valid_field(): Return early on error
 7:  98346110 =  7:  3bac758b lib/fields.c: valid_field(): Use strisprint() instead of its pattern
 8:  548f2c0c =  8:  2f04db4a lib/fields.c: valid_field(): Use strchriscntrl() instead of its pattern
 9:  9789471c =  9:  99ffa0ee lib/fields.c: valid_field(): Clarify comments
```
</details>