### PR TITLE
strtolower(): Add API, and use it instead of its pattern

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -187,6 +187,8 @@ libshadow_la_SOURCES = \
 	sssd.h \
 	string/ctype/strisascii/strisdigit.c \
 	string/ctype/strisascii/strisdigit.h \
+	string/ctype/strtoascii/strtolower.c \
+	string/ctype/strtoascii/strtolower.h \
 	string/memset/memzero.c \
 	string/memset/memzero.h \
 	string/sprintf/snprintf.c \

--- a/lib/obscure.c
+++ b/lib/obscure.c
@@ -1,11 +1,10 @@
-/*
- * SPDX-FileCopyrightText: 1989 - 1994, Julianne Frances Haugh
- * SPDX-FileCopyrightText: 1996 - 1999, Marek Michałkiewicz
- * SPDX-FileCopyrightText: 2003 - 2005, Tomasz Kłoczko
- * SPDX-FileCopyrightText: 2007 - 2010, Nicolas François
- *
- * SPDX-License-Identifier: BSD-3-Clause
- */
+// SPDX-FileCopyrightText: 1989-1994, Julianne Frances Haugh
+// SPDX-FileCopyrightText: 1996-1999, Marek Michałkiewicz
+// SPDX-FileCopyrightText: 2003-2005, Tomasz Kłoczko
+// SPDX-FileCopyrightText: 2007-2010, Nicolas François
+// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
 
 #include <config.h>
 
@@ -19,6 +18,7 @@
 #include "prototypes.h"
 #include "defines.h"
 #include "getdef.h"
+#include "string/ctype/strtoascii/strtolower.h"
 #include "string/memset/memzero.h"
 #include "string/sprintf/xasprintf.h"
 #include "string/strcmp/streq.h"
@@ -78,15 +78,6 @@ static bool similar (/*@notnull@*/const char *old, /*@notnull@*/const char *new)
 	return true;
 }
 
-static char *str_lower (/*@returned@*/char *string)
-{
-	char *cp;
-
-	for (cp = string; !streq(cp, ""); cp++) {
-		*cp = tolower (*cp);
-	}
-	return string;
-}
 
 static /*@observer@*//*@null@*/const char *password_check (
 	/*@notnull@*/const char *old,
@@ -100,8 +91,8 @@ static /*@observer@*//*@null@*/const char *password_check (
 		return _("no change");
 	}
 
-	newmono = str_lower (xstrdup (new));
-	oldmono = str_lower (xstrdup (old));
+	newmono = strtolower(xstrdup(new));
+	oldmono = strtolower(xstrdup(old));
 	xasprintf(&wrapped, "%s%s", oldmono, oldmono);
 
 	if (palindrome (oldmono, newmono)) {

--- a/lib/string/ctype/strtoascii/strtolower.c
+++ b/lib/string/ctype/strtoascii/strtolower.c
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#include <config.h>
+
+#include "string/ctype/strtoascii/strtolower.h"
+
+
+extern inline char *strtolower(char *str);

--- a/lib/string/ctype/strtoascii/strtolower.h
+++ b/lib/string/ctype/strtoascii/strtolower.h
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#ifndef SHADOW_INCLUDE_LIB_STRING_CTYPE_STRTOASCII_STRTOLOWER_H_
+#define SHADOW_INCLUDE_LIB_STRING_CTYPE_STRTOASCII_STRTOLOWER_H_
+
+
+#include <config.h>
+
+#include <ctype.h>
+
+#include "string/strcmp/streq.h"
+
+
+inline char *strtolower(char *str);
+
+
+// string convert-to lower-case
+// Like tolower(3), but convert all characters in the string.
+// Returns the input pointer.
+inline char *
+strtolower(char *str)
+{
+	for (char *s = str; !streq(s, ""); s++) {
+		unsigned char  c = *s;
+
+		*s = tolower(c);
+	}
+	return str;
+}
+
+
+#endif  // include guard


### PR DESCRIPTION
---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git range-diff master..gh/stl shadow/master..stl 
1:  851d24b5 = 1:  2740e5ff lib/string/ctype/strtoascii/: strtolower(): Add API
2:  6436ac02 = 2:  a6e78233 lib/: Use strtolower() instead of its pattern
```
</details>

<details>
<summary>v1c</summary>

-  Rebase

```
$ git rd
1:  2740e5ff = 1:  7db4fb87 lib/string/ctype/strtoascii/: strtolower(): Add API
2:  a6e78233 = 2:  9c7bc74e lib/: Use strtolower() instead of its pattern
```
</details>

<details>
<summary>v1d</summary>

-  Rebase

```
$ git rd 
1:  7db4fb87 = 1:  6fda0b3b lib/string/ctype/strtoascii/: strtolower(): Add API
2:  9c7bc74e ! 2:  b6e7a38f lib/: Use strtolower() instead of its pattern
    @@ Commit message
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    - ## lib/getdate.y ##
    -@@
    - 
    - #include "attr.h"
    - #include "getdate.h"
    -+#include "string/ctype/strtoascii/strtolower.h"
    - #include "string/strcmp/streq.h"
    - #include "string/strspn/stpspn.h"
    - 
    -@@ lib/getdate.y: static int LookupWord (char *buff)
    -   int i;
    -   bool abbrev;
    - 
    --  /* Make it lowercase. */
    --  for (p = buff; !streq(p, ""); p++)
    --    if (isupper (*p))
    --      *p = tolower (*p);
    -+  strtolower(buff);
    - 
    -   if (streq(buff, "am") || streq(buff, "a.m."))
    -     {
    -
      ## lib/obscure.c ##
     @@
     -/*
```
</details>

<details>
<summary>v1e</summary>

-  Rebase

```
$ git rd
1:  6fda0b3b = 1:  edba59c8 lib/string/ctype/strtoascii/: strtolower(): Add API
2:  b6e7a38f = 2:  7ead7cdb lib/: Use strtolower() instead of its pattern
```
</details>

<details>
<summary>v1f</summary>

-  Rebase

```
$ git rd
1:  edba59c8 = 1:  ac0b8d74 lib/string/ctype/strtoascii/: strtolower(): Add API
2:  7ead7cdb = 2:  02e604d6 lib/: Use strtolower() instead of its pattern
```
</details>