### PR TITLE
[scp] Add strcaseprefix(), and use it instead of its pattern

### DIFF
--- a/contrib/adduser.c
+++ b/contrib/adduser.c
@@ -119,7 +119,7 @@
 #include <syslog.h>
 
 #include "string/strcmp/streq.h"
-#include "string/strcmp/strprefix.h"
+#include "string/strcmp/strcaseprefix.h"
 
 
 #define IMMEDIATE_CHANGE	/* Expire newly created password, must be changed
@@ -389,7 +389,7 @@ main (void)
       fflush (stdout);
       safeget (foo, sizeof (foo));
 
-      done = bad = correct = (strprefix(foo, "y") || strprefix(foo, "Y"));
+      done = bad = correct = strcaseprefix(foo, "y");
 
       if (bad != 1)
 	printf ("\nUser [%s] not added\n", usrname);

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -199,6 +199,8 @@ libshadow_la_SOURCES = \
 	string/strchr/strnul.h \
 	string/strcmp/strcaseeq.c \
 	string/strcmp/strcaseeq.h \
+	string/strcmp/strcaseprefix.c \
+	string/strcmp/strcaseprefix.h \
 	string/strcmp/streq.c \
 	string/strcmp/streq.h \
 	string/strcmp/strprefix.c \

--- a/lib/nss.c
+++ b/lib/nss.c
@@ -15,6 +15,7 @@
 #include "shadowlog_internal.h"
 #include "shadowlog.h"
 #include "string/sprintf/snprintf.h"
+#include "string/strcmp/strcaseprefix.h"
 #include "string/strcmp/streq.h"
 #include "string/strcmp/strprefix.h"
 #include "string/strspn/stpspn.h"
@@ -84,7 +85,7 @@ nss_init(const char *nsswitch_path) {
 			continue;
 		if (strlen(line) < 8)
 			continue;
-		if (strncasecmp(line, "subid:", 6) != 0)
+		if (!strcaseprefix(line, "subid:"))
 			continue;
 		p = &line[6];
 		p = stpspn(p, " \t\n");

--- a/lib/string/strcmp/strcaseprefix.c
+++ b/lib/string/strcmp/strcaseprefix.c
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2024-2025, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#include <config.h>
+
+#include "string/strcmp/strcaseprefix.h"
+
+
+extern inline const char *strcaseprefix_(const char *s, const char *prefix);

--- a/lib/string/strcmp/strcaseprefix.h
+++ b/lib/string/strcmp/strcaseprefix.h
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2024-2025, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#ifndef SHADOW_INCLUDE_LIB_STRING_STRCMP_STRCASEPREFIX_H_
+#define SHADOW_INCLUDE_LIB_STRING_STRCMP_STRCASEPREFIX_H_
+
+
+#include <config.h>
+
+#include <stddef.h>
+#include <string.h>
+
+#include "attr.h"
+#include "cast.h"
+
+
+// string case-insensitive prefix
+#define strcaseprefix(s, prefix)                                      \
+({                                                                    \
+	const char  *p_;                                              \
+                                                                      \
+	p_ = strcaseprefix_(s, prefix);                               \
+                                                                      \
+	_Generic(s,                                                   \
+		const char *:                     p_,                 \
+		const void *:                     p_,                 \
+		char *:        const_cast(char *, p_),                \
+		void *:        const_cast(char *, p_)                 \
+	);                                                            \
+})
+
+
+ATTR_STRING(1) ATTR_STRING(2)
+inline const char *strcaseprefix_(const char *s, const char *prefix);
+
+
+// strprefix_(), but case-insensitive.
+inline const char *
+strcaseprefix_(const char *s, const char *prefix)
+{
+	if (strncasecmp(s, prefix, strlen(prefix)) != 0)
+		return NULL;
+
+	return s + strlen(prefix);
+}
+
+
+#endif  // include guard

--- a/lib/yesno.c
+++ b/lib/yesno.c
@@ -16,7 +16,7 @@
 #include <stdlib.h>
 
 #include "prototypes.h"
-#include "string/strcmp/strprefix.h"
+#include "string/strcmp/strcaseprefix.h"
 
 
 /*
@@ -78,9 +78,9 @@ yes_or_no(bool read_only)
 static int
 rpmatch(const char *response)
 {
-	if (strprefix(response, "y") || strprefix(response, "Y"))
+	if (strcaseprefix(response, "y"))
 		return 1;
-	if (strprefix(response, "n") || strprefix(response, "N"))
+	if (strcaseprefix(response, "n"))
 		return 0;
 
 	return -1;


### PR DESCRIPTION
---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git rd
1:  6d2e00ce = 1:  8eaa91b9 lib/string/strcmp/: strcaseprefix(): Add API
2:  9bc969ce = 2:  ab4a23b4 contrib/, lib/: Use strcaseprefix() instead of its pattern
3:  0bd6d7fd = 3:  77ca3e54 lib/nss.c: Use !strcaseprefix() instead of its pattern
```
</details>

<details>
<summary>v1c</summary>

-  Rebase

```
$ git rd
1:  8eaa91b9 = 1:  ac554acf lib/string/strcmp/: strcaseprefix(): Add API
2:  ab4a23b4 = 2:  cc1abefc contrib/, lib/: Use strcaseprefix() instead of its pattern
3:  77ca3e54 = 3:  daf5fa96 lib/nss.c: Use !strcaseprefix() instead of its pattern
```
</details>

<details>
<summary>v1d</summary>

-  Rebase

```
$ git rd
1:  ac554acf = 1:  7b7c8496 lib/string/strcmp/: strcaseprefix(): Add API
2:  cc1abefc = 2:  63f34ab8 contrib/, lib/: Use strcaseprefix() instead of its pattern
3:  daf5fa96 = 3:  c73831ba lib/nss.c: Use !strcaseprefix() instead of its pattern
```
</details>

<details>
<summary>v1e</summary>

-  Rebase

```
$ git rd
1:  7b7c8496 = 1:  1d89d205 lib/string/strcmp/: strcaseprefix(): Add API
2:  63f34ab8 = 2:  de3925e7 contrib/, lib/: Use strcaseprefix() instead of its pattern
3:  c73831ba = 3:  c4e1dc94 lib/nss.c: Use !strcaseprefix() instead of its pattern
```
</details>

<details>
<summary>v1f</summary>

-  Rebase

```
$ git rd
1:  1d89d205 = 1:  bccbd48b lib/string/strcmp/: strcaseprefix(): Add API
2:  de3925e7 = 2:  b30918ea contrib/, lib/: Use strcaseprefix() instead of its pattern
3:  c4e1dc94 = 3:  cd1f039d lib/nss.c: Use !strcaseprefix() instead of its pattern
```
</details>