### PR TITLE
lib/commonio.c: Rely on the POSIX.1-2008 behavior of realpath(3)

### DIFF
--- a/lib/commonio.c
+++ b/lib/commonio.c
@@ -74,17 +74,10 @@ int lrename (const char *old, const char *new)
 {
 	int res;
 	char *r = NULL;
-
-#ifndef __GLIBC__
-	char resolved_path[PATH_MAX];
-#endif				/* !__GLIBC__ */
 	struct stat sb;
+
 	if (lstat (new, &sb) == 0 && S_ISLNK (sb.st_mode)) {
-#ifdef __GLIBC__ /* now a POSIX.1-2008 feature */
 		r = realpath (new, NULL);
-#else				/* !__GLIBC__ */
-		r = realpath (new, resolved_path);
-#endif				/* !__GLIBC__ */
 		if (NULL == r) {
 			perror ("realpath in lrename()");
 		} else {
@@ -94,9 +87,7 @@ int lrename (const char *old, const char *new)
 
 	res = rename (old, new);
 
-#ifdef __GLIBC__
 	free (r);
-#endif				/* __GLIBC__ */
 
 	return res;
 }


### PR DESCRIPTION
Link: <https://github.com/shadow-maint/shadow/pull/1222#discussion_r1966612238>
Link: <https://stackoverflow.com/questions/60802732/are-realpath-portability-concerns-obsolete>
Reported-by: @sthibaul 