### PR TITLE
chpasswd: Check hash before write when using -e

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -75,6 +75,8 @@ libshadow_la_SOURCES = \
 	cast.h \
 	chkname.c \
 	chkname.h \
+	chkhash.c \
+	chkhash.h \
 	chowndir.c \
 	chowntty.c \
 	cleanup.c \

--- a/lib/chkhash.c
+++ b/lib/chkhash.c
@@ -1,0 +1,70 @@
+#include "config.h"
+
+#include "chkhash.h"
+
+#include <regex.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+
+
+/*
+ * match_regex - return true if match, false if not
+ */
+bool 
+match_regex(const char *pattern, const char *string) 
+{
+	regex_t regex;
+	int result;
+
+	if (regcomp(&regex, pattern, REG_EXTENDED) != 0)
+		return false;
+
+	result = regexec(&regex, string, 0, NULL, 0);
+	regfree(&regex);
+
+	return result == 0;
+}
+
+
+/*
+ * is_valid_hash - check if the given string is a valid password hash
+ *
+ * Returns true if the string appears to be a valid hash, false otherwise.
+ *
+ * regex from: https://man.archlinux.org/man/crypt.5.en
+ */
+bool 
+is_valid_hash(const char *hash) 
+{
+	// Minimum hash length
+	if (strlen(hash) < 13)
+		return false;
+
+	// Yescrypt: $y$ + algorithm parameters + $ + salt + $ + 43-char (minimum) hash
+	if (match_regex("^\\$y\\$[./A-Za-z0-9]+\\$[./A-Za-z0-9]{1,86}\\$[./A-Za-z0-9]{43}$", hash))
+		return true;
+
+	// Bcrypt: $2[abxy]$ + 2-digit cost + $ + 53-char hash
+	if (match_regex("^\\$2[abxy]\\$[0-9]{2}\\$[./A-Za-z0-9]{53}$", hash))
+		return true;
+
+	// SHA-512: $6$ + salt + $ + 86-char hash
+	if (match_regex("^\\$6\\$(rounds=[1-9][0-9]{3,8}\\$)?[^$:\\n]{1,16}\\$[./A-Za-z0-9]{86}$", hash))
+		return true;
+
+	// SHA-256: $5$ + salt + $ + 43-char hash
+	if (match_regex("^\\$5\\$(rounds=[1-9][0-9]{3,8}\\$)?[^$:\\n]{1,16}\\$[./A-Za-z0-9]{43}$", hash))
+		return true;
+
+	// MD5: $1$ + salt + $ + 22-char hash
+	if (match_regex("^\\$1\\$[^$:\\n]{1,8}\\$[./A-Za-z0-9]{22}$", hash))
+		return true;
+
+	// DES: exactly 13 characters from [A-Za-z0-9./]
+	if (match_regex("^[./A-Za-z0-9]{13}$", hash))
+		return true;
+
+	// Not a valid hash
+	return false;
+}

--- a/lib/chkhash.h
+++ b/lib/chkhash.h
@@ -1,0 +1,13 @@
+#ifndef SHADOW_INCLUDE_CHKHASH_H
+#define SHADOW_INCLUDE_CHKHASH_H
+
+
+#include "config.h"
+
+#include <stdbool.h>
+
+
+bool is_valid_hash(const char *hash);
+
+
+#endif

--- a/src/chpasswd.c
+++ b/src/chpasswd.c
@@ -22,6 +22,7 @@
 #include "pam_defs.h"
 #endif				/* USE_PAM */
 #include "atoi/str2i.h"
+#include "chkhash.h"
 #include "defines.h"
 #include "nscd.h"
 #include "sssd.h"
@@ -554,6 +555,21 @@ int main (int argc, char **argv)
 		} else
 #endif				/* USE_PAM */
 		{
+
+		/*
+		 * Prevent adding a non valid hash to /etc/shadow and
+		 * potentialy lock account
+		 */
+
+		if (eflg) {
+			if (!is_valid_hash(newpwd)) {
+				fprintf (stderr,
+					_("%s: (line %jd, user %s) invalid password hash\n"),
+					Prog, line, name);
+				errors = true;
+				continue;
+			}
+		}
 		const struct spwd *sp;
 		struct spwd newsp;
 		const struct passwd *pw;


### PR DESCRIPTION
Add is_valid_hash to prevent adding a bad hash in /etc/shadow (and so prevent user to be lock) when using chpasswd -e

```sh
# before
echo 'vinz:test123' | chpasswd -e
grep vinz /etc/shadow
vinz:test123:20280:0:99999:7:::

# now
echo 'vinz:test123' |sudo ./chpasswd -e
chpasswd: (line: 1) invalid password hash for user 'vinz'
chpasswd: error detected, changes ignored
```