### PR TITLE
Add LOGIN_ENV_SAFELIST to FOREIGNDEFS

### DIFF
--- a/lib/getdef.c
+++ b/lib/getdef.c
@@ -76,6 +76,7 @@ struct itemdef {
 #define FOREIGNDEFS				\
 	{"ALWAYS_SET_PATH", NULL},		\
 	{"ENV_ROOTPATH", NULL},			\
+	{"LOGIN_ENV_SAFELIST", NULL},		\
 	{"LOGIN_KEEP_USERNAME", NULL},		\
 	{"LOGIN_PLAIN_PROMPT", NULL},		\
 	{"MOTD_FIRSTONLY", NULL},		\


### PR DESCRIPTION
util-linux-2.41 introduced new variable: LOGIN_ENV_SAFELIST. Add it to known login.defs variables.