### PR TITLE
Extend basic test cases to check shadow and gshadow entries

### DIFF
--- a/tests/system/etc/login.defs
+++ b/tests/system/etc/login.defs
@@ -446,7 +446,7 @@ CREATE_HOME     yes
 # Force use shadow, even if shadow passwd & shadow group files are
 # missing.
 #
-#FORCE_SHADOW    yes
+FORCE_SHADOW    yes
 
 #
 # Allow newuidmap and newgidmap when running under an alternative

--- a/tests/system/framework/hosts/base.py
+++ b/tests/system/framework/hosts/base.py
@@ -54,7 +54,8 @@ class BaseLinuxHost(MultihostHost[ShadowMultihostDomain]):
         """
         self.logger.info(f"Detecting distro information on {self.hostname}")
         os_release = self.fs.read("/etc/os-release")
-        self._os_release = dict(csv.reader([x for x in os_release.splitlines() if x], delimiter="="))
+        valid_lines = [line for line in os_release.splitlines() if line and not line.startswith("#")]
+        self._os_release = dict(csv.reader(valid_lines, delimiter="="))
         if "NAME" in self._os_release:
             self._distro_name = self._os_release["NAME"]
         if "VERSION_ID" not in self._os_release:

--- a/tests/system/framework/hosts/base.py
+++ b/tests/system/framework/hosts/base.py
@@ -47,6 +47,7 @@ class BaseLinuxHost(MultihostHost[ShadowMultihostDomain]):
         self._distro_name: str = "unknown"
         self._distro_major: int = 0
         self._distro_minor: int = 0
+        self._revision: int = 0
 
     def _distro_information(self):
         """
@@ -60,9 +61,13 @@ class BaseLinuxHost(MultihostHost[ShadowMultihostDomain]):
             self._distro_name = self._os_release["NAME"]
         if "VERSION_ID" not in self._os_release:
             return
-        if "." in self._os_release["VERSION_ID"]:
-            self._distro_major = int(self._os_release["VERSION_ID"].split(".", maxsplit=1)[0])
-            self._distro_minor = int(self._os_release["VERSION_ID"].split(".", maxsplit=1)[1])
+        if self._os_release["VERSION_ID"].count(".") == 2:
+            self._distro_major = int(self._os_release["VERSION_ID"].split(".")[0])
+            self._distro_minor = int(self._os_release["VERSION_ID"].split(".")[1])
+            self._revision = int(self._os_release["VERSION_ID"].split(".")[2])
+        elif self._os_release["VERSION_ID"].count(".") == 1:
+            self._distro_major = int(self._os_release["VERSION_ID"].split(".")[0])
+            self._distro_minor = int(self._os_release["VERSION_ID"].split(".")[1])
         else:
             self._distro_major = int(self._os_release["VERSION_ID"])
 

--- a/tests/system/framework/misc/__init__.py
+++ b/tests/system/framework/misc/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime
 from typing import Any
 
 
@@ -40,3 +41,14 @@ def to_list_of_strings(value: Any | list[Any] | None) -> list[str]:
     :rtype: list[str]
     """
     return [str(x) for x in to_list(value)]
+
+
+def days_since_epoch():
+    """
+    Gets the current date and returns the number of days since 1970-01-01 UTC, this time is also referred to as the
+    Unix epoch.
+    """
+    epoch = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
+    now_utc = datetime.datetime.now(datetime.timezone.utc)
+    delta = now_utc - epoch
+    return delta.days

--- a/tests/system/framework/utils/tools.py
+++ b/tests/system/framework/utils/tools.py
@@ -14,6 +14,7 @@ __all__ = [
     "UnixGroup",
     "IdEntry",
     "PasswdEntry",
+    "ShadowEntry",
     "GroupEntry",
     "InitgroupsEntry",
     "LinuxToolsUtils",
@@ -212,6 +213,98 @@ class PasswdEntry(object):
     @classmethod
     def FromOutput(cls, stdout: str) -> PasswdEntry:
         result = jc.parse("passwd", stdout)
+
+        if not isinstance(result, list):
+            raise TypeError(f"Unexpected type: {type(result)}, expecting list")
+
+        if len(result) != 1:
+            raise ValueError("More then one entry was returned")
+
+        return cls.FromDict(result[0])
+
+
+class ShadowEntry(object):
+    """
+    Result of ``getent shadow``
+    """
+
+    def __init__(
+        self,
+        name: str,
+        password: str,
+        last_changed: int,
+        min_days: int,
+        max_days: int,
+        warn_days: int,
+        inactivity_days: int,
+        expiration_date: int,
+    ) -> None:
+        self.name: str | None = name
+        """
+        User name.
+        """
+
+        self.password: str | None = password
+        """
+        User password.
+        """
+
+        self.last_changed: int = last_changed
+        """
+        Last password change.
+        """
+
+        self.min_days: int = min_days
+        """
+        Minimum number of days before a password change is allowed.
+        """
+
+        self.max_days: int = max_days
+        """
+        Maximum number of days a password is valid.
+        """
+
+        self.warn_days: int = warn_days
+        """
+        Number of days to warn the user before the password expires.
+        """
+
+        self.inactivity_days: int | None = inactivity_days
+        """
+        Number of days after a password expires before the account is disabled.
+        """
+
+        self.expiration_date: int | None = expiration_date
+        """
+        The account expiration date, expressed as the number of days since 1970-01-01 00:00:00 UTC.
+        """
+
+    def __str__(self) -> str:
+        return (
+            f"({self.name}:{self.password}:{self.last_changed}:"
+            f"{self.min_days}:{self.max_days}:{self.warn_days}:"
+            f"{self.inactivity_days}:{self.expiration_date}:)"
+        )
+
+    def __repr__(self) -> str:
+        return str(self)
+
+    @classmethod
+    def FromDict(cls, d: dict[str, Any]) -> ShadowEntry:
+        return cls(
+            name=d.get("username", None),
+            password=d.get("password", None),
+            last_changed=d.get("last_changed", None),
+            min_days=d.get("minimum", None),
+            max_days=d.get("maximum", None),
+            warn_days=d.get("warn", None),
+            inactivity_days=d.get("inactive", None),
+            expiration_date=d.get("expire", None),
+        )
+
+    @classmethod
+    def FromOutput(cls, stdout: str) -> ShadowEntry:
+        result = jc.parse("shadow", stdout)
 
         if not isinstance(result, list):
             raise TypeError(f"Unexpected type: {type(result)}, expecting list")
@@ -434,6 +527,19 @@ class GetentUtils(MultihostUtility[MultihostHost]):
         :rtype: PasswdEntry | None
         """
         return self.__exec(PasswdEntry, "passwd", name, service)
+
+    def shadow(self, name: str | int, *, service: str | None = None) -> ShadowEntry | None:
+        """
+        Call ``getent shadow $name``
+
+        :param name: User name or id.
+        :type name: str | int
+        :param service: Service used, defaults to None
+        :type service: str | None
+        :return: shadow data, None if not found
+        :rtype: ShadowEntry | None
+        """
+        return self.__exec(ShadowEntry, "shadow", name, service)
 
     def group(self, name: str | int, *, service: str | None = None) -> GroupEntry | None:
         """

--- a/tests/system/tests/test_groupadd.py
+++ b/tests/system/tests/test_groupadd.py
@@ -17,9 +17,11 @@ def test_groupadd__add_group(shadow: Shadow):
     :setup:
         1. Create group
     :steps:
-        1. Group exists and GID is 1000
+        1. Check group entry
+        2. Check gshadow entry
     :expectedresults:
-        1. Group is found and GID matches
+        1. group entry for the user exists and the attributes are correct
+        2. gshadow entry for the user exists and the attributes are correct
     :customerscenario: False
     """
     shadow.groupadd("tgroup")
@@ -28,3 +30,9 @@ def test_groupadd__add_group(shadow: Shadow):
     assert result is not None, "Group should be found"
     assert result.name == "tgroup", "Incorrect groupname"
     assert result.gid == 1000, "Incorrect GID"
+
+    if shadow.host.features["gshadow"]:
+        result = shadow.tools.getent.gshadow("tgroup")
+        assert result is not None, "Group should be found"
+        assert result.name == "tgroup", "Incorrect groupname"
+        assert result.password == "!", "Incorrect password"

--- a/tests/system/tests/test_groupdel.py
+++ b/tests/system/tests/test_groupdel.py
@@ -18,13 +18,18 @@ def test_groupdel__delete_group(shadow: Shadow):
         1. Create group
         2. Delete group
     :steps:
-        1. Group doesn't exist
+        1. Check group entry
+        2. Check gshadow entry
     :expectedresults:
-        1. Group is not found
+        1. group entry for the user doesn't exist
+        2. gshadow entry for the user doesn't exist
     :customerscenario: False
     """
     shadow.groupadd("tgroup")
     shadow.groupdel("tgroup")
 
     result = shadow.tools.getent.group("tgroup")
+    assert result is None, "Group should not be found"
+
+    result = shadow.tools.getent.gshadow("tgroup")
     assert result is None, "Group should not be found"

--- a/tests/system/tests/test_groupmod.py
+++ b/tests/system/tests/test_groupmod.py
@@ -18,9 +18,11 @@ def test_groupmod__change_gid(shadow: Shadow):
         1. Create group
         2. Change GID
     :steps:
-        1. Group exists and GID is 1001
+        1. Check group entry
+        2. Check gshadow entry
     :expectedresults:
-        1. Group is found and GID matches
+        1. group entry for the user exists and the attributes are correct
+        2. gshadow entry for the user exists and the attributes are correct
     :customerscenario: False
     """
     shadow.groupadd("tgroup")
@@ -30,3 +32,9 @@ def test_groupmod__change_gid(shadow: Shadow):
     assert result is not None, "Group should be found"
     assert result.name == "tgroup", "Incorrect groupname"
     assert result.gid == 1001, "Incorrect GID"
+
+    if shadow.host.features["gshadow"]:
+        result = shadow.tools.getent.gshadow("tgroup")
+        assert result is not None, "Group should be found"
+        assert result.name == "tgroup", "Incorrect groupname"
+        assert result.password == "!", "Incorrect password"

--- a/tests/system/tests/test_useradd.py
+++ b/tests/system/tests/test_useradd.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import pytest
 
+from framework.misc import days_since_epoch
 from framework.roles.shadow import Shadow
 from framework.topology import KnownTopology
 
@@ -17,26 +18,52 @@ def test_useradd__add_user(shadow: Shadow):
     :setup:
         1. Create user
     :steps:
-        1. User exists and UID is 1000
-        2. Group exists and GID is 1000
-        3. Home folder exists
+        1. Check passwd entry
+        2. Check shadow entry
+        3. Check group entry
+        4. Check gshadow entry
+        5. Check home folder
     :expectedresults:
-        1. User is found and UID matches
-        2. Group is found and GID matches
-        3. Home folder is found
+        1. passwd entry for the user exists and the attributes are correct
+        2. shadow entry for the user exists and the attributes are correct
+        3. group entry for the user exists and the attributes are correct
+        4. gshadow entry for the user exists and the attributes are correct
+        5. Home folder exists
     :customerscenario: False
     """
     shadow.useradd("tuser")
 
-    result = shadow.tools.id("tuser")
+    result = shadow.tools.getent.passwd("tuser")
     assert result is not None, "User should be found"
-    assert result.user.name == "tuser", "Incorrect username"
-    assert result.user.id == 1000, "Incorrect UID"
+    assert result.name == "tuser", "Incorrect username"
+    assert result.password == "x", "Incorrect password"
+    assert result.uid == 1000, "Incorrect UID"
+    assert result.gid == 1000, "Incorrect GID"
+    assert result.home == "/home/tuser", "Incorrect home"
+    if "Debian" in shadow.host.distro_name:
+        assert result.shell == "/bin/sh", "Incorrect shell"
+    else:
+        assert result.shell == "/bin/bash", "Incorrect shell"
+
+    result = shadow.tools.getent.shadow("tuser")
+    assert result is not None, "User should be found"
+    assert result.name == "tuser", "Incorrect username"
+    assert result.password == "!", "Incorrect password"
+    assert result.last_changed == days_since_epoch(), "Incorrect last changed"
+    assert result.min_days == 0, "Incorrect min days"
+    assert result.max_days == 99999, "Incorrect max days"
+    assert result.warn_days == 7, "Incorrect warn days"
 
     result = shadow.tools.getent.group("tuser")
     assert result is not None, "Group should be found"
     assert result.name == "tuser", "Incorrect groupname"
     assert result.gid == 1000, "Incorrect GID"
+
+    if shadow.host.features["gshadow"]:
+        result = shadow.tools.getent.gshadow("tuser")
+        assert result is not None, "User should be found"
+        assert result.name == "tuser", "Incorrect username"
+        assert result.password == "!", "Incorrect password"
 
     assert shadow.fs.exists("/home/tuser"), "Home folder should be found"
 

--- a/tests/system/tests/test_userdel.py
+++ b/tests/system/tests/test_userdel.py
@@ -18,22 +18,32 @@ def test_userdel__homedir_removed(shadow: Shadow):
         1. Create user
         2. Delete the user and the homedir
     :steps:
-        1. User doesn't exist
-        2. Group doesn't exist
-        3. Home folder doesn't exist
+        1. Check passwd entry
+        2. Check shadow entry
+        3. Check group entry
+        4. Check gshadow entry
+        5. Check home folder
     :expectedresults:
-        1. User is not found
-        2. Group is not found
-        3. Home folder is not found
+        1. passwd entry for the user doesn't exist
+        2. shadow entry for the user doesn't exist
+        3. group entry for the user doesn't exist
+        4. gshadow entry for the user doesn't exist
+        5. Home folder doesn't exist
     :customerscenario: False
     """
     shadow.useradd("tuser")
     shadow.userdel("-r tuser")
 
-    result = shadow.tools.id("tuser")
+    result = shadow.tools.getent.passwd("tuser")
+    assert result is None, "User should not be found"
+
+    result = shadow.tools.getent.shadow("tuser")
     assert result is None, "User should not be found"
 
     result = shadow.tools.getent.group("tuser")
     assert result is None, "Group should not be found"
+
+    result = shadow.tools.getent.gshadow("tuser1")
+    assert result is None, "User should not be found"
 
     assert not shadow.fs.exists("/home/tuser"), "Home folder should not exist"

--- a/tests/system/tests/test_usermod.py
+++ b/tests/system/tests/test_usermod.py
@@ -18,26 +18,39 @@ def test_usermod__rename_user(shadow: Shadow):
         1. Create user
         2. Rename user
     :steps:
-        1. User exists with new name and GID is 1000
-        2. Group exists and GID is 1000
-        3. Home folder exists
+        1. Check passwd entry
+        2. Check shadow entry
+        3. Check group entry
+        4. Check gshadow entry
+        5. Check home folder
     :expectedresults:
-        1. User is found and UID matches
-        2. Group is found and GID matches
-        3. Home folder is found
+        1. passwd entry for the user exists and the attributes are correct
+        2. shadow entry for the user exists and the attributes are correct
+        3. group entry for the user exists and the attributes are correct
+        4. gshadow entry for the user exists and the attributes are correct
+        5. Home folder exists
     :customerscenario: False
     """
     shadow.useradd("tuser1")
     shadow.usermod("-l tuser2 tuser1")
 
-    result = shadow.tools.id("tuser2")
+    result = shadow.tools.getent.passwd("tuser2")
     assert result is not None, "User should be found"
-    assert result.user.name == "tuser2", "Incorrect username"
-    assert result.user.id == 1000, "Incorrect UID"
+    assert result.name == "tuser2", "Incorrect username"
+    assert result.uid == 1000, "Incorrect UID"
+
+    result = shadow.tools.getent.shadow("tuser2")
+    assert result is not None, "User should be found"
+    assert result.name == "tuser2", "Incorrect username"
 
     result = shadow.tools.getent.group("tuser1")
     assert result is not None, "Group should be found"
     assert result.name == "tuser1", "Incorrect groupname"
     assert result.gid == 1000, "Incorrect GID"
+
+    if shadow.host.features["gshadow"]:
+        result = shadow.tools.getent.gshadow("tuser1")
+        assert result is not None, "User should be found"
+        assert result.name == "tuser1", "Incorrect username"
 
     assert shadow.fs.exists("/home/tuser1"), "Home folder should be found"


### PR DESCRIPTION
The test framework PoC only provided basic checks. I've added additional
functionality to the framework by checking shadow and gshadow entries
and I've extended the basic test cases to check those too.

This should give us more coverage over the changes we make to the basic
functionality and ensure that we don't change anything inadvertently.