### PR TITLE
lib/fs/readlink/areadlink.h: areadlink(): Avoid inconditionally using PATH_MAX

### DIFF
--- a/lib/defines.h
+++ b/lib/defines.h
@@ -65,6 +65,14 @@
 #endif
 #endif
 
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
+#ifndef MAXHOSTNAMELEN
+#define MAXHOSTNAMELEN 64
+#endif
+
 #include <syslog.h>
 
 #ifndef LOG_WARN

--- a/lib/fs/readlink/areadlink.h
+++ b/lib/fs/readlink/areadlink.h
@@ -9,11 +9,11 @@
 #include <config.h>
 
 #include <errno.h>
-#include <limits.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdlib.h>
 
+#include "defines.h"
 #include "alloc/malloc.h"
 #include "attr.h"
 #include "fs/readlink/readlinknul.h"

--- a/lib/get_pid.c
+++ b/lib/get_pid.c
@@ -10,6 +10,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#include "defines.h"
 #include "atoi/getnum.h"
 #include "defines.h"
 #include "prototypes.h"

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -57,6 +57,7 @@
 #include <syslog.h>
 #include <unistd.h>
 
+#include "defines.h"
 #include "prototypes.h"
 #include "sizeof.h"
 #include "string/strcmp/strcaseeq.h"


### PR DESCRIPTION
86451e374b90 ("lib/fs/readlink/areadlink.h: areadlink(): Use PATH_MAX instead of a magic value") introduced using PATH_MAX, but e.g. GNU/Hurd does not define such a limitation.