### PR TITLE
passwd: document exit code when PAM has errored

### DIFF
--- a/lib/pam_pass.c
+++ b/lib/pam_pass.c
@@ -40,7 +40,7 @@ void do_pam_passwd (const char *user, bool silent, bool change_expired)
 	if (ret != PAM_SUCCESS) {
 		fprintf (shadow_logfd,
 			 _("passwd: pam_start() failed, error %d\n"), ret);
-		exit (10);	/* XXX */
+		exit (E_PAM_ERR);
 	}
 
 	ret = pam_chauthtok (pamh, flags);
@@ -48,7 +48,7 @@ void do_pam_passwd (const char *user, bool silent, bool change_expired)
 		fprintf (shadow_logfd, _("passwd: %s\n"), pam_strerror (pamh, ret));
 		fputs (_("passwd: password unchanged\n"), shadow_logfd);
 		pam_end (pamh, ret);
-		exit (10);	/* XXX */
+		exit (E_PAM_ERR);
 	}
 
 	fputs (_("passwd: password updated successfully\n"), shadow_logfd);

--- a/man/passwd.1.xml
+++ b/man/passwd.1.xml
@@ -484,6 +484,12 @@
 	    <para>invalid argument to option</para>
 	  </listitem>
 	</varlistentry>
+	<varlistentry>
+	  <term><replaceable>10</replaceable></term>
+	  <listitem>
+	    <para>an error was returned by pam(3).</para>
+	  </listitem>
+	</varlistentry>
       </variablelist>
     </para>
   </refsect1>

--- a/src/passwd.c
+++ b/src/passwd.c
@@ -51,6 +51,7 @@
 #define E_MISSING	4	/* unexpected failure, passwd file missing */
 #define E_PWDBUSY	5	/* passwd file busy, try again later */
 #define E_BAD_ARG	6	/* invalid argument to option */
+#define E_PAM_ERR	10	/* PAM returned an error */
 /*
  * Global variables
  */


### PR DESCRIPTION
closes #1219

When pam returns an error, we were exiting with exit code 10, which was hardcoded and not documented.  Create a name for it, and document it in the manpage.


Reported-by: Marc Haber <githubvisible@zugschlus.de>