### PR TITLE
Quick fix: define E_PAM_ERR in lib/pam_pass.c

### DIFF
--- a/lib/pam_pass.c
+++ b/lib/pam_pass.c
@@ -10,6 +10,9 @@
 
 #ifdef USE_PAM
 
+/* Copied from src/passwd.c */
+#define E_PAM_ERR	10	/* PAM returned an error */
+
 #ident "$Id$"
 
 


### PR DESCRIPTION
The exit code situation is a hot mess. Do a
  git grep "define.*E_SUCCESS"
Each src/*.c is defining its own set of error codes, and they are frequently conflicting, e.g. more than one use 10.

We should probably have a common set defined in lib/exitcodes.h. I'm thinking for a first cut, we just move all the definitions from src/*.c to lib/exitcodes.h, and let the conflicts stand. If we later want to change some defines to make them unambiguous across the project, we can do that separately.