### PR TITLE
lib/getdate.y: Restrict the date formats that we support

### DIFF
--- a/lib/getdate.y
+++ b/lib/getdate.y
@@ -132,7 +132,6 @@ spec	: /* NULL */
 	;
 
 item	: date
-	| number
 	;
 
 date	: tUNUMBER tSNUMBER tSNUMBER {
@@ -141,14 +140,6 @@ date	: tUNUMBER tSNUMBER tSNUMBER {
 	    yyMonth = -$2;
 	    yyDay = -$3;
 	}
-	;
-
-number	: tUNUMBER
-          {
-		    yyDay= ($1)%100;
-		    yyMonth= ($1/100)%100;
-		    yyYear = $1/10000;
-	  }
 	;
 
 %%

--- a/lib/getdate.y
+++ b/lib/getdate.y
@@ -352,7 +352,6 @@ yylex (void)
 time_t get_date (const char *p, const time_t *now)
 {
   struct tm  tm;
-  time_t Start;
 
   yyInput = p;
   yyHaveDate = 0;
@@ -367,14 +366,7 @@ time_t get_date (const char *p, const time_t *now)
   tm.tm_hour = tm.tm_min = tm.tm_sec = 0;
   tm.tm_isdst = 0;
 
-  Start = timegm(&tm);
-
-  if (Start == (time_t) -1)
-    {
-	return Start;
-    }
-
-  return Start;
+  return timegm(&tm);
 }
 
 #if	defined (TEST)

--- a/lib/strtoday.c
+++ b/lib/strtoday.c
@@ -19,20 +19,7 @@
 #include "string/strspn/stpspn.h"
 
 
-/*
- * strtoday() now uses get_date() (borrowed from GNU shellutils)
- * which can handle many date formats, for example:
- *	1970-09-17	# ISO 8601.
- *	70-9-17		# This century assumed by default.
- *	70-09-17	# Leading zeros are ignored.
- *	9/17/72		# Common U.S. writing.
- *	24 September 1972
- *	24 Sept 72	# September has a special abbreviation.
- *	24 Sep 72	# Three-letter abbreviations always allowed.
- *	Sep 24, 1972
- *	24-sep-72
- *	24sep72
- */
+// string parse-to day-since-Epoch
 long strtoday (const char *str)
 {
 	time_t t;

--- a/man/chage.1.xml
+++ b/man/chage.1.xml
@@ -75,7 +75,7 @@
 	</term>
 	<listitem>
 	  <para>
-	    Set the number of days since January 1st, 1970 when the password
+	    Set the number of days since 1970-01-01 when the password
 	    was last changed. The date may also be expressed in the format
 	    YYYY-MM-DD (or the format more commonly used in your area).
 	    If the <replaceable>LAST_DAY</replaceable> is set to
@@ -90,7 +90,7 @@
 	</term>
 	<listitem>
 	  <para>
-	    Set the date or number of days since January 1, 1970 on which the
+	    Set the date or number of days since 1970-01-01 on which the
 	    user's account will no longer be accessible. The date may also
 	    be expressed in the format YYYY-MM-DD (or the format more
 	    commonly used in your area). A user whose account is locked must
@@ -102,7 +102,7 @@
 	    in 180 days:
 	  </para>
 	  <programlisting>
-	    chage -E $(date -d +180days +%Y-%m-%d)
+	    chage -E $(date -d +180days +%F)
 	  </programlisting>
 	  <para>
 	    Passing the number <emphasis remap='I'>-1</emphasis> as the

--- a/man/chage.1.xml
+++ b/man/chage.1.xml
@@ -77,7 +77,7 @@
 	  <para>
 	    Set the number of days since 1970-01-01 when the password
 	    was last changed. The date may also be expressed in the format
-	    YYYY-MM-DD (or the format more commonly used in your area).
+	    YYYY-MM-DD.
 	    If the <replaceable>LAST_DAY</replaceable> is set to
 	    <emphasis>0</emphasis> the user is forced to change his password
 	    on the next log on.
@@ -92,8 +92,8 @@
 	  <para>
 	    Set the date or number of days since 1970-01-01 on which the
 	    user's account will no longer be accessible. The date may also
-	    be expressed in the format YYYY-MM-DD (or the format more
-	    commonly used in your area). A user whose account is locked must
+	    be expressed in the format YYYY-MM-DD.
+	    A user whose account is locked must
 	    contact the system administrator before being able to use the
 	    system again.
 	  </para>

--- a/man/passwd.1.xml
+++ b/man/passwd.1.xml
@@ -229,7 +229,7 @@
 	    still be able to login using another authentication token
 	    (e.g. an SSH key). To disable the account, administrators
 	    should use <command>usermod --expiredate 1</command> (this sets
-	    the account's expire date to Jan 2, 1970).
+	    the account's expire date to 1970-01-02).
 	  </para>
 	  <para>
 	    Users with a locked password are not allowed to change their

--- a/man/shadow.5.xml
+++ b/man/shadow.5.xml
@@ -105,7 +105,7 @@
 	<listitem>
 	  <para>
 	    The date of the last password change, expressed as the number
-	    of days since Jan 1, 1970 00:00 UTC.
+	    of days since 1970-01-01 00:00:00 UTC.
 	  </para>
 	  <para>
 	    The value 0 has a special meaning, which is that the user
@@ -200,7 +200,7 @@
 	<listitem>
 	  <para>
 	    The date of expiration of the account, expressed as the number
-	    of days since Jan 1, 1970 00:00 UTC.
+	    of days since 1970-01-01 00:00:00 UTC.
 	  </para>
 	  <para>
 	    Note that an account expiration differs from a password


### PR DESCRIPTION
-  This is a subset of <https://github.com/shadow-maint/shadow/pull/1217> (revision v2h), to make it easier to review.

This PR removes features of get_date() that we don't really need or want.

It is in preparation of a future replacement of this code by a C implementation.

Cc: @zeha , @timparenti

---

Revisions:

<details>
<summary>v1b</summary>

-  Squash a few commits.  [@timparenti ]

<details>
<summary>Range-diff:</summary>

```
alx@devuan:~/src/shadow/shadow/master$ git range-diff shadow/master gh/gd gd
 1:  0b830153 <  -:  -------- lib/getdate.y: Do not parse am/pm time syntax; just 24h
 2:  ce35738c !  1:  13de308c lib/getdate.y: Do not parse times; just dates
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/getdate.y: Do not parse times; just dates
    +    lib/getdate.y: Don't parse times; just dates
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/getdate.y ##
    +@@ lib/getdate.y: typedef struct _TABLE {
    + } TABLE;
    + 
    + 
    +-/*
    +-**  Meridian:  am, pm, or 24-hour style.
    +-*/
    +-typedef enum _MERIDIAN {
    +-    MERam, MERpm, MER24
    +-} MERIDIAN;
    +-
    +-
    + /*
    + **  Global variables.  We could get rid of most of these by using a good
    + **  union as the yacc stack.  (This routine was originally written before
     @@ lib/getdate.y: static int       yyDayNumber;
      static int        yyHaveDate;
      static int        yyHaveDay;
    @@ lib/getdate.y: static int        yyDayNumber;
      static int        yyMonth;
     -static int        yySeconds;
      static int        yyYear;
    +-static MERIDIAN   yyMeridian;
      static int        yyRelDay;
     -static int        yyRelHour;
     -static int        yyRelMinutes;
    @@ lib/getdate.y: static int        yyDayNumber;
      static int        yyRelYear;
      
      %}
    -@@ lib/getdate.y: static int       yyRelYear;
    + 
    + %union {
          int                   Number;
    +-    enum _MERIDIAN        Meridian;
      }
      
     -%token    tAGO tDAY tDAY_UNIT tHOUR_UNIT tID
    --%token    tMINUTE_UNIT tMONTH tMONTH_UNIT
    +-%token    tMERIDIAN tMINUTE_UNIT tMONTH tMONTH_UNIT
     -%token    tSEC_UNIT tSNUMBER tUNUMBER tYEAR_UNIT
     +%token    tAGO tDAY tDAY_UNIT tID
     +%token    tMONTH tMONTH_UNIT
    @@ lib/getdate.y: static int        yyRelYear;
     +%type     <Number>        tDAY tDAY_UNIT
      %type     <Number>        tMONTH tMONTH_UNIT
     -%type     <Number>        tSEC_UNIT tSNUMBER tUNUMBER tYEAR_UNIT
    +-%type     <Meridian>      tMERIDIAN o_merid
     +%type     <Number>        tSNUMBER tUNUMBER tYEAR_UNIT
      
      %%
    @@ lib/getdate.y: item      : time {
        | number
        ;
      
    --time      : tUNUMBER ':' tUNUMBER {
    +-time      : tUNUMBER tMERIDIAN {
    +-      yyHour = $1;
    +-      yyMinutes = 0;
    +-      yySeconds = 0;
    +-      yyMeridian = $2;
    +-  }
    +-  | tUNUMBER ':' tUNUMBER o_merid {
     -      yyHour = $1;
     -      yyMinutes = $3;
    +-      yySeconds = 0;
    +-      yyMeridian = $4;
    +-  }
    +-  | tUNUMBER ':' tUNUMBER {
    +-      yyHour = $1;
    +-      yyMinutes = $3;
    +-      yyMeridian = MER24;
    +-  }
    +-  | tUNUMBER ':' tUNUMBER ':' tUNUMBER o_merid {
    +-      yyHour = $1;
    +-      yyMinutes = $3;
    +-      yySeconds = $5;
    +-      yyMeridian = $6;
     -  }
     -  | tUNUMBER ':' tUNUMBER ':' tUNUMBER {
     -      yyHour = $1;
     -      yyMinutes = $3;
     -      yySeconds = $5;
    +-      yyMeridian = MER24;
     -  }
     -  ;
     -
    @@ lib/getdate.y: relunit   : tUNUMBER tYEAR_UNIT {
     -                  yyMinutes = $1 % 100;
     -                }
     -              yySeconds = 0;
    +-              yyMeridian = MER24;
     -            }
     -        }
    +-    }
    +-  ;
    +-
    +-o_merid   : /* NULL */
    +-    {
    +-      $$ = MER24;
    +-    }
    +-  | tMERIDIAN
    +-    {
    +-      $$ = $1;
          }
        ;
      
    @@ lib/getdate.y: static TABLE const UnitsTable[] = {
          { "next",             tUNUMBER,       2 },
          { "first",            tUNUMBER,       1 },
      /*  { "second",           tUNUMBER,       2 }, */
    +@@ lib/getdate.y: static int yyerror (MAYBE_UNUSED const char *s)
    +   return 0;
    + }
    + 
    +-static int ToHour (int Hours, MERIDIAN Meridian)
    +-{
    +-  switch (Meridian)
    +-    {
    +-    case MER24:
    +-      if (Hours < 0 || Hours > 23)
    +-  return -1;
    +-      return Hours;
    +-    case MERam:
    +-      if (Hours < 1 || Hours > 12)
    +-  return -1;
    +-      if (Hours == 12)
    +-  Hours = 0;
    +-      return Hours;
    +-    case MERpm:
    +-      if (Hours < 1 || Hours > 12)
    +-  return -1;
    +-      if (Hours == 12)
    +-  Hours = 0;
    +-      return Hours + 12;
    +-    default:
    +-      abort ();
    +-    }
    +-  /* NOTREACHED */
    +-}
    +-
    + static int ToYear (int Year)
    + {
    +   if (Year < 0)
    +@@ lib/getdate.y: static int LookupWord (char *buff)
    +     if (isupper (*p))
    +       *p = tolower (*p);
    + 
    +-  if (streq(buff, "am") || streq(buff, "a.m."))
    +-    {
    +-      yylval.Meridian = MERam;
    +-      return tMERIDIAN;
    +-    }
    +-  if (streq(buff, "pm") || streq(buff, "p.m."))
    +-    {
    +-      yylval.Meridian = MERpm;
    +-      return tMERIDIAN;
    +-    }
    +-
    +   /* See if we have an abbreviation for a month. */
    +   if (strlen (buff) == 3)
    +     abbrev = true;
     @@ lib/getdate.y: time_t get_date (const char *p, const time_t *now)
        yyYear = tmp->tm_year + TM_YEAR_ORIGIN;
        yyMonth = tmp->tm_mon + 1;
    @@ lib/getdate.y: time_t get_date (const char *p, const time_t *now)
     -  yyHour = tmp->tm_hour;
     -  yyMinutes = tmp->tm_min;
     -  yySeconds = tmp->tm_sec;
    +-  yyMeridian = MER24;
     -  yyRelSeconds = 0;
     -  yyRelMinutes = 0;
     -  yyRelHour = 0;
    @@ lib/getdate.y: time_t get_date (const char *p, const time_t *now)
     -  if ((yyHaveTime != 0) ||
     -      ( (yyHaveRel != 0) && (yyHaveDate == 0) && (yyHaveDay == 0) ))
     -    {
    --      tm.tm_hour = yyHour;
    +-      tm.tm_hour = ToHour (yyHour, yyMeridian);
     -      if (tm.tm_hour < 0)
     -  return -1;
     -      tm.tm_min = yyMinutes;
 3:  64d5d8de !  2:  4e143c9f lib/getdate.y: Do not parse relative dates, such as 'yesterday'
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/getdate.y: Do not parse relative dates, such as 'yesterday'
    +    lib/getdate.y: Don't parse relative dates, such as 'yesterday'
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
 4:  0851afca =  3:  7812415b lib/getdate.y: Don't parse week days
 5:  8c581d5e =  4:  3908b9f9 lib/getdate.y: Remove unnecessary variable
 6:  4c923f93 !  5:  05ce266b lib/getdate.y: Don't parse dates in local formats; just YYYY-MM-DD
    @@ Metadata
      ## Commit message ##
         lib/getdate.y: Don't parse dates in local formats; just YYYY-MM-DD
     
    -    Signed-off-by: Alejandro Colomar <alx@kernel.org>
    -
      ## lib/getdate.y ##
     @@
      
    @@ lib/getdate.y
      #include "string/strspn/stpspn.h"
      
      
    +@@ lib/getdate.y: typedef struct _TABLE {
    + **  the %union very rarely.
    + */
    + static const char *yyInput;
    +-static int        yyHaveDate;
    + static int        yyDay;
    + static int        yyMonth;
    + static int        yyYear;
     @@ lib/getdate.y: static int       yyYear;
          int                   Number;
      }
    @@ lib/getdate.y: static int        yyYear;
      %type     <Number>        tSNUMBER tUNUMBER
      
      %%
    -@@ lib/getdate.y: item     : date {
    +@@ lib/getdate.y: spec     : /* NULL */
    +   | spec item
    +   ;
    + 
    +-item      : date {
    +-      yyHaveDate++;
    +-  }
    ++item      : date
        | number
        ;
      
    @@ lib/getdate.y: item      : date {
        ;
      
      number    : tUNUMBER
    +           {
    +-              yyHaveDate++;
    +               yyDay= ($1)%100;
    +               yyMonth= ($1/100)%100;
    +               yyYear = $1/10000;
     @@ lib/getdate.y: number   : tUNUMBER
      
      %%
    @@ lib/getdate.y: number    : tUNUMBER
      ^L
      
      
    -@@ lib/getdate.y: static int ToYear (int Year)
    -   return Year;
    +@@ lib/getdate.y: static int yyerror (MAYBE_UNUSED const char *s)
    +   return 0;
      }
      
    +-static int ToYear (int Year)
    +-{
    +-  if (Year < 0)
    +-    Year = -Year;
    +-
    +-  /* XPG4 suggests that years 00-68 map to 2000-2068, and
    +-     years 69-99 map to 1969-1999.  */
    +-  if (Year < 69)
    +-    Year += 2000;
    +-  else if (Year < 100)
    +-    Year += 1900;
    +-
    +-  return Year;
    +-}
    +-
     -static int LookupWord (char *buff)
     -{
     -  register char *p;
    @@ lib/getdate.y: yylex (void)
            if (c != '(')
        return *yyInput++;
            Count = 0;
    +@@ lib/getdate.y: time_t get_date (const char *p, const time_t *now)
    +   struct tm  tm;
    + 
    +   yyInput = p;
    +-  yyHaveDate = 0;
    + 
    +-  if (yyparse ()
    +-      || yyHaveDate > 1)
    ++  if (yyparse())
    +     return -1;
    + 
    +-  tm.tm_year = ToYear (yyYear) - TM_YEAR_ORIGIN;
    ++  tm.tm_year = yyYear - TM_YEAR_ORIGIN;
    +   tm.tm_mon = yyMonth - 1;
    +   tm.tm_mday = yyDay;
    +   tm.tm_hour = tm.tm_min = tm.tm_sec = 0;
 7:  e385099d <  -:  -------- lib/getdate.y: Remove unnecessary variable
 8:  8928c17e <  -:  -------- lib/getdate.y: Don't parse 2-digit years as if 19xx/20xx years
 9:  a842f13b !  6:  ad501f36 lib/getdate.y: Don't parse a raw number; just a yyyy-mm-dd date
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/getdate.y: Don't parse a raw number; just a yyyy-mm-dd date
    +    lib/getdate.y: Don't parse a raw number; just a calendar date
     
         Our caller, strtoday(), already handles a raw number.
     
```
</details>
<details>
<summary>Interdiff:</summary>

```diff
$ git diff gh/gd..gd
$
```
</details>
</details>

<details>
<summary>v2</summary>

-  Update docs.  [@timparenti ]
-  Remove obsolete comment.

```
$ git range-diff shadow/master gh/gd gd
 1:  13de308c =  1:  13de308c lib/getdate.y: Don't parse times; just dates
 2:  4e143c9f =  2:  4e143c9f lib/getdate.y: Don't parse relative dates, such as 'yesterday'
 3:  7812415b =  3:  7812415b lib/getdate.y: Don't parse week days
 4:  3908b9f9 =  4:  3908b9f9 lib/getdate.y: Remove unnecessary variable
 5:  05ce266b =  5:  05ce266b lib/getdate.y: Don't parse dates in local formats; just YYYY-MM-DD
 6:  ad501f36 =  6:  ad501f36 lib/getdate.y: Don't parse a raw number; just a calendar date
 -:  -------- >  7:  4811959b man/: Consistently express dates in standard format
 -:  -------- >  8:  ea6be66b man/: Localized dates are not accepted anymore
 -:  -------- >  9:  07e7004b lib/strtoday.c: strtoday(): Remove obsolete comment
```
</details>

<details>
<summary>v3</summary>

-  Add comment documenting the name of `strtoday()`.

```
$ git range-diff shadow/master gh/gd gd
 1:  13de308c =  1:  13de308c lib/getdate.y: Don't parse times; just dates
 2:  4e143c9f =  2:  4e143c9f lib/getdate.y: Don't parse relative dates, such as 'yesterday'
 3:  7812415b =  3:  7812415b lib/getdate.y: Don't parse week days
 4:  3908b9f9 =  4:  3908b9f9 lib/getdate.y: Remove unnecessary variable
 5:  05ce266b =  5:  05ce266b lib/getdate.y: Don't parse dates in local formats; just YYYY-MM-DD
 6:  ad501f36 =  6:  ad501f36 lib/getdate.y: Don't parse a raw number; just a calendar date
 7:  4811959b =  7:  4811959b man/: Consistently express dates in standard format
 8:  ea6be66b =  8:  ea6be66b man/: Localized dates are not accepted anymore
 9:  07e7004b !  9:  c225d27b lib/strtoday.c: strtoday(): Remove obsolete comment
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/strtoday.c: strtoday(): Remove obsolete comment
    +    lib/strtoday.c: strtoday(): Replace obsolete comment
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    @@ lib/strtoday.c
     - *        24-sep-72
     - *        24sep72
     - */
    ++// string parse-to day-since-Epoch
      long strtoday (const char *str)
      {
        time_t t;
```
</details>

<details>
<summary>v4</summary>

-  Apply two documentation patches from @domiborges .

```
$ git range-diff shadow/master gh/gd gd
 1:  13de308c =  1:  13de308c lib/getdate.y: Don't parse times; just dates
 2:  4e143c9f =  2:  4e143c9f lib/getdate.y: Don't parse relative dates, such as 'yesterday'
 3:  7812415b =  3:  7812415b lib/getdate.y: Don't parse week days
 4:  3908b9f9 =  4:  3908b9f9 lib/getdate.y: Remove unnecessary variable
 5:  05ce266b =  5:  05ce266b lib/getdate.y: Don't parse dates in local formats; just YYYY-MM-DD
 6:  ad501f36 =  6:  ad501f36 lib/getdate.y: Don't parse a raw number; just a calendar date
 7:  4811959b =  7:  4811959b man/: Consistently express dates in standard format
 8:  ea6be66b =  8:  ea6be66b man/: Localized dates are not accepted anymore
 9:  c225d27b =  9:  c225d27b lib/strtoday.c: strtoday(): Replace obsolete comment
 -:  -------- > 10:  87f31e27 man/chage.1.xml: Update -d -E options
 -:  -------- > 11:  1264b960 man/chage.1.xml: wfix
```
</details>

<details>
<summary>v4b</summary>

-  Fix documentation.  [@ikerexxe ]

```
$ git range-diff db/master gh/gd gd
 1:  13de308c =  1:  13de308c lib/getdate.y: Don't parse times; just dates
 2:  4e143c9f =  2:  4e143c9f lib/getdate.y: Don't parse relative dates, such as 'yesterday'
 3:  7812415b =  3:  7812415b lib/getdate.y: Don't parse week days
 4:  3908b9f9 =  4:  3908b9f9 lib/getdate.y: Remove unnecessary variable
 5:  05ce266b =  5:  05ce266b lib/getdate.y: Don't parse dates in local formats; just YYYY-MM-DD
 6:  ad501f36 =  6:  ad501f36 lib/getdate.y: Don't parse a raw number; just a calendar date
 7:  4811959b =  7:  4811959b man/: Consistently express dates in standard format
 8:  ea6be66b =  8:  ea6be66b man/: Localized dates are not accepted anymore
 9:  c225d27b =  9:  c225d27b lib/strtoday.c: strtoday(): Replace obsolete comment
10:  87f31e27 ! 10:  1e8395be man/chage.1.xml: Update -d -E options
    @@ Commit message
         man/chage.1.xml: Update -d -E options
     
         Signed-off-by: Dominika Borges <dvagnero@redhat.com>
    +    Cc: Iker Pedrosa <ipedrosa@redhat.com>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## man/chage.1.xml ##
    @@ man/chage.1.xml
     -      Passing the number <emphasis remap='I'>-1</emphasis> as the
     -      <replaceable>EXPIRE_DATE</replaceable> will remove an account
     -      expiration date.
    -+      Passing the value <emphasis remap='I'>-1</emphasis>
    ++      Passing the value <emphasis>-1</emphasis> or an empty string
     +      as the <replaceable>EXPIRE_DATE</replaceable>
     +      removes the account expiration date.
          </para>
11:  1264b960 = 11:  19f564e1 man/chage.1.xml: wfix
```
</details>

<details>
<summary>v4c</summary>

-  Rebase

```
$ git range-diff db/master..gh/gd shadow/master..gd
 1:  13de308c =  1:  25f1e0eb lib/getdate.y: Don't parse times; just dates
 2:  4e143c9f =  2:  1f7b4913 lib/getdate.y: Don't parse relative dates, such as 'yesterday'
 3:  7812415b =  3:  53b6cfa6 lib/getdate.y: Don't parse week days
 4:  3908b9f9 =  4:  43ea4a50 lib/getdate.y: Remove unnecessary variable
 5:  05ce266b =  5:  d6d5af7a lib/getdate.y: Don't parse dates in local formats; just YYYY-MM-DD
 6:  ad501f36 =  6:  d4edc28e lib/getdate.y: Don't parse a raw number; just a calendar date
 7:  4811959b =  7:  2bf69d03 man/: Consistently express dates in standard format
 8:  ea6be66b =  8:  ead78c5a man/: Localized dates are not accepted anymore
 9:  c225d27b =  9:  fa04e51d lib/strtoday.c: strtoday(): Replace obsolete comment
10:  1e8395be = 10:  90f74d69 man/chage.1.xml: Update -d -E options
11:  19f564e1 = 11:  640a1eb2 man/chage.1.xml: wfix
```
</details>

<details>
<summary>v5</summary>

-  Drop docs commits.  [@ikerexxe ]

```
$ git range-diff gh/master gh/gd gd 
 1:  25f1e0eb =  1:  25f1e0eb lib/getdate.y: Don't parse times; just dates
 2:  1f7b4913 =  2:  1f7b4913 lib/getdate.y: Don't parse relative dates, such as 'yesterday'
 3:  53b6cfa6 =  3:  53b6cfa6 lib/getdate.y: Don't parse week days
 4:  43ea4a50 =  4:  43ea4a50 lib/getdate.y: Remove unnecessary variable
 5:  d6d5af7a =  5:  d6d5af7a lib/getdate.y: Don't parse dates in local formats; just YYYY-MM-DD
 6:  d4edc28e =  6:  d4edc28e lib/getdate.y: Don't parse a raw number; just a calendar date
 7:  2bf69d03 =  7:  2bf69d03 man/: Consistently express dates in standard format
 8:  ead78c5a =  8:  ead78c5a man/: Localized dates are not accepted anymore
 9:  fa04e51d =  9:  fa04e51d lib/strtoday.c: strtoday(): Replace obsolete comment
10:  90f74d69 <  -:  -------- man/chage.1.xml: Update -d -E options
11:  640a1eb2 <  -:  -------- man/chage.1.xml: wfix
```
</details>