### PR TITLE
src/newusers.c: Fix off-by-one benign bug in array declaration

### DIFF
--- a/src/newusers.c
+++ b/src/newusers.c
@@ -1059,7 +1059,7 @@ static bool want_subgids(void)
 int main (int argc, char **argv)
 {
 	char buf[BUFSIZ];
-	char *fields[8];
+	char *fields[7];
 	int nfields;
 	char *cp;
 	const struct passwd *pw;


### PR DESCRIPTION
This array is only ever used as an array of 7.

```
alx@devuan:/srv/alx/src/shadow/shadow/master$ sed_rm_ccomments() {
        perl -p -e 's%/\*.*?\*/%%g' \
        |sed -E '\%/\*%, \%\*/% {\%(\*/|/\*)%!d}' \
        |sed -E '\%/\*% {s%/\*.*%%; n; s%.*\*/%%;}' \
        |sed -E '\%/\*% {s%/\*.*%%; n; s%.*\*/%%;}' \
        |sed 's%//.*%%';
}
alx@devuan:/srv/alx/src/shadow/shadow/master$ cat src/newusers.c | grepc main | sed_rm_ccomments | grep -nT 'n\?fields\(\[.*]\)\?'
                  4:		char *fields[8];
                  5:		int nfields;
                 59:			for (cp = buf, nfields = 0; nfields < 7; nfields++) {
                 60:				fields[nfields] = strsep(&cp, ":");
                 64:			if (nfields != 6) {
                 72:			pw = pw_locate (fields[0]);
                 74:			if (NULL == pw && getpwnam(fields[0]) != NULL) {
                 77:					 Prog, fields[0]);
                 81:			if (NULL == pw && get_user_id(fields[2], &uid) != 0) {
                 91:			    && (add_group (fields[0], fields[3], &gid, uid) != 0)) {
                101:			    && (add_user (fields[0], uid, gid) != 0)) {
                110:			pw = pw_locate (fields[0]);
                114:				         Prog, line, fields[0], pw_dbname ());
                132:			usernames[nusers-1] = xstrdup(fields[0]);
                133:			passwords[nusers-1] = xstrdup(fields[1]);
                135:			if (add_passwd (&newpw, fields[1]) != 0) {
                141:			if (!streq(fields[4], "")) {
                142:				newpw.pw_gecos = fields[4];
                145:			if (!streq(fields[5], "")) {
                146:				newpw.pw_dir = fields[5];
                149:			if (!streq(fields[6], "")) {
                150:				newpw.pw_shell = fields[6];
                153:			if (   !streq(fields[5], "")
                195:			if (is_sub_uid && want_subuids() && !local_sub_uid_assigned(fields[0])) {
                205:				if (sub_uid_add(fields[0], sub_uid_start, sub_uid_count) == 0)
                216:			if (is_sub_gid && want_subgids() && !local_sub_gid_assigned(fields[0])) {
                225:				if (sub_gid_add(fields[0], sub_gid_start, sub_gid_count) == 0) {
alx@devuan:/srv/alx/src/shadow/shadow/master$ cat src/newusers.c | grepc main | sed_rm_ccomments | grep -nTo 'n\?fields\(\[.*]\)\?'
                  4:	fields[8]
                  5:	nfields
                 59:	nfields
                 59:	nfields
                 59:	nfields
                 60:	fields[nfields]
                 64:	nfields
                 72:	fields[0]
                 74:	fields[0]
                 77:	fields[0]
                 81:	fields[2]
                 91:	fields[0], fields[3]
                101:	fields[0]
                110:	fields[0]
                114:	fields[0]
                132:	fields[0]
                133:	fields[1]
                135:	fields[1]
                141:	fields[4]
                142:	fields[4]
                145:	fields[5]
                146:	fields[5]
                149:	fields[6]
                150:	fields[6]
                153:	fields[5]
                195:	fields[0]
                205:	fields[0]
                216:	fields[0]
                225:	fields[0]
```

Fixes: 45c6603cc86c (2007-10-07; "[svn-upgrade] Integrating new upstream version, shadow (19990709)")
Link: <https://github.com/shadow-maint/shadow/pull/1155#discussion_r2132261260>