### PR TITLE
Implement ability to use both utmp and logind

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -41,21 +41,11 @@ AC_CHECK_HEADER([shadow.h],,[AC_MSG_ERROR([You need a libc with shadow.h])])
 AC_CHECK_FUNCS(arc4random_buf \
 	getentropy getrandom \
 	lckpwdf lutimes \
-	updwtmpx innetgr \
+	innetgr \
 	getspnam_r \
 	rpmatch \
 	memset_explicit explicit_bzero stpecpy stpeprintf)
 AC_SYS_LARGEFILE
-
-dnl Checks for typedefs, structures, and compiler characteristics.
-
-AC_CHECK_MEMBERS([struct utmpx.ut_name,
-                  struct utmpx.ut_host,
-                  struct utmpx.ut_syslen,
-                  struct utmpx.ut_addr,
-                  struct utmpx.ut_addr_v6,
-                  struct utmpx.ut_time,
-                  struct utmpx.ut_xtime],,,[[#include <utmpx.h>]])
 
 dnl Checks for library functions.
 AC_FUNC_UTIME_NULL
@@ -104,6 +94,40 @@ AC_DEFINE_UNQUOTED(FAILLOG_FILE, "$shadow_cv_logdir/faillog",
 
 AC_DEFINE_UNQUOTED(PASSWD_PROGRAM, "$exec_prefix/bin/passwd",
 	[Path to passwd program.])
+
+AC_ARG_ENABLE([utmp],
+	[AS_HELP_STRING([--enable-utmp],
+		[enable utmp and wtmp access and update @<:@default=yes if supported@:>@])],
+	[AS_CASE([${enableval}],
+			 [yes],[:]
+			 [no],[:],
+			 [AC_MSG_ERROR([bad value ${enableval} for --enable-utmp])])],
+	[enable_utmp="maybe"]
+)
+AS_IF([test "X$enable_utmp" != "Xno"], [
+	found_utmp="no"
+	AC_CHECK_HEADERS([utmpx.h],[
+		AC_CHECK_FUNCS([setutxent],[found_utmp="yes"])
+	])
+	AS_IF([test "X$found_utmp" != "Xyes"],[
+		AS_IF([test "X$enable_utmp" = "Xyes"],[
+			AC_MSG_ERROR([utmp is not supported by libc, utmp cannot be enabled])
+		])
+		enable_utmp="no"
+	],[
+		enable_utmp="yes"
+		AC_CHECK_MEMBERS([struct utmpx.ut_name,
+						struct utmpx.ut_host,
+						struct utmpx.ut_syslen,
+						struct utmpx.ut_addr,
+						struct utmpx.ut_addr_v6,
+						struct utmpx.ut_time,
+						struct utmpx.ut_xtime],,,[[#include <utmpx.h>]])
+		AC_CHECK_FUNCS([updwtmpx])
+		AC_DEFINE([ENABLE_UTMP],[1],[Define to have utmp and wtmp access and update])
+	])
+])
+AM_CONDITIONAL([ENABLE_UTMP], [test "X$enable_utmp" = "Xyes"])
 
 AC_ARG_ENABLE(shadowgrp,
 	[AS_HELP_STRING([--enable-shadowgrp], [enable shadow group support @<:@default=yes@:>@])],
@@ -344,6 +368,8 @@ if test "$enable_logind" = "yes"; then
 		[enable_logind="no"])
 fi
 AM_CONDITIONAL(ENABLE_LOGIND, test "x$enable_logind" != "xno")
+AS_IF([test "x$enable_logind" != "xyes" && "X$enable_utmp" != "Xyes"],
+	[AC_MSG_ERROR([both logind and utmp cannot be disabled. At least one of them must be enabled])])
 
 AC_SUBST(LIBCRYPT)
 AC_CHECK_LIB(crypt, crypt, [LIBCRYPT=-lcrypt],
@@ -713,6 +739,7 @@ echo "	sssd support:			$with_sssd"
 echo "	subordinate IDs support:	$enable_subids"
 echo "	enable lastlog:			$enable_lastlog"
 echo "	enable logind:			$enable_logind"
+echo "	enable utmp:			$enable_utmp"
 echo "	use file caps:			$with_fcaps"
 echo "	install su:			$with_su"
 echo "	enabled vendor dir:             $enable_vendordir"

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -287,7 +287,9 @@ endif
 
 if ENABLE_LOGIND
 libshadow_la_SOURCES += logind.c
-else
+endif
+
+if ENABLE_UTMP
 libshadow_la_SOURCES += utmp.c
 endif
 

--- a/lib/logind.c
+++ b/lib/logind.c
@@ -14,7 +14,7 @@
 
 #include <systemd/sd-login.h>
 
-int get_session_host (char **out)
+int get_session_host_lgnd (char **out)
 {
     char *host = NULL;
     char *session = NULL;
@@ -36,17 +36,17 @@ done:
     return ret;
 }
 
-unsigned long active_sessions_count(const char *name, MAYBE_UNUSED unsigned long limit)
+int active_sessions_limit_exceeded_lgnd(const char *name, unsigned long limit)
 {
     struct passwd *pw;
     unsigned long count = 0;
 
     pw = prefix_getpwnam(name);
     if (pw == NULL) {
-        return 0;
+        return -1;
     }
 
     count = sd_uid_get_sessions(pw->pw_uid, 0, NULL);
 
-    return count;
+	return (count > limit) ? 1 : 0;
 }

--- a/lib/prototypes.h
+++ b/lib/prototypes.h
@@ -463,17 +463,18 @@ extern int user_busy (const char *name, uid_t uid);
 /*
  * Session management: utmp.c or logind.c
  */
+#ifdef ENABLE_UTMP
 
 /**
- * @brief Get host for the current session
+ * @brief Get host for the current session from utmp
  *
  * @param[out] out Host name
  *
  * @return 0 or a positive integer if the host was obtained properly,
  *         another value on error.
  */
-extern int get_session_host (char **out);
-#ifndef ENABLE_LOGIND
+extern int get_session_host_utmp (char **out);
+
 /**
  * @brief Update or create an utmp entry in utmp, wtmp, utmpw, or wtmpx
  *
@@ -498,19 +499,50 @@ extern int update_utmp (const char *user,
 extern void record_failure(const char *failent_user,
                            const char *tty,
                            const char *hostname);
-#endif /* ENABLE_LOGIND */
 
 /**
- * @brief Number of active user sessions
+ * @brief Check if the number of active utmp user sessions has exceeded limit
  *
  * @param[in] name username
  * @param[in] limit maximum number of active sessions
  *
- * @return number of active sessions.
+ * @return 1 if number of active user sessions has exceeded the limit,
+ *         0 if number of active user sessions less or equal the limit,
+ *         -1 on error
  *
  */
-extern unsigned long active_sessions_count(const char *name,
-                                           unsigned long limit);
+extern int active_sessions_limit_exceeded_utmp(const char *name,
+											   unsigned long limit);
+
+#endif /* ENABLE_UTMP */
+#ifdef ENABLE_LOGIND
+
+/**
+ * @brief Get host for the current session from logind
+ *
+ * @param[out] out Host name
+ *
+ * @return 0 or a positive integer if the host was obtained properly,
+ *         another value on error.
+ */
+extern int get_session_host_lgnd (char **out);
+
+/**
+ * @brief Check if the number of active logind user sessions has exceeded limit
+ *
+ * @param[in] name username
+ * @param[in] limit maximum number of active sessions
+ *
+ * @return 1 if number of active user sessions has exceeded the limit,
+ *         0 if number of active user sessions less or equal the limit,
+ *         -1 on error
+ *
+ */
+extern int active_sessions_limit_exceeded_lgnd(const char *name,
+											   unsigned long limit);
+
+#endif /* ENABLE_LOGIND */
+
 
 /* valid.c */
 extern bool valid (const char *, const struct passwd *);

--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -181,7 +181,7 @@ get_current_utmp(void)
 
 
 int
-get_session_host(char **out)
+get_session_host_utmp(char **out)
 {
 	int           ret = 0;
 	struct utmpx  *ut;
@@ -397,15 +397,14 @@ record_failure(const char *failent_user, const char *tty, const char *hostname)
 	}
 }
 
-
-unsigned long
-active_sessions_count(const char *name, unsigned long limit)
+int
+active_sessions_limit_exceeded_utmp(const char *name, unsigned long limit)
 {
 	struct utmpx   *ut;
 	unsigned long  count = 0;
 
 	setutxent();
-	while ((ut = getutxent()))
+	while ((ut = getutxent()) && (count <= limit))
 	{
 		if (USER_PROCESS != ut->ut_type) {
 			continue;
@@ -417,11 +416,8 @@ active_sessions_count(const char *name, unsigned long limit)
 			continue;
 		}
 		count++;
-		if (count > limit) {
-			break;
-		}
 	}
 	endutxent();
 
-	return count;
+	return (count > limit) ? 1 : 0;
 }

--- a/tests/unit/test_logind.c
+++ b/tests/unit/test_logind.c
@@ -35,34 +35,52 @@ __wrap_sd_uid_get_sessions(uid_t uid, int require_active, char ***sessions)
  **********************/
 static void test_active_sessions_count_return_ok(void **state)
 {
-    int count;
+    int res;
     struct passwd *pw = malloc(sizeof(struct passwd));
 
     will_return(__wrap_prefix_getpwnam, pw);
     will_return(__wrap_sd_uid_get_sessions, 1);
 
-    count = active_sessions_count("testuser", 0);
+    res = active_sessions_limit_exceeded_lgnd("testuser", 1);
 
-    assert_int_equal(count, 1);
+    assert_int_equal(res, 0);
 }
 
-static void test_active_sessions_count_prefix_getpwnam_failure(void **state)
+static void
+test_active_sessions_limit_exceeded_lgnd_return_exceeded(void **state)
 {
-    int count;
+    int res;
+    struct passwd *pw = malloc(sizeof(struct passwd));
+
+    will_return(__wrap_prefix_getpwnam, pw);
+    will_return(__wrap_sd_uid_get_sessions, 1);
+
+    res = active_sessions_limit_exceeded_lgnd("testuser", 0);
+
+    assert_int_equal(res, 1);
+}
+
+static void
+test_active_sessions_limit_exceeded_lgnd_prefix_failure(void **state)
+{
+    int res;
     struct passwd *pw = NULL;
 
     will_return(__wrap_prefix_getpwnam, pw);
 
-    count = active_sessions_count("testuser", 0);
+    res = active_sessions_limit_exceeded_lgnd("testuser", 0);
 
-    assert_int_equal(count, 0);
+    assert_int_equal(res, -1);
 }
 
 int main(void)
 {
     const struct CMUnitTest tests[] = {
-        cmocka_unit_test(test_active_sessions_count_return_ok),
-        cmocka_unit_test(test_active_sessions_count_prefix_getpwnam_failure),
+        cmocka_unit_test(test_active_sessions_limit_exceeded_lgnd_return_ok),
+        cmocka_unit_test(\
+        test_active_sessions_limit_exceeded_lgnd_return_exceeded),
+        cmocka_unit_test(\
+        test_active_sessions_limit_exceeded_lgnd_prefix_failure),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
This PR adds ability to use BOTH utmp and logind.
If both enabled, then for the number of active sessions logind used first, and utmp is used as a fallback. The same for "get_session_host": logind tried first and then utmp tried as a fallback.
Other utmp functionality enabled independently from logind.

This patch is needed because modern systemd (at least 256, 257) does not update utmp. Neither pad_systemd, nor logind does not write information to utmp.
This still breaks some software, including basic `logname` command.

With the patch utmp and logind can be enabled/disabled independently, allowing building a package that suits particular needs.
The only limitation is that utmp and logind cannot be simultaneously disabled (at least one option must be enabled).

The updated test has not been check for proper functioning on my machine.
