### PR TITLE
configure.ac: Make sure that logind is enabled if requested

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -154,7 +154,13 @@ AC_ARG_ENABLE([lastlog],
 AC_ARG_ENABLE([logind],
 	[AS_HELP_STRING([--enable-logind],
 		[enable logind @<:@default=yes if found@:>@])],
-	[enable_logind="${enableval}"],
+	[
+		AS_CASE([${enableval}],
+			[yes],[],
+			[no],[],
+			[AC_MSG_ERROR([bad parameter value for --enable-logind=${enableval}])]
+		)
+	],
 	[enable_logind="yes"]
 )
 

--- a/configure.ac
+++ b/configure.ac
@@ -346,10 +346,14 @@ AM_CONDITIONAL([ENABLE_LASTLOG], [test "x$enable_lastlog" != "xno"])
 AC_SUBST([LIBSYSTEMD])
 if test "X$enable_logind" = "Xyes"; then
 	AC_CHECK_LIB([systemd], [sd_session_get_remote_host],
-		[enable_logind="yes"; [LIBSYSTEMD=-lsystemd];
-		AC_DEFINE([ENABLE_LOGIND], [1],
-			[Define to manage session support with logind.])],
-		[enable_logind="no"])
+		[
+			enable_logind="yes"
+			LIBSYSTEMD=-lsystemd
+			AC_DEFINE([ENABLE_LOGIND], [1], [Define to manage session support with logind.])
+		],[
+			enable_logind="no"
+		]
+	)
 fi
 AM_CONDITIONAL([ENABLE_LOGIND], [test "x$enable_logind" != "xno"])
 

--- a/configure.ac
+++ b/configure.ac
@@ -153,7 +153,7 @@ AC_ARG_ENABLE([lastlog],
 
 AC_ARG_ENABLE([logind],
 	[AS_HELP_STRING([--enable-logind],
-		[enable logind @<:@default=yes@:>@])],
+		[enable logind @<:@default=yes if found@:>@])],
 	[enable_logind="${enableval}"],
 	[enable_logind="yes"]
 )

--- a/configure.ac
+++ b/configure.ac
@@ -158,10 +158,11 @@ AC_ARG_ENABLE([logind],
 		AS_CASE([${enableval}],
 			[yes],[],
 			[no],[],
+			[maybe|auto],[enable_logind="auto"],
 			[AC_MSG_ERROR([bad parameter value for --enable-logind=${enableval}])]
 		)
 	],
-	[enable_logind="yes"]
+	[enable_logind="auto"]
 )
 
 AC_ARG_WITH([audit],
@@ -344,18 +345,20 @@ fi
 AM_CONDITIONAL([ENABLE_LASTLOG], [test "x$enable_lastlog" != "xno"])
 
 AC_SUBST([LIBSYSTEMD])
-if test "X$enable_logind" = "Xyes"; then
+if test "X$enable_logind" != "Xno"; then
 	AC_CHECK_LIB([systemd], [sd_session_get_remote_host],
 		[
 			enable_logind="yes"
 			LIBSYSTEMD=-lsystemd
 			AC_DEFINE([ENABLE_LOGIND], [1], [Define to manage session support with logind.])
 		],[
+			AS_IF([test "X$enable_logind" = "Xyes"],
+				[AC_MSG_ERROR([libsystemd not found, logind cannot be enabled])])
 			enable_logind="no"
 		]
 	)
 fi
-AM_CONDITIONAL([ENABLE_LOGIND], [test "x$enable_logind" != "xno"])
+AM_CONDITIONAL([ENABLE_LOGIND], [test "x$enable_logind" = "xyes"])
 
 AC_CHECK_LIB([crypt], [crypt], [LIBCRYPT=-lcrypt],
 	[AC_MSG_ERROR([crypt() not found])])


### PR DESCRIPTION
Currently if configured with --enable-logind, but `libsystemd` is not found, `configure` silently succeed, but `logind` is efficiently disabled. 
With this patch `configure` fails if `logind` is explicitly requested, but `libsystemd` is not found.
If `logind` is not requested explicitly, it is enabled only if found.