### PR TITLE
tests/unit/test_xaprintf.c: Fix test by using streq() instead of strcmp(3)

### DIFF
--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -132,6 +132,7 @@ test_typetraits_LDADD = \
 test_xaprintf_SOURCES = \
     ../../lib/string/sprintf/aprintf.c \
     ../../lib/string/sprintf/xaprintf.c \
+    ../../lib/string/strcmp/streq.c \
     test_xaprintf.c \
     $(NULL)
 test_xaprintf_CFLAGS = \

--- a/tests/unit/test_xaprintf.c
+++ b/tests/unit/test_xaprintf.c
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
+#include "string/sprintf/xaprintf.h"
+
 #include <setjmp.h>
 #include <stdarg.h>
 #include <stddef.h>
@@ -14,7 +16,7 @@
 #include <stdint.h>  // Required by <cmocka.h>
 #include <cmocka.h>
 
-#include "string/sprintf/xaprintf.h"
+#include "string/strcmp/streq.h"
 
 
 #define smock()               _Generic(mock(), uintmax_t: (intmax_t) mock())
@@ -76,7 +78,7 @@ test_xaprintf_exit(void **state)
 		assert_unreachable();
 		break;
 	case EXIT_CALLED:
-		assert_true(strcmp(p, "xaprintf_called"));
+		assert_true(streq(p, "xaprintf_called"));
 		p = "test_ok";
 		break;
 	default:
@@ -84,7 +86,7 @@ test_xaprintf_exit(void **state)
 		break;
 	}
 
-	assert_true(strcmp(p, "test_ok"));
+	assert_true(streq(p, "test_ok"));
 }
 
 


### PR DESCRIPTION
Fixes: 423fd652b563 (2025-06-03; "lib/string/sprintf/, tests/unit/: Transform x[v]asprintf() into x[v]aprintf()")
Closes: <https://github.com/shadow-maint/shadow/issues/1279>
Reported-by: @tgurr