### PR TITLE
configure.ac: be deterministic about passwd location

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -115,13 +115,7 @@ AC_DEFINE_UNQUOTED(LASTLOG_FILE, "$shadow_cv_logdir/lastlog",
 AC_DEFINE_UNQUOTED(FAILLOG_FILE, "$shadow_cv_logdir/faillog",
 	[Path for faillog file.])
 
-AC_CACHE_CHECK([location of the passwd program], shadow_cv_passwd_dir,
-[if test -f /usr/bin/passwd; then
-	shadow_cv_passwd_dir=/usr/bin
-else
-	shadow_cv_passwd_dir=/bin
-fi])
-AC_DEFINE_UNQUOTED(PASSWD_PROGRAM, "$shadow_cv_passwd_dir/passwd",
+AC_DEFINE_UNQUOTED(PASSWD_PROGRAM, "$exec_prefix/bin/passwd",
 	[Path to passwd program.])
 
 AC_ARG_ENABLE(shadowgrp,


### PR DESCRIPTION
Statically set PASSWD_PROGRAM depending on exec_prefix, and not by where the passwd program was at configure time.

Depending on the specific build situation before, this may or may not change the embedded passwd program path. Also configure.ac sets exec_prefix=/ for prefix=/usr, so this might be a bit confusing, but at least deterministic.

Closes: #1224

