### PR TITLE
Accept /usr/sbin/nologin as an alternate to /sbin/nologin

### DIFF
--- a/src/useradd.c
+++ b/src/useradd.c
@@ -1377,6 +1377,7 @@ static void process_flags (int argc, char **argv)
 				if (!streq(optarg, "")
 				     && '*'  != optarg[0]
 				     && !streq(optarg, "/sbin/nologin")
+				     && !streq(optarg, "/usr/sbin/nologin")
 				     && (   stat(optarg, &st) != 0
 				         || S_ISDIR(st.st_mode)
 				         || access(optarg, X_OK) != 0)) {

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -1176,6 +1176,7 @@ process_flags(int argc, char **argv)
 				if (!streq(optarg, "")
 				     && '*'  != optarg[0]
 				     && !streq(optarg, "/sbin/nologin")
+				     && !streq(optarg, "/usr/sbin/nologin")
 				     && (   stat(optarg, &st) != 0
 				         || S_ISDIR(st.st_mode)
 				         || access(optarg, X_OK) != 0)) {


### PR DESCRIPTION
Relevant on fully-usr-merged distributions.

Reported-by: Marc Haber @zugschlus
