### PR TITLE
src/chfn.c: Fix bogus transformation

### DIFF
--- a/src/chfn.c
+++ b/src/chfn.c
@@ -216,27 +216,32 @@ static void new_fields (void)
  */
 static char *copy_field (char *in, char *out, char *extra)
 {
+	char *cp = NULL;
+
 	while (NULL != in) {
-		char  *f;
+		cp = strchr (in, ',');
+		if (NULL != cp) {
+			*cp++ = '\0';
+		}
 
-		f = strsep(&in, ",");
-
-		if (strchr(f, '=') == NULL)
+		if (strchr (in, '=') == NULL) {
 			break;
+		}
 
 		if (NULL != extra) {
 			if (!streq(extra, "")) {
 				strcat (extra, ",");
 			}
 
-			strcat(extra, f);
+			strcat (extra, in);
 		}
+		in = cp;
 	}
 	if ((NULL != in) && (NULL != out)) {
 		strcpy (out, in);
 	}
 
-	return in;
+	return cp;
 }
 
 /*

--- a/src/chfn.c
+++ b/src/chfn.c
@@ -217,13 +217,13 @@ static void new_fields (void)
  */
 static char *copy_field (char *in, char *out, char *extra)
 {
-	char *cp = NULL;
+	char  *next = NULL;
 
 	while (NULL != in) {
 		const char  *f;
 
 		f = in;
-		cp = stpsep(in, ",");
+		next = stpsep(in, ",");
 
 		if (strchr(f, '=') == NULL)
 			break;
@@ -235,13 +235,13 @@ static char *copy_field (char *in, char *out, char *extra)
 
 			strcat(extra, f);
 		}
-		in = cp;
+		in = next;
 	}
 	if ((NULL != in) && (NULL != out)) {
 		strcpy (out, in);
 	}
 
-	return cp;
+	return next;
 }
 
 /*

--- a/src/chfn.c
+++ b/src/chfn.c
@@ -36,6 +36,7 @@
 #include "string/strcmp/streq.h"
 #include "string/strcpy/strtcpy.h"
 #include "string/strdup/xstrdup.h"
+#include "string/strtok/stpsep.h"
 
 
 /*
@@ -219,10 +220,7 @@ static char *copy_field (char *in, char *out, char *extra)
 	char *cp = NULL;
 
 	while (NULL != in) {
-		cp = strchr (in, ',');
-		if (NULL != cp) {
-			*cp++ = '\0';
-		}
+		cp = stpsep(in, ",");
 
 		if (strchr (in, '=') == NULL) {
 			break;

--- a/src/chfn.c
+++ b/src/chfn.c
@@ -220,18 +220,20 @@ static char *copy_field (char *in, char *out, char *extra)
 	char *cp = NULL;
 
 	while (NULL != in) {
+		const char  *f;
+
+		f = in;
 		cp = stpsep(in, ",");
 
-		if (strchr (in, '=') == NULL) {
+		if (strchr(f, '=') == NULL)
 			break;
-		}
 
 		if (NULL != extra) {
 			if (!streq(extra, "")) {
 				strcat (extra, ",");
 			}
 
-			strcat (extra, in);
+			strcat(extra, f);
 		}
 		in = cp;
 	}


### PR DESCRIPTION
This partially reverts commit 16cb664865541162c504a6f5ef5ca4b38b5e0c9a.

I'll try to reintroduce this change more carefully after investigation. For now, let's revert to a known-good state.

Fixes: 16cb66486554 (2024-07-01; "lib/, src/: Use strsep(3) instead of its pattern")
Closes: <https://github.com/shadow-maint/shadow/issues/1210>
Reported-by: @zeha 
Suggested-by: @zeha 

---

Revisions:

<details>
<summary>v2</summary>

-  Reintroduce part of the transformation which is correct.  We can use stpsep().  See <https://github.com/shadow-maint/shadow/pull/1213>.

```
$ git range-diff master gh/strsep strsep
1:  db6885ed = 1:  db6885ed src/chfn.c: Partially revert "lib/, src/: Use strsep(3) instead of its pattern"
-:  -------- > 2:  e2ac691a src/chfn.c: Use stpsep() instead of its pattern
-:  -------- > 3:  ca40e692 src/chfn.c: Add local variable to refer to the separated field
-:  -------- > 4:  50bb48a6 src/chfn.c: copy_field(): Rename local variable
```
</details>

<details>
<summary>v2b</summary>

-  Add details about the bug in the commit message.  Thanks to @zeha for the help debugging this!

```
$ git range-diff master gh/strsep strsep
1:  db6885ed ! 1:  34ebcf81 src/chfn.c: Partially revert "lib/, src/: Use strsep(3) instead of its pattern"
    @@ Commit message
     
         This partially reverts commit 16cb664865541162c504a6f5ef5ca4b38b5e0c9a.
     
    -    I'll try to reintroduce this change more carefully after investigation.
    +    I'll try to reintroduce this change more carefully.
         For now, let's revert to a known-good state.
     
    +    The problem was due to accidentally ignoring the effects of the 'break'
    +    on the 'cp' variable.
    +
         Fixes: 16cb66486554 (2024-07-01; "lib/, src/: Use strsep(3) instead of its pattern")
         Closes: <https://github.com/shadow-maint/shadow/issues/1210>
    +    Link: <https://github.com/shadow-maint/shadow/pull/1213>
    +    Link: <https://github.com/shadow-maint/shadow/pull/1212>
         Reported-by: Chris Hofstaedtler <zeha@debian.org>
         Suggested-by: Chris Hofstaedtler <zeha@debian.org>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
2:  e2ac691a = 2:  654f6cf5 src/chfn.c: Use stpsep() instead of its pattern
3:  ca40e692 = 3:  4b2bcda3 src/chfn.c: Add local variable to refer to the separated field
4:  50bb48a6 = 4:  a2a4d6af src/chfn.c: copy_field(): Rename local variable
```
</details>

<details>
<summary>v2c</summary>

-  Add missing `const`.

```
$ git range-diff master gh/strsep strsep 
1:  34ebcf81 = 1:  34ebcf81 src/chfn.c: Partially revert "lib/, src/: Use strsep(3) instead of its pattern"
2:  654f6cf5 = 2:  654f6cf5 src/chfn.c: Use stpsep() instead of its pattern
3:  4b2bcda3 ! 3:  fbc423ea src/chfn.c: Add local variable to refer to the separated field
    @@ src/chfn.c: static char *copy_field (char *in, char *out, char *extra)
        char *cp = NULL;
      
        while (NULL != in) {
    -+          char  *f;
    ++          const char  *f;
     +
     +          f = in;
                cp = stpsep(in, ",");
4:  a2a4d6af ! 4:  bbfe20b2 src/chfn.c: copy_field(): Rename local variable
    @@ src/chfn.c: static void new_fields (void)
     +  char *next = NULL;
      
        while (NULL != in) {
    -           char  *f;
    +           const char  *f;
      
                f = in;
     -          cp = stpsep(in, ",");
```
</details>

<details>
<summary>v2d</summary>

-  Remove braces.  This reduces the global diff.

```
$ git range-diff master gh/strsep strsep 
1:  34ebcf81 = 1:  34ebcf81 src/chfn.c: Partially revert "lib/, src/: Use strsep(3) instead of its pattern"
2:  654f6cf5 = 2:  654f6cf5 src/chfn.c: Use stpsep() instead of its pattern
3:  fbc423ea ! 3:  b3d893af src/chfn.c: Add local variable to refer to the separated field
    @@ src/chfn.c: static char *copy_field (char *in, char *out, char *extra)
                cp = stpsep(in, ",");
      
     -          if (strchr (in, '=') == NULL) {
    -+          if (strchr(f, '=') == NULL) {
    ++          if (strchr(f, '=') == NULL)
                        break;
    -           }
    +-          }
      
    -@@ src/chfn.c: static char *copy_field (char *in, char *out, char *extra)
    +           if (NULL != extra) {
    +                   if (!streq(extra, "")) {
                                strcat (extra, ",");
                        }
      
4:  bbfe20b2 ! 4:  53f08839 src/chfn.c: copy_field(): Rename local variable
    @@ src/chfn.c: static void new_fields (void)
     -          cp = stpsep(in, ",");
     +          next = stpsep(in, ",");
      
    -           if (strchr(f, '=') == NULL) {
    +           if (strchr(f, '=') == NULL)
                        break;
     @@ src/chfn.c: static char *copy_field (char *in, char *out, char *extra)
      
```
</details>

<details>
<summary>v2e</summary>

-  Tested-by: @zeha 
-  wsfix

```
$ git range-diff master gh/strsep strsep 
1:  34ebcf81 ! 1:  ab407abc src/chfn.c: Partially revert "lib/, src/: Use strsep(3) instead of its pattern"
    @@ Commit message
         Link: <https://github.com/shadow-maint/shadow/pull/1212>
         Reported-by: Chris Hofstaedtler <zeha@debian.org>
         Suggested-by: Chris Hofstaedtler <zeha@debian.org>
    +    Tested-by: Chris Hofstaedtler <zeha@debian.org>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## src/chfn.c ##
2:  654f6cf5 ! 2:  9b680a0f src/chfn.c: Use stpsep() instead of its pattern
    @@ Metadata
      ## Commit message ##
         src/chfn.c: Use stpsep() instead of its pattern
     
    +    Tested-by: Chris Hofstaedtler <zeha@debian.org>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## src/chfn.c ##
3:  b3d893af ! 3:  c8496334 src/chfn.c: Add local variable to refer to the separated field
    @@ Metadata
      ## Commit message ##
         src/chfn.c: Add local variable to refer to the separated field
     
    +    Tested-by: Chris Hofstaedtler <zeha@debian.org>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## src/chfn.c ##
4:  53f08839 ! 4:  23c26ad5 src/chfn.c: copy_field(): Rename local variable
    @@ Commit message
     
         This makes it more obvious what that pointer is.
     
    +    Tested-by: Chris Hofstaedtler <zeha@debian.org>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## src/chfn.c ##
    @@ src/chfn.c: static void new_fields (void)
      static char *copy_field (char *in, char *out, char *extra)
      {
     -  char *cp = NULL;
    -+  char *next = NULL;
    ++  char  *next = NULL;
      
        while (NULL != in) {
                const char  *f;
```
</details>