### PR TITLE
chsh: do not warn about blank shell

### DIFF
--- a/src/chsh.c
+++ b/src/chsh.c
@@ -555,9 +555,11 @@ int main (int argc, char **argv)
 		fprintf (stderr, _("%s: Invalid entry: %s\n"), Prog, loginsh);
 		fail_exit (1);
 	}
-	if (loginsh[0] != '/'
-			|| is_restricted_shell (loginsh)
-			|| (access (loginsh, X_OK) != 0)) {
+	if (!streq(loginsh, "")
+	    && (loginsh[0] != '/'
+	        || is_restricted_shell (loginsh)
+	        || (access (loginsh, X_OK) != 0)))
+	{
 		if (amroot) {
 			fprintf (stderr, _("%s: Warning: %s is an invalid shell\n"), Prog, loginsh);
 		} else {
@@ -567,10 +569,13 @@ int main (int argc, char **argv)
 	}
 
 	/* Even for root, warn if an invalid shell is specified. */
-	if (access (loginsh, F_OK) != 0) {
-		fprintf (stderr, _("%s: Warning: %s does not exist\n"), Prog, loginsh);
-	} else if (access (loginsh, X_OK) != 0) {
-		fprintf (stderr, _("%s: Warning: %s is not executable\n"), Prog, loginsh);
+	if (!streq(loginsh, "")) {
+		/* But not if an empty string is given, documented as meaning the default shell */
+		if (access (loginsh, F_OK) != 0) {
+			fprintf (stderr, _("%s: Warning: %s does not exist\n"), Prog, loginsh);
+		} else if (access (loginsh, X_OK) != 0) {
+			fprintf (stderr, _("%s: Warning: %s is not executable\n"), Prog, loginsh);
+		}
 	}
 
 	update_shell (user, loginsh);


### PR DESCRIPTION
chsh(1) documents the -s option with this extra sentence:
> Setting this field to blank causes the system to select the default login shell.

As such warning about a blank string seems wrong.

Closes: <https://bugs.debian.org/876542>
Reported-by: 積丹尼 Dan Jacobson <jidanni@jidanni.org>