### PR TITLE
newuidmap: better error logging on failure

### DIFF
--- a/src/newgidmap.c
+++ b/src/newgidmap.c
@@ -190,8 +190,9 @@ int main(int argc, char **argv)
 
 	/* Get the effective uid and effective gid of the target process */
 	if (fstat(proc_dir_fd, &st) < 0) {
-		fprintf(stderr, _("%s: Could not stat directory for process\n"),
-			Prog);
+		fprintf(stderr,
+		        _("%s: Could not stat directory for target process: %s\n"),
+		        Prog, strerror (errno));
 		return EXIT_FAILURE;
 	}
 
@@ -211,6 +212,9 @@ int main(int argc, char **argv)
 	}
 
 	if (!sub_gid_open(O_RDONLY)) {
+		fprintf (stderr,
+		         _("%s: cannot open %s: %s\n"),
+		         Prog, sub_gid_dbname (), strerror (errno));
 		return EXIT_FAILURE;
 	}
 

--- a/src/newuidmap.c
+++ b/src/newuidmap.c
@@ -119,7 +119,9 @@ int main(int argc, char **argv)
 
 	/* Get the effective uid and effective gid of the target process */
 	if (fstat(proc_dir_fd, &st) < 0) {
-		fprintf(stderr, _("%s: Could not stat directory for target process\n"), Prog);
+		fprintf(stderr,
+		        _("%s: Could not stat directory for target process: %s\n"),
+		        Prog, strerror (errno));
 		return EXIT_FAILURE;
 	}
 
@@ -139,6 +141,9 @@ int main(int argc, char **argv)
 	}
 
 	if (!sub_uid_open(O_RDONLY)) {
+		fprintf (stderr,
+		         _("%s: cannot open %s: %s\n"),
+		         Prog, sub_uid_dbname (), strerror (errno));
 		return EXIT_FAILURE;
 	}
 


### PR DESCRIPTION
The handling for `sub_uid_open` relies on `commonio_open` preserving `errno`, which it appears to make an effort do, but doesn't explicitly document.

Closes: #1253