### PR TITLE
ls

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -112,6 +112,7 @@ libshadow_la_SOURCES = \
 	isexpired.c \
 	limits.c \
 	list.c \
+	list.h \
 	lockpw.c \
 	loginprompt.c \
 	mail.c \

--- a/lib/age.c
+++ b/lib/age.c
@@ -125,7 +125,8 @@ int expire (const struct passwd *pw, /*@null@*/const struct spwd *sp)
 		exit (EXIT_FAILURE);
 	}
 
-	while (((child = wait (&status)) != pid) && (child != (pid_t)-1));
+	while (((child = wait (&status)) != pid) && (child != (pid_t)-1))
+		continue;
 
 	if ((child == pid) && (0 == status)) {
 		return 1;

--- a/lib/cleanup.c
+++ b/lib/cleanup.c
@@ -78,7 +78,8 @@ void add_cleanup (/*@notnull@*/cleanup_function pcf, /*@null@*/void *arg)
 	}
 
 	/* Add the cleanup_function at the end of the stack */
-	for (i=0; NULL != cleanup_functions[i]; i++);
+	for (i=0; NULL != cleanup_functions[i]; i++)
+		continue;
 	cleanup_functions[i] = pcf;
 	cleanup_function_args[i] = arg;
 }

--- a/lib/groupio.c
+++ b/lib/groupio.c
@@ -330,7 +330,8 @@ static /*@null@*/struct commonio_entry *merge_group_entries (
 		return NULL;
 
 	/* Concatenate the 2 list of members */
-	for (i=0; NULL != gptr1->gr_mem[i]; i++);
+	for (i=0; NULL != gptr1->gr_mem[i]; i++)
+		continue;
 	members += i;
 	for (i=0; NULL != gptr2->gr_mem[i]; i++) {
 		char **pmember = gptr1->gr_mem;
@@ -400,7 +401,8 @@ static int split_groups (unsigned int max_members)
 		if (NULL == gptr) {
 			continue;
 		}
-		for (members = 0; NULL != gptr->gr_mem[members]; members++);
+		for (members = 0; NULL != gptr->gr_mem[members]; members++)
+			continue;
 		if (members <= max_members) {
 			continue;
 		}

--- a/lib/groupmem.c
+++ b/lib/groupmem.c
@@ -46,7 +46,8 @@
 		return NULL;
 	}
 
-	for (i = 0; grent->gr_mem[i]; i++);
+	for (i = 0; grent->gr_mem[i]; i++)
+		continue;
 
 	/*@-mustfreeonly@*/
 	gr->gr_mem = malloc_T(i + 1, char *);

--- a/lib/limits.c
+++ b/lib/limits.c
@@ -17,21 +17,20 @@
 
 #ifndef USE_PAM
 
-#ident "$Id$"
-
+#include <ctype.h>
+#include <pwd.h>
+#include <stdio.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <stdio.h>
-#include <ctype.h>
-#include "prototypes.h"
-#include "defines.h"
-#include <pwd.h>
-#include "getdef.h"
-#include "shadowlog.h"
 #include <sys/resource.h>
 
 #include "atoi/a2i.h"
 #include "io/fgets/fgets.h"
+#include "defines.h"
+#include "list.h"
+#include "getdef.h"
+#include "prototypes.h"
+#include "shadowlog.h"
 #include "string/memset/memzero.h"
 #include "string/strcmp/streq.h"
 #include "string/strcmp/strprefix.h"

--- a/lib/list.c
+++ b/lib/list.c
@@ -141,7 +141,8 @@ dup_list(char *const *list)
 
 	assert (NULL != list);
 
-	for (i = 0; NULL != list[i]; i++);
+	for (i = 0; NULL != list[i]; i++)
+		continue;
 
 	tmp = xmalloc_T(i + 1, char *);
 

--- a/lib/list.c
+++ b/lib/list.c
@@ -209,7 +209,7 @@ comma_to_list(const char *comma)
 
 	members = xstrdup (comma);
 
-	array = build_list(members);
+	array = acsv2ls(members);
 	if (array == NULL)
 		exit(EXIT_FAILURE);
 
@@ -221,7 +221,7 @@ comma_to_list(const char *comma)
 
 
 char **
-build_list(char *s)
+acsv2ls(char *s)
 {
 	char    **l;
 	size_t  n;

--- a/lib/list.c
+++ b/lib/list.c
@@ -14,6 +14,7 @@
 #include "string/strchr/strchrcnt.h"
 #include "string/strcmp/streq.h"
 #include "string/strdup/strdup.h"
+#include "string/strtok/astrsep2ls.h"
 #include "string/strtok/strsep2ls.h"
 
 #undef NDEBUG
@@ -231,3 +232,19 @@ comma_to_list(const char *comma)
 	return array;
 }
 
+
+char **
+build_list(char *s)
+{
+	char    **l;
+	size_t  n;
+
+	l = astrsep2ls(s, ",", &n);
+	if (l == NULL)
+		return NULL;
+
+	if (streq(l[n-1], ""))
+		l[n-1] = NULL;
+
+	return l;
+}

--- a/lib/list.c
+++ b/lib/list.c
@@ -8,11 +8,12 @@
 
 #include "config.h"
 
+#include "list.h"
+
 #include <stddef.h>
 #include <stdlib.h>
 
 #include "alloc/malloc.h"
-#include "prototypes.h"
 #include "defines.h"
 #include "string/strcmp/streq.h"
 #include "string/strdup/strdup.h"

--- a/lib/list.c
+++ b/lib/list.c
@@ -8,13 +8,15 @@
 
 #include "config.h"
 
+#include <stddef.h>
+#include <stdlib.h>
+
 #include "alloc/malloc.h"
 #include "prototypes.h"
 #include "defines.h"
 #include "string/strcmp/streq.h"
 #include "string/strdup/strdup.h"
 #include "string/strtok/astrsep2ls.h"
-#include "string/strtok/xastrsep2ls.h"
 
 #undef NDEBUG
 #include <assert.h>
@@ -198,7 +200,6 @@ comma_to_list(const char *comma)
 {
 	char *members;
 	char **array;
-	size_t  n;
 
 	assert (NULL != comma);
 
@@ -208,10 +209,10 @@ comma_to_list(const char *comma)
 
 	members = xstrdup (comma);
 
-	array = xastrsep2ls(members, ",", &n);
+	array = build_list(members);
+	if (array == NULL)
+		exit(EXIT_FAILURE);
 
-	if (streq(array[n-1], ""))
-		array[n-1] = NULL;
 	if (array[0] == NULL)
 		free(members);
 

--- a/lib/list.c
+++ b/lib/list.c
@@ -11,11 +11,10 @@
 #include "alloc/malloc.h"
 #include "prototypes.h"
 #include "defines.h"
-#include "string/strchr/strchrcnt.h"
 #include "string/strcmp/streq.h"
 #include "string/strdup/strdup.h"
 #include "string/strtok/astrsep2ls.h"
-#include "string/strtok/strsep2ls.h"
+#include "string/strtok/xastrsep2ls.h"
 
 #undef NDEBUG
 #include <assert.h>
@@ -209,15 +208,7 @@ comma_to_list(const char *comma)
 
 	members = xstrdup (comma);
 
-	/*
-	 * Allocate the array we're going to store the pointers into.
-	 * n: number of delimiters + last element + NULL
-	 */
-
-	n = strchrcnt(members, ',') + 2;
-	array = xmalloc_T(n, char *);
-
-	strsep2ls(members, ",", n, array);
+	array = xastrsep2ls(members, ",", &n);
 
 	if (streq(array[n-1], ""))
 		array[n-1] = NULL;

--- a/lib/list.c
+++ b/lib/list.c
@@ -217,17 +217,12 @@ comma_to_list(const char *comma)
 	n = strchrcnt(members, ',') + 2;
 	array = xmalloc_T(n, char *);
 
-	/*
-	 * Empty list is special - 0 members, not 1 empty member.  --marekm
-	 */
-
-	if (streq(members, "")) {
-		*array = NULL;
-		free (members);
-		return array;
-	}
-
 	strsep2ls(members, ",", n, array);
+
+	if (streq(array[n-1], ""))
+		array[n-1] = NULL;
+	if (array[0] == NULL)
+		free(members);
 
 	return array;
 }

--- a/lib/list.h
+++ b/lib/list.h
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#ifndef SHADOW_INCLUDE_LIB_LIST_H_
+#define SHADOW_INCLUDE_LIB_LIST_H_
+
+
+#include "config.h"
+
+#include <stdbool.h>
+
+
+extern /*@only@*/char **add_list (/*@returned@*/ /*@only@*/char **, const char *);
+extern /*@only@*/char **del_list (/*@returned@*/ /*@only@*/char **, const char *);
+extern /*@only@*/char **dup_list (char *const *);
+extern void free_list (char **);
+extern bool is_on_list (char *const *list, const char *member);
+extern /*@only@*/char **comma_to_list (const char *);
+extern char **acsv2ls(char *s);
+
+
+#endif  // include guard

--- a/lib/prototypes.h
+++ b/lib/prototypes.h
@@ -183,15 +183,6 @@ void audit_logger_with_group(int type, const char *op, const char *name,
 extern void setup_limits (const struct passwd *);
 #endif
 
-/* list.c */
-extern /*@only@*/char **add_list (/*@returned@*/ /*@only@*/char **, const char *);
-extern /*@only@*/char **del_list (/*@returned@*/ /*@only@*/char **, const char *);
-extern /*@only@*/char **dup_list (char *const *);
-extern void free_list (char **);
-extern bool is_on_list (char *const *list, const char *member);
-extern /*@only@*/char **comma_to_list (const char *);
-extern char **acsv2ls(char *s);
-
 #ifdef ENABLE_LASTLOG
 /* log.c */
 extern void dolastlog (

--- a/lib/prototypes.h
+++ b/lib/prototypes.h
@@ -190,7 +190,7 @@ extern /*@only@*/char **dup_list (char *const *);
 extern void free_list (char **);
 extern bool is_on_list (char *const *list, const char *member);
 extern /*@only@*/char **comma_to_list (const char *);
-extern char **build_list(char *s);
+extern char **acsv2ls(char *s);
 
 #ifdef ENABLE_LASTLOG
 /* log.c */

--- a/lib/prototypes.h
+++ b/lib/prototypes.h
@@ -190,6 +190,7 @@ extern /*@only@*/char **dup_list (char *const *);
 extern void free_list (char **);
 extern bool is_on_list (char *const *list, const char *member);
 extern /*@only@*/char **comma_to_list (const char *);
+extern char **build_list(char *s);
 
 #ifdef ENABLE_LASTLOG
 /* log.c */

--- a/lib/sgroupio.c
+++ b/lib/sgroupio.c
@@ -56,7 +56,8 @@
 		return NULL;
 	}
 
-	for (i = 0; NULL != sgent->sg_adm[i]; i++);
+	for (i = 0; NULL != sgent->sg_adm[i]; i++)
+		continue;
 	/*@-mustfreeonly@*/
 	sg->sg_adm = malloc_T(i + 1, char *);
 	/*@=mustfreeonly@*/
@@ -81,7 +82,8 @@
 	}
 	sg->sg_adm[i] = NULL;
 
-	for (i = 0; NULL != sgent->sg_mem[i]; i++);
+	for (i = 0; NULL != sgent->sg_mem[i]; i++)
+		continue;
 	/*@-mustfreeonly@*/
 	sg->sg_mem = malloc_T(i + 1, char *);
 	/*@=mustfreeonly@*/

--- a/lib/shadow/group/sgetgrent.c
+++ b/lib/shadow/group/sgetgrent.c
@@ -50,7 +50,7 @@ sgetgrent(const char *s)
 
 	free(grent.gr_mem);
 
-	grent.gr_mem = build_list(fields[3]);
+	grent.gr_mem = acsv2ls(fields[3]);
 	if (NULL == grent.gr_mem) {
 		return NULL;	/* out of memory */
 	}

--- a/lib/shadow/group/sgetgrent.c
+++ b/lib/shadow/group/sgetgrent.c
@@ -38,11 +38,8 @@
 static char **
 list(char *s)
 {
-	static char **members = NULL;
-
+	char    **members;
 	size_t  n;
-
-	free(members);
 
 	members = astrsep2ls(s, ",", &n);
 	if (members == NULL)
@@ -60,7 +57,7 @@ struct group *
 sgetgrent(const char *s)
 {
 	static char         *dup = NULL;
-	static struct group grent;
+	static struct group grent = {};
 
 	char  *fields[4];
 
@@ -82,6 +79,9 @@ sgetgrent(const char *s)
 	if (get_gid(fields[2], &grent.gr_gid) == -1) {
 		return NULL;
 	}
+
+	free(grent.gr_mem);
+
 	grent.gr_mem = list(fields[3]);
 	if (NULL == grent.gr_mem) {
 		return NULL;	/* out of memory */

--- a/lib/shadow/group/sgetgrent.c
+++ b/lib/shadow/group/sgetgrent.c
@@ -23,33 +23,6 @@
 #include "string/strcmp/streq.h"
 #include "string/strtok/stpsep.h"
 #include "string/strtok/strsep2arr.h"
-#include "string/strtok/astrsep2ls.h"
-
-
-/*
- * list - turn a comma-separated string into an array of (char *)'s
- *
- *	list() converts the comma-separated list of member names into
- *	an array of character pointers.
- *
- * FINALLY added dynamic allocation.  Still need to fix sgetsgent().
- *  --marekm
- */
-static char **
-list(char *s)
-{
-	char    **members;
-	size_t  n;
-
-	members = astrsep2ls(s, ",", &n);
-	if (members == NULL)
-		return NULL;
-
-	if (streq(members[n-1], ""))
-		members[n-1] = NULL;
-
-	return members;
-}
 
 
 // from-string get group entry
@@ -82,7 +55,7 @@ sgetgrent(const char *s)
 
 	free(grent.gr_mem);
 
-	grent.gr_mem = list(fields[3]);
+	grent.gr_mem = build_list(fields[3]);
 	if (NULL == grent.gr_mem) {
 		return NULL;	/* out of memory */
 	}

--- a/lib/shadow/group/sgetgrent.c
+++ b/lib/shadow/group/sgetgrent.c
@@ -18,8 +18,7 @@
 
 #include "alloc/malloc.h"
 #include "atoi/getnum.h"
-#include "defines.h"
-#include "prototypes.h"
+#include "list.h"
 #include "string/strtok/stpsep.h"
 #include "string/strtok/strsep2arr.h"
 

--- a/lib/shadow/group/sgetgrent.c
+++ b/lib/shadow/group/sgetgrent.c
@@ -20,7 +20,6 @@
 #include "atoi/getnum.h"
 #include "defines.h"
 #include "prototypes.h"
-#include "string/strcmp/streq.h"
 #include "string/strtok/stpsep.h"
 #include "string/strtok/strsep2arr.h"
 
@@ -44,14 +43,10 @@ sgetgrent(const char *s)
 	if (strsep2arr_a(dup, ":", fields) == -1)
 		return NULL;
 
-	if (streq(fields[2], ""))
-		return NULL;
-
 	grent.gr_name = fields[0];
 	grent.gr_passwd = fields[1];
-	if (get_gid(fields[2], &grent.gr_gid) == -1) {
+	if (get_gid(fields[2], &grent.gr_gid) == -1)
 		return NULL;
-	}
 
 	free(grent.gr_mem);
 

--- a/lib/shadow/gshadow/sgetsgent.c
+++ b/lib/shadow/gshadow/sgetsgent.c
@@ -14,7 +14,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "prototypes.h"
+#include "list.h"
 #include "shadow/gshadow/sgrp.h"
 #include "string/strcmp/streq.h"
 #include "string/strtok/stpsep.h"

--- a/lib/shadow/gshadow/sgetsgent.c
+++ b/lib/shadow/gshadow/sgetsgent.c
@@ -14,18 +14,15 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "prototypes.h"
 #include "shadow/gshadow/sgrp.h"
 #include "string/strcmp/streq.h"
-#include "string/strtok/astrsep2ls.h"
 #include "string/strtok/stpsep.h"
 #include "string/strtok/strsep2arr.h"
 
 
 #if defined(SHADOWGRP) && !__has_include(<gshadow.h>)
 static struct sgrp  sgroup = {};
-
-
-static char **build_list(char *s);
 
 
 // from-string get shadow group entry
@@ -59,22 +56,5 @@ sgetsgent(const char *s)
 		return NULL;
 
 	return &sgroup;
-}
-
-
-static char **
-build_list(char *s)
-{
-	char    **l;
-	size_t  n;
-
-	l = astrsep2ls(s, ",", &n);
-	if (l == NULL)
-		return NULL;
-
-	if (streq(l[n-1], ""))
-		l[n-1] = NULL;
-
-	return l;
 }
 #endif

--- a/lib/shadow/gshadow/sgetsgent.c
+++ b/lib/shadow/gshadow/sgetsgent.c
@@ -55,6 +55,9 @@ sgetsgent(const char *s)
 	sgroup.sg_adm = build_list(fields[2]);
 	sgroup.sg_mem = build_list(fields[3]);
 
+	if (sgroup.sg_adm == NULL || sgroup.sg_mem == NULL)
+		return NULL;
+
 	return &sgroup;
 }
 
@@ -65,7 +68,9 @@ build_list(char *s)
 	char    **l;
 	size_t  n;
 
-	l = xastrsep2ls(s, ",", &n);
+	l = astrsep2ls(s, ",", &n);
+	if (l == NULL)
+		return NULL;
 
 	if (streq(l[n-1], ""))
 		l[n-1] = NULL;

--- a/lib/shadow/gshadow/sgetsgent.c
+++ b/lib/shadow/gshadow/sgetsgent.c
@@ -49,8 +49,8 @@ sgetsgent(const char *s)
 	free(sgroup.sg_adm);
 	free(sgroup.sg_mem);
 
-	sgroup.sg_adm = build_list(fields[2]);
-	sgroup.sg_mem = build_list(fields[3]);
+	sgroup.sg_adm = acsv2ls(fields[2]);
+	sgroup.sg_mem = acsv2ls(fields[3]);
 
 	if (sgroup.sg_adm == NULL || sgroup.sg_mem == NULL)
 		return NULL;

--- a/src/chgpasswd.c
+++ b/src/chgpasswd.c
@@ -22,6 +22,7 @@
 #include "defines.h"
 #include "groupio.h"
 #include "io/fprintf.h"
+#include "list.h"
 #include "nscd.h"
 #include "sssd.h"
 #include "prototypes.h"

--- a/src/gpasswd.c
+++ b/src/gpasswd.c
@@ -28,6 +28,7 @@
 #include "exitcodes.h"
 #include "groupio.h"
 #include "io/fprintf.h"
+#include "list.h"
 #include "nscd.h"
 #include "prototypes.h"
 #ifdef SHADOWGRP

--- a/src/groupadd.c
+++ b/src/groupadd.c
@@ -26,6 +26,7 @@
 #include "groupio.h"
 #include "io/fprintf.h"
 #include "io/syslog.h"
+#include "list.h"
 #include "nscd.h"
 #include "sssd.h"
 #include "prototypes.h"

--- a/src/groupdel.c
+++ b/src/groupdel.c
@@ -267,7 +267,8 @@ static void group_busy (gid_t gid)
 
 	prefix_setpwent ();
 
-	while ( ((pwd = prefix_getpwent ()) != NULL) && (pwd->pw_gid != gid) );
+	while ( ((pwd = prefix_getpwent ()) != NULL) && (pwd->pw_gid != gid) )
+		continue;
 
 	prefix_endpwent ();
 

--- a/src/groupmod.c
+++ b/src/groupmod.c
@@ -27,6 +27,7 @@
 #include "defines.h"
 #include "groupio.h"
 #include "io/fprintf.h"
+#include "list.h"
 #include "nscd.h"
 #include "prototypes.h"
 #include "pwio.h"

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -25,6 +25,7 @@
 #include "exitcodes.h"
 #include "getdef.h"
 #include "io/fprintf.h"
+#include "list.h"
 #include "prototypes.h"
 #include "search/l/lfind.h"
 #include "search/l/lsearch.h"

--- a/src/su.c
+++ b/src/su.c
@@ -54,6 +54,7 @@
 #include "exitcodes.h"
 #include "getdef.h"
 #include "io/fprintf.h"
+#include "list.h"
 #ifdef USE_PAM
 #include "pam_defs.h"
 #endif				/* USE_PAM */

--- a/src/suauth.c
+++ b/src/suauth.c
@@ -20,6 +20,7 @@
 #include "defines.h"
 #include "io/fgets/fgets.h"
 #include "io/syslog.h"
+#include "list.h"
 #include "prototypes.h"
 #include "string/strcmp/streq.h"
 #include "string/strcmp/strprefix.h"

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -44,6 +44,7 @@
 #include "io/fgets/fgets.h"
 #include "io/fprintf.h"
 #include "io/syslog.h"
+#include "list.h"
 #include "nscd.h"
 #include "prototypes.h"
 #include "pwauth.h"

--- a/src/userdel.c
+++ b/src/userdel.c
@@ -26,6 +26,7 @@
 #include "groupio.h"
 #include "io/fprintf.h"
 #include "io/syslog.h"
+#include "list.h"
 #include "nscd.h"
 #include "sssd.h"
 #include "prototypes.h"

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -40,6 +40,7 @@
 #include "groupio.h"
 #include "io/fprintf.h"
 #include "io/syslog.h"
+#include "list.h"
 #include "nscd.h"
 #include "prototypes.h"
 #include "pwauth.h"


### PR DESCRIPTION
I've managed to remove one of the `static`, but most of them seem necessary, since these shadow APIs are either libc APIs or similar to libc APIs, and they're specified as using static memory.

I've also done a lot of simplification and de-duplication work in surrounding code, especially in code transforming CSVs to lists.

---

-  Queued after <https://github.com/shadow-maint/shadow/pull/1404>, which is a subset of this PR at v3c.

Cc: @uecker 

---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git rd 
 1:  bc196a4c =  1:  e030f9f9 lib/shadow/group/sgetgrent.c: Move free(3) call outside of helper
 2:  03fd5229 =  2:  922cd79c lib/shadow/gshadow/sgetsgent.c: Don't exit from library code
 3:  da4f193d =  3:  6087810b lib/, src/: Use more readable syntax for empty loops
 4:  969c53f6 =  4:  2b9b392d lib/: Deduplicate code
 5:  6bd67e17 =  5:  5a34d66d lib/list.c: comma_to_list(): Allow a trailing comma
 6:  140d5c09 =  6:  7ff2273b lib/list.c: comma_to_list(): Use xastrsep2ls() instead of its pattern
 7:  c1cf0676 =  7:  d6c5e912 lib/shadow/group/sgetgrent.c: Remove redundant code
 8:  09918ba6 =  8:  156085ca lib/list.c: comma_to_list(): Use build_list() instead of its pattern
 9:  06062942 =  9:  f1ee9cd3 lib/: Rename build_list() => acsv2ls()
10:  f0e13f5b = 10:  4f27d718 lib/, src/: Move list.c prototypes to new file list.h
```
</details>

<details>
<summary>v1c</summary>

-  Rebase

```
$ git rd 
 1:  e030f9f9 =  1:  fdba8427 lib/shadow/group/sgetgrent.c: Move free(3) call outside of helper
 2:  922cd79c =  2:  721a5846 lib/shadow/gshadow/sgetsgent.c: Don't exit from library code
 3:  6087810b =  3:  baac1e9f lib/, src/: Use more readable syntax for empty loops
 4:  2b9b392d =  4:  1b10b043 lib/: Deduplicate code
 5:  5a34d66d =  5:  56803058 lib/list.c: comma_to_list(): Allow a trailing comma
 6:  7ff2273b =  6:  2ad1c605 lib/list.c: comma_to_list(): Use xastrsep2ls() instead of its pattern
 7:  d6c5e912 =  7:  070df553 lib/shadow/group/sgetgrent.c: Remove redundant code
 8:  156085ca =  8:  5ae417e6 lib/list.c: comma_to_list(): Use build_list() instead of its pattern
 9:  f1ee9cd3 =  9:  f3e1a203 lib/: Rename build_list() => acsv2ls()
10:  4f27d718 = 10:  5ec6addd lib/, src/: Move list.c prototypes to new file list.h
```
</details>

<details>
<summary>v1d</summary>

-  Rebase

```
$ git rd 
 1:  fdba8427c =  1:  3ed5c07dd lib/shadow/group/sgetgrent.c: Move free(3) call outside of helper
 2:  721a5846d !  2:  a5f67fa47 lib/shadow/gshadow/sgetsgent.c: Don't exit from library code
    @@ Commit message
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/shadow/gshadow/sgetsgent.c ##
    -@@
    - 
    - #include "shadow/gshadow/sgrp.h"
    - #include "string/strcmp/streq.h"
    -+#include "string/strtok/astrsep2ls.h"
    - #include "string/strtok/stpsep.h"
    - #include "string/strtok/strsep2arr.h"
    --#include "string/strtok/xastrsep2ls.h"
    - 
    - 
    - #if defined(SHADOWGRP) && !__has_include(<gshadow.h>)
     @@ lib/shadow/gshadow/sgetsgent.c: sgetsgent(const char *s)
        sgroup.sg_adm = build_list(fields[2]);
        sgroup.sg_mem = build_list(fields[3]);
 3:  baac1e9ff =  3:  b148e9e58 lib/, src/: Use more readable syntax for empty loops
 4:  1b10b0432 !  4:  35f0cf989 lib/: Deduplicate code
    @@ lib/list.c
     @@
      #include "string/strchr/strchrcnt.h"
      #include "string/strcmp/streq.h"
    - #include "string/strdup/xstrdup.h"
    + #include "string/strdup/strdup.h"
     +#include "string/strtok/astrsep2ls.h"
      #include "string/strtok/strsep2ls.h"
      
 5:  568030588 =  5:  aecafd272 lib/list.c: comma_to_list(): Allow a trailing comma
 6:  2ad1c6058 !  6:  dbaa72cad lib/list.c: comma_to_list(): Use xastrsep2ls() instead of its pattern
    @@ Commit message
     
      ## lib/list.c ##
     @@
    - #include "alloc/x/xmalloc.h"
    + #include "alloc/malloc.h"
      #include "prototypes.h"
      #include "defines.h"
     -#include "string/strchr/strchrcnt.h"
      #include "string/strcmp/streq.h"
    - #include "string/strdup/xstrdup.h"
    + #include "string/strdup/strdup.h"
      #include "string/strtok/astrsep2ls.h"
     -#include "string/strtok/strsep2ls.h"
     +#include "string/strtok/xastrsep2ls.h"
 7:  070df5533 =  7:  904bbf690 lib/shadow/group/sgetgrent.c: Remove redundant code
 8:  5ae417e6d !  8:  0e6a1845b lib/list.c: comma_to_list(): Use build_list() instead of its pattern
    @@ lib/list.c
      
     @@
      #include "string/strcmp/streq.h"
    - #include "string/strdup/xstrdup.h"
    + #include "string/strdup/strdup.h"
      #include "string/strtok/astrsep2ls.h"
     -#include "string/strtok/xastrsep2ls.h"
      
 9:  f3e1a203f =  9:  4e16128ca lib/: Rename build_list() => acsv2ls()
10:  5ec6adddb ! 10:  df842fb78 lib/, src/: Move list.c prototypes to new file list.h
    @@ lib/list.c
      
      #include <assert.h>
      
    - #include "alloc/x/xmalloc.h"
    + #include "alloc/malloc.h"
     -#include "prototypes.h"
      #include "defines.h"
      #include "string/strcmp/streq.h"
    - #include "string/strdup/xstrdup.h"
    + #include "string/strdup/strdup.h"
     
      ## lib/list.h (new) ##
     @@
    @@ src/groupadd.c
     
      ## src/groupmems.c ##
     @@
    - #include "alloc/x/xmalloc.h"
    + #include "alloc/malloc.h"
      #include "defines.h"
      #include "groupio.h"
     +#include "list.h"
```
</details>

<details>
<summary>v1e</summary>

-  Rebase

```
$ git rd 
 1:  3ed5c07dd =  1:  12ea33aa8 lib/shadow/group/sgetgrent.c: Move free(3) call outside of helper
 2:  a5f67fa47 =  2:  212fb4e94 lib/shadow/gshadow/sgetsgent.c: Don't exit from library code
 3:  b148e9e58 =  3:  cc2e96c87 lib/, src/: Use more readable syntax for empty loops
 4:  35f0cf989 =  4:  2b6b59b8c lib/: Deduplicate code
 5:  aecafd272 =  5:  aa2531ebc lib/list.c: comma_to_list(): Allow a trailing comma
 6:  dbaa72cad =  6:  521212d54 lib/list.c: comma_to_list(): Use xastrsep2ls() instead of its pattern
 7:  904bbf690 =  7:  b16de7a41 lib/shadow/group/sgetgrent.c: Remove redundant code
 8:  0e6a1845b =  8:  a41fd8c6a lib/list.c: comma_to_list(): Use build_list() instead of its pattern
 9:  4e16128ca =  9:  2c199ddda lib/: Rename build_list() => acsv2ls()
10:  df842fb78 = 10:  fcb515161 lib/, src/: Move list.c prototypes to new file list.h
```
</details>

<details>
<summary>v1f</summary>

-  Rebase

```
$ git rd 
 1:  12ea33aa8 =  1:  f2e930dab lib/shadow/group/sgetgrent.c: Move free(3) call outside of helper
 2:  212fb4e94 =  2:  e84fcbd2e lib/shadow/gshadow/sgetsgent.c: Don't exit from library code
 3:  cc2e96c87 =  3:  244d6c5a0 lib/, src/: Use more readable syntax for empty loops
 4:  2b6b59b8c =  4:  89a7b9d07 lib/: Deduplicate code
 5:  aa2531ebc =  5:  a136eb65a lib/list.c: comma_to_list(): Allow a trailing comma
 6:  521212d54 =  6:  1991a4d0f lib/list.c: comma_to_list(): Use xastrsep2ls() instead of its pattern
 7:  b16de7a41 =  7:  304937926 lib/shadow/group/sgetgrent.c: Remove redundant code
 8:  a41fd8c6a =  8:  bd643b492 lib/list.c: comma_to_list(): Use build_list() instead of its pattern
 9:  2c199ddda =  9:  63bc6eb32 lib/: Rename build_list() => acsv2ls()
10:  fcb515161 = 10:  989b2ab20 lib/, src/: Move list.c prototypes to new file list.h
```
</details>

<details>
<summary>v2</summary>

-  Rebase

```
$ git rd 
 1:  f2e930dab =  1:  e7e79c05a lib/shadow/group/sgetgrent.c: Move free(3) call outside of helper
 2:  e84fcbd2e =  2:  b7996af99 lib/shadow/gshadow/sgetsgent.c: Don't exit from library code
 3:  244d6c5a0 =  3:  9495b008a lib/, src/: Use more readable syntax for empty loops
 4:  89a7b9d07 !  4:  415754ce3 lib/: Deduplicate code
    @@ lib/list.c: comma_to_list(const char *comma)
     +}
     
      ## lib/prototypes.h ##
    -@@ lib/prototypes.h: extern /*@only@*/char **del_list (/*@returned@*/ /*@only@*/char **, const char *
    - extern /*@only@*/char **dup_list (char *const *);
    +@@ lib/prototypes.h: extern /*@only@*/char **dup_list (char *const *);
    + extern void free_list (char **);
      extern bool is_on_list (char *const *list, const char *member);
      extern /*@only@*/char **comma_to_list (const char *);
     +extern char **build_list(char *s);
 5:  a136eb65a =  5:  07ed7fb10 lib/list.c: comma_to_list(): Allow a trailing comma
 6:  1991a4d0f =  6:  751a277e5 lib/list.c: comma_to_list(): Use xastrsep2ls() instead of its pattern
 7:  304937926 !  7:  71ef200c0 lib/shadow/group/sgetgrent.c: Remove redundant code
    @@ lib/shadow/group/sgetgrent.c
      #include "string/strtok/strsep2arr.h"
      
     @@ lib/shadow/group/sgetgrent.c: sgetgrent(const char *s)
    -   if (STRSEP2ARR(dup, ":", fields) == -1)
    +   if (strsep2arr_a(dup, ":", fields) == -1)
                return NULL;
      
     -  if (streq(fields[2], ""))
 8:  bd643b492 =  8:  a3db219a5 lib/list.c: comma_to_list(): Use build_list() instead of its pattern
 9:  63bc6eb32 !  9:  ee367ee75 lib/: Rename build_list() => acsv2ls()
    @@ lib/list.c: comma_to_list(const char *comma)
        size_t  n;
     
      ## lib/prototypes.h ##
    -@@ lib/prototypes.h: extern /*@only@*/char **del_list (/*@returned@*/ /*@only@*/char **, const char *
    - extern /*@only@*/char **dup_list (char *const *);
    +@@ lib/prototypes.h: extern /*@only@*/char **dup_list (char *const *);
    + extern void free_list (char **);
      extern bool is_on_list (char *const *list, const char *member);
      extern /*@only@*/char **comma_to_list (const char *);
     -extern char **build_list(char *s);
10:  989b2ab20 ! 10:  a0b24e54b lib/, src/: Move list.c prototypes to new file list.h
    @@ lib/limits.c
     -#include "shadowlog.h"
      #include <sys/resource.h>
      
    - #include "atoi/a2i/a2i.h"
    - #include "atoi/a2i/a2s.h"
    - #include "atoi/str2i.h"
    + #include "atoi/a2i.h"
     +#include "defines.h"
     +#include "list.h"
     +#include "getdef.h"
    @@ lib/list.h (new)
     +extern /*@only@*/char **add_list (/*@returned@*/ /*@only@*/char **, const char *);
     +extern /*@only@*/char **del_list (/*@returned@*/ /*@only@*/char **, const char *);
     +extern /*@only@*/char **dup_list (char *const *);
    ++extern void free_list (char **);
     +extern bool is_on_list (char *const *list, const char *member);
     +extern /*@only@*/char **comma_to_list (const char *);
     +extern char **acsv2ls(char *s);
    @@ lib/prototypes.h: void audit_logger_with_group(int type, const char *op, const c
     -extern /*@only@*/char **add_list (/*@returned@*/ /*@only@*/char **, const char *);
     -extern /*@only@*/char **del_list (/*@returned@*/ /*@only@*/char **, const char *);
     -extern /*@only@*/char **dup_list (char *const *);
    +-extern void free_list (char **);
     -extern bool is_on_list (char *const *list, const char *member);
     -extern /*@only@*/char **comma_to_list (const char *);
     -extern char **acsv2ls(char *s);
    @@ lib/shadow/gshadow/sgetsgent.c
      ## src/chgpasswd.c ##
     @@
      #endif                            /* ACCT_TOOLS_SETUID */
    - #include "atoi/str2i.h"
    + #include "atoi/a2i.h"
      #include "defines.h"
     +#include "list.h"
      #include "nscd.h"
```
</details>

<details>
<summary>v2b</summary>

-  Rebase

```
$ git rd 
 1:  e7e79c05a =  1:  97b9ac63c lib/shadow/group/sgetgrent.c: Move free(3) call outside of helper
 2:  b7996af99 =  2:  999b32c17 lib/shadow/gshadow/sgetsgent.c: Don't exit from library code
 3:  9495b008a !  3:  85f64c986 lib/, src/: Use more readable syntax for empty loops
    @@ src/groupdel.c: static void group_busy (gid_t gid)
      
     
      ## src/logoutd.c ##
    -@@ src/logoutd.c: main(int argc, char **argv)
    +@@ src/logoutd.c: main(int argc, char *[])
        (void) textdomain (PACKAGE);
      
      #ifndef DEBUG
    @@ src/logoutd.c: main(int argc, char **argv)
      
        setpgrp ();
      
    -@@ src/logoutd.c: main(int argc, char **argv)
    +@@ src/logoutd.c: main(int argc, char *[])
                /*
                 * Reap any dead babies ...
                 */
 4:  415754ce3 =  4:  5e0eaa277 lib/: Deduplicate code
 5:  07ed7fb10 =  5:  2c42a8f69 lib/list.c: comma_to_list(): Allow a trailing comma
 6:  751a277e5 =  6:  fda4d2fd3 lib/list.c: comma_to_list(): Use xastrsep2ls() instead of its pattern
 7:  71ef200c0 =  7:  2317c26a0 lib/shadow/group/sgetgrent.c: Remove redundant code
 8:  a3db219a5 =  8:  e63a13df3 lib/list.c: comma_to_list(): Use build_list() instead of its pattern
 9:  ee367ee75 =  9:  05686fa62 lib/: Rename build_list() => acsv2ls()
10:  a0b24e54b ! 10:  7dd70a10c lib/, src/: Move list.c prototypes to new file list.h
    @@ src/groupadd.c
     
      ## src/groupmems.c ##
     @@
    - #include "alloc/malloc.h"
    + #include "attr.h"
      #include "defines.h"
      #include "groupio.h"
     +#include "list.h"
```
</details>

<details>
<summary>v3</summary>

-  Remove unused variable.

```
$ git rd 
 1:  97b9ac63c =  1:  97b9ac63c lib/shadow/group/sgetgrent.c: Move free(3) call outside of helper
 2:  999b32c17 =  2:  999b32c17 lib/shadow/gshadow/sgetsgent.c: Don't exit from library code
 3:  85f64c986 =  3:  85f64c986 lib/, src/: Use more readable syntax for empty loops
 4:  5e0eaa277 =  4:  5e0eaa277 lib/: Deduplicate code
 5:  2c42a8f69 =  5:  2c42a8f69 lib/list.c: comma_to_list(): Allow a trailing comma
 6:  fda4d2fd3 =  6:  fda4d2fd3 lib/list.c: comma_to_list(): Use xastrsep2ls() instead of its pattern
 7:  2317c26a0 =  7:  2317c26a0 lib/shadow/group/sgetgrent.c: Remove redundant code
 8:  e63a13df3 !  8:  12b367aba lib/list.c: comma_to_list(): Use build_list() instead of its pattern
    @@ lib/list.c
      
      
      /*
    +@@ lib/list.c: comma_to_list(const char *comma)
    + {
    +   char *members;
    +   char **array;
    +-  size_t  n;
    + 
    +   assert (NULL != comma);
    + 
     @@ lib/list.c: comma_to_list(const char *comma)
      
        members = xstrdup (comma);
 9:  05686fa62 =  9:  a5a569e3f lib/: Rename build_list() => acsv2ls()
10:  7dd70a10c = 10:  2505a9c4d lib/, src/: Move list.c prototypes to new file list.h
```
</details>

<details>
<summary>v3b</summary>

-  Rebase

```
$ git rd 
 1:  97b9ac63c =  1:  c2c737e4e lib/shadow/group/sgetgrent.c: Move free(3) call outside of helper
 2:  999b32c17 =  2:  c368da517 lib/shadow/gshadow/sgetsgent.c: Don't exit from library code
 3:  85f64c986 =  3:  6cb4a353e lib/, src/: Use more readable syntax for empty loops
 4:  5e0eaa277 =  4:  578b59a75 lib/: Deduplicate code
 5:  2c42a8f69 =  5:  b671f1a46 lib/list.c: comma_to_list(): Allow a trailing comma
 6:  fda4d2fd3 =  6:  8b86ea0f0 lib/list.c: comma_to_list(): Use xastrsep2ls() instead of its pattern
 7:  2317c26a0 =  7:  095be028f lib/shadow/group/sgetgrent.c: Remove redundant code
 8:  12b367aba =  8:  2d70caf13 lib/list.c: comma_to_list(): Use build_list() instead of its pattern
 9:  a5a569e3f =  9:  33b16470b lib/: Rename build_list() => acsv2ls()
10:  2505a9c4d = 10:  09688365c lib/, src/: Move list.c prototypes to new file list.h
```
</details>

<details>
<summary>v3c</summary>

-  Rebase

```
$ git rd 
 1:  c2c737e4e =  1:  93eb0220f lib/shadow/group/sgetgrent.c: Move free(3) call outside of helper
 2:  c368da517 =  2:  7fe566213 lib/shadow/gshadow/sgetsgent.c: Don't exit from library code
 3:  6cb4a353e !  3:  2831c4297 lib/, src/: Use more readable syntax for empty loops
    @@ lib/groupmem.c
     +          continue;
      
        /*@-mustfreeonly@*/
    -   gr->gr_mem = MALLOC(i + 1, char *);
    +   gr->gr_mem = malloc_T(i + 1, char *);
     
      ## lib/list.c ##
     @@ lib/list.c: dup_list(char *const *list)
    @@ lib/list.c: dup_list(char *const *list)
     +  for (i = 0; NULL != list[i]; i++)
     +          continue;
      
    -   tmp = XMALLOC(i + 1, char *);
    +   tmp = xmalloc_T(i + 1, char *);
      
     
      ## lib/sgroupio.c ##
    @@ lib/sgroupio.c
     +  for (i = 0; NULL != sgent->sg_adm[i]; i++)
     +          continue;
        /*@-mustfreeonly@*/
    -   sg->sg_adm = MALLOC(i + 1, char *);
    +   sg->sg_adm = malloc_T(i + 1, char *);
        /*@=mustfreeonly@*/
     @@
        }
    @@ lib/sgroupio.c
     +  for (i = 0; NULL != sgent->sg_mem[i]; i++)
     +          continue;
        /*@-mustfreeonly@*/
    -   sg->sg_mem = MALLOC(i + 1, char *);
    +   sg->sg_mem = malloc_T(i + 1, char *);
        /*@=mustfreeonly@*/
     
      ## src/groupdel.c ##
 4:  578b59a75 =  4:  35befcc1c lib/: Deduplicate code
 5:  b671f1a46 !  5:  ceb4fa62d lib/list.c: comma_to_list(): Allow a trailing comma
    @@ Commit message
      ## lib/list.c ##
     @@ lib/list.c: comma_to_list(const char *comma)
        n = strchrcnt(members, ',') + 2;
    -   array = XMALLOC(n, char *);
    +   array = xmalloc_T(n, char *);
      
     -  /*
     -   * Empty list is special - 0 members, not 1 empty member.  --marekm
 6:  8b86ea0f0 !  6:  3726f1aef lib/list.c: comma_to_list(): Use xastrsep2ls() instead of its pattern
    @@ lib/list.c: comma_to_list(const char *comma)
     -   */
     -
     -  n = strchrcnt(members, ',') + 2;
    --  array = XMALLOC(n, char *);
    +-  array = xmalloc_T(n, char *);
     -
     -  strsep2ls(members, ",", n, array);
     +  array = xastrsep2ls(members, ",", &n);
 7:  095be028f =  7:  dcc2f6f18 lib/shadow/group/sgetgrent.c: Remove redundant code
 8:  2d70caf13 =  8:  f5b455110 lib/list.c: comma_to_list(): Use build_list() instead of its pattern
 9:  33b16470b =  9:  e2e8660c5 lib/: Rename build_list() => acsv2ls()
10:  09688365c = 10:  df8d07178 lib/, src/: Move list.c prototypes to new file list.h
```
</details>

<details>
<summary>v3d</summary>

-  Rebase

```
$ git range-diff gh/static..gh/ls static..ls 
 1:  7fe566213 =  1:  ac39d279c lib/shadow/gshadow/sgetsgent.c: Don't exit from library code
 2:  2831c4297 =  2:  61675a896 lib/, src/: Use more readable syntax for empty loops
 3:  35befcc1c =  3:  6080b62c6 lib/: Deduplicate code
 4:  ceb4fa62d =  4:  0e889365a lib/list.c: comma_to_list(): Allow a trailing comma
 5:  3726f1aef =  5:  b24ff7962 lib/list.c: comma_to_list(): Use xastrsep2ls() instead of its pattern
 6:  dcc2f6f18 =  6:  9ce952a5e lib/shadow/group/sgetgrent.c: Remove redundant code
 7:  f5b455110 =  7:  5a638fde4 lib/list.c: comma_to_list(): Use build_list() instead of its pattern
 8:  e2e8660c5 =  8:  b13c904b0 lib/: Rename build_list() => acsv2ls()
 9:  df8d07178 =  9:  dcae3d85d lib/, src/: Move list.c prototypes to new file list.h
```
</details>

<details>
<summary>v3e</summary>

-  Rebase

```
$ git range-diff gh/static..gh/ls static..ls 
 1:  ac39d279c =  1:  2486c3de1 lib/shadow/gshadow/sgetsgent.c: Don't exit from library code
 2:  61675a896 =  2:  afe0ebf6c lib/, src/: Use more readable syntax for empty loops
 3:  6080b62c6 =  3:  70546abae lib/: Deduplicate code
 4:  0e889365a =  4:  961cc8fa4 lib/list.c: comma_to_list(): Allow a trailing comma
 5:  b24ff7962 =  5:  5e971f5e5 lib/list.c: comma_to_list(): Use xastrsep2ls() instead of its pattern
 6:  9ce952a5e =  6:  76754e2e9 lib/shadow/group/sgetgrent.c: Remove redundant code
 7:  5a638fde4 =  7:  dbe7eee33 lib/list.c: comma_to_list(): Use build_list() instead of its pattern
 8:  b13c904b0 =  8:  61b9daf51 lib/: Rename build_list() => acsv2ls()
 9:  dcae3d85d =  9:  d0c84ec6d lib/, src/: Move list.c prototypes to new file list.h
```
</details>

<details>
<summary>v3f</summary>

-  Rebase

```
$ git range-diff gh/static..gh/ls static..ls
 1:  2486c3de14ad =  1:  964a60c802ca lib/shadow/gshadow/sgetsgent.c: Don't exit from library code
 2:  afe0ebf6c493 !  2:  7fa74f65c1e1 lib/, src/: Use more readable syntax for empty loops
    @@ src/groupdel.c: static void group_busy (gid_t gid)
      
        prefix_endpwent ();
      
    -
    - ## src/logoutd.c ##
    -@@ src/logoutd.c: main(int argc, char *[])
    -   (void) textdomain (PACKAGE);
    - 
    - #ifndef DEBUG
    --  for (int i = 0; close(i) == 0; i++);
    -+  for (int i = 0; close(i) == 0; i++)
    -+          continue;
    - 
    -   setpgrp ();
    - 
    -@@ src/logoutd.c: main(int argc, char *[])
    -           /*
    -            * Reap any dead babies ...
    -            */
    --          while (wait(NULL) != -1);
    -+          while (wait(NULL) != -1)
    -+                  continue;
    -   }
    - 
    -   return EXIT_FAILURE;
 3:  70546abae362 =  3:  b62e2609f153 lib/: Deduplicate code
 4:  961cc8fa406f =  4:  d3b39dea82cd lib/list.c: comma_to_list(): Allow a trailing comma
 5:  5e971f5e51cd =  5:  3e1a56d98750 lib/list.c: comma_to_list(): Use xastrsep2ls() instead of its pattern
 6:  76754e2e96ea =  6:  4fe84b0a159d lib/shadow/group/sgetgrent.c: Remove redundant code
 7:  dbe7eee3356f =  7:  4f9b01408b87 lib/list.c: comma_to_list(): Use build_list() instead of its pattern
 8:  61b9daf51507 =  8:  d68a59ac6164 lib/: Rename build_list() => acsv2ls()
 9:  d0c84ec6d1ce !  9:  e1f89d3f7b84 lib/, src/: Move list.c prototypes to new file list.h
    @@ lib/shadow/gshadow/sgetsgent.c
     
      ## src/chgpasswd.c ##
     @@
    - #endif                            /* ACCT_TOOLS_SETUID */
    + 
      #include "atoi/a2i.h"
      #include "defines.h"
     +#include "list.h"
```
</details>

<details>
<summary>v3g</summary>

-  Rebase

```
$ git range-diff gh/static..gh/ls static..ls
 1:  964a60c8 =  1:  1919e3f4 lib/shadow/gshadow/sgetsgent.c: Don't exit from library code
 2:  7fa74f65 =  2:  19bc4808 lib/, src/: Use more readable syntax for empty loops
 3:  b62e2609 =  3:  f0655733 lib/: Deduplicate code
 4:  d3b39dea =  4:  d36b2588 lib/list.c: comma_to_list(): Allow a trailing comma
 5:  3e1a56d9 =  5:  37e349cf lib/list.c: comma_to_list(): Use xastrsep2ls() instead of its pattern
 6:  4fe84b0a =  6:  2d87f46d lib/shadow/group/sgetgrent.c: Remove redundant code
 7:  4f9b0140 =  7:  1801f7ba lib/list.c: comma_to_list(): Use build_list() instead of its pattern
 8:  d68a59ac =  8:  8a72ffa3 lib/: Rename build_list() => acsv2ls()
 9:  e1f89d3f =  9:  d9b0acbc lib/, src/: Move list.c prototypes to new file list.h
```
</details>

<details>
<summary>v3h</summary>

-  Rebase

```
$ git range-diff gh/static..gh/ls static..ls 
 1:  1919e3f4 =  1:  e4827e45 lib/shadow/gshadow/sgetsgent.c: Don't exit from library code
 2:  19bc4808 =  2:  3ae14ef3 lib/, src/: Use more readable syntax for empty loops
 3:  f0655733 !  3:  1135bea3 lib/: Deduplicate code
    @@ lib/list.c
     +#include "string/strtok/astrsep2ls.h"
      #include "string/strtok/strsep2ls.h"
      
    - 
    + #undef NDEBUG
     @@ lib/list.c: comma_to_list(const char *comma)
        return array;
      }
 4:  d36b2588 =  4:  9d689de1 lib/list.c: comma_to_list(): Allow a trailing comma
 5:  37e349cf !  5:  ece907a3 lib/list.c: comma_to_list(): Use xastrsep2ls() instead of its pattern
    @@ lib/list.c
     -#include "string/strtok/strsep2ls.h"
     +#include "string/strtok/xastrsep2ls.h"
      
    - 
    - /*
    + #undef NDEBUG
    + #include <assert.h>
     @@ lib/list.c: comma_to_list(const char *comma)
      
        members = xstrdup (comma);
 6:  2d87f46d =  6:  ad4da71c lib/shadow/group/sgetgrent.c: Remove redundant code
 7:  1801f7ba !  7:  28a0be81 lib/list.c: comma_to_list(): Use build_list() instead of its pattern
    @@ lib/list.c
      
      #include "config.h"
      
    --#ident "$Id$"
    ++#include <stddef.h>
     +#include <stdlib.h>
    - 
    - #include <assert.h>
    - 
    -@@
    ++
    + #include "alloc/malloc.h"
    + #include "prototypes.h"
    + #include "defines.h"
      #include "string/strcmp/streq.h"
      #include "string/strdup/strdup.h"
      #include "string/strtok/astrsep2ls.h"
     -#include "string/strtok/xastrsep2ls.h"
      
    - 
    - /*
    + #undef NDEBUG
    + #include <assert.h>
     @@ lib/list.c: comma_to_list(const char *comma)
      {
        char *members;
 8:  8a72ffa3 =  8:  8d335889 lib/: Rename build_list() => acsv2ls()
 9:  d9b0acbc !  9:  c116d585 lib/, src/: Move list.c prototypes to new file list.h
    @@ lib/limits.c
      #include <sys/resource.h>
      
      #include "atoi/a2i.h"
    + #include "io/fgets/fgets.h"
     +#include "defines.h"
     +#include "list.h"
     +#include "getdef.h"
    @@ lib/list.c
      
     +#include "list.h"
     +
    + #include <stddef.h>
      #include <stdlib.h>
      
    - #include <assert.h>
    - 
      #include "alloc/malloc.h"
     -#include "prototypes.h"
      #include "defines.h"
    @@ src/groupadd.c
      #include "sssd.h"
      #include "prototypes.h"
     
    - ## src/groupmems.c ##
    -@@
    - #include "attr.h"
    - #include "defines.h"
    - #include "groupio.h"
    -+#include "list.h"
    - #include "prototypes.h"
    - #ifdef SHADOWGRP
    - #include "sgroupio.h"
    -
      ## src/groupmod.c ##
     @@
      #include "chkname.h"
    @@ src/su.c
     
      ## src/suauth.c ##
     @@
    - #include <sys/types.h>
      
      #include "defines.h"
    + #include "io/fgets/fgets.h"
     +#include "list.h"
      #include "prototypes.h"
      #include "string/strcmp/streq.h"
    @@ src/suauth.c
     
      ## src/useradd.c ##
     @@
    - #include "fs/mkstemp/fmkomstemp.h"
      #include "getdef.h"
      #include "groupio.h"
    + #include "io/fgets/fgets.h"
     +#include "list.h"
      #include "nscd.h"
      #include "prototypes.h"
```
</details>

<details>
<summary>v3i</summary>

-  Rebase

```
$ git range-diff gh/static..gh/ls static..ls 
 1:  e4827e45 =  1:  2449aa45 lib/shadow/gshadow/sgetsgent.c: Don't exit from library code
 2:  3ae14ef3 =  2:  4e45bab3 lib/, src/: Use more readable syntax for empty loops
 3:  1135bea3 =  3:  3ab8baa7 lib/: Deduplicate code
 4:  9d689de1 =  4:  1c4e5074 lib/list.c: comma_to_list(): Allow a trailing comma
 5:  ece907a3 =  5:  d78eadc0 lib/list.c: comma_to_list(): Use xastrsep2ls() instead of its pattern
 6:  ad4da71c =  6:  193da9c8 lib/shadow/group/sgetgrent.c: Remove redundant code
 7:  28a0be81 =  7:  306347ec lib/list.c: comma_to_list(): Use build_list() instead of its pattern
 8:  8d335889 =  8:  67b73005 lib/: Rename build_list() => acsv2ls()
 9:  c116d585 =  9:  1d40e278 lib/, src/: Move list.c prototypes to new file list.h
```
</details>

<details>
<summary>v3j</summary>

-  Rebase

```
$ git range-diff 2449aa45bc5b^..gh/ls static..ls -U0
 1:  2449aa45bc5b =  1:  e1bf5b8b2500 lib/shadow/gshadow/sgetsgent.c: Don't exit from library code
 2:  4e45bab3cc34 =  2:  5bcf8a04d990 lib/, src/: Use more readable syntax for empty loops
 3:  3ab8baa7a43f =  3:  b6b2d3e96505 lib/: Deduplicate code
 4:  1c4e5074e8ff =  4:  e9f3b1ca5e00 lib/list.c: comma_to_list(): Allow a trailing comma
 5:  d78eadc000c5 =  5:  438c095f7401 lib/list.c: comma_to_list(): Use xastrsep2ls() instead of its pattern
 6:  193da9c82ae6 =  6:  09e21002edbd lib/shadow/group/sgetgrent.c: Remove redundant code
 7:  306347ec0cae =  7:  63f8ff9346f6 lib/list.c: comma_to_list(): Use build_list() instead of its pattern
 8:  67b730058ffd =  8:  8ab79ee78c6f lib/: Rename build_list() => acsv2ls()
 9:  1d40e2782148 !  9:  a05a861e605c lib/, src/: Move list.c prototypes to new file list.h
    @@ src/chgpasswd.c
    - 
    - #include "atoi/a2i.h"
    @@ src/chgpasswd.c
    + #include "groupio.h"
    + #include "io/fprintf.h"
    @@ src/gpasswd.c
    - /*@-exitarg@*/
    @@ src/gpasswd.c
    + #include "io/fprintf.h"
    @@ src/groupadd.c
    - #include "defines.h"
    - #include "getdef.h"
    @@ src/groupadd.c
    + #include "io/fprintf.h"
    + #include "io/syslog.h"
    @@ src/groupmod.c
    - #include "chkname.h"
    @@ src/groupmod.c
    + #include "io/fprintf.h"
    @@ src/newgrp.c
    - /*@-exitarg@*/
    @@ src/newgrp.c
    + #include "io/fprintf.h"
    @@ src/su.c
    - /*@-exitarg@*/
    @@ src/su.c
    + #include "io/fprintf.h"
    @@ src/suauth.c
    - 
    @@ src/suauth.c
    + #include "io/syslog.h"
    @@ src/useradd.c
    - #include "getdef.h"
    - #include "groupio.h"
    @@ src/useradd.c
    + #include "io/fprintf.h"
    + #include "io/syslog.h"
    @@ src/userdel.c
    - #include "defines.h"
    - #include "getdef.h"
    @@ src/userdel.c
    + #include "io/fprintf.h"
    + #include "io/syslog.h"
    @@ src/usermod.c
    - #include "faillog.h"
    - #include "getdef.h"
    @@ src/usermod.c
    + #include "io/fprintf.h"
    + #include "io/syslog.h"
```
</details>

<details>
<summary>v3k</summary>

-  Rebase

```
$ git range-diff gh/static..gh/ls static..ls 
 1:  e1bf5b8b2500 =  1:  d4d8fdb730bc lib/shadow/gshadow/sgetsgent.c: Don't exit from library code
 2:  5bcf8a04d990 =  2:  d7a5ae462c62 lib/, src/: Use more readable syntax for empty loops
 3:  b6b2d3e96505 =  3:  3787c360fb74 lib/: Deduplicate code
 4:  e9f3b1ca5e00 =  4:  634da81512fc lib/list.c: comma_to_list(): Allow a trailing comma
 5:  438c095f7401 =  5:  afd6951fe2c4 lib/list.c: comma_to_list(): Use xastrsep2ls() instead of its pattern
 6:  09e21002edbd =  6:  d0337be1c2cc lib/shadow/group/sgetgrent.c: Remove redundant code
 7:  63f8ff9346f6 =  7:  1e7fbed2fa09 lib/list.c: comma_to_list(): Use build_list() instead of its pattern
 8:  8ab79ee78c6f =  8:  dd08ff5377ec lib/: Rename build_list() => acsv2ls()
 9:  a05a861e605c !  9:  ff245f44e736 lib/, src/: Move list.c prototypes to new file list.h
    @@ lib/limits.c
      #include <sys/resource.h>
      
      #include "atoi/a2i.h"
    - #include "io/fgets/fgets.h"
     +#include "defines.h"
     +#include "list.h"
     +#include "getdef.h"
    + #include "io/fgets/fgets.h"
    + #include "memory/memset/memzero.h"
     +#include "prototypes.h"
     +#include "shadowlog.h"
    - #include "string/memset/memzero.h"
      #include "string/strcmp/streq.h"
      #include "string/strcmp/strprefix.h"
    + #include "string/strspn/stpspn.h"
     
      ## lib/list.c ##
     @@
    @@ src/gpasswd.c
      #include "groupio.h"
      #include "io/fprintf.h"
     +#include "list.h"
    + #include "memory/memset/memzero.h"
      #include "nscd.h"
      #include "prototypes.h"
    - #ifdef SHADOWGRP
     
      ## src/groupadd.c ##
     @@
    @@ src/groupadd.c
      #include "io/fprintf.h"
      #include "io/syslog.h"
     +#include "list.h"
    + #include "memory/memset/memzero.h"
      #include "nscd.h"
      #include "sssd.h"
    - #include "prototypes.h"
     
      ## src/groupmod.c ##
     @@
    @@ src/useradd.c
      #include "io/fprintf.h"
      #include "io/syslog.h"
     +#include "list.h"
    + #include "memory/memset/memzero.h"
      #include "nscd.h"
      #include "prototypes.h"
    - #include "pwauth.h"
     
      ## src/userdel.c ##
     @@
    @@ src/usermod.c
      #include "io/fprintf.h"
      #include "io/syslog.h"
     +#include "list.h"
    + #include "memory/memset/memzero.h"
      #include "nscd.h"
      #include "prototypes.h"
    - #include "pwauth.h"
```
</details>