### PR TITLE
ci: add `gawk` as a fedora dependency

### DIFF
--- a/share/ansible/roles/ci_run/tasks/fedora.yml
+++ b/share/ansible/roles/ci_run/tasks/fedora.yml
@@ -8,6 +8,7 @@
     use_backend: dnf4
     name:
       - dnf-plugins-core
+      - gawk
       - libcmocka-devel
       - systemd-devel
     state: present


### PR DESCRIPTION
Recently fedora 42 was released and `gawk` was missing as a dependency.