### PR TITLE
src/login.c: fixed check for "init" process, when PAM is not used

### DIFF
--- a/src/login.c
+++ b/src/login.c
@@ -464,6 +464,7 @@ int main (int argc, char **argv)
 	unsigned int   retries;
 	unsigned int   timeout;
 	struct passwd  *pwd = NULL;
+	bool           is_init;
 
 #if defined(USE_PAM)
 	int            retcode;
@@ -1083,6 +1084,7 @@ int main (int argc, char **argv)
 #endif				/* ! USE_PAM */
 	chown_tty (pwd);
 
+	is_init = (getpid() == 1); /* Check before forking */
 #ifdef USE_PAM
 	/*
 	 * We must fork before setuid() because we need to call
@@ -1109,7 +1111,7 @@ int main (int argc, char **argv)
 #endif
 
 	/* If we were init, we need to start a new session */
-	if (getppid() == 1) {
+	if (is_init) {
 		setsid();
 		if (ioctl(0, TIOCSCTTY, 1) != 0) {
 			fprintf (stderr, _("TIOCSCTTY failed on %s"), tty);


### PR DESCRIPTION
When 'login' is started as 'init' process it has PID == 1. If PAM is not used, 'login' does not fork itself and getppid() return 0. To simplify the code, check for own PID before forking which gives correct value ('1' for 'init' process) for both PAM and non-PAM builds.

Initially the code for 'init' mode was introduced to support starting by `init=/bin/login`.
See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=374547