### PR TITLE
lib/audit_help.c: We don't support names that need encoding

### DIFF
--- a/lib/audit_help.c
+++ b/lib/audit_help.c
@@ -95,20 +95,12 @@ audit_logger_with_group(int type, const char *op, const char *name,
     id_t id, const char *grp_type, const char *grp,
     shadow_audit_result result)
 {
-	int len;
-	char enc_group[GROUP_NAME_MAX_LENGTH * 2 + 1];
-	char buf[countof(enc_group) + 100];
+	char  buf[GROUP_NAME_MAX_LENGTH + 100];
 
 	if (audit_fd < 0)
 		return;
 
-	len = strnlen(grp, sizeof(enc_group)/2);
-	if (audit_value_needs_encoding(grp, len)) {
-		stprintf_a(buf, "%s %s=%s", op, grp_type,
-			audit_encode_value(enc_group, grp, len));
-	} else {
-		stprintf_a(buf, "%s %s=\"%s\"", op, grp_type, grp);
-	}
+	stprintf_a(buf, "%s %s=\"%s\"", op, grp_type, grp);
 
 	audit_log_acct_message(audit_fd, type, NULL, buf, name, id,
 		               NULL, NULL, NULL, result);

--- a/lib/audit_help.c
+++ b/lib/audit_help.c
@@ -65,12 +65,11 @@ void audit_logger (int type, const char *op,
                    const char *name, unsigned int id,
                    shadow_audit_result result)
 {
-	if (audit_fd < 0) {
+	if (audit_fd < 0)
 		return;
-	} else {
-		audit_log_acct_message (audit_fd, type, NULL, op, name, id,
-		                        NULL, NULL, NULL, result);
-	}
+
+	audit_log_acct_message(audit_fd, type, NULL, op, name, id,
+	                       NULL, NULL, NULL, result);
 }
 
 /*
@@ -108,20 +107,18 @@ audit_logger_with_group(int type, const char *op, const char *name,
 
 void audit_logger_message (const char *message, shadow_audit_result result)
 {
-	if (audit_fd < 0) {
+	if (audit_fd < 0)
 		return;
-	} else {
-		audit_log_user_message (audit_fd,
-		                        AUDIT_USYS_CONFIG,
-		                        message,
-		                        NULL, /* hostname */
-		                        NULL, /* addr */
-		                        NULL, /* tty */
-		                        result);
-	}
+
+	audit_log_user_message (audit_fd,
+	                        AUDIT_USYS_CONFIG,
+	                        message,
+	                        NULL, /* hostname */
+	                        NULL, /* addr */
+	                        NULL, /* tty */
+	                        result);
 }
 
 #else				/* WITH_AUDIT */
 extern int ISO_C_forbids_an_empty_translation_unit;
 #endif				/* WITH_AUDIT */
-


### PR DESCRIPTION
See `is_valid_name()`, which reports EINVAL for any such names.

---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git rd 
1:  b36a9eba875a = 1:  e7bdeb9158bc lib/audit_help.c: We don't support names that need encoding
2:  5566e0646a26 = 2:  095ea93f1469 lib/audit_help.c: Don't else after return
```
</details>

<details>
<summary>v1c</summary>

-  Rebase

```
$ git rd 
1:  e7bdeb91 = 1:  5414bd67 lib/audit_help.c: We don't support names that need encoding
2:  095ea93f = 2:  3731bbc8 lib/audit_help.c: Don't else after return
```
</details>

<details>
<summary>v1d</summary>

-  Rebase

```
$ git rd 
1:  5414bd67 = 1:  dbed7429 lib/audit_help.c: We don't support names that need encoding
2:  3731bbc8 = 2:  0358ac85 lib/audit_help.c: Don't else after return
```
</details>

<details>
<summary>v1e</summary>

-  Rebase

```
$ git rd 
1:  dbed74290bd4 = 1:  5ae6e425bf8a lib/audit_help.c: We don't support names that need encoding
2:  0358ac854f96 = 2:  97c7b321109f lib/audit_help.c: Don't else after return
```
</details>