### PR TITLE
configure.ac, src/Makefile.am: Follow GNU coding standards regarding directory variables

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -19,10 +19,6 @@ AC_SUBST([LIBSUBID_ABI_MAJOR], [libsubid_abi_major])
 AC_SUBST([LIBSUBID_ABI_MINOR], [libsubid_abi_minor])
 AC_SUBST([LIBSUBID_ABI_MICRO], [libsubid_abi_micro])
 
-dnl Some hacks...
-test "x$prefix" = "xNONE" && prefix="/usr"
-test "X$prefix" = "X/usr" && exec_prefix=""
-
 AC_USE_SYSTEM_EXTENSIONS
 
 AC_ENABLE_STATIC

--- a/configure.ac
+++ b/configure.ac
@@ -97,9 +97,6 @@ done])
 AC_DEFINE_UNQUOTED([FAILLOG_FILE], ["$shadow_cv_logdir/faillog"],
 	[Path for faillog file.])
 
-AC_DEFINE_UNQUOTED([PASSWD_PROGRAM], ["$exec_prefix/bin/passwd"],
-	[Path to passwd program.])
-
 AC_ARG_ENABLE([shadowgrp],
 	[AS_HELP_STRING([--enable-shadowgrp], [enable shadow group support @<:@default=yes@:>@])],
 	[case "${enableval}" in

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -2,7 +2,7 @@
 AUTOMAKE_OPTIONS = 1.0 foreign
 
 DEFS = \
-	-DPASSWD_PROGRAM='"$(bindir)/passwd"'
+	-DPATH_PASSWD='"$(bindir)/passwd"'
 
 noinst_LTLIBRARIES = libshadow.la
 

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,7 +1,8 @@
 
 AUTOMAKE_OPTIONS = 1.0 foreign
 
-DEFS =
+DEFS = \
+	-DPASSWD_PROGRAM='"$(bindir)/passwd"'
 
 noinst_LTLIBRARIES = libshadow.la
 

--- a/lib/age.c
+++ b/lib/age.c
@@ -23,11 +23,11 @@
 #include "shadow/gshadow/endsgent.h"
 
 
-#ident "$Id$"
-
-#ifndef PASSWD_PROGRAM
-#define PASSWD_PROGRAM "/bin/passwd"
+#ifndef PATH_PASSWD
+#define PATH_PASSWD "/bin/passwd"
 #endif
+
+
 /*
  * expire - force password change if password expired
  *
@@ -116,9 +116,9 @@ int expire (const struct passwd *pw, /*@null@*/const struct spwd *sp)
 			_exit (126);
 		}
 
-		(void) execl (PASSWD_PROGRAM, PASSWD_PROGRAM, pw->pw_name, (char *) NULL);
+		(void) execl(PATH_PASSWD, PATH_PASSWD, pw->pw_name, (char *) NULL);
 		err = errno;
-		perror ("Can't execute " PASSWD_PROGRAM);
+		perror("Can't execute " PATH_PASSWD);
 		_exit ((ENOENT == err) ? E_CMD_NOTFOUND : E_CMD_NOEXEC);
 	} else if ((pid_t) -1 == pid) {
 		perror ("fork");

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,13 +2,13 @@
 EXTRA_DIST = \
 	.indent.pro
 
-ubindir = ${exec_prefix}/bin
-usbindir = ${exec_prefix}/sbin
+ubindir = $(exec_prefix)/bin
+usbindir = $(exec_prefix)/sbin
 suidperms = 4755
 sgidperms = 2755
 
 AM_CPPFLAGS = \
-	-I${top_srcdir}/lib \
+	-I$(top_srcdir)/lib \
 	-I$(top_srcdir) \
 	-DLOCALEDIR=\"$(datadir)/locale\" \
 	$(ECONF_CPPFLAGS)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,8 +2,8 @@
 EXTRA_DIST = \
 	.indent.pro
 
-ubindir = ${prefix}/bin
-usbindir = ${prefix}/sbin
+ubindir = ${exec_prefix}/bin
+usbindir = ${exec_prefix}/sbin
 suidperms = 4755
 sgidperms = 2755
 
@@ -24,7 +24,7 @@ AM_CFLAGS = $(LIBBSD_CFLAGS)
 #
 # also /lib/libshadow.so.x.xx (if any) could be moved to /usr/lib
 # and installation would be much simpler (just two directories,
-# $prefix/bin and $prefix/sbin, no install-data hacks...)
+# $exec_prefix/bin and $exec_prefix/sbin, no install-data hacks...)
 
 bin_PROGRAMS   = login
 sbin_PROGRAMS  = nologin


### PR DESCRIPTION
Closes: <https://github.com/shadow-maint/shadow/issues/1229>
Reported-by: @zeha 
Cc: @thesamesam 

---

-  Queued after <https://github.com/shadow-maint/shadow/pull/1468>.

---

Is this okay?

---

Revisions:

<details>
<summary>v2</summary>

-  Remove definitions of $prefix and $exec_prefix.  [@thesamesam ]

```
$ git range-diff master gh/ep ep 
1:  8840d0e3 ! 1:  6f4e5d61 configure.ac, src/Makefile.am: Follow GNU coding standards regarding directory variables
    @@ Metadata
      ## Commit message ##
         configure.ac, src/Makefile.am: Follow GNU coding standards regarding directory variables
     
    +    According to Sam, if we just remove the definitions, autotools will
    +    provide the right values.
    +
    +    Note that this changes the default from /usr to /usr/local, which is the
    +    right value according to the GNU conding standards (and also what the
    +    BSDs prefer, according to one conversation I had with Ingo Schwarze from
    +    OpenBSD).
    +
         Closes: <https://github.com/shadow-maint/shadow/issues/1229>
    +    Link: <https://www.gnu.org/software/autoconf/manual/autoconf-2.72/html_node/Default-Prefix.html>
         Reported-by: Chris Hofstaedtler <zeha@debian.org>
         Cc: Sam James <sam@gentoo.org>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
    @@ src/Makefile.am
      
     -ubindir = ${prefix}/bin
     -usbindir = ${prefix}/sbin
    -+prefix = /usr/local
    -+exec_prefix = ${prefix}
     +ubindir = ${exec_prefix}/bin
     +usbindir = ${exec_prefix}/sbin
      suidperms = 4755
```
</details>

<details>
<summary>v3</summary>

-  Replace `${}` by `$()` in surrounding code.  [@thesamesam ]

```
$ git range-diff master gh/ep ep 
1:  6f4e5d61 = 1:  6f4e5d61 configure.ac, src/Makefile.am: Follow GNU coding standards regarding directory variables
-:  -------- > 2:  0fada16b src/Makefile.am: Use $() for consistency
```
</details>

<details>
<summary>v3b</summary>

-  Rebase

```
$ git range-diff master..gh/ep shadow/master..ep 
1:  6f4e5d61 = 1:  983e3308 configure.ac, src/Makefile.am: Follow GNU coding standards regarding directory variables
2:  0fada16b = 2:  8d0eb980 src/Makefile.am: Use $() for consistency
```
</details>

<details>
<summary>v3c</summary>

-  Rebase

```
$ git rd
1:  983e3308 = 1:  3d09f4f9 configure.ac, src/Makefile.am: Follow GNU coding standards regarding directory variables
2:  8d0eb980 = 2:  51b0e9f9 src/Makefile.am: Use $() for consistency
```
</details>

<details>
<summary>v3d</summary>

-  Rebase

```
$ git range-diff db/master..gh/ep shadow/master..ep 
1:  3d09f4f9 = 1:  d19fdb29 configure.ac, src/Makefile.am: Follow GNU coding standards regarding directory variables
2:  51b0e9f9 = 2:  33142670 src/Makefile.am: Use $() for consistency
```
</details>

<details>
<summary>v3e</summary>

-  Rebase

```
$ git rd
1:  d19fdb29 = 1:  c499e815 configure.ac, src/Makefile.am: Follow GNU coding standards regarding directory variables
2:  33142670 = 2:  8738df50 src/Makefile.am: Use $() for consistency
```
</details>

<details>
<summary>v3f</summary>

-  Rebase

```
$ git rd
1:  c499e815 = 1:  905759e6 configure.ac, src/Makefile.am: Follow GNU coding standards regarding directory variables
2:  8738df50 = 2:  ba3c8f90 src/Makefile.am: Use $() for consistency
```
</details>

<details>
<summary>v3g</summary>

-  Rebase

```
$ git rd 
1:  905759e6 = 1:  657b01f1 configure.ac, src/Makefile.am: Follow GNU coding standards regarding directory variables
2:  ba3c8f90 = 2:  9dff75be src/Makefile.am: Use $() for consistency
```
</details>

<details>
<summary>v3h</summary>

-  Rebase

```
$ git rd
1:  657b01f1 = 1:  ca0daff9 configure.ac, src/Makefile.am: Follow GNU coding standards regarding directory variables
2:  9dff75be = 2:  3f86cfbb src/Makefile.am: Use $() for consistency
```
</details>

<details>
<summary>v3i</summary>

-  Rebase

```
$ git rd
1:  ca0daff9 = 1:  f793375e configure.ac, src/Makefile.am: Follow GNU coding standards regarding directory variables
2:  3f86cfbb = 2:  cc9e79c7 src/Makefile.am: Use $() for consistency
```
</details>

<details>
<summary>v3j</summary>

-  Rebase

```
$ git rd
1:  f793375e = 1:  4309e187 configure.ac, src/Makefile.am: Follow GNU coding standards regarding directory variables
2:  cc9e79c7 = 2:  b28fb398 src/Makefile.am: Use $() for consistency
```
</details>

<details>
<summary>v3k</summary>

-  Rebase

```
$ git rd 
1:  4309e187 = 1:  e9fc9e1b configure.ac, src/Makefile.am: Follow GNU coding standards regarding directory variables
2:  b28fb398 = 2:  7ab69930 src/Makefile.am: Use $() for consistency
```
</details>

<details>
<summary>v3l</summary>

-  Rebase

```
$ git rd 
1:  e9fc9e1b = 1:  0eeb7f4c configure.ac, src/Makefile.am: Follow GNU coding standards regarding directory variables
2:  7ab69930 = 2:  e471ea0d src/Makefile.am: Use $() for consistency
```
</details>

<details>
<summary>v3m</summary>

-  Rebase

```
$ git rd 
1:  0eeb7f4c = 1:  389a4058 configure.ac, src/Makefile.am: Follow GNU coding standards regarding directory variables
2:  e471ea0d = 2:  a7585cb7 src/Makefile.am: Use $() for consistency
```
</details>

<details>
<summary>v3n</summary>

-  Rebase

```
$ git rd 
1:  389a4058 = 1:  71ea3767 configure.ac, src/Makefile.am: Follow GNU coding standards regarding directory variables
2:  a7585cb7 = 2:  4f6598bb src/Makefile.am: Use $() for consistency
```
</details>

<details>
<summary>v3o</summary>

-  Rebase

```
$ git rd 
1:  71ea3767 = 1:  57bd9370 configure.ac, src/Makefile.am: Follow GNU coding standards regarding directory variables
2:  4f6598bb = 2:  cf00ba24 src/Makefile.am: Use $() for consistency
```
</details>

<details>
<summary>v3p</summary>

-  Rebase

```
$ git rd 
1:  57bd9370 = 1:  89a30f10 configure.ac, src/Makefile.am: Follow GNU coding standards regarding directory variables
2:  cf00ba24 = 2:  0d718ce4 src/Makefile.am: Use $() for consistency
```
</details>

<details>
<summary>v3q</summary>

-  Rebase

```
$ git rd 
1:  89a30f10 = 1:  800aaa5d configure.ac, src/Makefile.am: Follow GNU coding standards regarding directory variables
2:  0d718ce4 = 2:  c3b6e0c3 src/Makefile.am: Use $() for consistency
```
</details>

<details>
<summary>v4</summary>

-  Rebase

```
$ git rd 
1:  800aaa5d ! 1:  88acb4f1 configure.ac, src/Makefile.am: Follow GNU coding standards regarding directory variables
    @@ configure.ac: AC_SUBST([LIBSUBID_ABI_MINOR], [libsubid_abi_minor])
      AC_SUBST([LIBSUBID_ABI], [libsubid_abi])
      
     -dnl Some hacks...
    --test "$prefix" = "NONE" && prefix="/usr"
    --test "$prefix" = "/usr" && exec_prefix=""
    +-test "x$prefix" = "xNONE" && prefix="/usr"
    +-test "X$prefix" = "X/usr" && exec_prefix=""
     -
      AC_USE_SYSTEM_EXTENSIONS
      
2:  c3b6e0c3 = 2:  fbcd57ed src/Makefile.am: Use $() for consistency
```
</details>

<details>
<summary>v4b</summary>

-  Rebase

```
$ git rd 
1:  88acb4f1 = 1:  aac8ef2f configure.ac, src/Makefile.am: Follow GNU coding standards regarding directory variables
2:  fbcd57ed = 2:  e13042b0 src/Makefile.am: Use $() for consistency
```
</details>

<details>
<summary>v4c</summary>

-  Rebase

```
$ git rd 
1:  aac8ef2f = 1:  7e76060c configure.ac, src/Makefile.am: Follow GNU coding standards regarding directory variables
2:  e13042b0 = 2:  04adb6df src/Makefile.am: Use $() for consistency
```
</details>

<details>
<summary>v4d</summary>

-  Rebase

```
$ git rd 
1:  7e76060c = 1:  40f81475 configure.ac, src/Makefile.am: Follow GNU coding standards regarding directory variables
2:  04adb6df = 2:  f9deed24 src/Makefile.am: Use $() for consistency
```
</details>

<details>
<summary>v4e</summary>

-  Rebase

```
$ git rd 
1:  40f81475 = 1:  bd86b89c configure.ac, src/Makefile.am: Follow GNU coding standards regarding directory variables
2:  f9deed24 = 2:  c6816608 src/Makefile.am: Use $() for consistency
```
</details>

<details>
<summary>v4f</summary>

-  Rebase

```
$ git rd 
1:  bd86b89c9 = 1:  b5bbddca8 configure.ac, src/Makefile.am: Follow GNU coding standards regarding directory variables
2:  c6816608b = 2:  64fade5f7 src/Makefile.am: Use $() for consistency
```
</details>

<details>
<summary>v4g</summary>

-  Rebase

```
$ git rd 
1:  b5bbddca8 = 1:  d4743e4a1 configure.ac, src/Makefile.am: Follow GNU coding standards regarding directory variables
2:  64fade5f7 = 2:  8cacf6b31 src/Makefile.am: Use $() for consistency
```
</details>

<details>
<summary>v4h</summary>

-  Rebase

```
$ git rd 
1:  d4743e4a1 = 1:  4ab4da022 configure.ac, src/Makefile.am: Follow GNU coding standards regarding directory variables
2:  8cacf6b31 = 2:  d7b978aae src/Makefile.am: Use $() for consistency
```
</details>

<details>
<summary>v5</summary>

-  Respect `$(sbindir)` in PASSWD_PROGRAM.  [@Karlson2k ]

```
$ git rd 
-:  --------- > 1:  5d4e20a93 configure.ac, lib/Makefile.am: Respect $(sbindir) in PASSWD_PROGRAM
1:  4ab4da022 = 2:  0ff5aa752 configure.ac, src/Makefile.am: Follow GNU coding standards regarding directory variables
2:  d7b978aae = 3:  921e7348c src/Makefile.am: Use $() for consistency
```
</details>

<details>
<summary>v5b</summary>

-  Escape double quotes, so that we have a string literal in the C code.

```
$ git rd 
1:  5d4e20a93 ! 1:  a884b9bd5 configure.ac, lib/Makefile.am: Respect $(sbindir) in PASSWD_PROGRAM
    @@ lib/Makefile.am
      
     -DEFS =
     +DEFS = \
    -+  -DPASSWD_PROGRAM="$(sbindir)/passwd"
    ++  -DPASSWD_PROGRAM='"$(sbindir)/passwd"'
      
      noinst_LTLIBRARIES = libshadow.la
      
2:  0ff5aa752 = 2:  86adba75d configure.ac, src/Makefile.am: Follow GNU coding standards regarding directory variables
3:  921e7348c = 3:  fc101c6c1 src/Makefile.am: Use $() for consistency
```
</details>

<details>
<summary>v6</summary>

-  Rebase after #1468.

```
$ git range-diff master..gh/ep PASSWD_PROGRAM..ep 
1:  a884b9bd5 < -:  --------- configure.ac, lib/Makefile.am: Respect $(sbindir) in PASSWD_PROGRAM
2:  86adba75d = 1:  64bfdfd55 configure.ac, src/Makefile.am: Follow GNU coding standards regarding directory variables
3:  fc101c6c1 = 2:  092b283d7 src/Makefile.am: Use $() for consistency
```
</details>

<details>
<summary>v6b</summary>

-  Rebase

```
$ git range-diff 64bfdfd55a83^..gh/ep PASSWD_PROGRAM..ep 
1:  64bfdfd55 = 1:  e3239be5a configure.ac, src/Makefile.am: Follow GNU coding standards regarding directory variables
2:  092b283d7 = 2:  b33540fc7 src/Makefile.am: Use $() for consistency
```
</details>

<details>
<summary>v6c</summary>

-  Rebase

```
$ git range-diff gh/PASSWD_PROGRAM..gh/ep PASSWD_PROGRAM..ep 
1:  e3239be5addb ! 1:  d8cd8c5bc7bc configure.ac, src/Makefile.am: Follow GNU coding standards regarding directory variables
    @@ Commit message
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## configure.ac ##
    -@@ configure.ac: AC_SUBST([LIBSUBID_ABI_MINOR], [libsubid_abi_minor])
    +@@ configure.ac: AC_SUBST([LIBSUBID_ABI_MAJOR], [libsubid_abi_major])
    + AC_SUBST([LIBSUBID_ABI_MINOR], [libsubid_abi_minor])
      AC_SUBST([LIBSUBID_ABI_MICRO], [libsubid_abi_micro])
    - AC_SUBST([LIBSUBID_ABI], [libsubid_abi])
      
     -dnl Some hacks...
     -test "x$prefix" = "xNONE" && prefix="/usr"
2:  b33540fc7524 = 2:  4ab5f848fd39 src/Makefile.am: Use $() for consistency
```
</details>

<details>
<summary>v6d</summary>

-  Rebase

```
$ git range-diff gh/PASSWD_PROGRAM..gh/ep PASSWD_PROGRAM..ep 
1:  d8cd8c5b = 1:  21a93750 configure.ac, src/Makefile.am: Follow GNU coding standards regarding directory variables
2:  4ab5f848 = 2:  bb50f101 src/Makefile.am: Use $() for consistency
```
</details>

<details>
<summary>v6e</summary>

-  Rebase

```
$ git range-diff gh/PASSWD_PROGRAM..gh/ep PASSWD_PROGRAM..ep 
1:  21a93750 = 1:  68432d56 configure.ac, src/Makefile.am: Follow GNU coding standards regarding directory variables
2:  bb50f101 = 2:  fe66955c src/Makefile.am: Use $() for consistency
```
</details>

<details>
<summary>v6f</summary>

-  Rebase

```
$ git range-diff gh/PASSWD_PROGRAM..gh/ep PASSWD_PROGRAM..ep 
1:  68432d56dd41 = 1:  fe06f2a62c51 configure.ac, src/Makefile.am: Follow GNU coding standards regarding directory variables
2:  fe66955c0b88 = 2:  0ede07a3c148 src/Makefile.am: Use $() for consistency
```
</details>