### PR TITLE
Add and use eprintf(), fprinte(), and eprinte()

### DIFF
--- a/lib/get_pid.c
+++ b/lib/get_pid.c
@@ -60,13 +60,13 @@ int open_pidfd(const char *pidstr)
 		return -ENOENT;
 
 	if (stprintf_a(proc_dir_name, "/proc/%d/", target) == -1) {
-		fprinte(stderr, "snprintf of proc path failed for %d", target);
+		eprinte("snprintf of proc path failed for %d", target);
 		return -EINVAL;
 	}
 
 	proc_dir_fd = open(proc_dir_name, O_DIRECTORY);
 	if (proc_dir_fd < 0) {
-		fprinte(stderr, _("Could not open proc directory for target %d"), target);
+		eprinte(_("Could not open proc directory for target %d"), target);
 		return -EINVAL;
 	}
 	return proc_dir_fd;

--- a/lib/io/fprintf.h
+++ b/lib/io/fprintf.h
@@ -19,6 +19,9 @@
 // eprintf - stderr print formatted
 #define eprintf(...)  fprintf(stderr, __VA_ARGS__)
 
+// eprinte - stderr print errno
+#define eprinte(...)  fprinte(stderr, __VA_ARGS__)
+
 
 // fprinte - FILE* print errno
 #define fprinte(stream, ...)  do                                      \

--- a/lib/io/fprintf.h
+++ b/lib/io/fprintf.h
@@ -16,6 +16,10 @@
 #include "attr.h"
 
 
+// eprintf - stderr print formatted
+#define eprintf(...)  fprintf(stderr, __VA_ARGS__)
+
+
 // fprinte - FILE* print errno
 #define fprinte(stream, ...)  do                                      \
 {                                                                     \

--- a/src/chage.c
+++ b/src/chage.c
@@ -97,14 +97,14 @@ fail_exit (int code, bool process_selinux)
 {
 	if (spw_locked) {
 		if (spw_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, spw_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, spw_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", spw_dbname());
 			/* continue */
 		}
 	}
 	if (pw_locked) {
 		if (pw_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, pw_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", pw_dbname());
 			/* continue */
 		}
@@ -349,8 +349,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 			dflg = true;
 			lstchgdate = strtoday (optarg);
 			if (lstchgdate < -1) {
-				fprintf (stderr,
-				         _("%s: invalid date '%s'\n"),
+				eprintf(_("%s: invalid date '%s'\n"),
 				         Prog, optarg);
 				usage (E_USAGE);
 			}
@@ -359,8 +358,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 			Eflg = true;
 			expdate = strtoday (optarg);
 			if (expdate < -1) {
-				fprintf (stderr,
-				         _("%s: invalid date '%s'\n"),
+				eprintf(_("%s: invalid date '%s'\n"),
 				         Prog, optarg);
 				usage (E_USAGE);
 			}
@@ -374,8 +372,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 		case 'I':
 			Iflg = true;
 			if (a2sl(&inactdays, optarg, NULL, 0, -1, LONG_MAX) == -1) {
-				fprintf (stderr,
-				         _("%s: invalid numeric argument '%s'\n"),
+				eprintf(_("%s: invalid numeric argument '%s'\n"),
 				         Prog, optarg);
 				usage (E_USAGE);
 			}
@@ -386,8 +383,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 		case 'M':
 			Mflg = true;
 			if (a2sl(&maxdays, optarg, NULL, 0, -1, LONG_MAX) == -1) {
-				fprintf (stderr,
-				         _("%s: invalid numeric argument '%s'\n"),
+				eprintf(_("%s: invalid numeric argument '%s'\n"),
 				         Prog, optarg);
 				usage (E_USAGE);
 			}
@@ -401,8 +397,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 		case 'W':
 			Wflg = true;
 			if (a2sl(&warndays, optarg, NULL, 0, -1, LONG_MAX) == -1) {
-				fprintf (stderr,
-				         _("%s: invalid numeric argument '%s'\n"),
+				eprintf(_("%s: invalid numeric argument '%s'\n"),
 				         Prog, optarg);
 				usage (E_USAGE);
 			}
@@ -432,9 +427,7 @@ static void check_flags (int argc, int opt_index)
 	}
 
 	if (lflg && (Mflg || dflg || Wflg || Iflg || Eflg)) {
-		fprintf (stderr,
-		         _("%s: do not include \"l\" with other flags\n"),
-		         Prog);
+		eprintf(_("%s: do not include \"l\" with other flags\n"), Prog);
 		usage (E_USAGE);
 	}
 }
@@ -461,7 +454,7 @@ static void check_perms(const struct option_flags *flags)
 	 */
 
 	if (!amroot && !lflg) {
-		fprintf (stderr, _("%s: Permission denied.\n"), Prog);
+		eprintf(_("%s: Permission denied.\n"), Prog);
 		fail_exit (E_NOPERM, process_selinux);
 	}
 }
@@ -485,15 +478,14 @@ static void open_files(bool readonly, const struct option_flags *flags)
 	 */
 	if (!readonly) {
 		if (pw_lock () == 0) {
-			fprintf (stderr,
-			         _("%s: cannot lock %s; try again later.\n"),
+			eprintf(_("%s: cannot lock %s; try again later.\n"),
 			         Prog, pw_dbname ());
 			fail_exit (E_NOPERM, process_selinux);
 		}
 		pw_locked = true;
 	}
 	if (pw_open (readonly ? O_RDONLY: O_CREAT | O_RDWR) == 0) {
-		fprintf (stderr, _("%s: cannot open %s\n"), Prog, pw_dbname ());
+		eprintf(_("%s: cannot open %s\n"), Prog, pw_dbname());
 		SYSLOG(LOG_WARN, "cannot open %s", pw_dbname());
 		fail_exit (E_NOPERM, process_selinux);
 	}
@@ -506,16 +498,14 @@ static void open_files(bool readonly, const struct option_flags *flags)
 	 */
 	if (!readonly) {
 		if (spw_lock () == 0) {
-			fprintf (stderr,
-			         _("%s: cannot lock %s; try again later.\n"),
+			eprintf(_("%s: cannot lock %s; try again later.\n"),
 			         Prog, spw_dbname ());
 			fail_exit (E_NOPERM, process_selinux);
 		}
 		spw_locked = true;
 	}
 	if (spw_open (readonly ? O_RDONLY: O_CREAT | O_RDWR) == 0) {
-		fprintf (stderr,
-		         _("%s: cannot open %s\n"), Prog, spw_dbname ());
+		eprintf(_("%s: cannot open %s\n"), Prog, spw_dbname());
 		SYSLOG(LOG_WARN, "cannot open %s", spw_dbname());
 		fail_exit (E_NOPERM, process_selinux);
 	}
@@ -535,8 +525,7 @@ static void close_files(const struct option_flags *flags)
 	 * entries to be re-written.
 	 */
 	if (spw_close (process_selinux) == 0) {
-		fprintf (stderr,
-		         _("%s: failure while writing changes to %s\n"), Prog, spw_dbname ());
+		eprintf(_("%s: failure while writing changes to %s\n"), Prog, spw_dbname());
 		SYSLOG(LOG_ERR, "failure while writing changes to %s", spw_dbname());
 		fail_exit (E_NOPERM, process_selinux);
 	}
@@ -546,18 +535,18 @@ static void close_files(const struct option_flags *flags)
 	 * will be re-written.
 	 */
 	if (pw_close (process_selinux) == 0) {
-		fprintf (stderr, _("%s: failure while writing changes to %s\n"), Prog, pw_dbname ());
+		eprintf(_("%s: failure while writing changes to %s\n"), Prog, pw_dbname());
 		SYSLOG(LOG_ERR, "failure while writing changes to %s", pw_dbname());
 		fail_exit (E_NOPERM, process_selinux);
 	}
 	if (spw_unlock (process_selinux) == 0) {
-		fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, spw_dbname ());
+		eprintf(_("%s: failed to unlock %s\n"), Prog, spw_dbname());
 		SYSLOG(LOG_ERR, "failed to unlock %s", spw_dbname());
 		/* continue */
 	}
 	spw_locked = false;
 	if (pw_unlock (process_selinux) == 0) {
-		fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, pw_dbname ());
+		eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
 		SYSLOG(LOG_ERR, "failed to unlock %s", pw_dbname());
 		/* continue */
 	}
@@ -590,8 +579,7 @@ static void update_age (/*@null@*/const struct spwd *sp,
 
 		pwent.pw_passwd = SHADOW_PASSWD_STRING;	/* XXX warning: const */
 		if (pw_update (&pwent) == 0) {
-			fprintf (stderr,
-			         _("%s: failed to prepare the new %s entry '%s'\n"), Prog, pw_dbname (), pwent.pw_name);
+			eprintf(_("%s: failed to prepare the new %s entry '%s'\n"), Prog, pw_dbname(), pwent.pw_name);
 			fail_exit (E_NOPERM, process_selinux);
 		}
 	} else {
@@ -613,8 +601,7 @@ static void update_age (/*@null@*/const struct spwd *sp,
 	spwent.sp_expire = expdate;
 
 	if (spw_update (&spwent) == 0) {
-		fprintf (stderr,
-		         _("%s: failed to prepare the new %s entry '%s'\n"), Prog, spw_dbname (), spwent.sp_namp);
+		eprintf(_("%s: failed to prepare the new %s entry '%s'\n"), Prog, spw_dbname(), spwent.sp_namp);
 		fail_exit (E_NOPERM, process_selinux);
 	}
 
@@ -730,9 +717,7 @@ int main (int argc, char **argv)
 	check_perms (&flags);
 
 	if (!spw_file_present ()) {
-		fprintf (stderr,
-		         _("%s: the shadow password file is not present\n"),
-		         Prog);
+		eprintf(_("%s: the shadow password file is not present\n"), Prog);
 		SYSLOG(LOG_WARN, "can't find the shadow password file");
 		closelog ();
 		exit (E_SHADOW_NOTFOUND);
@@ -748,7 +733,7 @@ int main (int argc, char **argv)
 
 	pw = pw_locate (argv[optind]);
 	if (NULL == pw) {
-		fprintf (stderr, _("%s: user '%s' does not exist in %s\n"),
+		eprintf(_("%s: user '%s' does not exist in %s\n"),
 		         Prog, argv[optind], pw_dbname ());
 		closelog ();
 		fail_exit (E_NOPERM, process_selinux);
@@ -771,7 +756,7 @@ int main (int argc, char **argv)
 	 */
 	if (lflg) {
 		if (!amroot && (ruid != user_uid)) {
-			fprintf (stderr, _("%s: Permission denied.\n"), Prog);
+			eprintf(_("%s: Permission denied.\n"), Prog);
 			fail_exit (E_NOPERM, process_selinux);
 		}
 		/* Displaying fields is not of interest to audit */
@@ -787,8 +772,7 @@ int main (int argc, char **argv)
 		printf (_("Changing the aging information for %s\n"),
 		        user_name);
 		if (new_fields () == 0) {
-			fprintf (stderr, _("%s: error changing fields\n"),
-			         Prog);
+			eprintf(_("%s: error changing fields\n"), Prog);
 			fail_exit (E_NOPERM, process_selinux);
 		}
 #ifdef WITH_AUDIT

--- a/src/chage.c
+++ b/src/chage.c
@@ -727,7 +727,7 @@ int main (int argc, char **argv)
 	/* Drop privileges */
 	if (lflg && (   (setregid (rgid, rgid) != 0)
 	             || (setreuid (ruid, ruid) != 0))) {
-		fprinte(stderr, _("%s: failed to drop privileges"), Prog);
+		eprinte(_("%s: failed to drop privileges"), Prog);
 		fail_exit (E_NOPERM, process_selinux);
 	}
 

--- a/src/chfn.c
+++ b/src/chfn.c
@@ -25,6 +25,7 @@
 #include "exitcodes.h"
 #include "fields.h"
 #include "getdef.h"
+#include "io/fprintf.h"
 #include "nscd.h"
 #ifdef USE_PAM
 #include "pam_defs.h"
@@ -83,7 +84,7 @@ static void fail_exit (int code, bool process_selinux)
 {
 	if (pw_locked) {
 		if (pw_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, pw_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", pw_dbname());
 			/* continue */
 		}
@@ -239,8 +240,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 		switch (c) {
 		case 'f':
 			if (!may_change_field ('f')) {
-				fprintf (stderr,
-				         _("%s: Permission denied.\n"), Prog);
+				eprintf(_("%s: Permission denied.\n"), Prog);
 				exit (E_NOPERM);
 			}
 			fflg = true;
@@ -248,8 +248,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 			break;
 		case 'h':
 			if (!may_change_field ('h')) {
-				fprintf (stderr,
-				         _("%s: Permission denied.\n"), Prog);
+				eprintf(_("%s: Permission denied.\n"), Prog);
 				exit (E_NOPERM);
 			}
 			hflg = true;
@@ -257,22 +256,19 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 			break;
 		case 'o':
 			if (!amroot) {
-				fprintf (stderr,
-				         _("%s: Permission denied.\n"), Prog);
+				eprintf(_("%s: Permission denied.\n"), Prog);
 				exit (E_NOPERM);
 			}
 			oflg = true;
 			if (strlen (optarg) > (unsigned int) 80) {
-				fprintf (stderr,
-				         _("%s: fields too long\n"), Prog);
+				eprintf(_("%s: fields too long\n"), Prog);
 				exit (E_NOPERM);
 			}
 			strtcpy_a(slop, optarg);
 			break;
 		case 'r':
 			if (!may_change_field ('r')) {
-				fprintf (stderr,
-				         _("%s: Permission denied.\n"), Prog);
+				eprintf(_("%s: Permission denied.\n"), Prog);
 				exit (E_NOPERM);
 			}
 			rflg = true;
@@ -286,8 +282,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 			/*@notreached@*/break;
 		case 'w':
 			if (!may_change_field ('w')) {
-				fprintf (stderr,
-				         _("%s: Permission denied.\n"), Prog);
+				eprintf(_("%s: Permission denied.\n"), Prog);
 				exit (E_NOPERM);
 			}
 			wflg = true;
@@ -322,7 +317,7 @@ static void check_perms (const struct passwd *pw)
 	 * if the UID of the user matches the current real UID.
 	 */
 	if (!amroot && pw->pw_uid != getuid ()) {
-		fprintf (stderr, _("%s: Permission denied.\n"), Prog);
+		eprintf(_("%s: Permission denied.\n"), Prog);
 		closelog ();
 		exit (E_NOPERM);
 	}
@@ -333,7 +328,7 @@ static void check_perms (const struct passwd *pw)
 	 */
 	if ((pw->pw_uid != getuid ())
 	    && (check_selinux_permit (Prog) != 0)) {
-		fprintf (stderr, _("%s: Permission denied.\n"), Prog);
+		eprintf(_("%s: Permission denied.\n"), Prog);
 		closelog ();
 		exit (E_NOPERM);
 	}
@@ -353,9 +348,7 @@ static void check_perms (const struct passwd *pw)
 #else				/* !USE_PAM */
 	pampw = getpwuid (getuid ()); /* local, no need for xgetpwuid */
 	if (NULL == pampw) {
-		fprintf (stderr,
-		         _("%s: Cannot determine your user name.\n"),
-		         Prog);
+		eprintf(_("%s: Cannot determine your user name.\n"), Prog);
 		exit (E_NOPERM);
 	}
 
@@ -370,8 +363,7 @@ static void check_perms (const struct passwd *pw)
 	}
 
 	if (PAM_SUCCESS != retval) {
-		fprintf (stderr, _("%s: PAM: %s\n"),
-		         Prog, pam_strerror (pamh, retval));
+		eprintf(_("%s: PAM: %s\n"), Prog, pam_strerror(pamh, retval));
 		SYSLOG(LOG_ERR, "%s", pam_strerror(pamh, retval));
 		if (NULL != pamh) {
 			(void) pam_end (pamh, retval);
@@ -413,15 +405,13 @@ static void update_gecos(const char *user, char *gecos, const struct option_flag
 	 * password file. Get a lock on the file and open it.
 	 */
 	if (pw_lock () == 0) {
-		fprintf (stderr,
-		         _("%s: cannot lock %s; try again later.\n"),
+		eprintf(_("%s: cannot lock %s; try again later.\n"),
 		         Prog, pw_dbname ());
 		fail_exit (E_NOPERM, process_selinux);
 	}
 	pw_locked = true;
 	if (pw_open (O_CREAT | O_RDWR) == 0) {
-		fprintf (stderr,
-		         _("%s: cannot open %s\n"), Prog, pw_dbname ());
+		eprintf(_("%s: cannot open %s\n"), Prog, pw_dbname());
 		fail_exit (E_NOPERM, process_selinux);
 	}
 
@@ -433,8 +423,7 @@ static void update_gecos(const char *user, char *gecos, const struct option_flag
 	 */
 	pw = pw_locate (user);
 	if (NULL == pw) {
-		fprintf (stderr,
-		         _("%s: user '%s' does not exist in %s\n"),
+		eprintf(_("%s: user '%s' does not exist in %s\n"),
 		         Prog, user, pw_dbname ());
 		fail_exit (E_NOPERM, process_selinux);
 	}
@@ -451,8 +440,7 @@ static void update_gecos(const char *user, char *gecos, const struct option_flag
 	 * entry as well.
 	 */
 	if (pw_update (&pwent) == 0) {
-		fprintf (stderr,
-		         _("%s: failed to prepare the new %s entry '%s'\n"),
+		eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
 		         Prog, pw_dbname (), pwent.pw_name);
 		fail_exit (E_NOPERM, process_selinux);
 	}
@@ -461,12 +449,12 @@ static void update_gecos(const char *user, char *gecos, const struct option_flag
 	 * Changes have all been made, so commit them and unlock the file.
 	 */
 	if (pw_close (process_selinux) == 0) {
-		fprintf (stderr, _("%s: failure while writing changes to %s\n"), Prog, pw_dbname ());
+		eprintf(_("%s: failure while writing changes to %s\n"), Prog, pw_dbname());
 		SYSLOG(LOG_ERR, "failure while writing changes to %s", pw_dbname());
 		fail_exit (E_NOPERM, process_selinux);
 	}
 	if (pw_unlock (process_selinux) == 0) {
-		fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, pw_dbname ());
+		eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
 		SYSLOG(LOG_ERR, "failed to unlock %s", pw_dbname());
 		/* continue */
 	}
@@ -517,36 +505,31 @@ static void check_fields (bool process_selinux)
 	int err;
 	err = valid_field (fullnm, ":,=\n");
 	if (err > 0) {
-		fprintf (stderr, _("%s: name with non-ASCII characters: '%s'\n"), Prog, fullnm);
+		eprintf(_("%s: name with non-ASCII characters: '%s'\n"), Prog, fullnm);
 	} else if (err < 0) {
-		fprintf (stderr, _("%s: invalid name: '%s'\n"), Prog, fullnm);
 		fail_exit (E_NOPERM, process_selinux);
+		eprintf(_("%s: invalid name: '%s'\n"), Prog, fullnm);
 	}
 	err = valid_field (roomno, ":,=\n");
 	if (err > 0) {
-		fprintf (stderr, _("%s: room number with non-ASCII characters: '%s'\n"), Prog, roomno);
+		eprintf(_("%s: room number with non-ASCII characters: '%s'\n"), Prog, roomno);
 	} else if (err < 0) {
-		fprintf (stderr, _("%s: invalid room number: '%s'\n"),
-		         Prog, roomno);
+		eprintf(_("%s: invalid room number: '%s'\n"), Prog, roomno);
 		fail_exit (E_NOPERM, process_selinux);
 	}
 	if (valid_field (workph, ":,=\n") != 0) {
-		fprintf (stderr, _("%s: invalid work phone: '%s'\n"),
-		         Prog, workph);
+		eprintf(_("%s: invalid work phone: '%s'\n"), Prog, workph);
 		fail_exit (E_NOPERM, process_selinux);
 	}
 	if (valid_field (homeph, ":,=\n") != 0) {
-		fprintf (stderr, _("%s: invalid home phone: '%s'\n"),
-		         Prog, homeph);
+		eprintf(_("%s: invalid home phone: '%s'\n"), Prog, homeph);
 		fail_exit (E_NOPERM, process_selinux);
 	}
 	err = valid_field (slop, ":\n");
 	if (err > 0) {
-		fprintf (stderr, _("%s: '%s' contains non-ASCII characters\n"), Prog, slop);
+		eprintf(_("%s: '%s' contains non-ASCII characters\n"), Prog, slop);
 	} else if (err < 0) {
-		fprintf (stderr,
-		         _("%s: '%s' contains illegal characters\n"),
-		         Prog, slop);
+		eprintf(_("%s: '%s' contains illegal characters\n"), Prog, slop);
 		fail_exit (E_NOPERM, process_selinux);
 	}
 }
@@ -605,21 +588,19 @@ int main (int argc, char **argv)
 	 */
 	if (optind < argc) {
 		if (!is_valid_user_name(argv[optind], true)) {
-			fprintf (stderr, _("%s: Provided user name is not a valid name\n"), Prog);
+			eprintf(_("%s: Provided user name is not a valid name\n"), Prog);
 			fail_exit (E_NOPERM, process_selinux);
 		}
 		user = argv[optind];
 		pw = xgetpwnam (user);
 		if (NULL == pw) {
-			fprintf (stderr, _("%s: user '%s' does not exist\n"), Prog,
-			         user);
+			eprintf(_("%s: user '%s' does not exist\n"), Prog, user);
 			fail_exit (E_NOPERM, process_selinux);
 		}
 	} else {
 		pw = get_my_pwent ();
 		if (NULL == pw) {
-			fprintf (stderr,
-			         _("%s: Cannot determine your user name.\n"),
+			eprintf(_("%s: Cannot determine your user name.\n"),
 			         Prog);
 			SYSLOG(LOG_WARN, "Cannot determine the user name of the caller (UID %lu)",
 			       (unsigned long) getuid());
@@ -661,7 +642,7 @@ int main (int argc, char **argv)
 		p = seprintf(p, e, ",%s", slop);
 
 	if (p == e || p == NULL) {
-		fprintf (stderr, _("%s: fields too long\n"), Prog);
+		eprintf(_("%s: fields too long\n"), Prog);
 		fail_exit (E_NOPERM, process_selinux);
 	}
 

--- a/src/chgpasswd.c
+++ b/src/chgpasswd.c
@@ -81,7 +81,7 @@ static void fail_exit (int code, bool process_selinux)
 {
 	if (gr_locked) {
 		if (gr_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, gr_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, gr_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", gr_dbname());
 			/* continue */
 		}
@@ -90,7 +90,7 @@ static void fail_exit (int code, bool process_selinux)
 #ifdef	SHADOWGRP
 	if (sgr_locked) {
 		if (sgr_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, sgr_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, sgr_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sgr_dbname());
 			/* continue */
 		}
@@ -171,8 +171,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 			bad_s = 0;
 
 			if (!crypt_method) {
-				fprintf (stderr,
-				         _("%s: no crypt method defined\n"),
+				eprintf(_("%s: no crypt method defined\n"),
 				         Prog);
 				usage (E_USAGE);
 			}
@@ -193,8 +192,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 			}
 #endif				/* USE_YESCRYPT */
 			if (bad_s != 0) {
-				fprintf (stderr,
-				         _("%s: invalid numeric argument '%s'\n"),
+				eprintf(_("%s: invalid numeric argument '%s'\n"),
 				         Prog, optarg);
 				usage (E_USAGE);
 			}
@@ -217,16 +215,13 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 static void check_flags (void)
 {
 	if (sflg && !cflg) {
-		fprintf (stderr,
-		         _("%s: %s flag is only allowed with the %s flag\n"),
+		eprintf(_("%s: %s flag is only allowed with the %s flag\n"),
 		         Prog, "-s", "-c");
 		usage (E_USAGE);
 	}
 
 	if (eflg && cflg) {
-		fprintf (stderr,
-		         _("%s: the -c and -e flags are exclusive\n"),
-		         Prog);
+		eprintf(_("%s: the -c and -e flags are exclusive\n"), Prog);
 		usage (E_USAGE);
 	}
 
@@ -241,8 +236,7 @@ static void check_flags (void)
 		    && !streq(crypt_method, "YESCRYPT")
 #endif				/* USE_YESCRYPT */
 		    ) {
-			fprintf (stderr,
-			         _("%s: unsupported crypt method: %s\n"),
+			eprintf(_("%s: unsupported crypt method: %s\n"),
 			         Prog, crypt_method);
 			usage (E_USAGE);
 		}
@@ -259,15 +253,13 @@ static void open_files (bool process_selinux)
 	 * bring all of the entries into memory where they may be updated.
 	 */
 	if (gr_lock () == 0) {
-		fprintf (stderr,
-		         _("%s: cannot lock %s; try again later.\n"),
+		eprintf(_("%s: cannot lock %s; try again later.\n"),
 		         Prog, gr_dbname ());
 		fail_exit (1, process_selinux);
 	}
 	gr_locked = true;
 	if (gr_open (O_CREAT | O_RDWR) == 0) {
-		fprintf (stderr,
-		         _("%s: cannot open %s\n"), Prog, gr_dbname ());
+		eprintf(_("%s: cannot open %s\n"), Prog, gr_dbname());
 		fail_exit (1, process_selinux);
 	}
 
@@ -275,15 +267,13 @@ static void open_files (bool process_selinux)
 	/* Do the same for the shadowed database, if it exist */
 	if (is_shadow_grp) {
 		if (sgr_lock () == 0) {
-			fprintf (stderr,
-			         _("%s: cannot lock %s; try again later.\n"),
+			eprintf(_("%s: cannot lock %s; try again later.\n"),
 			         Prog, sgr_dbname ());
 			fail_exit (1, process_selinux);
 		}
 		sgr_locked = true;
 		if (sgr_open (O_CREAT | O_RDWR) == 0) {
-			fprintf (stderr, _("%s: cannot open %s\n"),
-			         Prog, sgr_dbname ());
+			eprintf(_("%s: cannot open %s\n"), Prog, sgr_dbname());
 			fail_exit (1, process_selinux);
 		}
 	}
@@ -301,14 +291,13 @@ static void close_files(const struct option_flags *flags)
 #ifdef SHADOWGRP
 	if (is_shadow_grp) {
 		if (sgr_close (process_selinux) == 0) {
-			fprintf (stderr,
-			         _("%s: failure while writing changes to %s\n"),
+			eprintf(_("%s: failure while writing changes to %s\n"),
 			         Prog, sgr_dbname ());
 			SYSLOG(LOG_ERR, "failure while writing changes to %s", sgr_dbname());
 			fail_exit (1, process_selinux);
 		}
 		if (sgr_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, sgr_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, sgr_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sgr_dbname());
 			/* continue */
 		}
@@ -317,14 +306,13 @@ static void close_files(const struct option_flags *flags)
 #endif
 
 	if (gr_close (process_selinux) == 0) {
-		fprintf (stderr,
-		         _("%s: failure while writing changes to %s\n"),
+		eprintf(_("%s: failure while writing changes to %s\n"),
 		         Prog, gr_dbname ());
 		SYSLOG(LOG_ERR, "failure while writing changes to %s", gr_dbname());
 		fail_exit (1, process_selinux);
 	}
 	if (gr_unlock (process_selinux) == 0) {
-		fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, gr_dbname ());
+		eprintf(_("%s: failed to unlock %s\n"), Prog, gr_dbname());
 		SYSLOG(LOG_ERR, "failed to unlock %s", gr_dbname());
 		/* continue */
 	}
@@ -384,8 +372,7 @@ int main (int argc, char **argv)
 	while (fgets_a(buf, stdin) != NULL) {
 		line++;
 		if (stpsep(buf, "\n") == NULL) {
-			fprintf (stderr, _("%s: line %jd: line too long\n"),
-			         Prog, line);
+			eprintf(_("%s: line %jd: line too long\n"), Prog, line);
 			errors = true;
 			continue;
 		}
@@ -402,8 +389,7 @@ int main (int argc, char **argv)
 		name = buf;
 		cp = stpsep(name, ":");
 		if (cp == NULL) {
-			fprintf (stderr,
-			         _("%s: line %jd: missing new password\n"),
+			eprintf(_("%s: line %jd: missing new password\n"),
 			         Prog, line);
 			errors = true;
 			continue;
@@ -445,8 +431,7 @@ int main (int argc, char **argv)
 		 */
 		gr = gr_locate (name);
 		if (NULL == gr) {
-			fprintf (stderr,
-			         _("%s: line %jd: group '%s' does not exist\n"), Prog,
+			eprintf(_("%s: line %jd: group '%s' does not exist\n"), Prog,
 			         line, name);
 			errors = true;
 			continue;
@@ -505,8 +490,7 @@ int main (int argc, char **argv)
 #ifdef SHADOWGRP
 		if (NULL != sg) {
 			if (sgr_update (&newsg) == 0) {
-				fprintf (stderr,
-				         _("%s: line %jd: failed to prepare the new %s entry '%s'\n"),
+				eprintf(_("%s: line %jd: failed to prepare the new %s entry '%s'\n"),
 				         Prog, line, sgr_dbname (), newsg.sg_namp);
 				errors = true;
 				continue;
@@ -517,8 +501,7 @@ int main (int argc, char **argv)
 #endif
 		{
 			if (gr_update (&newgr) == 0) {
-				fprintf (stderr,
-				         _("%s: line %jd: failed to prepare the new %s entry '%s'\n"),
+				eprintf(_("%s: line %jd: failed to prepare the new %s entry '%s'\n"),
 				         Prog, line, gr_dbname (), newgr.gr_name);
 				errors = true;
 				continue;
@@ -534,8 +517,7 @@ int main (int argc, char **argv)
 	 * afterwards.
 	 */
 	if (errors) {
-		fprintf (stderr,
-		         _("%s: error detected, changes ignored\n"), Prog);
+		eprintf(_("%s: error detected, changes ignored\n"), Prog);
 		fail_exit (1, process_selinux);
 	}
 

--- a/src/chgpasswd.c
+++ b/src/chgpasswd.c
@@ -419,7 +419,7 @@ int main (int argc, char **argv)
 			salt = crypt_make_salt (crypt_method, arg);
 			cp = pw_encrypt (newpwd, salt);
 			if (NULL == cp) {
-				fprinte(stderr, _("%s: failed to crypt password with salt '%s'"),
+				eprinte(_("%s: failed to crypt password with salt '%s'"),
 				        Prog, salt);
 				fail_exit (1, process_selinux);
 			}

--- a/src/chpasswd.c
+++ b/src/chpasswd.c
@@ -85,7 +85,7 @@ static void fail_exit (int code, bool process_selinux)
 {
 	if (pw_locked) {
 		if (pw_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, pw_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", pw_dbname());
 			/* continue */
 		}
@@ -93,7 +93,7 @@ static void fail_exit (int code, bool process_selinux)
 
 	if (spw_locked) {
 		if (spw_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, spw_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, spw_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", spw_dbname());
 			/* continue */
 		}
@@ -194,8 +194,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 			}
 #endif				/* USE_YESCRYPT */
 			if (bad_s != 0) {
-				fprintf (stderr,
-				         _("%s: invalid numeric argument '%s'\n"),
+				eprintf(_("%s: invalid numeric argument '%s'\n"),
 				         Prog, optarg);
 				usage (E_USAGE);
 			}
@@ -218,16 +217,13 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 static void check_flags (void)
 {
 	if (sflg && !cflg) {
-		fprintf (stderr,
-		         _("%s: %s flag is only allowed with the %s flag\n"),
+		eprintf(_("%s: %s flag is only allowed with the %s flag\n"),
 		         Prog, "-s", "-c");
 		usage (E_USAGE);
 	}
 
 	if (eflg && cflg) {
-		fprintf (stderr,
-		         _("%s: the -c and -e flags are exclusive\n"),
-		         Prog);
+		eprintf(_("%s: the -c and -e flags are exclusive\n"), Prog);
 		usage (E_USAGE);
 	}
 
@@ -242,8 +238,7 @@ static void check_flags (void)
 		    &&(!IS_CRYPT_METHOD("YESCRYPT"))
 #endif				/* USE_YESCRYPT */
 		    ) {
-			fprintf (stderr,
-			         _("%s: unsupported crypt method: %s\n"),
+			eprintf(_("%s: unsupported crypt method: %s\n"),
 			         Prog, crypt_method);
 			usage (E_USAGE);
 		}
@@ -264,31 +259,26 @@ static void open_files(const struct option_flags *flags)
 	 * will bring all of the entries into memory where they may be updated.
 	 */
 	if (pw_lock () == 0) {
-		fprintf (stderr,
-		         _("%s: cannot lock %s; try again later.\n"),
+		eprintf(_("%s: cannot lock %s; try again later.\n"),
 		         Prog, pw_dbname ());
 		fail_exit (1, process_selinux);
 	}
 	pw_locked = true;
 	if (pw_open (O_CREAT | O_RDWR) == 0) {
-		fprintf (stderr,
-		         _("%s: cannot open %s\n"), Prog, pw_dbname ());
+		eprintf(_("%s: cannot open %s\n"), Prog, pw_dbname());
 		fail_exit (1, process_selinux);
 	}
 
 	/* Do the same for the shadowed database, if it exist */
 	if (is_shadow_pwd) {
 		if (spw_lock () == 0) {
-			fprintf (stderr,
-			         _("%s: cannot lock %s; try again later.\n"),
+			eprintf(_("%s: cannot lock %s; try again later.\n"),
 			         Prog, spw_dbname ());
 			fail_exit (1, process_selinux);
 		}
 		spw_locked = true;
 		if (spw_open (O_CREAT | O_RDWR) == 0) {
-			fprintf (stderr,
-			         _("%s: cannot open %s\n"),
-			         Prog, spw_dbname ());
+			eprintf(_("%s: cannot open %s\n"), Prog, spw_dbname());
 			fail_exit (1, process_selinux);
 		}
 	}
@@ -305,14 +295,13 @@ static void close_files(const struct option_flags *flags)
 
 	if (is_shadow_pwd) {
 		if (spw_close (process_selinux) == 0) {
-			fprintf (stderr,
-			         _("%s: failure while writing changes to %s\n"),
+			eprintf(_("%s: failure while writing changes to %s\n"),
 			         Prog, spw_dbname ());
 			SYSLOG(LOG_ERR, "failure while writing changes to %s", spw_dbname());
 			fail_exit (1, process_selinux);
 		}
 		if (spw_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, spw_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, spw_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", spw_dbname());
 			/* continue */
 		}
@@ -320,14 +309,13 @@ static void close_files(const struct option_flags *flags)
 	}
 
 	if (pw_close (process_selinux) == 0) {
-		fprintf (stderr,
-		         _("%s: failure while writing changes to %s\n"),
+		eprintf(_("%s: failure while writing changes to %s\n"),
 		         Prog, pw_dbname ());
 		SYSLOG(LOG_ERR, "failure while writing changes to %s", pw_dbname());
 		fail_exit (1, process_selinux);
 	}
 	if (pw_unlock (process_selinux) == 0) {
-		fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, pw_dbname ());
+		eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
 		SYSLOG(LOG_ERR, "failed to unlock %s", pw_dbname());
 		/* continue */
 	}
@@ -433,8 +421,7 @@ int main (int argc, char **argv)
 						break;
 				}
 
-				fprintf (stderr,
-				         _("%s: line %jd: line too long\n"),
+				eprintf(_("%s: line %jd: line too long\n"),
 				         Prog, line);
 				errors = true;
 				continue;
@@ -453,8 +440,7 @@ int main (int argc, char **argv)
 		name = buf;
 		cp = stpsep(name, ":");
 		if (cp == NULL) {
-			fprintf (stderr,
-			         _("%s: line %jd: missing new password\n"),
+			eprintf(_("%s: line %jd: missing new password\n"),
 			         Prog, line);
 			errors = true;
 			continue;
@@ -464,8 +450,7 @@ int main (int argc, char **argv)
 #ifdef USE_PAM
 		if (use_pam) {
 			if (do_pam_passwd_non_interactive (Prog, name, newpwd) != 0) {
-				fprintf (stderr,
-				         _("%s: (line %jd, user %s) password not changed\n"),
+				eprintf(_("%s: (line %jd, user %s) password not changed\n"),
 				         Prog, line, name);
 				errors = true;
 			}
@@ -507,8 +492,7 @@ int main (int argc, char **argv)
 		 */
 		pw = pw_locate (name);
 		if (NULL == pw) {
-			fprintf (stderr,
-			         _("%s: line %jd: user '%s' does not exist\n"), Prog,
+			eprintf(_("%s: line %jd: user '%s' does not exist\n"), Prog,
 			         line, name);
 			errors = true;
 			continue;
@@ -573,8 +557,7 @@ int main (int argc, char **argv)
 		 */
 		if (NULL != sp) {
 			if (spw_update (&newsp) == 0) {
-				fprintf (stderr,
-				         _("%s: line %jd: failed to prepare the new %s entry '%s'\n"),
+				eprintf(_("%s: line %jd: failed to prepare the new %s entry '%s'\n"),
 				         Prog, line, spw_dbname (), newsp.sp_namp);
 				errors = true;
 				continue;
@@ -583,8 +566,7 @@ int main (int argc, char **argv)
 		if (   (NULL == sp)
 		    || !streq(pw->pw_passwd, SHADOW_PASSWD_STRING)) {
 			if (pw_update (&newpw) == 0) {
-				fprintf (stderr,
-				         _("%s: line %jd: failed to prepare the new %s entry '%s'\n"),
+				eprintf(_("%s: line %jd: failed to prepare the new %s entry '%s'\n"),
 				         Prog, line, pw_dbname (), newpw.pw_name);
 				errors = true;
 				continue;
@@ -608,8 +590,7 @@ int main (int argc, char **argv)
 		if (!use_pam)
 #endif				/* USE_PAM */
 		{
-			fprintf (stderr,
-			         _("%s: error detected, changes ignored\n"),
+			eprintf(_("%s: error detected, changes ignored\n"),
 			         Prog);
 		}
 		fail_exit (1, process_selinux);

--- a/src/chpasswd.c
+++ b/src/chpasswd.c
@@ -480,7 +480,7 @@ int main (int argc, char **argv)
 		if (salt) {
 			cp = pw_encrypt (newpwd, salt);
 			if (NULL == cp) {
-				fprinte(stderr, _("%s: failed to crypt password with salt '%s'"),
+				eprinte(_("%s: failed to crypt password with salt '%s'"),
 				        Prog, salt);
 				fail_exit (1, process_selinux);
 			}

--- a/src/chsh.c
+++ b/src/chsh.c
@@ -23,6 +23,7 @@
 #include "exitcodes.h"
 #include "fields.h"
 #include "getdef.h"
+#include "io/fprintf.h"
 #include "nscd.h"
 #include "prototypes.h"
 #include "pwauth.h"
@@ -83,7 +84,7 @@ fail_exit (int code, bool process_selinux)
 {
 	if (pw_locked) {
 		if (pw_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, pw_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", pw_dbname());
 			/* continue */
 		}
@@ -169,16 +170,14 @@ static bool shell_is_listed (const char *sh, bool process_selinux)
 			       "", /* key only */
 			       "#" /* comment */);
 	if (error) {
-		fprintf (stderr,
-			 _("Cannot parse shell files: %s"),
+		eprintf(_("Cannot parse shell files: %s"),
 			 econf_errString(error));
 		fail_exit (1, process_selinux);
 	}
 
 	error = econf_getKeys(key_file, NULL, &size, &keys);
 	if (error) {
-		fprintf (stderr,
-			 _("Cannot evaluate entries in shell files: %s"),
+		eprintf(_("Cannot evaluate entries in shell files: %s"),
 			 econf_errString(error));
 		econf_free (key_file);
 		fail_exit (1, process_selinux);
@@ -285,9 +284,7 @@ static void check_perms(const struct passwd *pw, const struct option_flags *flag
 	 */
 	if (!amroot && pw->pw_uid != getuid ()) {
 		SYSLOG(LOG_WARN, "can't change shell for '%s'", pw->pw_name);
-		fprintf (stderr,
-		         _("You may not change the shell for '%s'.\n"),
-		         pw->pw_name);
+		eprintf(_("You may not change the shell for '%s'.\n"), pw->pw_name);
 		fail_exit (1, process_selinux);
 	}
 
@@ -297,9 +294,7 @@ static void check_perms(const struct passwd *pw, const struct option_flags *flag
 	 */
 	if (!amroot && is_restricted_shell (pw->pw_shell, process_selinux)) {
 		SYSLOG(LOG_WARN, "can't change shell for '%s'", pw->pw_name);
-		fprintf (stderr,
-		         _("You may not change the shell for '%s'.\n"),
-		         pw->pw_name);
+		eprintf(_("You may not change the shell for '%s'.\n"), pw->pw_name);
 		fail_exit (1, process_selinux);
 	}
 #ifdef WITH_SELINUX
@@ -310,9 +305,7 @@ static void check_perms(const struct passwd *pw, const struct option_flags *flag
 	if ((pw->pw_uid != getuid ())
 	    && (check_selinux_permit(Prog) != 0)) {
 		SYSLOG(LOG_WARN, "can't change shell for '%s'", pw->pw_name);
-		fprintf (stderr,
-		         _("You may not change the shell for '%s'.\n"),
-		         pw->pw_name);
+		eprintf(_("You may not change the shell for '%s'.\n"), pw->pw_name);
 		fail_exit (1, process_selinux);
 	}
 #endif
@@ -331,9 +324,7 @@ static void check_perms(const struct passwd *pw, const struct option_flags *flag
 #else				/* !USE_PAM */
 	pampw = getpwuid (getuid ()); /* local, no need for xgetpwuid */
 	if (NULL == pampw) {
-		fprintf (stderr,
-		         _("%s: Cannot determine your user name.\n"),
-		         Prog);
+		eprintf(_("%s: Cannot determine your user name.\n"), Prog);
 		exit (E_NOPERM);
 	}
 
@@ -348,8 +339,7 @@ static void check_perms(const struct passwd *pw, const struct option_flags *flag
 	}
 
 	if (PAM_SUCCESS != retval) {
-		fprintf (stderr, _("%s: PAM: %s\n"),
-		         Prog, pam_strerror (pamh, retval));
+		eprintf(_("%s: PAM: %s\n"), Prog, pam_strerror(pamh, retval));
 		SYSLOG(LOG_ERR, "%s", pam_strerror(pamh, retval));
 		if (NULL != pamh) {
 			(void) pam_end (pamh, retval);
@@ -393,13 +383,13 @@ static void update_shell (const char *user, char *newshell, const struct option_
 	 * the password file. Get a lock on the file and open it.
 	 */
 	if (pw_lock () == 0) {
-		fprintf (stderr, _("%s: cannot lock %s; try again later.\n"),
+		eprintf(_("%s: cannot lock %s; try again later.\n"),
 		         Prog, pw_dbname ());
 		fail_exit (1, process_selinux);
 	}
 	pw_locked = true;
 	if (pw_open (O_CREAT | O_RDWR) == 0) {
-		fprintf (stderr, _("%s: cannot open %s\n"), Prog, pw_dbname ());
+		eprintf(_("%s: cannot open %s\n"), Prog, pw_dbname());
 		SYSLOG(LOG_WARN, "cannot open %s", pw_dbname());
 		fail_exit (1, process_selinux);
 	}
@@ -412,8 +402,7 @@ static void update_shell (const char *user, char *newshell, const struct option_
 	 */
 	pw = pw_locate (user);
 	if (NULL == pw) {
-		fprintf (stderr,
-		         _("%s: user '%s' does not exist in %s\n"),
+		eprintf(_("%s: user '%s' does not exist in %s\n"),
 		         Prog, user, pw_dbname ());
 		fail_exit (1, process_selinux);
 	}
@@ -430,8 +419,7 @@ static void update_shell (const char *user, char *newshell, const struct option_
 	 * that entry as well.
 	 */
 	if (pw_update (&pwent) == 0) {
-		fprintf (stderr,
-		         _("%s: failed to prepare the new %s entry '%s'\n"),
+		eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
 		         Prog, pw_dbname (), pwent.pw_name);
 		fail_exit (1, process_selinux);
 	}
@@ -440,12 +428,12 @@ static void update_shell (const char *user, char *newshell, const struct option_
 	 * Changes have all been made, so commit them and unlock the file.
 	 */
 	if (pw_close (process_selinux) == 0) {
-		fprintf (stderr, _("%s: failure while writing changes to %s\n"), Prog, pw_dbname ());
+		eprintf(_("%s: failure while writing changes to %s\n"), Prog, pw_dbname());
 		SYSLOG(LOG_ERR, "failure while writing changes to %s", pw_dbname());
 		fail_exit (1, process_selinux);
 	}
 	if (pw_unlock (process_selinux) == 0) {
-		fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, pw_dbname ());
+		eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
 		SYSLOG(LOG_ERR, "failed to unlock %s", pw_dbname());
 		/* continue */
 	}
@@ -494,21 +482,19 @@ int main (int argc, char **argv)
 	 */
 	if (optind < argc) {
 		if (!is_valid_user_name(argv[optind], true)) {
-			fprintf (stderr, _("%s: Provided user name is not a valid name\n"), Prog);
+			eprintf(_("%s: Provided user name is not a valid name\n"), Prog);
 			fail_exit (1, process_selinux);
 		}
 		user = argv[optind];
 		pw = xgetpwnam (user);
 		if (NULL == pw) {
-			fprintf (stderr,
-			         _("%s: user '%s' does not exist\n"), Prog, user);
+			eprintf(_("%s: user '%s' does not exist\n"), Prog, user);
 			fail_exit (1, process_selinux);
 		}
 	} else {
 		pw = get_my_pwent ();
 		if (NULL == pw) {
-			fprintf (stderr,
-			         _("%s: Cannot determine your user name.\n"),
+			eprintf(_("%s: Cannot determine your user name.\n"),
 			         Prog);
 			SYSLOG(LOG_WARN, "Cannot determine the user name of the caller (UID %lu)",
 			       (unsigned long) getuid());
@@ -543,7 +529,7 @@ int main (int argc, char **argv)
 	 * The shell must be executable by the user.
 	 */
 	if (valid_field (loginsh, ":,=\n") != 0) {
-		fprintf (stderr, _("%s: Invalid entry: %s\n"), Prog, loginsh);
+		eprintf(_("%s: Invalid entry: %s\n"), Prog, loginsh);
 		fail_exit (1, process_selinux);
 	}
 	if (!streq(loginsh, "")
@@ -552,9 +538,9 @@ int main (int argc, char **argv)
 	        || (access (loginsh, X_OK) != 0)))
 	{
 		if (amroot) {
-			fprintf (stderr, _("%s: Warning: %s is an invalid shell\n"), Prog, loginsh);
+			eprintf(_("%s: Warning: %s is an invalid shell\n"), Prog, loginsh);
 		} else {
-			fprintf (stderr, _("%s: %s is an invalid shell\n"), Prog, loginsh);
+			eprintf(_("%s: %s is an invalid shell\n"), Prog, loginsh);
 			fail_exit (1, process_selinux);
 		}
 	}
@@ -563,9 +549,9 @@ int main (int argc, char **argv)
 	if (!streq(loginsh, "")) {
 		/* But not if an empty string is given, documented as meaning the default shell */
 		if (access (loginsh, F_OK) != 0) {
-			fprintf (stderr, _("%s: Warning: %s does not exist\n"), Prog, loginsh);
+			eprintf(_("%s: Warning: %s does not exist\n"), Prog, loginsh);
 		} else if (access (loginsh, X_OK) != 0) {
-			fprintf (stderr, _("%s: Warning: %s is not executable\n"), Prog, loginsh);
+			eprintf(_("%s: Warning: %s is not executable\n"), Prog, loginsh);
 		}
 	}
 

--- a/src/faillog.c
+++ b/src/faillog.c
@@ -628,13 +628,13 @@ int main (int argc, char **argv)
 		fail = fopen (FAILLOG_FILE, "r");
 	}
 	if (NULL == fail) {
-		fprinte(stderr, _("%s: Cannot open %s"), Prog, FAILLOG_FILE);
+		eprinte(_("%s: Cannot open %s"), Prog, FAILLOG_FILE);
 		exit (E_NOPERM);
 	}
 
 	/* Get the size of the faillog */
 	if (fstat (fileno (fail), &statbuf) != 0) {
-		fprinte(stderr, _("%s: Cannot get the size of %s"), Prog, FAILLOG_FILE);
+		eprinte(_("%s: Cannot get the size of %s"), Prog, FAILLOG_FILE);
 		exit (E_NOPERM);
 	}
 
@@ -659,7 +659,7 @@ int main (int argc, char **argv)
 		    || (fflush (fail) != 0)
 		    || (fsync  (fileno (fail)) != 0)
 		    || (fclose (fail) != 0)) {
-			fprinte(stderr, _("%s: Failed to write %s"), Prog, FAILLOG_FILE);
+			eprinte(_("%s: Failed to write %s"), Prog, FAILLOG_FILE);
 			(void) fclose (fail);
 			errors = true;
 		}

--- a/src/faillog.c
+++ b/src/faillog.c
@@ -101,8 +101,7 @@ static off_t lookup_faillog(struct faillog *fl, uid_t uid)
 
 	/* Ensure multiplication does not overflow and retrieving a wrong entry */
 	if (__builtin_mul_overflow(uid, sizeof(*fl), &offset)) {
-		fprintf(stderr,
-		        _("%s: Failed to get the entry for UID %lu\n"),
+		eprintf(_("%s: Failed to get the entry for UID %lu\n"),
 		        Prog, (unsigned long)uid);
 		return -1;
 	}
@@ -117,8 +116,7 @@ static off_t lookup_faillog(struct faillog *fl, uid_t uid)
 		 * empty entry in this case.
 		 */
 		if (fread(fl, sizeof(*fl), 1, fail) != 1) {
-			fprintf(stderr,
-			        _("%s: Failed to get the entry for UID %lu\n"),
+			eprintf(_("%s: Failed to get the entry for UID %lu\n"),
 			        Prog, (unsigned long)uid);
 			return -1;
 		}
@@ -171,7 +169,7 @@ static void print_one (/*@null@*/const struct passwd *pw, bool force)
 
 	tm = localtime (&fl.fail_time);
 	if (!tm) {
-		fprintf (stderr, "Cannot read time from faillog.\n");
+		eprintf("Cannot read time from faillog.\n");
 		return;
 	}
 	strftime_a(ptime, "%D %H:%M:%S %z", tm);
@@ -251,8 +249,7 @@ static bool reset_one (uid_t uid)
 		return false;
 	}
 
-	fprintf (stderr,
-	         _("%s: Failed to reset fail count for UID %lu\n"),
+	eprintf(_("%s: Failed to reset fail count for UID %lu\n"),
 	         Prog, (unsigned long)uid);
 	return true;
 }
@@ -347,8 +344,7 @@ static bool setmax_one (uid_t uid, short max)
 		return false;
 	}
 
-	fprintf (stderr,
-	         _("%s: Failed to set max for UID %lu\n"),
+	eprintf(_("%s: Failed to set max for UID %lu\n"),
 	         Prog, (unsigned long)uid);
 	return true;
 }
@@ -445,8 +441,7 @@ static bool set_locktime_one (uid_t uid, long locktime)
 		return false;
 	}
 
-	fprintf (stderr,
-	         _("%s: Failed to set locktime for UID %lu\n"),
+	eprintf(_("%s: Failed to set locktime for UID %lu\n"),
 	         Prog, (unsigned long)uid);
 	return true;
 }
@@ -550,8 +545,7 @@ int main (int argc, char **argv)
 				/*@notreached@*/break;
 			case 'l':
 				if (str2sl(&fail_locktime, optarg) == -1) {
-					fprintf (stderr,
-					         _("%s: invalid numeric argument '%s'\n"),
+					eprintf(_("%s: invalid numeric argument '%s'\n"),
 					         Prog, optarg);
 					exit (E_BAD_ARG);
 				}
@@ -560,8 +554,7 @@ int main (int argc, char **argv)
 			case 'm':
 			{
 				if (str2sh(&fail_max, optarg) == -1) {
-					fprintf (stderr,
-					         _("%s: invalid numeric argument '%s'\n"),
+					eprintf(_("%s: invalid numeric argument '%s'\n"),
 					         Prog, optarg);
 					exit (E_BAD_ARG);
 				}
@@ -575,8 +568,7 @@ int main (int argc, char **argv)
 				break;
 			case 't':
 				if (str2sl(&days, optarg) == -1) {
-					fprintf (stderr,
-					         _("%s: invalid numeric argument '%s'\n"),
+					eprintf(_("%s: invalid numeric argument '%s'\n"),
 					         Prog, optarg);
 					exit (E_BAD_ARG);
 				}
@@ -606,8 +598,7 @@ int main (int argc, char **argv)
 					if (getrange(optarg,
 					             &umin, &has_umin,
 					             &umax, &has_umax) == -1) {
-						fprintf (stderr,
-						         _("%s: Unknown user or range: %s\n"),
+						eprintf(_("%s: Unknown user or range: %s\n"),
 						         Prog, optarg);
 						exit (E_BAD_ARG);
 					}
@@ -620,8 +611,7 @@ int main (int argc, char **argv)
 			}
 		}
 		if (argc > optind) {
-			fprintf (stderr,
-			         _("%s: unexpected argument: %s\n"),
+			eprintf(_("%s: unexpected argument: %s\n"),
 			         Prog, argv[optind]);
 			usage (EXIT_FAILURE);
 		}

--- a/src/free_subid_range.c
+++ b/src/free_subid_range.c
@@ -29,7 +29,7 @@ int main(int argc, char *argv[])
 	bool group = false;   // get subuids by default
 
 	if (!subid_init(Prog, stderr))
-		fprinte(stderr, "subid_init");
+		eprinte("subid_init");
 	while ((c = getopt(argc, argv, "g")) != EOF) {
 		switch(c) {
 		case 'g': group = true; break;

--- a/src/free_subid_range.c
+++ b/src/free_subid_range.c
@@ -16,8 +16,8 @@ static const char Prog[] = "free_subid_range";
 
 static void usage(void)
 {
-	fprintf(stderr, "Usage: %s [-g] user start count\n", Prog);
-	fprintf(stderr, "    Release a user's subuid (or with -g, subgid) range\n");
+	eprintf("Usage: %s [-g] user start count\n", Prog);
+	eprintf("    Release a user's subuid (or with -g, subgid) range\n");
 	exit(EXIT_FAILURE);
 }
 
@@ -49,7 +49,7 @@ int main(int argc, char *argv[])
 		ok = subid_ungrant_uid_range(&range);
 
 	if (!ok) {
-		fprintf(stderr, "Failed freeing id range\n");
+		eprintf("Failed freeing id range\n");
 		exit(EXIT_FAILURE);
 	}
 

--- a/src/get_subid_owners.c
+++ b/src/get_subid_owners.c
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
 		n = subid_get_uid_owners(u, &uids);
 	}
 	if (n < 0) {
-		fprintf(stderr, "No owners found\n");
+		eprintf("No owners found\n");
 		exit(1);
 	}
 	for (i = 0; i < n; i++) {
@@ -53,8 +53,8 @@ int main(int argc, char *argv[])
 static void
 usage(void)
 {
-	fprintf(stderr, "Usage: [-g] %s subuid\n", Prog);
-	fprintf(stderr, "    list uids who own the given subuid\n");
-	fprintf(stderr, "    pass -g to query a subgid\n");
+	eprintf("Usage: [-g] %s subuid\n", Prog);
+	eprintf("    list uids who own the given subuid\n");
+	eprintf("    pass -g to query a subgid\n");
 	exit(EXIT_FAILURE);
 }

--- a/src/get_subid_owners.c
+++ b/src/get_subid_owners.c
@@ -25,7 +25,7 @@ int main(int argc, char *argv[])
 	uid_t  *uids;
 
 	if (!subid_init(Prog, stderr))
-		fprinte(stderr, "subid_init");
+		eprinte("subid_init");
 	if (argc < 2) {
 		usage();
 	}

--- a/src/getsubids.c
+++ b/src/getsubids.c
@@ -36,7 +36,7 @@ int main(int argc, char *argv[])
 		count = subid_get_uid_ranges(owner, &ranges);
 	}
 	if (!ranges) {
-		fprintf(stderr, "Error fetching ranges\n");
+		eprintf("Error fetching ranges\n");
 		exit(1);
 	}
 	for (i = 0; i < count; i++) {
@@ -51,8 +51,8 @@ int main(int argc, char *argv[])
 static void
 usage(void)
 {
-	fprintf(stderr, "Usage: %s [-g] user\n", Prog);
-	fprintf(stderr, "    list subuid ranges for user\n");
-	fprintf(stderr, "    pass -g to list subgid ranges\n");
+	eprintf("Usage: %s [-g] user\n", Prog);
+	eprintf("    list subuid ranges for user\n");
+	eprintf("    pass -g to list subgid ranges\n");
 	exit(EXIT_FAILURE);
 }

--- a/src/getsubids.c
+++ b/src/getsubids.c
@@ -23,7 +23,7 @@ int main(int argc, char *argv[])
 	const char *owner;
 
 	if (!subid_init(Prog, stderr))
-		fprinte(stderr, "subid_init");
+		eprinte("subid_init");
 	if (argc < 2)
 		usage();
 	owner = argv[1];

--- a/src/gpasswd.c
+++ b/src/gpasswd.c
@@ -828,7 +828,7 @@ static void change_passwd (struct group *gr)
 	cp = pw_encrypt (pass, salt);
 	memzero_a(pass);
 	if (NULL == cp) {
-		fprinte(stderr, _("%s: failed to crypt password with salt '%s'"), Prog, salt);
+		eprinte(_("%s: failed to crypt password with salt '%s'"), Prog, salt);
 		exit (1);
 	}
 #ifdef SHADOWGRP

--- a/src/gpasswd.c
+++ b/src/gpasswd.c
@@ -196,8 +196,7 @@ static bool is_valid_user_list (const char *users)
 
 		/* local, no need for xgetpwnam */
 		if (getpwnam(u) == NULL) {
-			fprintf (stderr, _("%s: user '%s' does not exist\n"),
-			         Prog, u);
+			eprintf(_("%s: user '%s' does not exist\n"), Prog, u);
 			is_valid = false;
 		}
 	}
@@ -209,7 +208,7 @@ static bool is_valid_user_list (const char *users)
 
 static void failure(void)
 {
-	fprintf(stderr, _("%s: Permission denied.\n"), Prog);
+	eprintf(_("%s: Permission denied.\n"), Prog);
 	log_gpasswd_failure(": Permission denied");
 	exit(E_NOPERM);
 }
@@ -240,8 +239,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 			user = optarg;
 			/* local, no need for xgetpwnam */
 			if (getpwnam (user) == NULL) {
-				fprintf (stderr,
-				         _("%s: user '%s' does not exist\n"),
+				eprintf(_("%s: user '%s' does not exist\n"),
 				         Prog, user);
 				exit (E_BAD_ARG);
 			}
@@ -249,8 +247,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 #ifdef SHADOWGRP
 		case 'A':	/* set the list of administrators */
 			if (!is_shadowgrp) {
-				fprintf (stderr,
-				         _("%s: shadow group passwords required for -A\n"),
+				eprintf(_("%s: shadow group passwords required for -A\n"),
 				         Prog);
 				exit (E_GSHADOW_NOTFOUND);
 			}
@@ -345,8 +342,7 @@ static void open_files(const struct option_flags *flags)
 	process_selinux = !flags->chroot;
 
 	if (gr_lock () == 0) {
-		fprintf (stderr,
-		         _("%s: cannot lock %s; try again later.\n"),
+		eprintf(_("%s: cannot lock %s; try again later.\n"),
 		         Prog, gr_dbname ());
 		exit (E_NOPERM);
 	}
@@ -355,8 +351,7 @@ static void open_files(const struct option_flags *flags)
 #ifdef SHADOWGRP
 	if (is_shadowgrp) {
 		if (sgr_lock () == 0) {
-			fprintf (stderr,
-			         _("%s: cannot lock %s; try again later.\n"),
+			eprintf(_("%s: cannot lock %s; try again later.\n"),
 			         Prog, sgr_dbname ());
 			exit (E_NOPERM);
 		}
@@ -367,9 +362,7 @@ static void open_files(const struct option_flags *flags)
 	add_cleanup (log_gpasswd_failure_system, NULL);
 
 	if (gr_open (O_CREAT | O_RDWR) == 0) {
-		fprintf (stderr,
-		         _("%s: cannot open %s\n"),
-		         Prog, gr_dbname ());
+		eprintf(_("%s: cannot open %s\n"), Prog, gr_dbname());
 		SYSLOG(LOG_WARN, "cannot open %s", gr_dbname());
 		exit (E_NOPERM);
 	}
@@ -377,9 +370,7 @@ static void open_files(const struct option_flags *flags)
 #ifdef SHADOWGRP
 	if (is_shadowgrp) {
 		if (sgr_open (O_CREAT | O_RDWR) == 0) {
-			fprintf (stderr,
-			         _("%s: cannot open %s\n"),
-			         Prog, sgr_dbname ());
+			eprintf(_("%s: cannot open %s\n"), Prog, sgr_dbname());
 			SYSLOG(LOG_WARN, "cannot open %s", sgr_dbname());
 			exit (E_NOPERM);
 		}
@@ -602,8 +593,7 @@ static void close_files(const struct option_flags *flags)
 	process_selinux = !flags->chroot;
 
 	if (gr_close (process_selinux) == 0) {
-		fprintf (stderr,
-		         _("%s: failure while writing changes to %s\n"),
+		eprintf(_("%s: failure while writing changes to %s\n"),
 		         Prog, gr_dbname ());
 		exit (E_NOPERM);
 	}
@@ -616,8 +606,7 @@ static void close_files(const struct option_flags *flags)
 #ifdef SHADOWGRP
 	if (is_shadowgrp) {
 		if (sgr_close (process_selinux) == 0) {
-			fprintf (stderr,
-			         _("%s: failure while writing changes to %s\n"),
+			eprintf(_("%s: failure while writing changes to %s\n"),
 			         Prog, sgr_dbname ());
 			exit (E_NOPERM);
 		}
@@ -679,15 +668,13 @@ static void update_group (struct group *gr)
 #endif
 {
 	if (gr_update (gr) == 0) {
-		fprintf (stderr,
-		         _("%s: failed to prepare the new %s entry '%s'\n"),
+		eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
 		         Prog, gr_dbname (), gr->gr_name);
 		exit (1);
 	}
 #ifdef SHADOWGRP
 	if (is_shadowgrp && (sgr_update (sg) == 0)) {
-		fprintf (stderr,
-		         _("%s: failed to prepare the new %s entry '%s'\n"),
+		eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
 		         Prog, sgr_dbname (), sg->sg_namp);
 		exit (1);
 	}
@@ -717,15 +704,14 @@ static void get_group(struct group *gr, const struct option_flags *flags)
 	process_selinux = !flags->chroot;
 
 	if (gr_open (O_RDONLY) == 0) {
-		fprintf (stderr, _("%s: cannot open %s\n"), Prog, gr_dbname ());
+		eprintf(_("%s: cannot open %s\n"), Prog, gr_dbname());
 		SYSLOG(LOG_WARN, "cannot open %s", gr_dbname());
 		exit (E_NOPERM);
 	}
 
 	tmpgr = gr_locate (group);
 	if (NULL == tmpgr) {
-		fprintf (stderr,
-		         _("%s: group '%s' does not exist in %s\n"),
+		eprintf(_("%s: group '%s' does not exist in %s\n"),
 		         Prog, group, gr_dbname ());
 		exit (E_BAD_ARG);
 	}
@@ -736,8 +722,7 @@ static void get_group(struct group *gr, const struct option_flags *flags)
 	gr->gr_mem = dup_list (tmpgr->gr_mem);
 
 	if (gr_close (process_selinux) == 0) {
-		fprintf (stderr,
-		         _("%s: failure while closing read-only %s\n"),
+		eprintf(_("%s: failure while closing read-only %s\n"),
 		         Prog, gr_dbname ());
 		SYSLOG(LOG_ERR, "failure while closing read-only %s", gr_dbname());
 		exit (E_NOPERM);
@@ -746,9 +731,7 @@ static void get_group(struct group *gr, const struct option_flags *flags)
 #ifdef SHADOWGRP
 	if (is_shadowgrp) {
 		if (sgr_open (O_RDONLY) == 0) {
-			fprintf (stderr,
-			         _("%s: cannot open %s\n"),
-			         Prog, sgr_dbname ());
+			eprintf(_("%s: cannot open %s\n"), Prog, sgr_dbname());
 			SYSLOG(LOG_WARN, "cannot open %s", sgr_dbname());
 			exit (E_NOPERM);
 		}
@@ -772,8 +755,7 @@ static void get_group(struct group *gr, const struct option_flags *flags)
 
 		}
 		if (sgr_close (process_selinux) == 0) {
-			fprintf (stderr,
-			         _("%s: failure while closing read-only %s\n"),
+			eprintf(_("%s: failure while closing read-only %s\n"),
 			         Prog, sgr_dbname ());
 			SYSLOG(LOG_ERR, "failure while closing read-only %s",
 			       sgr_dbname());
@@ -838,7 +820,7 @@ static void change_passwd (struct group *gr)
 	}
 
 	if (retries == RETRIES) {
-		fprintf (stderr, _("%s: Try again later\n"), Prog);
+		eprintf(_("%s: Try again later\n"), Prog);
 		exit (1);
 	}
 
@@ -912,8 +894,7 @@ int main (int argc, char **argv)
 	 */
 	pw = get_my_pwent ();
 	if (NULL == pw) {
-		fprintf (stderr, _("%s: Cannot determine your user name.\n"),
-		         Prog);
+		eprintf(_("%s: Cannot determine your user name.\n"), Prog);
 		SYSLOG(LOG_WARN,
 		       "Cannot determine the user name of the caller (UID %lu)",
 		       (unsigned long) getuid());
@@ -926,7 +907,7 @@ int main (int argc, char **argv)
 	 * could create.
 	 */
 	if (atexit (do_cleanups) != 0) {
-		fprintf(stderr, "%s: cannot set exit function\n", Prog);
+		eprintf("%s: cannot set exit function\n", Prog);
 		exit (1);
 	}
 
@@ -1020,8 +1001,7 @@ int main (int argc, char **argv)
 		}
 #endif
 		if (!removed) {
-			fprintf (stderr,
-			         _("%s: user '%s' is not a member of '%s'\n"),
+			eprintf(_("%s: user '%s' is not a member of '%s'\n"),
 			         Prog, user, group);
 			exit (E_BAD_ARG);
 		}
@@ -1060,7 +1040,7 @@ int main (int argc, char **argv)
 	 * modes can be restored.
 	 */
 	if ((isatty (0) == 0) || (isatty (1) == 0)) {
-		fprintf (stderr, _("%s: Not a tty\n"), Prog);
+		eprintf(_("%s: Not a tty\n"), Prog);
 		exit (E_NOPERM);
 	}
 

--- a/src/groupadd.c
+++ b/src/groupadd.c
@@ -365,7 +365,7 @@ static void open_files(const struct option_flags *flags)
 
 	/* And now open the databases */
 	if (gr_open (O_CREAT | O_RDWR) == 0) {
-		fprinte(stderr, _("%s: cannot open %s"), Prog, gr_dbname());
+		eprinte(_("%s: cannot open %s"), Prog, gr_dbname());
 		SYSLOGE(LOG_WARN, "cannot open %s", gr_dbname());
 		fail_exit (E_GRP_UPDATE);
 	}
@@ -373,7 +373,7 @@ static void open_files(const struct option_flags *flags)
 #ifdef	SHADOWGRP
 	if (is_shadow_grp) {
 		if (sgr_open (O_CREAT | O_RDWR) == 0) {
-			fprinte(stderr, _("%s: cannot open %s"), Prog, sgr_dbname());
+			eprinte(_("%s: cannot open %s"), Prog, sgr_dbname());
 			SYSLOGE(LOG_WARN, "cannot open %s", sgr_dbname());
 			fail_exit (E_GRP_UPDATE);
 		}

--- a/src/groupadd.c
+++ b/src/groupadd.c
@@ -218,7 +218,7 @@ grp_update(void)
 		ul = user_list;
 		while (NULL != (u = strsep(&ul, ","))) {
 			if (prefix_getpwnam(u) == NULL) {
-				fprintf(stderr, _("Invalid member username %s\n"), u);
+				eprintf(_("Invalid member username %s\n"), u);
 				exit (E_GRP_UPDATE);
 			}
 
@@ -234,8 +234,7 @@ grp_update(void)
 	 * Write out the new group file entry.
 	 */
 	if (gr_update (&grp) == 0) {
-		fprintf (stderr,
-		         _("%s: failed to prepare the new %s entry '%s'\n"),
+		eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
 		         Prog, gr_dbname (), grp.gr_name);
 		fail_exit (E_GRP_UPDATE);
 	}
@@ -244,8 +243,7 @@ grp_update(void)
 	 * Write out the new shadow group entries as well.
 	 */
 	if (is_shadow_grp && (sgr_update (&sgrp) == 0)) {
-		fprintf (stderr,
-		         _("%s: failed to prepare the new %s entry '%s'\n"),
+		eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
 		         Prog, sgr_dbname (), sgrp.sg_namp);
 		fail_exit (E_GRP_UPDATE);
 	}
@@ -262,7 +260,7 @@ static void
 check_new_name(void)
 {
 	if (!is_valid_group_name(group_name)) {
-		fprintf(stderr, _("%s: '%s' is not a valid group name\n"),
+		eprintf(_("%s: '%s' is not a valid group name\n"),
 			Prog, group_name);
 
 		fail_exit (E_BAD_ARG);
@@ -285,8 +283,7 @@ static void close_files(const struct option_flags *flags)
 
 	/* First, write the changes in the regular group database */
 	if (gr_close (process_selinux) == 0) {
-		fprintf (stderr,
-		         _("%s: failure while writing changes to %s\n"),
+		eprintf(_("%s: failure while writing changes to %s\n"),
 		         Prog, gr_dbname ());
 		fail_exit (E_GRP_UPDATE);
 	}
@@ -306,8 +303,7 @@ static void close_files(const struct option_flags *flags)
 #ifdef	SHADOWGRP
 	if (is_shadow_grp) {
 		if (sgr_close (process_selinux) == 0) {
-			fprintf (stderr,
-			         _("%s: failure while writing changes to %s\n"),
+			eprintf(_("%s: failure while writing changes to %s\n"),
 			         Prog, sgr_dbname ());
 			fail_exit (E_GRP_UPDATE);
 		}
@@ -344,8 +340,7 @@ static void open_files(const struct option_flags *flags)
 
 	/* First, lock the databases */
 	if (gr_lock () == 0) {
-		fprintf (stderr,
-		         _("%s: cannot lock %s; try again later.\n"),
+		eprintf(_("%s: cannot lock %s; try again later.\n"),
 		         Prog, gr_dbname ());
 		fail_exit (E_GRP_UPDATE);
 	}
@@ -354,8 +349,7 @@ static void open_files(const struct option_flags *flags)
 #ifdef	SHADOWGRP
 	if (is_shadow_grp) {
 		if (sgr_lock () == 0) {
-			fprintf (stderr,
-			         _("%s: cannot lock %s; try again later.\n"),
+			eprintf(_("%s: cannot lock %s; try again later.\n"),
 			         Prog, sgr_dbname ());
 			fail_exit (E_GRP_UPDATE);
 		}
@@ -430,8 +424,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 			gflg = true;
 			if (   (get_gid(optarg, &group_id) == -1)
 			    || (group_id == (gid_t)-1)) {
-				fprintf (stderr,
-				         _("%s: invalid group ID '%s'\n"),
+				eprintf(_("%s: invalid group ID '%s'\n"),
 				         Prog, optarg);
 				exit (E_BAD_ARG);
 			}
@@ -447,8 +440,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 			 */
 			cp = stpsep(optarg, "=");
 			if (NULL == cp) {
-				fprintf (stderr,
-				         _("%s: -K requires KEY=VALUE\n"),
+				eprintf(_("%s: -K requires KEY=VALUE\n"),
 				         Prog);
 				exit (E_BAD_ARG);
 			}
@@ -515,8 +507,7 @@ static void check_flags (void)
 			/* OK, no need to do anything */
 			exit (E_SUCCESS);
 		}
-		fprintf (stderr,
-		         _("%s: group '%s' already exists\n"),
+		eprintf(_("%s: group '%s' already exists\n"),
 		         Prog, group_name);
 		fail_exit (E_NAME_IN_USE);
 	}
@@ -534,8 +525,7 @@ static void check_flags (void)
 			/* Turn off -g, we can use any GID */
 			gflg = false;
 		} else {
-			fprintf (stderr,
-			         _("%s: GID '%lu' already exists\n"),
+			eprintf(_("%s: GID '%lu' already exists\n"),
 			         Prog, (unsigned long) group_id);
 			fail_exit (E_GID_IN_USE);
 		}
@@ -565,9 +555,7 @@ int main (int argc, char **argv)
 #endif
 
 	if (atexit (do_cleanups) != 0) {
-		fprintf (stderr,
-		         _("%s: Cannot setup cleanup service.\n"),
-		         Prog);
+		eprintf(_("%s: Cannot setup cleanup service.\n"), Prog);
 		fail_exit (1);
 	}
 

--- a/src/groupdel.c
+++ b/src/groupdel.c
@@ -18,8 +18,10 @@
 #include <stdio.h>
 #include <sys/types.h>
 #include <getopt.h>
+
 #include "defines.h"
 #include "groupio.h"
+#include "io/fprintf.h"
 #include "nscd.h"
 #include "sssd.h"
 #include "prototypes.h"
@@ -120,8 +122,7 @@ static void grp_update (void)
 	 * Delete the group entry.
 	 */
 	if (gr_remove (group_name) == 0) {
-		fprintf (stderr,
-		         _("%s: cannot remove entry '%s' from %s\n"),
+		eprintf(_("%s: cannot remove entry '%s' from %s\n"),
 		         Prog, group_name, gr_dbname ());
 		fail_exit (E_GRP_UPDATE);
 	}
@@ -132,8 +133,7 @@ static void grp_update (void)
 	 */
 	if (is_shadow_grp && (sgr_locate (group_name) != NULL)) {
 		if (sgr_remove (group_name) == 0) {
-			fprintf (stderr,
-			         _("%s: cannot remove entry '%s' from %s\n"),
+			eprintf(_("%s: cannot remove entry '%s' from %s\n"),
 			         Prog, group_name, sgr_dbname ());
 			fail_exit (E_GRP_UPDATE);
 		}
@@ -155,8 +155,7 @@ static void close_files(const struct option_flags *flags)
 
 	/* First, write the changes in the regular group database */
 	if (gr_close (process_selinux) == 0) {
-		fprintf (stderr,
-		         _("%s: failure while writing changes to %s\n"),
+		eprintf(_("%s: failure while writing changes to %s\n"),
 		         Prog, gr_dbname ());
 		fail_exit (E_GRP_UPDATE);
 	}
@@ -177,8 +176,7 @@ static void close_files(const struct option_flags *flags)
 #ifdef	SHADOWGRP
 	if (is_shadow_grp) {
 		if (sgr_close (process_selinux) == 0) {
-			fprintf (stderr,
-			         _("%s: failure while writing changes to %s\n"),
+			eprintf(_("%s: failure while writing changes to %s\n"),
 			         Prog, sgr_dbname ());
 			fail_exit (E_GRP_UPDATE);
 		}
@@ -213,8 +211,7 @@ static void open_files(const struct option_flags *flags)
 
 	/* First, lock the databases */
 	if (gr_lock () == 0) {
-		fprintf (stderr,
-		         _("%s: cannot lock %s; try again later.\n"),
+		eprintf(_("%s: cannot lock %s; try again later.\n"),
 		         Prog, gr_dbname ());
 		fail_exit (E_GRP_UPDATE);
 	}
@@ -222,8 +219,7 @@ static void open_files(const struct option_flags *flags)
 #ifdef	SHADOWGRP
 	if (is_shadow_grp) {
 		if (sgr_lock () == 0) {
-			fprintf (stderr,
-			         _("%s: cannot lock %s; try again later.\n"),
+			eprintf(_("%s: cannot lock %s; try again later.\n"),
 			         Prog, sgr_dbname ());
 			fail_exit (E_GRP_UPDATE);
 		}
@@ -239,18 +235,14 @@ static void open_files(const struct option_flags *flags)
 
 	/* An now open the databases */
 	if (gr_open (O_CREAT | O_RDWR) == 0) {
-		fprintf (stderr,
-		         _("%s: cannot open %s\n"),
-		         Prog, gr_dbname ());
+		eprintf(_("%s: cannot open %s\n"), Prog, gr_dbname());
 		SYSLOG(LOG_WARN, "cannot open %s", gr_dbname());
 		fail_exit (E_GRP_UPDATE);
 	}
 #ifdef	SHADOWGRP
 	if (is_shadow_grp) {
 		if (sgr_open (O_CREAT | O_RDWR) == 0) {
-			fprintf (stderr,
-			         _("%s: cannot open %s\n"),
-			         Prog, sgr_dbname ());
+			eprintf(_("%s: cannot open %s\n"), Prog, sgr_dbname());
 			SYSLOG(LOG_WARN, "cannot open %s", sgr_dbname());
 			fail_exit (E_GRP_UPDATE);
 		}
@@ -290,8 +282,7 @@ static void group_busy (gid_t gid)
 	/*
 	 * Can't remove the group.
 	 */
-	fprintf (stderr,
-	         _("%s: cannot remove the primary group of user '%s'\n"),
+	eprintf(_("%s: cannot remove the primary group of user '%s'\n"),
 	         Prog, pwd->pw_name);
 	fail_exit (E_GROUP_BUSY);
 }
@@ -371,9 +362,7 @@ int main (int argc, char **argv)
 #endif
 
 	if (atexit (do_cleanups) != 0) {
-		fprintf (stderr,
-		         _("%s: Cannot setup cleanup service.\n"),
-		         Prog);
+		eprintf(_("%s: Cannot setup cleanup service.\n"), Prog);
 		fail_exit (1);
 	}
 
@@ -391,8 +380,7 @@ int main (int argc, char **argv)
 		 */
 		grp = prefix_getgrnam (group_name); /* local, no need for xgetgrnam */
 		if (NULL == grp) {
-			fprintf (stderr,
-			         _("%s: group '%s' does not exist\n"),
+			eprintf(_("%s: group '%s' does not exist\n"),
 			         Prog, group_name);
 			fail_exit (E_NOTFOUND);
 		}

--- a/src/groupmod.c
+++ b/src/groupmod.c
@@ -26,6 +26,7 @@
 #include "chkname.h"
 #include "defines.h"
 #include "groupio.h"
+#include "io/fprintf.h"
 #include "nscd.h"
 #include "prototypes.h"
 #include "pwio.h"
@@ -215,8 +216,7 @@ grp_update(void)
 	 */
 	ogrp = gr_locate (group_name);
 	if (NULL == ogrp) {
-		fprintf (stderr,
-		         _("%s: group '%s' does not exist in %s\n"),
+		eprintf(_("%s: group '%s' does not exist in %s\n"),
 		         Prog, group_name, gr_dbname ());
 		exit (E_GRP_UPDATE);
 	}
@@ -280,7 +280,7 @@ grp_update(void)
 			ul = user_list;
 			while (NULL != (u = strsep(&ul, ","))) {
 				if (prefix_getpwnam(u) == NULL) {
-					fprintf(stderr, _("Invalid member username %s\n"), u);
+					eprintf(_("Invalid member username %s\n"), u);
 					exit(E_GRP_UPDATE);
 				}
 
@@ -297,14 +297,12 @@ grp_update(void)
 	 * Write out the new group file entry.
 	 */
 	if (gr_update (&grp) == 0) {
-		fprintf (stderr,
-		         _("%s: failed to prepare the new %s entry '%s'\n"),
+		eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
 		         Prog, gr_dbname (), grp.gr_name);
 		exit (E_GRP_UPDATE);
 	}
 	if (nflg && (gr_remove (group_name) == 0)) {
-		fprintf (stderr,
-		         _("%s: cannot remove entry '%s' from %s\n"),
+		eprintf(_("%s: cannot remove entry '%s' from %s\n"),
 		         Prog, grp.gr_name, gr_dbname ());
 		exit (E_GRP_UPDATE);
 	}
@@ -318,14 +316,12 @@ grp_update(void)
 		 * Write out the new shadow group entries as well.
 		 */
 		if (sgr_update (&sgrp) == 0) {
-			fprintf (stderr,
-			         _("%s: failed to prepare the new %s entry '%s'\n"),
+			eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
 			         Prog, sgr_dbname (), sgrp.sg_namp);
 			exit (E_GRP_UPDATE);
 		}
 		if (nflg && (sgr_remove (group_name) == 0)) {
-			fprintf (stderr,
-			         _("%s: cannot remove entry '%s' from %s\n"),
+			eprintf(_("%s: cannot remove entry '%s' from %s\n"),
 			         Prog, group_name, sgr_dbname ());
 			exit (E_GRP_UPDATE);
 		}
@@ -359,8 +355,7 @@ static void check_new_gid (void)
 	/*
 	 * Tell the user what they did wrong.
 	 */
-	fprintf (stderr,
-	         _("%s: GID '%lu' already exists\n"),
+	eprintf(_("%s: GID '%lu' already exists\n"),
 	         Prog, (unsigned long) group_newid);
 	exit (E_GID_IN_USE);
 }
@@ -383,17 +378,13 @@ check_new_name(void)
 	}
 
 	if (!is_valid_group_name(group_newname)) {
-		fprintf(stderr,
-			_("%s: invalid group name '%s'\n"),
-			Prog, group_newname);
+		eprintf(_("%s: invalid group name '%s'\n"), Prog, group_newname);
 		exit(E_BAD_ARG);
 	}
 
 	/* local, no need for xgetgrnam */
 	if (prefix_getgrnam(group_newname) != NULL) {
-		fprintf(stderr,
-			_("%s: group '%s' already exists\n"),
-			Prog, group_newname);
+		eprintf(_("%s: group '%s' already exists\n"), Prog, group_newname);
 		exit(E_NAME_IN_USE);
 	}
 
@@ -432,8 +423,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 			gflg = true;
 			if (   (get_gid(optarg, &group_newid) == -1)
 			    || (group_newid == (gid_t)-1)) {
-				fprintf (stderr,
-				         _("%s: invalid group ID '%s'\n"),
+				eprintf(_("%s: invalid group ID '%s'\n"),
 				         Prog, optarg);
 				exit (E_BAD_ARG);
 			}
@@ -490,8 +480,7 @@ static void close_files(const struct option_flags *flags)
 	process_selinux = !flags->chroot && !flags->prefix;
 
 	if (gr_close (process_selinux) == 0) {
-		fprintf (stderr,
-		         _("%s: failure while writing changes to %s\n"),
+		eprintf(_("%s: failure while writing changes to %s\n"),
 		         Prog, gr_dbname ());
 		exit (E_GRP_UPDATE);
 	}
@@ -511,8 +500,7 @@ static void close_files(const struct option_flags *flags)
 	if (   is_shadow_grp
 	    && (pflg || nflg || user_list)) {
 		if (sgr_close (process_selinux) == 0) {
-			fprintf (stderr,
-			         _("%s: failure while writing changes to %s\n"),
+			eprintf(_("%s: failure while writing changes to %s\n"),
 			         Prog, sgr_dbname ());
 			exit (E_GRP_UPDATE);
 		}
@@ -540,8 +528,7 @@ static void close_files(const struct option_flags *flags)
 
 	if (gflg) {
 		if (pw_close (process_selinux) == 0) {
-			fprintf (stderr,
-			         _("%s: failure while writing changes to %s\n"),
+			eprintf(_("%s: failure while writing changes to %s\n"),
 			         Prog, pw_dbname ());
 			exit (E_GRP_UPDATE);
 		}
@@ -665,8 +652,7 @@ static void lock_files(const struct option_flags *flags)
 	process_selinux = !flags->chroot && !flags->prefix;
 
 	if (gr_lock () == 0) {
-		fprintf (stderr,
-		         _("%s: cannot lock %s; try again later.\n"),
+		eprintf(_("%s: cannot lock %s; try again later.\n"),
 		         Prog, gr_dbname ());
 		exit (E_GRP_UPDATE);
 	}
@@ -676,8 +662,7 @@ static void lock_files(const struct option_flags *flags)
 	if (   is_shadow_grp
 	    && (pflg || nflg || user_list)) {
 		if (sgr_lock () == 0) {
-			fprintf (stderr,
-			         _("%s: cannot lock %s; try again later.\n"),
+			eprintf(_("%s: cannot lock %s; try again later.\n"),
 			         Prog, sgr_dbname ());
 			exit (E_GRP_UPDATE);
 		}
@@ -687,8 +672,7 @@ static void lock_files(const struct option_flags *flags)
 
 	if (gflg) {
 		if (pw_lock () == 0) {
-			fprintf (stderr,
-			         _("%s: cannot lock %s; try again later.\n"),
+			eprintf(_("%s: cannot lock %s; try again later.\n"),
 			         Prog, pw_dbname ());
 			exit (E_GRP_UPDATE);
 		}
@@ -705,7 +689,7 @@ static void lock_files(const struct option_flags *flags)
 static void open_files (void)
 {
 	if (gr_open (O_CREAT | O_RDWR) == 0) {
-		fprintf (stderr, _("%s: cannot open %s\n"), Prog, gr_dbname ());
+		eprintf(_("%s: cannot open %s\n"), Prog, gr_dbname());
 		SYSLOG(LOG_WARN, "cannot open %s", gr_dbname());
 		exit (E_GRP_UPDATE);
 	}
@@ -714,9 +698,7 @@ static void open_files (void)
 	if (   is_shadow_grp
 	    && (pflg || nflg || user_list)) {
 		if (sgr_open (O_CREAT | O_RDWR) == 0) {
-			fprintf (stderr,
-			         _("%s: cannot open %s\n"),
-			         Prog, sgr_dbname ());
+			eprintf(_("%s: cannot open %s\n"), Prog, sgr_dbname());
 			SYSLOG(LOG_WARN, "cannot open %s", sgr_dbname());
 			exit (E_GRP_UPDATE);
 		}
@@ -725,9 +707,7 @@ static void open_files (void)
 
 	if (gflg) {
 		if (pw_open (O_CREAT | O_RDWR) == 0) {
-			fprintf (stderr,
-			         _("%s: cannot open %s\n"),
-			         Prog, pw_dbname ());
+			eprintf(_("%s: cannot open %s\n"), Prog, pw_dbname());
 			SYSLOG(LOG_WARN, "cannot open %s", gr_dbname());
 			exit (E_GRP_UPDATE);
 		}
@@ -745,16 +725,14 @@ void update_primary_groups (gid_t ogid, gid_t ngid)
 			struct passwd npwd;
 			lpwd = pw_locate (pwd->pw_name);
 			if (NULL == lpwd) {
-				fprintf (stderr,
-				         _("%s: user '%s' does not exist in %s\n"),
+				eprintf(_("%s: user '%s' does not exist in %s\n"),
 				         Prog, pwd->pw_name, pw_dbname ());
 				exit (E_GRP_UPDATE);
 			} else {
 				npwd = *lpwd;
 				npwd.pw_gid = ngid;
 				if (pw_update (&npwd) == 0) {
-					fprintf (stderr,
-					         _("%s: failed to prepare the new %s entry '%s'\n"),
+					eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
 					         Prog, pw_dbname (), npwd.pw_name);
 					exit (E_GRP_UPDATE);
 				}
@@ -788,9 +766,7 @@ int main (int argc, char **argv)
 #endif
 
 	if (atexit (do_cleanups) != 0) {
-		fprintf (stderr,
-		         _("%s: Cannot setup cleanup service.\n"),
-		         Prog);
+		eprintf(_("%s: Cannot setup cleanup service.\n"), Prog);
 		exit (E_CLEANUP_SERVICE);
 	}
 
@@ -806,8 +782,7 @@ int main (int argc, char **argv)
 		 */
 		grp = prefix_getgrnam (group_name); /* local, no need for xgetgrnam */
 		if (NULL == grp) {
-			fprintf (stderr,
-			         _("%s: group '%s' does not exist\n"),
+			eprintf(_("%s: group '%s' does not exist\n"),
 			         Prog, group_name);
 			exit (E_NOTFOUND);
 		} else {

--- a/src/grpck.c
+++ b/src/grpck.c
@@ -21,6 +21,7 @@
 #include "commonio.h"
 #include "defines.h"
 #include "groupio.h"
+#include "io/fprintf.h"
 #include "nscd.h"
 #include "prototypes.h"
 #include "shadow/gshadow/gshadow.h"
@@ -105,7 +106,7 @@ static void fail_exit (int status, bool process_selinux)
 {
 	if (gr_locked) {
 		if (gr_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, gr_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, gr_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", gr_dbname());
 			/* continue */
 		}
@@ -114,7 +115,7 @@ static void fail_exit (int status, bool process_selinux)
 #ifdef	SHADOWGRP
 	if (sgr_locked) {
 		if (sgr_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, sgr_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, sgr_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sgr_dbname());
 			/* continue */
 		}
@@ -227,7 +228,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 	}
 
 	if (sort_mode && read_only) {
-		fprintf (stderr, _("%s: -s and -r are incompatible\n"), Prog);
+		eprintf(_("%s: -s and -r are incompatible\n"), Prog);
 		exit (E_USAGE);
 	}
 
@@ -277,8 +278,7 @@ static void open_files (bool process_selinux)
 	 */
 	if (!read_only) {
 		if (gr_lock () == 0) {
-			fprintf (stderr,
-			         _("%s: cannot lock %s; try again later.\n"),
+			eprintf(_("%s: cannot lock %s; try again later.\n"),
 			         Prog, grp_file);
 			fail_exit (E_CANT_LOCK, process_selinux);
 		}
@@ -286,8 +286,7 @@ static void open_files (bool process_selinux)
 #ifdef	SHADOWGRP
 		if (is_shadow) {
 			if (sgr_lock () == 0) {
-				fprintf (stderr,
-				         _("%s: cannot lock %s; try again later.\n"),
+				eprintf(_("%s: cannot lock %s; try again later.\n"),
 				         Prog, sgr_file);
 				fail_exit (E_CANT_LOCK, process_selinux);
 			}
@@ -301,8 +300,7 @@ static void open_files (bool process_selinux)
 	 * O_RDWR otherwise.
 	 */
 	if (gr_open (read_only ? O_RDONLY : O_CREAT | O_RDWR) == 0) {
-		fprintf (stderr, _("%s: cannot open %s\n"), Prog,
-		         grp_file);
+		eprintf(_("%s: cannot open %s\n"), Prog, grp_file);
 		if (use_system_grp_file) {
 			SYSLOG(LOG_WARN, "cannot open %s", grp_file);
 		}
@@ -310,8 +308,7 @@ static void open_files (bool process_selinux)
 	}
 #ifdef	SHADOWGRP
 	if (is_shadow && (sgr_open (read_only ? O_RDONLY : O_CREAT | O_RDWR) == 0)) {
-		fprintf (stderr, _("%s: cannot open %s\n"), Prog,
-		         sgr_file);
+		eprintf(_("%s: cannot open %s\n"), Prog, sgr_file);
 		if (use_system_sgr_file) {
 			SYSLOG(LOG_WARN, "cannot open %s", sgr_file);
 		}
@@ -339,13 +336,13 @@ static void close_files(bool changed, const struct option_flags *flags)
 	 */
 	if (changed) {
 		if (gr_close (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failure while writing changes to %s\n"),
+			eprintf(_("%s: failure while writing changes to %s\n"),
 			         Prog, grp_file);
 			fail_exit (E_CANT_UPDATE, process_selinux);
 		}
 #ifdef	SHADOWGRP
 		if (is_shadow && (sgr_close (process_selinux) == 0)) {
-			fprintf (stderr, _("%s: failure while writing changes to %s\n"),
+			eprintf(_("%s: failure while writing changes to %s\n"),
 			         Prog, sgr_file);
 			fail_exit (E_CANT_UPDATE, process_selinux);
 		}
@@ -358,7 +355,7 @@ static void close_files(bool changed, const struct option_flags *flags)
 #ifdef	SHADOWGRP
 	if (sgr_locked) {
 		if (sgr_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, sgr_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, sgr_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sgr_dbname());
 			/* continue */
 		}
@@ -367,7 +364,7 @@ static void close_files(bool changed, const struct option_flags *flags)
 #endif
 	if (gr_locked) {
 		if (gr_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, gr_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, gr_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", gr_dbname());
 			/* continue */
 		}
@@ -642,8 +639,7 @@ static void check_grp_file(bool *errors, bool *changed, const struct option_flag
 					*changed = true;
 
 					if (sgr_update (&sg) == 0) {
-						fprintf (stderr,
-						         _("%s: failed to prepare the new %s entry '%s'\n"),
+						eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
 						         Prog, sgr_dbname (), sg.sg_namp);
 						fail_exit (E_CANT_UPDATE, process_selinux);
 					}
@@ -651,8 +647,7 @@ static void check_grp_file(bool *errors, bool *changed, const struct option_flag
 					gr = *grp;
 					gr.gr_passwd = SHADOW_PASSWD_STRING;	/* XXX warning: const */
 					if (gr_update (&gr) == 0) {
-						fprintf (stderr,
-						         _("%s: failed to prepare the new %s entry '%s'\n"),
+						eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
 						         Prog, gr_dbname (), gr.gr_name);
 						fail_exit (E_CANT_UPDATE, process_selinux);
 					}

--- a/src/grpconv.c
+++ b/src/grpconv.c
@@ -29,6 +29,7 @@
 #include "attr.h"
 /*@-exitarg@*/
 #include "exitcodes.h"
+#include "io/fprintf.h"
 #include "nscd.h"
 #include "prototypes.h"
 #include "string/strcmp/streq.h"
@@ -64,7 +65,7 @@ static void fail_exit (int status, bool process_selinux)
 {
 	if (gr_locked) {
 		if (gr_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, gr_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, gr_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", gr_dbname());
 			/* continue */
 		}
@@ -72,7 +73,7 @@ static void fail_exit (int status, bool process_selinux)
 
 	if (sgr_locked) {
 		if (sgr_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, sgr_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, sgr_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sgr_dbname());
 			/* continue */
 		}
@@ -155,26 +156,24 @@ int main (int argc, char **argv)
 	process_selinux = !flags.chroot;
 
 	if (gr_lock () == 0) {
-		fprintf (stderr,
-		         _("%s: cannot lock %s; try again later.\n"),
+		eprintf(_("%s: cannot lock %s; try again later.\n"),
 		         Prog, gr_dbname ());
 		fail_exit (5, process_selinux);
 	}
 	gr_locked = true;
 	if (gr_open (O_CREAT | O_RDWR) == 0) {
-		fprintf (stderr, _("%s: cannot open %s\n"), Prog, gr_dbname ());
+		eprintf(_("%s: cannot open %s\n"), Prog, gr_dbname());
 		fail_exit (1, process_selinux);
 	}
 
 	if (sgr_lock () == 0) {
-		fprintf (stderr,
-		         _("%s: cannot lock %s; try again later.\n"),
+		eprintf(_("%s: cannot lock %s; try again later.\n"),
 		         Prog, sgr_dbname ());
 		fail_exit (5, process_selinux);
 	}
 	sgr_locked = true;
 	if (sgr_open (O_CREAT | O_RDWR) == 0) {
-		fprintf (stderr, _("%s: cannot open %s\n"), Prog, sgr_dbname ());
+		eprintf(_("%s: cannot open %s\n"), Prog, sgr_dbname());
 		fail_exit (1, process_selinux);
 	}
 
@@ -191,8 +190,7 @@ int main (int argc, char **argv)
 			/*
 			 * This shouldn't happen (the entry exists) but...
 			 */
-			fprintf (stderr,
-			         _("%s: cannot remove entry '%s' from %s\n"),
+			eprintf(_("%s: cannot remove entry '%s' from %s\n"),
 			         Prog, sg->sg_namp, sgr_dbname ());
 			fail_exit (3, process_selinux);
 		}
@@ -229,8 +227,7 @@ int main (int argc, char **argv)
 		sgent.sg_mem = gr->gr_mem;
 
 		if (sgr_update (&sgent) == 0) {
-			fprintf (stderr,
-			         _("%s: failed to prepare the new %s entry '%s'\n"),
+			eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
 			         Prog, sgr_dbname (), sgent.sg_namp);
 			fail_exit (3, process_selinux);
 		}
@@ -238,34 +235,31 @@ int main (int argc, char **argv)
 		grent = *gr;
 		grent.gr_passwd = SHADOW_PASSWD_STRING;	/* XXX warning: const */
 		if (gr_update (&grent) == 0) {
-			fprintf (stderr,
-			         _("%s: failed to prepare the new %s entry '%s'\n"),
+			eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
 			         Prog, gr_dbname (), grent.gr_name);
 			fail_exit (3, process_selinux);
 		}
 	}
 
 	if (sgr_close (process_selinux) == 0) {
-		fprintf (stderr,
-		         _("%s: failure while writing changes to %s\n"),
+		eprintf(_("%s: failure while writing changes to %s\n"),
 		         Prog, sgr_dbname ());
 		SYSLOG(LOG_ERR, "failure while writing changes to %s", sgr_dbname());
 		fail_exit (3, process_selinux);
 	}
 	if (gr_close (process_selinux) == 0) {
-		fprintf (stderr,
-		         _("%s: failure while writing changes to %s\n"),
+		eprintf(_("%s: failure while writing changes to %s\n"),
 		         Prog, gr_dbname ());
 		SYSLOG(LOG_ERR, "failure while writing changes to %s", gr_dbname());
 		fail_exit (3, process_selinux);
 	}
 	if (sgr_unlock (process_selinux) == 0) {
-		fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, sgr_dbname ());
+		eprintf(_("%s: failed to unlock %s\n"), Prog, sgr_dbname());
 		SYSLOG(LOG_ERR, "failed to unlock %s", sgr_dbname());
 		/* continue */
 	}
 	if (gr_unlock (process_selinux) == 0) {
-		fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, gr_dbname ());
+		eprintf(_("%s: failed to unlock %s\n"), Prog, gr_dbname());
 		SYSLOG(LOG_ERR, "failed to unlock %s", gr_dbname());
 		/* continue */
 	}
@@ -279,8 +273,7 @@ int main (int argc, char **argv)
 int
 main(MAYBE_UNUSED int _1, char **argv)
 {
-	fprintf (stderr,
-		 "%s: not configured for shadow group support.\n", argv[0]);
+	eprintf("%s: not configured for shadow group support.\n", argv[0]);
 	exit (1);
 }
 #endif				/* !SHADOWGRP */

--- a/src/grpunconv.c
+++ b/src/grpunconv.c
@@ -27,6 +27,7 @@
 #include "attr.h"
 /*@-exitarg@*/
 #include "exitcodes.h"
+#include "io/fprintf.h"
 #include "nscd.h"
 #include "prototypes.h"
 #include "sssd.h"
@@ -63,7 +64,7 @@ static void fail_exit (int status, bool process_selinux)
 {
 	if (gr_locked) {
 		if (gr_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, gr_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, gr_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", gr_dbname());
 			/* continue */
 		}
@@ -71,7 +72,7 @@ static void fail_exit (int status, bool process_selinux)
 
 	if (sgr_locked) {
 		if (sgr_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, sgr_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, sgr_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sgr_dbname());
 			/* continue */
 		}
@@ -157,28 +158,24 @@ int main (int argc, char **argv)
 	}
 
 	if (gr_lock () == 0) {
-		fprintf (stderr,
-		         _("%s: cannot lock %s; try again later.\n"),
+		eprintf(_("%s: cannot lock %s; try again later.\n"),
 		         Prog, gr_dbname ());
 		fail_exit (5, process_selinux);
 	}
 	gr_locked = true;
 	if (gr_open (O_CREAT | O_RDWR) == 0) {
-		fprintf (stderr,
-		         _("%s: cannot open %s\n"), Prog, gr_dbname ());
+		eprintf(_("%s: cannot open %s\n"), Prog, gr_dbname());
 		fail_exit (1, process_selinux);
 	}
 
 	if (sgr_lock () == 0) {
-		fprintf (stderr,
-		         _("%s: cannot lock %s; try again later.\n"),
+		eprintf(_("%s: cannot lock %s; try again later.\n"),
 		         Prog, sgr_dbname ());
 		fail_exit (5, process_selinux);
 	}
 	sgr_locked = true;
 	if (sgr_open (O_RDONLY) == 0) {
-		fprintf (stderr,
-		         _("%s: cannot open %s\n"), Prog, sgr_dbname ());
+		eprintf(_("%s: cannot open %s\n"), Prog, sgr_dbname());
 		fail_exit (1, process_selinux);
 	}
 
@@ -194,8 +191,7 @@ int main (int argc, char **argv)
 			grent = *gr;
 			grent.gr_passwd = sg->sg_passwd;
 			if (gr_update (&grent) == 0) {
-				fprintf (stderr,
-				         _("%s: failed to prepare the new %s entry '%s'\n"),
+				eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
 				         Prog, gr_dbname (), grent.gr_name);
 				fail_exit (3, process_selinux);
 			}
@@ -205,29 +201,26 @@ int main (int argc, char **argv)
 	(void) sgr_close (process_selinux); /* was only open O_RDONLY */
 
 	if (gr_close (process_selinux) == 0) {
-		fprintf (stderr,
-		         _("%s: failure while writing changes to %s\n"),
+		eprintf(_("%s: failure while writing changes to %s\n"),
 		         Prog, gr_dbname ());
 		SYSLOG(LOG_ERR, "failure while writing changes to %s", gr_dbname());
 		fail_exit (3, process_selinux);
 	}
 
 	if (unlink(_PATH_GSHADOW) != 0) {
-		fprintf (stderr,
-		         _("%s: cannot delete %s\n"),
-		         Prog, _PATH_GSHADOW);
+		eprintf(_("%s: cannot delete %s\n"), Prog, _PATH_GSHADOW);
 		SYSLOG(LOG_ERR, "cannot delete %s", _PATH_GSHADOW);
 		fail_exit (3, process_selinux);
 	}
 
 	if (gr_unlock (process_selinux) == 0) {
-		fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, gr_dbname ());
+		eprintf(_("%s: failed to unlock %s\n"), Prog, gr_dbname());
 		SYSLOG(LOG_ERR, "failed to unlock %s", gr_dbname());
 		/* continue */
 	}
 
 	if (sgr_unlock (process_selinux) == 0) {
-		fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, sgr_dbname ());
+		eprintf(_("%s: failed to unlock %s\n"), Prog, sgr_dbname());
 		SYSLOG(LOG_ERR, "failed to unlock %s", sgr_dbname());
 		/* continue */
 	}
@@ -241,8 +234,7 @@ int main (int argc, char **argv)
 int
 main(MAYBE_UNUSED int _1, char **argv)
 {
-	fprintf (stderr,
-		 "%s: not configured for shadow group support.\n", argv[0]);
+	eprintf("%s: not configured for shadow group support.\n", argv[0]);
 	exit (1);
 }
 #endif				/* !SHADOWGRP */

--- a/src/lastlog.c
+++ b/src/lastlog.c
@@ -122,8 +122,7 @@ static void print_one (/*@null@*/const struct passwd *pw)
 		 * empty entry in this case.
 		 */
 		if (fread(&ll, sizeof(ll), 1, lastlogfile) != 1) {
-			fprintf (stderr,
-			         _("%s: Failed to get the entry for UID %lu\n"),
+			eprintf(_("%s: Failed to get the entry for UID %lu\n"),
 			         Prog, (unsigned long)pw->pw_uid);
 			exit (EXIT_FAILURE);
 		}
@@ -187,8 +186,8 @@ static void print (void)
 	lastlog_uid_max = getdef_ulong ("LASTLOG_UID_MAX", 0xFFFFFFFFUL);
 	if (   (has_umin && umin > lastlog_uid_max)
 	    || (has_umax && umax > lastlog_uid_max)) {
-		fprintf (stderr, _("%s: Selected uid(s) are higher than LASTLOG_UID_MAX (%lu),\n"
-				   "\tthe output might be incorrect.\n"), Prog, lastlog_uid_max);
+		eprintf(_("%s: Selected uid(s) are higher than LASTLOG_UID_MAX (%lu),\n"
+			  "\tthe output might be incorrect.\n"), Prog, lastlog_uid_max);
 	}
 
 	if (uflg && has_umin && has_umax && (umin == umax)) {
@@ -247,8 +246,7 @@ static void update_one (/*@null@*/const struct passwd *pw)
 #endif
 
 	if (fwrite(&ll, sizeof(ll), 1, lastlogfile) != 1) {
-			fprintf (stderr,
-			         _("%s: Failed to update the entry for UID %lu\n"),
+			eprintf(_("%s: Failed to update the entry for UID %lu\n"),
 			         Prog, (unsigned long)pw->pw_uid);
 			exit (EXIT_FAILURE);
 	}
@@ -265,8 +263,8 @@ static void update (void)
 	lastlog_uid_max = getdef_ulong ("LASTLOG_UID_MAX", 0xFFFFFFFFUL);
 	if (   (has_umin && umin > lastlog_uid_max)
 	    || (has_umax && umax > lastlog_uid_max)) {
-		fprintf (stderr, _("%s: Selected uid(s) are higher than LASTLOG_UID_MAX (%lu),\n"
-				   "\tthey will not be updated.\n"), Prog, lastlog_uid_max);
+		eprintf(_("%s: Selected uid(s) are higher than LASTLOG_UID_MAX (%lu),\n"
+			  "\tthey will not be updated.\n"), Prog, lastlog_uid_max);
 		return;
 	}
 
@@ -285,8 +283,7 @@ static void update (void)
 	}
 
 	if (fflush (lastlogfile) != 0 || fsync (fileno (lastlogfile)) != 0) {
-			fprintf (stderr,
-			         _("%s: Failed to update the lastlog file\n"),
+			eprintf(_("%s: Failed to update the lastlog file\n"),
 			         Prog);
 			exit (EXIT_FAILURE);
 	}
@@ -332,8 +329,7 @@ int main (int argc, char **argv)
 			{
 				unsigned long inverse_days;
 				if (str2ul(&inverse_days, optarg) == -1) {
-					fprintf (stderr,
-					         _("%s: invalid numeric argument '%s'\n"),
+					eprintf(_("%s: invalid numeric argument '%s'\n"),
 					         Prog, optarg);
 					exit (EXIT_FAILURE);
 				}
@@ -360,8 +356,7 @@ int main (int argc, char **argv)
 			{
 				unsigned long days;
 				if (str2ul(&days, optarg) == -1) {
-					fprintf (stderr,
-					         _("%s: invalid numeric argument '%s'\n"),
+					eprintf(_("%s: invalid numeric argument '%s'\n"),
 					         Prog, optarg);
 					exit (EXIT_FAILURE);
 				}
@@ -391,8 +386,7 @@ int main (int argc, char **argv)
 					if (getrange(optarg,
 					             &umin, &has_umin,
 					             &umax, &has_umax) == -1) {
-						fprintf (stderr,
-						         _("%s: Unknown user or range: %s\n"),
+						eprintf(_("%s: Unknown user or range: %s\n"),
 						         Prog, optarg);
 						exit (EXIT_FAILURE);
 					}
@@ -410,20 +404,17 @@ int main (int argc, char **argv)
 			}
 		}
 		if (argc > optind) {
-			fprintf (stderr,
-			         _("%s: unexpected argument: %s\n"),
+			eprintf(_("%s: unexpected argument: %s\n"),
 			         Prog, argv[optind]);
 			usage (EXIT_FAILURE);
 		}
 		if (Cflg && Sflg) {
-			fprintf (stderr,
-			         _("%s: Option -C cannot be used together with option -S\n"),
+			eprintf(_("%s: Option -C cannot be used together with option -S\n"),
 			         Prog);
 			usage (EXIT_FAILURE);
 		}
 		if ((Cflg || Sflg) && !uflg) {
-			fprintf (stderr,
-			         _("%s: Options -C and -S require option -u to specify the user\n"),
+			eprintf(_("%s: Options -C and -S require option -u to specify the user\n"),
 			         Prog);
 			usage (EXIT_FAILURE);
 		}

--- a/src/lastlog.c
+++ b/src/lastlog.c
@@ -428,7 +428,7 @@ int main (int argc, char **argv)
 
 	/* Get the lastlog size */
 	if (fstat (fileno (lastlogfile), &statbuf) != 0) {
-		fprinte(stderr, _("%s: Cannot get the size of %s"), Prog, _PATH_LASTLOG);
+		eprinte(_("%s: Cannot get the size of %s"), Prog, _PATH_LASTLOG);
 		exit (EXIT_FAILURE);
 	}
 

--- a/src/login.c
+++ b/src/login.c
@@ -1087,7 +1087,7 @@ int main (int argc, char **argv)
 	child = fork ();
 	if (child < 0) {
 		/* error in fork() */
-		fprinte(stderr, _("%s: failure forking"), Prog);
+		eprinte(_("%s: failure forking"), Prog);
 		retcode = pam_close_session(pamh, 0);
 		pam_end(pamh, retcode);
 		exit (0);

--- a/src/login.c
+++ b/src/login.c
@@ -62,7 +62,7 @@
 static pam_handle_t *pamh = NULL;
 
 #define PAM_FAIL_CHECK if (retcode != PAM_SUCCESS) { \
-	fprintf(stderr,"\n%s\n",pam_strerror(pamh, retcode)); \
+	eprintf("\n%s\n",pam_strerror(pamh, retcode)); \
 	SYSLOG(LOG_ERR,"%s",pam_strerror(pamh, retcode)); \
 	(void) pam_end(pamh, retcode); \
 	exit(1); \
@@ -136,11 +136,11 @@ static void exit_handler (int);
  */
 static void usage (void)
 {
-	fprintf (stderr, _("Usage: %s [-p] [name]\n"), Prog);
+	eprintf(_("Usage: %s [-p] [name]\n"), Prog);
 	if (!amroot) {
 		exit (1);
 	}
-	fprintf (stderr, _("       %s [-p] [-h host] [-f name]\n"), Prog);
+	eprintf(_("       %s [-p] [-h host] [-f name]\n"), Prog);
 	exit (1);
 }
 
@@ -177,14 +177,12 @@ static void setup_tty (void)
 		 * getdef_num cannot validate this.
 		 */
 		if (erasechar != (int) termio.c_cc[VERASE]) {
-			fprintf (stderr,
-			         _("configuration error - cannot parse %s value: '%d'"),
+			eprintf(_("configuration error - cannot parse %s value: '%d'"),
 			         "ERASECHAR", erasechar);
 			exit (1);
 		}
 		if (killchar != (int) termio.c_cc[VKILL]) {
-			fprintf (stderr,
-			         _("configuration error - cannot parse %s value: '%d'"),
+			eprintf(_("configuration error - cannot parse %s value: '%d'"),
 			         "KILLCHAR", killchar);
 			exit (1);
 		}
@@ -303,7 +301,7 @@ static void process_flags (int argc, char *const *argv)
 	 */
 
 	if ((fflg || hflg) && !amroot) {
-		fprintf (stderr, _("%s: Permission denied.\n"), Prog);
+		eprintf(_("%s: Permission denied.\n"), Prog);
 		exit (1);
 	}
 
@@ -496,7 +494,7 @@ int main (int argc, char **argv)
 	log_set_logfd(stderr);
 
 	if (geteuid() != 0) {
-		fprintf (stderr, _("%s: Cannot possibly work without effective root\n"), Prog);
+		eprintf(_("%s: Cannot possibly work without effective root\n"), Prog);
 		exit (1);
 	}
 
@@ -618,8 +616,7 @@ int main (int argc, char **argv)
 #ifdef USE_PAM
 	retcode = pam_start (Prog, username, &conv, &pamh);
 	if (retcode != PAM_SUCCESS) {
-		fprintf (stderr,
-		         _("login: PAM Failure, aborting: %s\n"),
+		eprintf(_("login: PAM Failure, aborting: %s\n"),
 		         pam_strerror (pamh, retcode));
 		SYSLOG(LOG_ERR, "Couldn't initialize PAM: %s", pam_strerror(pamh, retcode));
 		exit (99);
@@ -694,8 +691,7 @@ int main (int argc, char **argv)
 				SYSLOG(LOG_NOTICE,
 				       "TOO MANY LOGIN TRIES (%u)%s FOR '%s'",
 				       failcount, fromhost, failent_user);
-				fprintf (stderr,
-				         _("Maximum number of tries exceeded (%u)\n"),
+				eprintf(_("Maximum number of tries exceeded (%u)\n"),
 				         failcount);
 				pam_end(pamh, retcode);
 				exit(0);
@@ -738,8 +734,7 @@ int main (int argc, char **argv)
 				SYSLOG(LOG_NOTICE,
 				       "TOO MANY LOGIN TRIES (%u)%s FOR '%s'",
 				       failcount, fromhost, failent_user);
-				fprintf (stderr,
-				         _("Maximum number of tries exceeded (%u)\n"),
+				eprintf(_("Maximum number of tries exceeded (%u)\n"),
 				         failcount);
 				pam_end(pamh, retcode);
 				exit(0);
@@ -779,9 +774,7 @@ int main (int argc, char **argv)
 	pwd = xgetpwnam (username);
 	if (NULL == pwd) {
 		SYSLOG(LOG_ERR, "cannot find user %s", failent_user);
-		fprintf (stderr,
-		         _("Cannot find user (%s)\n"),
-		         username);
+		eprintf(_("Cannot find user (%s)\n"), username);
 		exit (1);
 	}
 
@@ -1115,7 +1108,7 @@ int main (int argc, char **argv)
 	if (1 == initial_pid) {
 		setsid();
 		if (ioctl(0, TIOCSCTTY, 1) != 0) {
-			fprintf (stderr, _("TIOCSCTTY failed on %s"), tty);
+			eprintf(_("TIOCSCTTY failed on %s"), tty);
 		}
 	}
 

--- a/src/new_subid_range.c
+++ b/src/new_subid_range.c
@@ -16,10 +16,10 @@ static const char Prog[] = "new_subid_range";
 
 static void usage(void)
 {
-	fprintf(stderr, "Usage: %s [-g] [-n] user count\n", Prog);
-	fprintf(stderr, "    Find a subuid (or with -g, subgid) range for user\n");
-	fprintf(stderr, "    If -n is given, a new range will be created even if one exists\n");
-	fprintf(stderr, "    count defaults to 65536\n");
+	eprintf("Usage: %s [-g] [-n] user count\n", Prog);
+	eprintf("    Find a subuid (or with -g, subgid) range for user\n");
+	eprintf("    If -n is given, a new range will be created even if one exists\n");
+	eprintf("    count defaults to 65536\n");
 	exit(EXIT_FAILURE);
 }
 
@@ -55,7 +55,7 @@ int main(int argc, char *argv[])
 		ok = subid_grant_uid_range(&range, !makenew);
 
 	if (!ok) {
-		fprintf(stderr, "Failed creating new id range\n");
+		eprintf("Failed creating new id range\n");
 		exit(EXIT_FAILURE);
 	}
 	printf("Subuid range %lu:%lu\n", range.start, range.count);

--- a/src/new_subid_range.c
+++ b/src/new_subid_range.c
@@ -32,7 +32,7 @@ int main(int argc, char *argv[])
 	bool ok;
 
 	if (!subid_init(Prog, stderr))
-		fprinte(stderr, "subid_init");
+		eprinte("subid_init");
 	while ((c = getopt(argc, argv, "gn")) != EOF) {
 		switch(c) {
 		case 'n': makenew = true; break;

--- a/src/newgidmap.c
+++ b/src/newgidmap.c
@@ -60,7 +60,7 @@ static void verify_ranges(struct passwd *pw, int ranges,
 	mapping = mappings;
 	for (idx = 0; idx < ranges; idx++, mapping++) {
 		if (!verify_range(pw, mapping, allow_setgroups)) {
-			fprintf(stderr, _( "%s: gid range [%lu-%lu) -> [%lu-%lu) not allowed\n"),
+			eprintf(_( "%s: gid range [%lu-%lu) -> [%lu-%lu) not allowed\n"),
 				Prog,
 				mapping->upper,
 				mapping->upper + mapping->count,
@@ -73,7 +73,7 @@ static void verify_ranges(struct passwd *pw, int ranges,
 
 static void usage(void)
 {
-	fprintf(stderr, _("usage: %s [<pid|fd:<pidfd>] <gid> <lowergid> <count> [ <gid> <lowergid> <count> ] ... \n"), Prog);
+	eprintf(_("usage: %s [<pid|fd:<pidfd>] <gid> <lowergid> <count> [ <gid> <lowergid> <count> ] ... \n"), Prog);
 	exit(EXIT_FAILURE);
 }
 
@@ -100,7 +100,7 @@ static void write_setgroups(int proc_dir_fd, bool allow_setgroups)
 		 * code to exist. Emit a warning and bail on this.
 		 */
 		if (ENOENT == errno) {
-			fprintf(stderr, _("%s: kernel doesn't support setgroups restrictions\n"), Prog);
+			eprintf(_("%s: kernel doesn't support setgroups restrictions\n"), Prog);
 			goto out;
 		}
 		fprinte(stderr, _("%s: couldn't open process setgroups"), Prog);
@@ -175,9 +175,7 @@ int main(int argc, char **argv)
 	/* Who am I? */
 	pw = get_my_pwent ();
 	if (NULL == pw) {
-		fprintf (stderr,
-			_("%s: Cannot determine your user name.\n"),
-			Prog);
+		eprintf(_("%s: Cannot determine your user name.\n"), Prog);
 		SYSLOG(LOG_WARN, "Cannot determine the user name of the caller (UID %lu)",
 		       (unsigned long) getuid());
 		return EXIT_FAILURE;
@@ -197,7 +195,7 @@ int main(int argc, char **argv)
 	    (!getdef_bool("GRANT_AUX_GROUP_SUBIDS") && (getgid() != pw->pw_gid)) ||
 	    (pw->pw_uid != st.st_uid) ||
 	    (getgid() != st.st_gid)) {
-		fprintf(stderr, _( "%s: Target process is owned by a different user: uid:%lu pw_uid:%lu st_uid:%lu, gid:%lu pw_gid:%lu st_gid:%lu\n" ),
+		eprintf(_( "%s: Target process is owned by a different user: uid:%lu pw_uid:%lu st_uid:%lu, gid:%lu pw_gid:%lu st_gid:%lu\n" ),
 			Prog,
 			(unsigned long)getuid(), (unsigned long)pw->pw_uid, (unsigned long)st.st_uid,
 			(unsigned long)getgid(), (unsigned long)pw->pw_gid, (unsigned long)st.st_gid);

--- a/src/newgidmap.c
+++ b/src/newgidmap.c
@@ -103,7 +103,7 @@ static void write_setgroups(int proc_dir_fd, bool allow_setgroups)
 			eprintf(_("%s: kernel doesn't support setgroups restrictions\n"), Prog);
 			goto out;
 		}
-		fprinte(stderr, _("%s: couldn't open process setgroups"), Prog);
+		eprinte(_("%s: couldn't open process setgroups"), Prog);
 		exit(EXIT_FAILURE);
 	}
 
@@ -113,7 +113,7 @@ static void write_setgroups(int proc_dir_fd, bool allow_setgroups)
 	 * fail.
 	 */
 	if (read(setgroups_fd, policy_buffer, sizeof(policy_buffer)) < 0) {
-		fprinte(stderr, _("%s: failed to read setgroups"), Prog);
+		eprinte(_("%s: failed to read setgroups"), Prog);
 		exit(EXIT_FAILURE);
 	}
 	if (strprefix(policy_buffer, policy))
@@ -121,11 +121,11 @@ static void write_setgroups(int proc_dir_fd, bool allow_setgroups)
 
 	/* Write the policy. */
 	if (lseek(setgroups_fd, 0, SEEK_SET) < 0) {
-		fprinte(stderr, _("%s: failed to seek setgroups"), Prog);
+		eprinte(_("%s: failed to seek setgroups"), Prog);
 		exit(EXIT_FAILURE);
 	}
 	if (dprintf(setgroups_fd, "%s", policy) < 0) {
-		fprinte(stderr, _("%s: failed to setgroups %s policy"), Prog, policy);
+		eprinte(_("%s: failed to setgroups %s policy"), Prog, policy);
 		exit(EXIT_FAILURE);
 	}
 
@@ -183,7 +183,7 @@ int main(int argc, char **argv)
 
 	/* Get the effective uid and effective gid of the target process */
 	if (fstat(proc_dir_fd, &st) < 0) {
-		fprinte(stderr, _("%s: Could not stat directory for target process"), Prog);
+		eprinte(_("%s: Could not stat directory for target process"), Prog);
 		return EXIT_FAILURE;
 	}
 
@@ -203,7 +203,7 @@ int main(int argc, char **argv)
 	}
 
 	if (want_subgid_file() && !sub_gid_open(O_RDONLY)) {
-		fprinte(stderr, _("%s: cannot open %s"), Prog, sub_gid_dbname());
+		eprinte(_("%s: cannot open %s"), Prog, sub_gid_dbname());
 		return EXIT_FAILURE;
 	}
 

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -188,7 +188,7 @@ static void check_perms (const struct group *grp,
 		erase_pass (cp);
 
 		if (NULL == cpasswd) {
-			fprinte(stderr, _("%s: failed to crypt password with previous salt"),
+			eprinte(_("%s: failed to crypt password with previous salt"),
 			        Prog);
 			SYSLOG(LOG_INFO,
 			       "Failed to crypt password with previous salt of group '%s'",
@@ -294,8 +294,7 @@ static void syslog_sg (const char *name, const char *group)
 		child = fork ();
 		if ((pid_t)-1 == child) {
 			/* error in fork() */
-			fprinte(stderr, _("%s: failure forking"),
-				is_newgrp ? "newgrp" : "sg");
+			eprinte(_("%s: failure forking"), is_newgrp ? "newgrp" : "sg");
 #ifdef WITH_AUDIT
 			if (group) {
 				audit_logger_with_group(AUDIT_CHGRP_ID, "changing", NULL,

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -436,8 +436,7 @@ int main (int argc, char **argv)
 
 	pwd = get_my_pwent ();
 	if (NULL == pwd) {
-		fprintf (stderr, _("%s: Cannot determine your user name.\n"),
-		         Prog);
+		eprintf(_("%s: Cannot determine your user name.\n"), Prog);
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_CHGRP_ID,
 		              "changing", NULL, getuid (), SHADOW_AUDIT_FAILURE);
@@ -480,8 +479,7 @@ int main (int argc, char **argv)
 		 */
 		if ((argc > 0) && (argv[0][0] != '-')) {
 			if (!is_valid_group_name(argv[0])) {
-				fprintf (
-					stderr, _("%s: provided group is not a valid group name\n"),
+				eprintf(_("%s: provided group is not a valid group name\n"),
 					Prog);
 				goto failure;
 			}
@@ -516,8 +514,7 @@ int main (int argc, char **argv)
 			goto failure;
 		} else if (argv[0] != NULL) {
 			if (!is_valid_group_name(argv[0])) {
-				fprintf (
-					stderr, _("%s: provided group is not a valid group name\n"),
+				eprintf(_("%s: provided group is not a valid group name\n"),
 					Prog);
 				goto failure;
 			}
@@ -532,8 +529,7 @@ int main (int argc, char **argv)
 			 */
 			grp = xgetgrgid (pwd->pw_gid);
 			if (NULL == grp) {
-				fprintf (stderr,
-				         _("%s: GID '%lu' does not exist\n"),
+				eprintf(_("%s: GID '%lu' does not exist\n"),
 				         Prog, (unsigned long) pwd->pw_gid);
 				SYSLOG(LOG_CRIT, "GID '%lu' does not exist",
 				       (unsigned long) pwd->pw_gid);
@@ -607,7 +603,7 @@ int main (int argc, char **argv)
 	 */
 	grp = getgrnam (group); /* local, no need for xgetgrnam */
 	if (NULL == grp) {
-		fprintf (stderr, _("%s: group '%s' does not exist\n"), Prog, group);
+		eprintf(_("%s: group '%s' does not exist\n"), Prog, group);
 		goto failure;
 	}
 

--- a/src/newuidmap.c
+++ b/src/newuidmap.c
@@ -121,7 +121,7 @@ int main(int argc, char **argv)
 
 	/* Get the effective uid and effective gid of the target process */
 	if (fstat(proc_dir_fd, &st) < 0) {
-		fprinte(stderr, _("%s: Could not stat directory for target process"), Prog);
+		eprinte(_("%s: Could not stat directory for target process"), Prog);
 		return EXIT_FAILURE;
 	}
 
@@ -141,7 +141,7 @@ int main(int argc, char **argv)
 	}
 
 	if (want_subuid_file() && !sub_uid_open(O_RDONLY)) {
-		fprinte(stderr, _("%s: cannot open %s"), Prog, sub_uid_dbname());
+		eprinte(_("%s: cannot open %s"), Prog, sub_uid_dbname());
 		return EXIT_FAILURE;
 	}
 

--- a/src/newuidmap.c
+++ b/src/newuidmap.c
@@ -55,7 +55,7 @@ static void verify_ranges(struct passwd *pw, int ranges,
 	mapping = mappings;
 	for (idx = 0; idx < ranges; idx++, mapping++) {
 		if (!verify_range(pw, mapping)) {
-			fprintf(stderr, _( "%s: uid range [%lu-%lu) -> [%lu-%lu) not allowed\n"),
+			eprintf(_( "%s: uid range [%lu-%lu) -> [%lu-%lu) not allowed\n"),
 				Prog,
 				mapping->upper,
 				mapping->upper + mapping->count,
@@ -68,7 +68,7 @@ static void verify_ranges(struct passwd *pw, int ranges,
 
 static void usage(void)
 {
-	fprintf(stderr, _("usage: %s [<pid>|fd:<pidfd>] <uid> <loweruid> <count> [ <uid> <loweruid> <count> ] ... \n"), Prog);
+	eprintf(_("usage: %s [<pid>|fd:<pidfd>] <uid> <loweruid> <count> [ <uid> <loweruid> <count> ] ... \n"), Prog);
 	exit(EXIT_FAILURE);
 }
 
@@ -113,9 +113,7 @@ int main(int argc, char **argv)
 	/* Who am I? */
 	pw = get_my_pwent ();
 	if (NULL == pw) {
-		fprintf (stderr,
-			_("%s: Cannot determine your user name.\n"),
-			Prog);
+		eprintf(_("%s: Cannot determine your user name.\n"), Prog);
 		SYSLOG(LOG_WARN, "Cannot determine the user name of the caller (UID %lu)",
 			(unsigned long) getuid());
 		return EXIT_FAILURE;
@@ -135,7 +133,7 @@ int main(int argc, char **argv)
 	    (!getdef_bool("GRANT_AUX_GROUP_SUBIDS") && (getgid() != pw->pw_gid)) ||
 	    (pw->pw_uid != st.st_uid) ||
 	    (getgid() != st.st_gid)) {
-		fprintf(stderr, _( "%s: Target process is owned by a different user: uid:%lu pw_uid:%lu st_uid:%lu, gid:%lu pw_gid:%lu st_gid:%lu\n" ),
+		eprintf(_( "%s: Target process is owned by a different user: uid:%lu pw_uid:%lu st_uid:%lu, gid:%lu pw_gid:%lu st_gid:%lu\n" ),
 			Prog,
 			(unsigned long)getuid(), (unsigned long)pw->pw_uid, (unsigned long)st.st_uid,
 			(unsigned long)getgid(), (unsigned long)pw->pw_gid, (unsigned long)st.st_gid);

--- a/src/newusers.c
+++ b/src/newusers.c
@@ -161,21 +161,21 @@ static void fail_exit (int code, bool process_selinux)
 {
 	if (spw_locked) {
 		if (spw_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, spw_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, spw_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", spw_dbname());
 			/* continue */
 		}
 	}
 	if (pw_locked) {
 		if (pw_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, pw_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", pw_dbname());
 			/* continue */
 		}
 	}
 	if (gr_locked) {
 		if (gr_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, gr_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, gr_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", gr_dbname());
 			/* continue */
 		}
@@ -183,7 +183,7 @@ static void fail_exit (int code, bool process_selinux)
 #ifdef	SHADOWGRP
 	if (sgr_locked) {
 		if (sgr_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, sgr_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, sgr_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sgr_dbname());
 			/* continue */
 		}
@@ -192,14 +192,14 @@ static void fail_exit (int code, bool process_selinux)
 #ifdef ENABLE_SUBIDS
 	if (sub_uid_locked) {
 		if (sub_uid_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, sub_uid_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, sub_uid_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sub_uid_dbname());
 			/* continue */
 		}
 	}
 	if (sub_gid_locked) {
 		if (sub_gid_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, sub_gid_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, sub_gid_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sub_gid_dbname());
 			/* continue */
 		}
@@ -243,9 +243,7 @@ static int add_group (const char *name, const char *gid, gid_t *ngid, uid_t uid)
 		 */
 
 		if (get_gid(gid, &grent.gr_gid) == -1) {
-			fprintf (stderr,
-			         _("%s: invalid group ID '%s'\n"),
-			         Prog, gid);
+			eprintf(_("%s: invalid group ID '%s'\n"), Prog, gid);
 			return -1;
 		}
 
@@ -262,9 +260,7 @@ static int add_group (const char *name, const char *gid, gid_t *ngid, uid_t uid)
 
 		/* Do not create groups with GID == (gid_t)-1 */
 		if (grent.gr_gid == (gid_t)-1) {
-			fprintf (stderr,
-			         _("%s: invalid group ID '%s'\n"),
-			         Prog, gid);
+			eprintf(_("%s: invalid group ID '%s'\n"), Prog, gid);
 			return -1;
 		}
 	} else {
@@ -289,9 +285,7 @@ static int add_group (const char *name, const char *gid, gid_t *ngid, uid_t uid)
 
 	/* Check if this is a valid group name */
 	if (!is_valid_group_name(grent.gr_name)) {
-		fprintf (stderr,
-		         _("%s: invalid group name '%s'\n"),
-		         Prog, grent.gr_name);
+		eprintf(_("%s: invalid group name '%s'\n"), Prog, grent.gr_name);
 		free (grent.gr_name);
 		return -1;
 	}
@@ -307,8 +301,7 @@ static int add_group (const char *name, const char *gid, gid_t *ngid, uid_t uid)
 		sg = sgr_locate (grent.gr_name);
 
 		if (NULL != sg) {
-			fprintf (stderr,
-			         _("%s: group '%s' is a shadow group, but does not exist in /etc/group\n"),
+			eprintf(_("%s: group '%s' is a shadow group, but does not exist in /etc/group\n"),
 			         Prog, grent.gr_name);
 			return -1;
 		}
@@ -347,9 +340,7 @@ static int get_user_id (const char *uid, uid_t *nuid) {
 	 */
 	if (!streq(uid, "") && strisdigit_c(uid)) {
 		if ((get_uid(uid, nuid) == -1) || (*nuid == (uid_t)-1)) {
-			fprintf (stderr,
-			         _("%s: invalid user ID '%s'\n"),
-			         Prog, uid);
+			eprintf(_("%s: invalid user ID '%s'\n"), Prog, uid);
 			return -1;
 		}
 	} else {
@@ -361,8 +352,7 @@ static int get_user_id (const char *uid, uid_t *nuid) {
 				pwd = pw_locate (uid);
 
 			if (pwd == NULL) {
-				fprintf (stderr,
-				         _("%s: user '%s' does not exist\n"),
+				eprintf(_("%s: user '%s' does not exist\n"),
 				         Prog, uid);
 				return -1;
 			}
@@ -387,13 +377,10 @@ static int add_user (const char *name, uid_t uid, gid_t gid)
 	/* Check if this is a valid user name */
 	if (!is_valid_user_name(name, bflg)) {
 		if (errno == EILSEQ) {
-			fprintf(stderr,
-			        _("%s: invalid user name '%s': use --badname to ignore\n"),
+			eprintf(_("%s: invalid user name '%s': use --badname to ignore\n"),
 			        Prog, name);
 		} else {
-			fprintf(stderr,
-			        _("%s: invalid user name '%s'\n"),
-			        Prog, name);
+			eprintf(_("%s: invalid user name '%s'\n"), Prog, name);
 		}
 		return -1;
 	}
@@ -664,8 +651,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 			bad_s = 0;
 
 			if (!crypt_method){
-				fprintf(stderr,
-						_("%s: Provide '--crypt-method' before number of rounds\n"),
+				eprintf(_("%s: Provide '--crypt-method' before number of rounds\n"),
 						Prog);
 				usage (EXIT_FAILURE);
 			}
@@ -686,8 +672,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 			}
 #endif				/* USE_YESCRYPT */
 			if (bad_s != 0) {
-				fprintf (stderr,
-				         _("%s: invalid numeric argument '%s'\n"),
+				eprintf(_("%s: invalid numeric argument '%s'\n"),
 				         Prog, optarg);
 				usage (EXIT_FAILURE);
 			}
@@ -727,8 +712,7 @@ static void check_flags (void)
 {
 #ifndef USE_PAM
 	if (sflg && !cflg) {
-		fprintf (stderr,
-		         _("%s: %s flag is only allowed with the %s flag\n"),
+		eprintf(_("%s: %s flag is only allowed with the %s flag\n"),
 		         Prog, "-s", "-c");
 		usage (EXIT_FAILURE);
 	}
@@ -744,8 +728,7 @@ static void check_flags (void)
 		    && !streq(crypt_method, "YESCRYPT")
 #endif				/* USE_YESCRYPT */
 		    ) {
-			fprintf (stderr,
-			         _("%s: unsupported crypt method: %s\n"),
+			eprintf(_("%s: unsupported crypt method: %s\n"),
 			         Prog, crypt_method);
 			usage (EXIT_FAILURE);
 		}
@@ -765,24 +748,21 @@ static void open_files (bool process_selinux)
 	 * it gets locked, assume the others can be locked right away.
 	 */
 	if (pw_lock () == 0) {
-		fprintf (stderr,
-		         _("%s: cannot lock %s; try again later.\n"),
+		eprintf(_("%s: cannot lock %s; try again later.\n"),
 		         Prog, pw_dbname ());
 		fail_exit (EXIT_FAILURE, process_selinux);
 	}
 	pw_locked = true;
 	if (is_shadow) {
 		if (spw_lock () == 0) {
-			fprintf (stderr,
-			         _("%s: cannot lock %s; try again later.\n"),
+			eprintf(_("%s: cannot lock %s; try again later.\n"),
 			         Prog, spw_dbname ());
 			fail_exit (EXIT_FAILURE, process_selinux);
 		}
 		spw_locked = true;
 	}
 	if (gr_lock () == 0) {
-		fprintf (stderr,
-		         _("%s: cannot lock %s; try again later.\n"),
+		eprintf(_("%s: cannot lock %s; try again later.\n"),
 		         Prog, gr_dbname ());
 		fail_exit (EXIT_FAILURE, process_selinux);
 	}
@@ -790,8 +770,7 @@ static void open_files (bool process_selinux)
 #ifdef SHADOWGRP
 	if (is_shadow_grp) {
 		if (sgr_lock () == 0) {
-			fprintf (stderr,
-			         _("%s: cannot lock %s; try again later.\n"),
+			eprintf(_("%s: cannot lock %s; try again later.\n"),
 			         Prog, sgr_dbname ());
 			fail_exit (EXIT_FAILURE, process_selinux);
 		}
@@ -801,8 +780,7 @@ static void open_files (bool process_selinux)
 #ifdef ENABLE_SUBIDS
 	if (is_sub_uid) {
 		if (sub_uid_lock () == 0) {
-			fprintf (stderr,
-			         _("%s: cannot lock %s; try again later.\n"),
+			eprintf(_("%s: cannot lock %s; try again later.\n"),
 			         Prog, sub_uid_dbname ());
 			fail_exit (EXIT_FAILURE, process_selinux);
 		}
@@ -810,8 +788,7 @@ static void open_files (bool process_selinux)
 	}
 	if (is_sub_gid) {
 		if (sub_gid_lock () == 0) {
-			fprintf (stderr,
-			         _("%s: cannot lock %s; try again later.\n"),
+			eprintf(_("%s: cannot lock %s; try again later.\n"),
 			         Prog, sub_gid_dbname ());
 			fail_exit (EXIT_FAILURE, process_selinux);
 		}
@@ -820,37 +797,33 @@ static void open_files (bool process_selinux)
 #endif				/* ENABLE_SUBIDS */
 
 	if (pw_open (O_CREAT | O_RDWR) == 0) {
-		fprintf (stderr, _("%s: cannot open %s\n"), Prog, pw_dbname ());
+		eprintf(_("%s: cannot open %s\n"), Prog, pw_dbname());
 		fail_exit (EXIT_FAILURE, process_selinux);
 	}
 	if (is_shadow && (spw_open (O_CREAT | O_RDWR) == 0)) {
-		fprintf (stderr, _("%s: cannot open %s\n"), Prog, spw_dbname ());
+		eprintf(_("%s: cannot open %s\n"), Prog, spw_dbname());
 		fail_exit (EXIT_FAILURE, process_selinux);
 	}
 	if (gr_open (O_CREAT | O_RDWR) == 0) {
-		fprintf (stderr, _("%s: cannot open %s\n"), Prog, gr_dbname ());
+		eprintf(_("%s: cannot open %s\n"), Prog, gr_dbname());
 		fail_exit (EXIT_FAILURE, process_selinux);
 	}
 #ifdef SHADOWGRP
 	if (is_shadow_grp && (sgr_open (O_CREAT | O_RDWR) == 0)) {
-		fprintf (stderr, _("%s: cannot open %s\n"), Prog, sgr_dbname ());
+		eprintf(_("%s: cannot open %s\n"), Prog, sgr_dbname());
 		fail_exit (EXIT_FAILURE, process_selinux);
 	}
 #endif
 #ifdef ENABLE_SUBIDS
 	if (is_sub_uid) {
 		if (sub_uid_open (O_CREAT | O_RDWR) == 0) {
-			fprintf (stderr,
-			         _("%s: cannot open %s\n"),
-			         Prog, sub_uid_dbname ());
+			eprintf(_("%s: cannot open %s\n"), Prog, sub_uid_dbname());
 			fail_exit (EXIT_FAILURE, process_selinux);
 		}
 	}
 	if (is_sub_gid) {
 		if (sub_gid_open (O_CREAT | O_RDWR) == 0) {
-			fprintf (stderr,
-			         _("%s: cannot open %s\n"),
-			         Prog, sub_gid_dbname ());
+			eprintf(_("%s: cannot open %s\n"), Prog, sub_gid_dbname());
 			fail_exit (EXIT_FAILURE, process_selinux);
 		}
 	}
@@ -867,12 +840,12 @@ static void close_files(const struct option_flags *flags)
 	process_selinux = !flags->chroot;
 
 	if (pw_close (process_selinux) == 0) {
-		fprintf (stderr, _("%s: failure while writing changes to %s\n"), Prog, pw_dbname ());
+		eprintf(_("%s: failure while writing changes to %s\n"), Prog, pw_dbname());
 		SYSLOG(LOG_ERR, "failure while writing changes to %s", pw_dbname());
 		fail_exit (EXIT_FAILURE, process_selinux);
 	}
 	if (pw_unlock (process_selinux) == 0) {
-		fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, pw_dbname ());
+		eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
 		SYSLOG(LOG_ERR, "failed to unlock %s", pw_dbname());
 		/* continue */
 	}
@@ -880,16 +853,13 @@ static void close_files(const struct option_flags *flags)
 
 	if (is_shadow) {
 		if (spw_close (process_selinux) == 0) {
-			fprintf (stderr,
-			         _("%s: failure while writing changes to %s\n"),
+			eprintf(_("%s: failure while writing changes to %s\n"),
 			         Prog, spw_dbname ());
 			SYSLOG(LOG_ERR, "failure while writing changes to %s", spw_dbname());
 			fail_exit (EXIT_FAILURE, process_selinux);
 		}
 		if (spw_unlock (process_selinux) == 0) {
-			fprintf (stderr,
-			         _("%s: failed to unlock %s\n"),
-			         Prog, spw_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, spw_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", spw_dbname());
 			/* continue */
 		}
@@ -897,31 +867,26 @@ static void close_files(const struct option_flags *flags)
 	}
 
 	if (gr_close (process_selinux) == 0) {
-		fprintf (stderr,
-		         _("%s: failure while writing changes to %s\n"),
+		eprintf(_("%s: failure while writing changes to %s\n"),
 		         Prog, gr_dbname ());
 		SYSLOG(LOG_ERR, "failure while writing changes to %s", gr_dbname());
 		fail_exit (EXIT_FAILURE, process_selinux);
 	}
 #ifdef ENABLE_SUBIDS
 	if (is_sub_uid  && (sub_uid_close (process_selinux) == 0)) {
-		fprintf (stderr,
-		         _("%s: failure while writing changes to %s\n"), Prog, sub_uid_dbname ());
+		eprintf(_("%s: failure while writing changes to %s\n"), Prog, sub_uid_dbname());
 		SYSLOG(LOG_ERR, "failure while writing changes to %s", sub_uid_dbname());
 		fail_exit (EXIT_FAILURE, process_selinux);
 	}
 	if (is_sub_gid  && (sub_gid_close (process_selinux) == 0)) {
-		fprintf (stderr,
-		         _("%s: failure while writing changes to %s\n"), Prog, sub_gid_dbname ());
+		eprintf(_("%s: failure while writing changes to %s\n"), Prog, sub_gid_dbname());
 		SYSLOG(LOG_ERR, "failure while writing changes to %s", sub_gid_dbname());
 		fail_exit (EXIT_FAILURE, process_selinux);
 	}
 #endif				/* ENABLE_SUBIDS */
 
 	if (gr_unlock (process_selinux) == 0) {
-		fprintf (stderr,
-		         _("%s: failed to unlock %s\n"),
-		         Prog, gr_dbname ());
+		eprintf(_("%s: failed to unlock %s\n"), Prog, gr_dbname());
 		SYSLOG(LOG_ERR, "failed to unlock %s", gr_dbname());
 		/* continue */
 	}
@@ -930,16 +895,13 @@ static void close_files(const struct option_flags *flags)
 #ifdef SHADOWGRP
 	if (is_shadow_grp) {
 		if (sgr_close (process_selinux) == 0) {
-			fprintf (stderr,
-			         _("%s: failure while writing changes to %s\n"),
+			eprintf(_("%s: failure while writing changes to %s\n"),
 			         Prog, sgr_dbname ());
 			SYSLOG(LOG_ERR, "failure while writing changes to %s", sgr_dbname());
 			fail_exit (EXIT_FAILURE, process_selinux);
 		}
 		if (sgr_unlock (process_selinux) == 0) {
-			fprintf (stderr,
-			         _("%s: failed to unlock %s\n"),
-			         Prog, sgr_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, sgr_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sgr_dbname());
 			/* continue */
 		}
@@ -949,7 +911,7 @@ static void close_files(const struct option_flags *flags)
 #ifdef ENABLE_SUBIDS
 	if (is_sub_uid) {
 		if (sub_uid_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, sub_uid_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, sub_uid_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sub_uid_dbname());
 			/* continue */
 		}
@@ -957,7 +919,7 @@ static void close_files(const struct option_flags *flags)
 	}
 	if (is_sub_gid) {
 		if (sub_gid_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, sub_gid_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, sub_gid_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sub_gid_dbname());
 			/* continue */
 		}
@@ -1023,14 +985,12 @@ int main (int argc, char **argv)
 	while (fgets_a(buf, stdin) != NULL) {
 		line++;
 		if (stpsep(buf, "\n") == NULL && feof(stdin) == 0) {
-			fprintf (stderr, _("%s: line %jd: line too long\n"),
-				 Prog, line);
+			eprintf(_("%s: line %jd: line too long\n"), Prog, line);
 			fail_exit (EXIT_FAILURE, process_selinux);
 		}
 
 		if (strsep2arr_a(buf, ":", fields) == -1) {
-			fprintf (stderr, _("%s: line %jd: invalid line\n"),
-			         Prog, line);
+			eprintf(_("%s: line %jd: invalid line\n"), Prog, line);
 			fail_exit (EXIT_FAILURE, process_selinux);
 		}
 
@@ -1040,15 +1000,13 @@ int main (int argc, char **argv)
 		pw = pw_locate (fields[0]);
 		/* local, no need for xgetpwnam */
 		if (NULL == pw && getpwnam(fields[0]) != NULL) {
-			fprintf (stderr,
-				 _("%s: cannot update the entry of user %s (not in the passwd database)\n"),
+			eprintf(_("%s: cannot update the entry of user %s (not in the passwd database)\n"),
 				 Prog, fields[0]);
 			fail_exit (EXIT_FAILURE, process_selinux);
 		}
 
 		if (NULL == pw && get_user_id(fields[2], &uid) != 0) {
-			fprintf (stderr,
-			         _("%s: line %jd: can't create user\n"),
+			eprintf(_("%s: line %jd: can't create user\n"),
 			         Prog, line);
 			fail_exit (EXIT_FAILURE, process_selinux);
 		}
@@ -1067,8 +1025,7 @@ int main (int argc, char **argv)
 		 */
 		if (   (NULL == pw)
 		    && (add_group (fields[0], fields[3], &gid, uid) != 0)) {
-			fprintf (stderr,
-			         _("%s: line %jd: can't create group\n"),
+			eprintf(_("%s: line %jd: can't create group\n"),
 			         Prog, line);
 			fail_exit (EXIT_FAILURE, process_selinux);
 		}
@@ -1082,8 +1039,7 @@ int main (int argc, char **argv)
 		 */
 		if (   (NULL == pw)
 		    && (add_user (fields[0], uid, gid) != 0)) {
-			fprintf (stderr,
-			         _("%s: line %jd: can't create user\n"),
+			eprintf(_("%s: line %jd: can't create user\n"),
 			         Prog, line);
 			fail_exit (EXIT_FAILURE, process_selinux);
 		}
@@ -1094,8 +1050,7 @@ int main (int argc, char **argv)
 		 */
 		pw = pw_locate (fields[0]);
 		if (NULL == pw) {
-			fprintf (stderr,
-			         _("%s: line %jd: user '%s' does not exist in %s\n"),
+			eprintf(_("%s: line %jd: user '%s' does not exist in %s\n"),
 			         Prog, line, fields[0], pw_dbname ());
 			fail_exit (EXIT_FAILURE, process_selinux);
 		}
@@ -1116,8 +1071,7 @@ int main (int argc, char **argv)
 		passwords[nusers-1] = xstrdup(fields[1]);
 #endif				/* USE_PAM */
 		if (!streq(fields[1], "") && add_passwd(&newpw, fields[1]) != 0) {
-			fprintf (stderr,
-			         _("%s: line %jd: can't update password\n"),
+			eprintf(_("%s: line %jd: can't update password\n"),
 			         Prog, line);
 			fail_exit (EXIT_FAILURE, process_selinux);
 		}
@@ -1139,8 +1093,7 @@ int main (int argc, char **argv)
 			mode_t mode = getdef_num ("HOME_MODE",
 			                          0777 & ~getdef_num ("UMASK", GETDEF_DEFAULT_UMASK));
 			if (newpw.pw_dir[0] != '/') {
-				fprintf(stderr,
-					_("%s: line %jd: homedir must be an absolute path\n"),
+				eprintf(_("%s: line %jd: homedir must be an absolute path\n"),
 					Prog, line);
 				fail_exit (EXIT_FAILURE, process_selinux);
 			}
@@ -1163,8 +1116,7 @@ int main (int argc, char **argv)
 		 * Update the password entry with the new changes made.
 		 */
 		if (pw_update (&newpw) == 0) {
-			fprintf (stderr,
-			         _("%s: line %jd: can't update entry\n"),
+			eprintf(_("%s: line %jd: can't update entry\n"),
 			         Prog, line);
 			fail_exit (EXIT_FAILURE, process_selinux);
 		}
@@ -1178,16 +1130,13 @@ int main (int argc, char **argv)
 			unsigned long sub_uid_count = 0;
 			if (find_new_sub_uids(newpw.pw_uid, &sub_uid_start, &sub_uid_count) != 0)
 			{
-				fprinte(stderr,
-					_("%s: can't find subordinate user range"),
-					Prog);
+				eprinte(_("%s: can't find subordinate user range"), Prog);
 				SYSLOGE(LOG_WARN, "can't find subordinate user range");
 				fail_exit (EXIT_FAILURE, process_selinux);
 			}
 			if (sub_uid_add(fields[0], sub_uid_start, sub_uid_count) == 0)
 			{
-				fprintf (stderr,
-					_("%s: failed to prepare new %s entry\n"),
+				eprintf(_("%s: failed to prepare new %s entry\n"),
 					Prog, sub_uid_dbname ());
 				fail_exit (EXIT_FAILURE, process_selinux);
 			}
@@ -1200,15 +1149,12 @@ int main (int argc, char **argv)
 			gid_t sub_gid_start = 0;
 			unsigned long sub_gid_count = 0;
 			if (find_new_sub_gids(newpw.pw_uid, &sub_gid_start, &sub_gid_count) != 0) {
-				fprinte(stderr,
-					_("%s: can't find subordinate group range"),
-					Prog);
+				eprinte(_("%s: can't find subordinate group range"), Prog);
 				SYSLOGE(LOG_WARN, "can't find subordinate group range");
 				fail_exit (EXIT_FAILURE, process_selinux);
 			}
 			if (sub_gid_add(fields[0], sub_gid_start, sub_gid_count) == 0) {
-				fprintf (stderr,
-					_("%s: failed to prepare new %s entry\n"),
+				eprintf(_("%s: failed to prepare new %s entry\n"),
 					Prog, sub_uid_dbname ());
 				fail_exit (EXIT_FAILURE, process_selinux);
 			}
@@ -1235,8 +1181,7 @@ int main (int argc, char **argv)
 		if (streq(passwords[i], ""))
 			continue;
 		if (do_pam_passwd_non_interactive ("newusers", usernames[i], passwords[i]) != 0) {
-			fprintf (stderr,
-			         _("%s: (line %jd, user %s) password not changed\n"),
+			eprintf(_("%s: (line %jd, user %s) password not changed\n"),
 			         Prog, lines[i], usernames[i]);
 			exit (EXIT_FAILURE);
 		}

--- a/src/newusers.c
+++ b/src/newusers.c
@@ -440,7 +440,7 @@ static int update_passwd (struct passwd *pwd, const char *password)
 		const char *salt = crypt_make_salt (crypt_method, crypt_arg);
 		cp = pw_encrypt (password, salt);
 		if (NULL == cp) {
-			fprinte(stderr, _("%s: failed to crypt password with salt '%s'"),
+			eprinte(_("%s: failed to crypt password with salt '%s'"),
 			        Prog, salt);
 			return 1;
 		}
@@ -516,8 +516,7 @@ add_passwd(struct passwd *pwd, MAYBE_UNUSED const char *password)
 			                                    crypt_arg);
 			cp = pw_encrypt (password, salt);
 			if (NULL == cp) {
-				fprinte(stderr,
-				        _("%s: failed to crypt password with salt '%s'"),
+				eprinte(_("%s: failed to crypt password with salt '%s'"),
 				        Prog, salt);
 				return 1;
 			}
@@ -566,8 +565,7 @@ add_passwd(struct passwd *pwd, MAYBE_UNUSED const char *password)
 		const char *salt = crypt_make_salt (crypt_method, crypt_arg);
 		cp = pw_encrypt (password, salt);
 		if (NULL == cp) {
-			fprinte(stderr,
-			        _("%s: failed to crypt password with salt '%s'"),
+			eprinte(_("%s: failed to crypt password with salt '%s'"),
 			        Prog, salt);
 			return 1;
 		}
@@ -1063,7 +1061,7 @@ int main (int argc, char **argv)
 		usernames = reallocf_T(usernames, nusers, char *);
 		passwords = reallocf_T(passwords, nusers, char *);
 		if (lines == NULL || usernames == NULL || passwords == NULL) {
-			fprinte(stderr, _("%s: line %jd"), Prog, line);
+			eprinte(_("%s: line %jd"), Prog, line);
 			fail_exit (EXIT_FAILURE, process_selinux);
 		}
 		lines[nusers-1]     = line;
@@ -1098,7 +1096,7 @@ int main (int argc, char **argv)
 				fail_exit (EXIT_FAILURE, process_selinux);
 			}
 			if (mkdir (newpw.pw_dir, mode) != 0) {
-				fprinte(stderr, _("%s: line %jd: mkdir %s failed"),
+				eprinte(_("%s: line %jd: mkdir %s failed"),
 				        Prog, line, newpw.pw_dir);
 				if (errno != EEXIST) {
 					fail_exit (EXIT_FAILURE, process_selinux);
@@ -1106,7 +1104,7 @@ int main (int argc, char **argv)
 			}
 			if (chown(newpw.pw_dir, newpw.pw_uid, newpw.pw_gid) != 0)
 			{
-				fprinte(stderr, _("%s: line %jd: chown %s failed"),
+				eprinte(_("%s: line %jd: chown %s failed"),
 				        Prog, line, newpw.pw_dir);
 				fail_exit (EXIT_FAILURE, process_selinux);
 			}

--- a/src/passwd.c
+++ b/src/passwd.c
@@ -207,7 +207,7 @@ static int new_password (const struct passwd *pw)
 
 		if (NULL == cipher) {
 			erase_pass (clear);
-			fprinte(stderr, _("%s: failed to crypt password with previous salt"),
+			eprinte(_("%s: failed to crypt password with previous salt"),
 			        Prog);
 			SYSLOG(LOG_INFO,
 			       "Failed to crypt password with previous salt of user '%s'",
@@ -327,7 +327,7 @@ static int new_password (const struct passwd *pw)
 	memzero_a(pass);
 
 	if (NULL == cp) {
-		fprinte(stderr, _("%s: failed to crypt password with salt '%s'"),
+		eprinte(_("%s: failed to crypt password with salt '%s'"),
 		        Prog, salt);
 		return -1;
 	}

--- a/src/passwd.c
+++ b/src/passwd.c
@@ -220,8 +220,7 @@ static int new_password (const struct passwd *pw)
 			strzero (cipher);
 			SYSLOG(LOG_WARN, "incorrect password for %s", pw->pw_name);
 			(void) sleep (1);
-			(void) fprintf (stderr,
-			                _("Incorrect password for %s.\n"),
+			(void) eprintf(_("Incorrect password for %s.\n"),
 			                pw->pw_name);
 			return -1;
 		}
@@ -371,8 +370,7 @@ static void check_password (const struct passwd *pw, const struct spwd *sp, bool
 	 */
 	if (   strprefix(sp->sp_pwdp, "!")
 	    || (exp_status > 1)) {
-		(void) fprintf (stderr,
-		                _("The password for %s cannot be changed.\n"),
+		eprintf(_("The password for %s cannot be changed.\n"),
 		                sp->sp_namp);
 		SYSLOG(LOG_WARN, "password locked for '%s'", sp->sp_namp);
 		closelog ();
@@ -413,7 +411,7 @@ static void print_status (const struct passwd *pw)
 		(void) printf ("%s %s\n",
 		               pw->pw_name, pw_status (pw->pw_passwd));
 	} else {
-		(void) fprintf(stderr, _("%s: malformed password data obtained for user %s\n"),
+		(void) eprintf(_("%s: malformed password data obtained for user %s\n"),
 		               Prog, pw->pw_name);
 	}
 }
@@ -425,7 +423,7 @@ fail_exit (int status, bool process_selinux)
 {
 	if (spw_locked) {
 		if (spw_unlock (process_selinux) == 0) {
-			(void) fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, spw_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, spw_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", spw_dbname());
 			/* continue */
 		}
@@ -433,7 +431,7 @@ fail_exit (int status, bool process_selinux)
 
 	if (pw_locked) {
 		if (pw_unlock (process_selinux) == 0) {
-			(void) fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, pw_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", pw_dbname());
 			/* continue */
 		}
@@ -446,7 +444,7 @@ NORETURN
 static void
 oom (bool process_selinux)
 {
-	(void) fprintf (stderr, _("%s: out of memory\n"), Prog);
+	eprintf(_("%s: out of memory\n"), Prog);
 	fail_exit (E_FAILURE, process_selinux);
 }
 
@@ -458,16 +456,12 @@ oom (bool process_selinux)
 static void open_files(bool process_selinux)
 {
 	if (pw_lock () == 0) {
-		(void) fprintf (stderr,
-		                _("%s: cannot lock %s; try again later.\n"),
-		                Prog, pw_dbname ());
+		eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, pw_dbname());
 		exit (E_PWDBUSY);
 	}
 	pw_locked = true;
 	if (pw_open (O_CREAT | O_RDWR) == 0) {
-		(void) fprintf (stderr,
-		                _("%s: cannot open %s\n"),
-		                Prog, pw_dbname ());
+		eprintf(_("%s: cannot open %s\n"), Prog, pw_dbname());
 		SYSLOG(LOG_WARN, "cannot open %s", pw_dbname());
 		fail_exit (E_MISSING, process_selinux);
 	}
@@ -475,16 +469,12 @@ static void open_files(bool process_selinux)
 	if (!spw_file_present ())
 		return;
 	if (spw_lock () == 0) {
-		(void) fprintf (stderr,
-		                _("%s: cannot lock %s; try again later.\n"),
-		                Prog, spw_dbname ());
+		eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, spw_dbname());
 		fail_exit (E_PWDBUSY, process_selinux);
 	}
 	spw_locked = true;
 	if (spw_open (O_CREAT | O_RDWR) == 0) {
-		(void) fprintf (stderr,
-		                _("%s: cannot open %s\n"),
-		                Prog, spw_dbname ());
+		eprintf(_("%s: cannot open %s\n"), Prog, spw_dbname());
 		SYSLOG(LOG_WARN, "cannot open %s", spw_dbname());
 		fail_exit (E_FAILURE, process_selinux);
 	}
@@ -500,32 +490,24 @@ static void close_files(bool process_selinux)
 {
 	if (spw_locked) {
 		if (spw_close (process_selinux) == 0) {
-			(void) fprintf (stderr,
-			                _("%s: failure while writing changes to %s\n"),
-			                Prog, spw_dbname ());
+			eprintf(_("%s: failure while writing changes to %s\n"), Prog, spw_dbname());
 			SYSLOG(LOG_ERR, "failure while writing changes to %s", spw_dbname());
 			fail_exit (E_FAILURE, process_selinux);
 		}
 		if (spw_unlock (process_selinux) == 0) {
-			(void) fprintf (stderr,
-			                _("%s: failed to unlock %s\n"),
-			                Prog, spw_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, spw_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", spw_dbname());
 			/* continue */
 		}
 		spw_locked = false;
 	}
 	if (pw_close (process_selinux) == 0) {
-		(void) fprintf (stderr,
-		                _("%s: failure while writing changes to %s\n"),
-		                Prog, pw_dbname ());
+		eprintf(_("%s: failure while writing changes to %s\n"), Prog, pw_dbname());
 		SYSLOG(LOG_ERR, "failure while writing changes to %s", pw_dbname());
 		fail_exit (E_FAILURE, process_selinux);
 	}
 	if (pw_unlock (process_selinux) == 0) {
-		(void) fprintf (stderr,
-		                _("%s: failed to unlock %s\n"),
-		                Prog, pw_dbname ());
+		eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
 		SYSLOG(LOG_ERR, "failed to unlock %s", pw_dbname());
 		/* continue */
 	}
@@ -546,9 +528,8 @@ static char *update_crypt_pw (char *cp, bool process_selinux)
 
 	if (uflg && strprefix(cp, "!")) {
 		if (cp[1] == '\0') {
-			(void) fprintf (stderr,
-			                _("%s: unlocking the password would result in a passwordless account.\n"
-			                  "You should set a password with usermod -p to unlock the password of this account.\n"),
+			(void) eprintf(_("%s: unlocking the password would result in a passwordless account.\n"
+			                 "You should set a password with usermod -p to unlock the password of this account.\n"),
 			                Prog);
 			fail_exit (E_FAILURE, process_selinux);
 		} else {
@@ -580,8 +561,7 @@ static void update_noshadow(bool process_selinux)
 
 	pw = pw_locate (name);
 	if (NULL == pw) {
-		(void) fprintf (stderr,
-		                _("%s: user '%s' does not exist in %s\n"),
+		(void) eprintf(_("%s: user '%s' does not exist in %s\n"),
 		                Prog, name, pw_dbname ());
 		fail_exit (E_NOPERM, process_selinux);
 	}
@@ -613,8 +593,7 @@ static void update_noshadow(bool process_selinux)
 	}
 #endif /* WITH_AUDIT */
 	if (ret == 0) {
-		(void) fprintf (stderr,
-		                _("%s: failed to prepare the new %s entry '%s'\n"),
+		(void) eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
 		                Prog, pw_dbname (), npw->pw_name);
 		fail_exit (E_FAILURE, process_selinux);
 	}
@@ -716,8 +695,7 @@ static void update_shadow(bool process_selinux)
 	}
 #endif /* WITH_AUDIT */
 	if (ret == 0) {
-		(void) fprintf (stderr,
-		                _("%s: failed to prepare the new %s entry '%s'\n"),
+		(void) eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
 		                Prog, spw_dbname (), nsp->sp_namp);
 		fail_exit (E_FAILURE, process_selinux);
 	}
@@ -836,8 +814,7 @@ main(int argc, char **argv)
 				if (a2sl(&inact, optarg, NULL, 0, -1, LONG_MAX)
 				    == -1)
 				{
-					fprintf (stderr,
-					         _("%s: invalid numeric argument '%s'\n"),
+					eprintf(_("%s: invalid numeric argument '%s'\n"),
 					         Prog, optarg);
 					usage (E_BAD_ARG);
 				}
@@ -859,8 +836,7 @@ main(int argc, char **argv)
 				/* -r repository (files|nis|nisplus) */
 				/* only "files" supported for now */
 				if (!streq(optarg, "files")) {
-					fprintf (stderr,
-					         _("%s: repository %s not supported\n"),
+					eprintf(_("%s: repository %s not supported\n"),
 						 Prog, optarg);
 					exit (E_BAD_ARG);
 				}
@@ -882,8 +858,7 @@ main(int argc, char **argv)
 				if (a2sl(&warn, optarg, NULL, 0, -1, LONG_MAX)
 				    == -1)
 				{
-					(void) fprintf (stderr,
-					                _("%s: invalid numeric argument '%s'\n"),
+					(void) eprintf(_("%s: invalid numeric argument '%s'\n"),
 					                Prog, optarg);
 					usage (E_BAD_ARG);
 				}
@@ -894,8 +869,7 @@ main(int argc, char **argv)
 				if (a2sl(&age_max, optarg, NULL, 0, -1, LONG_MAX)
 				    == -1)
 				{
-					(void) fprintf (stderr,
-					                _("%s: invalid numeric argument '%s'\n"),
+					(void) eprintf(_("%s: invalid numeric argument '%s'\n"),
 					                Prog, optarg);
 					usage (E_BAD_ARG);
 				}
@@ -904,8 +878,7 @@ main(int argc, char **argv)
 				break;
 			case 's':
 				if (!amroot) {
-					(void) fprintf (stderr,
-					                _("%s: only root can use --stdin/-s option\n"),
+					(void) eprintf(_("%s: only root can use --stdin/-s option\n"),
 					                Prog);
 					usage (E_BAD_ARG);
 				}
@@ -925,9 +898,7 @@ main(int argc, char **argv)
 	 */
 	pw = get_my_pwent ();
 	if (NULL == pw) {
-		(void) fprintf (stderr,
-		                _("%s: Cannot determine your user name.\n"),
-		                Prog);
+		(void) eprintf(_("%s: Cannot determine your user name.\n"), Prog);
 		SYSLOG(LOG_WARN, "Cannot determine the user name of the caller (UID %lu)",
 		       (unsigned long) getuid());
 		exit (E_NOPERM);
@@ -935,7 +906,7 @@ main(int argc, char **argv)
 	myname = xstrdup (pw->pw_name);
 	if (optind < argc) {
 		if (!is_valid_user_name(argv[optind], true) && !is_valid_upn(argv[optind], true)) {
-			fprintf (stderr, _("%s: Provided user name is not a valid name\n"), Prog);
+			eprintf(_("%s: Provided user name is not a valid name\n"), Prog);
 			fail_exit (E_NOPERM, process_selinux);
 		}
 		name = argv[optind];
@@ -959,9 +930,7 @@ main(int argc, char **argv)
 			usage (E_USAGE);
 		}
 		if (!amroot) {
-			(void) fprintf (stderr,
-			                _("%s: Permission denied.\n"),
-			                Prog);
+			(void) eprintf(_("%s: Permission denied.\n"), Prog);
 			exit (E_NOPERM);
 		}
 		prefix_setpwent ();
@@ -1007,15 +976,13 @@ main(int argc, char **argv)
 		             NULL, getuid(),
 		             SHADOW_AUDIT_FAILURE);
 #endif /* WITH_AUDIT */
-		(void) fprintf (stderr, _("%s: Permission denied.\n"), Prog);
+		(void) eprintf(_("%s: Permission denied.\n"), Prog);
 		exit (E_NOPERM);
 	}
 
 	pw = xprefix_getpwnam (name);
 	if (NULL == pw) {
-		(void) fprintf (stderr,
-		                _("%s: user '%s' does not exist\n"),
-		                Prog, name);
+		(void) eprintf(_("%s: user '%s' does not exist\n"), Prog, name);
 		exit (E_NOPERM);
 	}
 #ifdef WITH_SELINUX
@@ -1031,8 +998,7 @@ main(int argc, char **argv)
 		SYSLOG(LOG_ALERT,
 		       "root is not authorized by SELinux to change the password of %s",
 		       name);
-		(void) fprintf(stderr,
-		               _("%s: root is not authorized by SELinux to change the password of %s\n"),
+		(void) eprintf(_("%s: root is not authorized by SELinux to change the password of %s\n"),
 		               Prog, name);
 		exit (E_NOPERM);
 	}
@@ -1049,8 +1015,7 @@ main(int argc, char **argv)
 		             NULL, pw->pw_uid,
 		             SHADOW_AUDIT_FAILURE);
 #endif /* WITH_AUDIT */
-		(void) fprintf (stderr,
-		                _("%s: You may not view or modify password information for %s.\n"),
+		(void) eprintf(_("%s: You may not view or modify password information for %s.\n"),
 		                Prog, name);
 		SYSLOG(LOG_WARN,
 		       "can't view or modify password information for %s",
@@ -1071,8 +1036,7 @@ main(int argc, char **argv)
 		sp = prefix_getspnam (name); /* !use_pam, no need for xprefix_getspnam */
 		if (NULL == sp) {
 			if (errno == EACCES) {
-				(void) fprintf (stderr,
-				                _("%s: Permission denied.\n"),
+				(void) eprintf(_("%s: Permission denied.\n"),
 				                Prog);
 				exit (E_NOPERM);
 			}
@@ -1101,8 +1065,7 @@ main(int argc, char **argv)
 			}
 
 			if (new_password (pw) != 0) {
-				(void) fprintf (stderr,
-				                _("The password for %s is unchanged.\n"),
+				(void) eprintf(_("The password for %s is unchanged.\n"),
 				                name);
 				closelog ();
 				exit (E_NOPERM);

--- a/src/pwck.c
+++ b/src/pwck.c
@@ -22,6 +22,7 @@
 #include "commonio.h"
 #include "defines.h"
 #include "getdef.h"
+#include "io/fprintf.h"
 #include "nscd.h"
 #include "prototypes.h"
 #include "pwio.h"
@@ -91,7 +92,7 @@ static void fail_exit (int code, bool process_selinux)
 {
 	if (spw_locked) {
 		if (spw_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, spw_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, spw_dbname());
 			if (use_system_spw_file) {
 				SYSLOG(LOG_ERR, "failed to unlock %s", spw_dbname());
 			}
@@ -101,7 +102,7 @@ static void fail_exit (int code, bool process_selinux)
 
 	if (pw_locked) {
 		if (pw_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, pw_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
 			if (use_system_pw_file) {
 				SYSLOG(LOG_ERR, "failed to unlock %s", pw_dbname());
 			}
@@ -202,7 +203,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 	}
 
 	if (sort_mode && read_only) {
-		fprintf (stderr, _("%s: -s and -r are incompatible\n"), Prog);
+		eprintf(_("%s: -s and -r are incompatible\n"), Prog);
 		exit (E_USAGE);
 	}
 
@@ -224,8 +225,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 	if ((optind + 2) == argc) {
 #ifdef WITH_TCB
 		if (getdef_bool ("USE_TCB")) {
-			fprintf (stderr,
-			         _("%s: no alternative shadow file allowed when USE_TCB is enabled.\n"),
+			eprintf(_("%s: no alternative shadow file allowed when USE_TCB is enabled.\n"),
 			         Prog);
 			usage (E_USAGE);
 		}
@@ -259,16 +259,14 @@ static void open_files(const struct option_flags *flags)
 	 */
 	if (!read_only) {
 		if (pw_lock () == 0) {
-			fprintf (stderr,
-			         _("%s: cannot lock %s; try again later.\n"),
+			eprintf(_("%s: cannot lock %s; try again later.\n"),
 			         Prog, pw_dbname ());
 			fail_exit (E_CANTLOCK, process_selinux);
 		}
 		pw_locked = true;
 		if (is_shadow && !use_tcb) {
 			if (spw_lock () == 0) {
-				fprintf (stderr,
-				         _("%s: cannot lock %s; try again later.\n"),
+				eprintf(_("%s: cannot lock %s; try again later.\n"),
 				         Prog, spw_dbname ());
 				fail_exit (E_CANTLOCK, process_selinux);
 			}
@@ -281,8 +279,7 @@ static void open_files(const struct option_flags *flags)
 	 * otherwise.
 	 */
 	if (pw_open (read_only ? O_RDONLY : O_RDWR) == 0) {
-		fprintf (stderr, _("%s: cannot open %s\n"),
-		         Prog, pw_dbname ());
+		eprintf(_("%s: cannot open %s\n"), Prog, pw_dbname());
 		if (use_system_pw_file) {
 			SYSLOG(LOG_WARN, "cannot open %s", pw_dbname());
 		}
@@ -290,8 +287,7 @@ static void open_files(const struct option_flags *flags)
 	}
 	if (is_shadow && !use_tcb) {
 		if (spw_open (read_only ? O_RDONLY : O_RDWR) == 0) {
-			fprintf (stderr, _("%s: cannot open %s\n"),
-			         Prog, spw_dbname ());
+			eprintf(_("%s: cannot open %s\n"), Prog, spw_dbname());
 			if (use_system_spw_file) {
 				SYSLOG(LOG_WARN, "cannot open %s", spw_dbname());
 			}
@@ -320,8 +316,7 @@ static void close_files(bool changed, const struct option_flags *flags)
 	 */
 	if (changed) {
 		if (pw_close (process_selinux) == 0) {
-			fprintf (stderr,
-			         _("%s: failure while writing changes to %s\n"),
+			eprintf(_("%s: failure while writing changes to %s\n"),
 			         Prog, pw_dbname ());
 			if (use_system_pw_file) {
 				SYSLOG(LOG_ERR,
@@ -331,8 +326,7 @@ static void close_files(bool changed, const struct option_flags *flags)
 			fail_exit (E_CANTUPDATE, process_selinux);
 		}
 		if (spw_opened && (spw_close (process_selinux) == 0)) {
-			fprintf (stderr,
-			         _("%s: failure while writing changes to %s\n"),
+			eprintf(_("%s: failure while writing changes to %s\n"),
 			         Prog, spw_dbname ());
 			if (use_system_spw_file) {
 				SYSLOG(LOG_ERR,
@@ -349,8 +343,7 @@ static void close_files(bool changed, const struct option_flags *flags)
 	 */
 	if (spw_locked) {
 		if (spw_unlock (process_selinux) == 0) {
-			fprintf (stderr,
-			         _("%s: failed to unlock %s\n"),
+			eprintf(_("%s: failed to unlock %s\n"),
 			         Prog, spw_dbname ());
 			if (use_system_spw_file) {
 				SYSLOG(LOG_ERR, "failed to unlock %s", spw_dbname());
@@ -361,8 +354,7 @@ static void close_files(bool changed, const struct option_flags *flags)
 	spw_locked = false;
 	if (pw_locked) {
 		if (pw_unlock (process_selinux) == 0) {
-			fprintf (stderr,
-			         _("%s: failed to unlock %s\n"),
+			eprintf(_("%s: failed to unlock %s\n"),
 			         Prog, pw_dbname ());
 			if (use_system_pw_file) {
 				SYSLOG(LOG_ERR, "failed to unlock %s", pw_dbname());
@@ -581,20 +573,17 @@ static void check_pw_file(bool *errors, bool *changed, const struct option_flags
 				}
 				if (spw_lock () == 0) {
 					*errors = true;
-					fprintf (stderr,
-					         _("%s: cannot lock %s.\n"),
+					eprintf(_("%s: cannot lock %s.\n"),
 					         Prog, spw_dbname ());
 					continue;
 				}
 				spw_locked = true;
 				if (spw_open (read_only ? O_RDONLY : O_RDWR) == 0) {
-					fprintf (stderr,
-					         _("%s: cannot open %s\n"),
+					eprintf(_("%s: cannot open %s\n"),
 					         Prog, spw_dbname ());
 					*errors = true;
 					if (spw_unlock (process_selinux) == 0) {
-						fprintf (stderr,
-						         _("%s: failed to unlock %s\n"),
+						eprintf(_("%s: failed to unlock %s\n"),
 						         Prog, spw_dbname ());
 						if (use_system_spw_file) {
 							SYSLOG(LOG_ERR,
@@ -638,8 +627,7 @@ static void check_pw_file(bool *errors, bool *changed, const struct option_flags
 					*changed = true;
 
 					if (spw_update (&sp) == 0) {
-						fprintf (stderr,
-						         _("%s: failed to prepare the new %s entry '%s'\n"),
+						eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
 						         Prog, spw_dbname (), sp.sp_namp);
 						fail_exit (E_CANTUPDATE, process_selinux);
 					}
@@ -647,8 +635,7 @@ static void check_pw_file(bool *errors, bool *changed, const struct option_flags
 					pw = *pwd;
 					pw.pw_passwd = SHADOW_PASSWD_STRING;	/* XXX warning: const */
 					if (pw_update (&pw) == 0) {
-						fprintf (stderr,
-						         _("%s: failed to prepare the new %s entry '%s'\n"),
+						eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
 						         Prog, pw_dbname (), pw.pw_name);
 						fail_exit (E_CANTUPDATE, process_selinux);
 					}
@@ -668,8 +655,7 @@ static void check_pw_file(bool *errors, bool *changed, const struct option_flags
 #ifdef WITH_TCB
 		if (getdef_bool ("USE_TCB") && spw_locked) {
 			if (spw_opened && (spw_close (process_selinux) == 0)) {
-				fprintf (stderr,
-				         _("%s: failure while writing changes to %s\n"),
+				eprintf(_("%s: failure while writing changes to %s\n"),
 				         Prog, spw_dbname ());
 				if (use_system_spw_file) {
 					SYSLOG(LOG_ERR,
@@ -680,8 +666,7 @@ static void check_pw_file(bool *errors, bool *changed, const struct option_flags
 				spw_opened = false;
 			}
 			if (spw_unlock (process_selinux) == 0) {
-				fprintf (stderr,
-				         _("%s: failed to unlock %s\n"),
+				eprintf(_("%s: failed to unlock %s\n"),
 				         Prog, spw_dbname ());
 				if (use_system_spw_file) {
 					SYSLOG(LOG_ERR, "failed to unlock %s",
@@ -872,15 +857,13 @@ int main (int argc, char **argv)
 
 	if (sort_mode) {
 		if (pw_sort () != 0) {
-			fprintf (stderr,
-			         _("%s: cannot sort entries in %s\n"),
+			eprintf(_("%s: cannot sort entries in %s\n"),
 			         Prog, pw_dbname ());
 			fail_exit (E_CANTSORT, process_selinux);
 		}
 		if (is_shadow) {
 			if (spw_sort () != 0) {
-				fprintf (stderr,
-				         _("%s: cannot sort entries in %s\n"),
+				eprintf(_("%s: cannot sort entries in %s\n"),
 				         Prog, spw_dbname ());
 				fail_exit (E_CANTSORT, process_selinux);
 			}

--- a/src/pwconv.c
+++ b/src/pwconv.c
@@ -47,6 +47,7 @@
 
 #include "defines.h"
 #include "getdef.h"
+#include "io/fprintf.h"
 #include "nscd.h"
 #include "prototypes.h"
 #include "pwio.h"
@@ -89,7 +90,7 @@ static void fail_exit (int status, bool process_selinux)
 {
 	if (pw_locked) {
 		if (pw_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, pw_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", pw_dbname());
 			/* continue */
 		}
@@ -97,7 +98,7 @@ static void fail_exit (int status, bool process_selinux)
 
 	if (spw_locked) {
 		if (spw_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, spw_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, spw_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", spw_dbname());
 			/* continue */
 		}
@@ -181,34 +182,30 @@ int main (int argc, char **argv)
 
 #ifdef WITH_TCB
 	if (getdef_bool("USE_TCB")) {
-		fprintf (stderr, _("%s: can't work with tcb enabled\n"), Prog);
+		eprintf(_("%s: can't work with tcb enabled\n"), Prog);
 		exit (E_FAILURE);
 	}
 #endif				/* WITH_TCB */
 
 	if (pw_lock () == 0) {
-		fprintf (stderr,
-		         _("%s: cannot lock %s; try again later.\n"),
+		eprintf(_("%s: cannot lock %s; try again later.\n"),
 		         Prog, pw_dbname ());
 		fail_exit (E_PWDBUSY, process_selinux);
 	}
 	pw_locked = true;
 	if (pw_open (O_CREAT | O_RDWR) == 0) {
-		fprintf (stderr,
-		         _("%s: cannot open %s\n"), Prog, pw_dbname ());
+		eprintf(_("%s: cannot open %s\n"), Prog, pw_dbname());
 		fail_exit (E_MISSING, process_selinux);
 	}
 
 	if (spw_lock () == 0) {
-		fprintf (stderr,
-		         _("%s: cannot lock %s; try again later.\n"),
+		eprintf(_("%s: cannot lock %s; try again later.\n"),
 		         Prog, spw_dbname ());
 		fail_exit (E_PWDBUSY, process_selinux);
 	}
 	spw_locked = true;
 	if (spw_open (O_CREAT | O_RDWR) == 0) {
-		fprintf (stderr,
-		         _("%s: cannot open %s\n"), Prog, spw_dbname ());
+		eprintf(_("%s: cannot open %s\n"), Prog, spw_dbname());
 		fail_exit (E_FAILURE, process_selinux);
 	}
 
@@ -225,8 +222,7 @@ int main (int argc, char **argv)
 			/*
 			 * This shouldn't happen (the entry exists) but...
 			 */
-			fprintf (stderr,
-			         _("%s: cannot remove entry '%s' from %s\n"),
+			eprintf(_("%s: cannot remove entry '%s' from %s\n"),
 			         Prog, sp->sp_namp, spw_dbname ());
 			fail_exit (E_FAILURE, process_selinux);
 		}
@@ -266,8 +262,7 @@ int main (int argc, char **argv)
 			spent.sp_lstchg = -1;
 		}
 		if (spw_update (&spent) == 0) {
-			fprintf (stderr,
-			         _("%s: failed to prepare the new %s entry '%s'\n"),
+			eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
 			         Prog, spw_dbname (), spent.sp_namp);
 			fail_exit (E_FAILURE, process_selinux);
 		}
@@ -276,23 +271,20 @@ int main (int argc, char **argv)
 		pwent = *pw;
 		pwent.pw_passwd = SHADOW_PASSWD_STRING;	/* XXX warning: const */
 		if (pw_update (&pwent) == 0) {
-			fprintf (stderr,
-			         _("%s: failed to prepare the new %s entry '%s'\n"),
+			eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
 			         Prog, pw_dbname (), pwent.pw_name);
 			fail_exit (E_FAILURE, process_selinux);
 		}
 	}
 
 	if (spw_close (process_selinux) == 0) {
-		fprintf (stderr,
-		         _("%s: failure while writing changes to %s\n"),
+		eprintf(_("%s: failure while writing changes to %s\n"),
 		         Prog, spw_dbname ());
 		SYSLOG(LOG_ERR, "failure while writing changes to %s", spw_dbname());
 		fail_exit (E_FAILURE, process_selinux);
 	}
 	if (pw_close (process_selinux) == 0) {
-		fprintf (stderr,
-		         _("%s: failure while writing changes to %s\n"),
+		eprintf(_("%s: failure while writing changes to %s\n"),
 		         Prog, pw_dbname ());
 		SYSLOG(LOG_ERR, "failure while writing changes to %s", pw_dbname());
 		fail_exit (E_FAILURE, process_selinux);
@@ -301,21 +293,20 @@ int main (int argc, char **argv)
 	/* /etc/passwd- (backup file) */
 	errno = 0;
 	if ((chmod (PASSWD_FILE "-", 0600) != 0) && (errno != ENOENT)) {
-		fprintf (stderr,
-		         _("%s: failed to change the mode of %s to 0600\n"),
+		eprintf(_("%s: failed to change the mode of %s to 0600\n"),
 		         Prog, PASSWD_FILE "-");
 		SYSLOG(LOG_ERR, "failed to change the mode of %s to 0600", PASSWD_FILE "-");
 		/* continue */
 	}
 
 	if (pw_unlock (process_selinux) == 0) {
-		fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, pw_dbname ());
+		eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
 		SYSLOG(LOG_ERR, "failed to unlock %s", pw_dbname());
 		/* continue */
 	}
 
 	if (spw_unlock (process_selinux) == 0) {
-		fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, spw_dbname ());
+		eprintf(_("%s: failed to unlock %s\n"), Prog, spw_dbname());
 		SYSLOG(LOG_ERR, "failed to unlock %s", spw_dbname());
 		/* continue */
 	}

--- a/src/pwunconv.c
+++ b/src/pwunconv.c
@@ -22,6 +22,7 @@
 /*@-exitarg@*/
 #include "exitcodes.h"
 #include "getdef.h"
+#include "io/fprintf.h"
 #include "nscd.h"
 #include "prototypes.h"
 #include "pwio.h"
@@ -51,14 +52,14 @@ static void fail_exit (int status, bool process_selinux)
 {
 	if (spw_locked) {
 		if (spw_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, spw_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, spw_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", spw_dbname());
 			/* continue */
 		}
 	}
 	if (pw_locked) {
 		if (pw_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, pw_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", pw_dbname());
 			/* continue */
 		}
@@ -140,7 +141,7 @@ int main (int argc, char **argv)
 
 #ifdef WITH_TCB
 	if (getdef_bool("USE_TCB")) {
-		fprintf (stderr, _("%s: can't work with tcb enabled\n"), Prog);
+		eprintf(_("%s: can't work with tcb enabled\n"), Prog);
 		exit (1);
 	}
 #endif				/* WITH_TCB */
@@ -151,30 +152,24 @@ int main (int argc, char **argv)
 	}
 
 	if (pw_lock () == 0) {
-		fprintf (stderr,
-		         _("%s: cannot lock %s; try again later.\n"),
+		eprintf(_("%s: cannot lock %s; try again later.\n"),
 		         Prog, pw_dbname ());
 		fail_exit (5, process_selinux);
 	}
 	pw_locked = true;
 	if (pw_open (O_CREAT | O_RDWR) == 0) {
-		fprintf (stderr,
-		         _("%s: cannot open %s\n"),
-		         Prog, pw_dbname ());
+		eprintf(_("%s: cannot open %s\n"), Prog, pw_dbname());
 		fail_exit (1, process_selinux);
 	}
 
 	if (spw_lock () == 0) {
-		fprintf (stderr,
-		         _("%s: cannot lock %s; try again later.\n"),
+		eprintf(_("%s: cannot lock %s; try again later.\n"),
 		         Prog, spw_dbname ());
 		fail_exit (5, process_selinux);
 	}
 	spw_locked = true;
 	if (spw_open (O_RDONLY) == 0) {
-		fprintf (stderr,
-		         _("%s: cannot open %s\n"),
-		         Prog, spw_dbname ());
+		eprintf(_("%s: cannot open %s\n"), Prog, spw_dbname());
 		fail_exit (1, process_selinux);
 	}
 
@@ -195,8 +190,7 @@ int main (int argc, char **argv)
 		}
 
 		if (pw_update (&pwent) == 0) {
-			fprintf (stderr,
-			         _("%s: failed to prepare the new %s entry '%s'\n"),
+			eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
 			         Prog, pw_dbname (), pwent.pw_name);
 			fail_exit (3, process_selinux);
 		}
@@ -205,27 +199,25 @@ int main (int argc, char **argv)
 	(void) spw_close (process_selinux); /* was only open O_RDONLY */
 
 	if (pw_close (process_selinux) == 0) {
-		fprintf (stderr,
-		         _("%s: failure while writing changes to %s\n"),
+		eprintf(_("%s: failure while writing changes to %s\n"),
 		         Prog, pw_dbname ());
 		SYSLOG(LOG_ERR, "failure while writing changes to %s", pw_dbname());
 		fail_exit (3, process_selinux);
 	}
 
 	if (unlink (SHADOW) != 0) {
-		fprintf (stderr,
-			 _("%s: cannot delete %s\n"), Prog, SHADOW);
+		eprintf(_("%s: cannot delete %s\n"), Prog, SHADOW);
 		SYSLOG(LOG_ERR, "cannot delete %s", SHADOW);
 		fail_exit (3, process_selinux);
 	}
 
 	if (spw_unlock (process_selinux) == 0) {
-		fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, spw_dbname ());
+		eprintf(_("%s: failed to unlock %s\n"), Prog, spw_dbname());
 		SYSLOG(LOG_ERR, "failed to unlock %s", spw_dbname());
 		/* continue */
 	}
 	if (pw_unlock (process_selinux) == 0) {
-		fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, pw_dbname ());
+		eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
 		SYSLOG(LOG_ERR, "failed to unlock %s", pw_dbname());
 		/* continue */
 	}

--- a/src/su.c
+++ b/src/su.c
@@ -53,6 +53,7 @@
 /*@-exitarg@*/
 #include "exitcodes.h"
 #include "getdef.h"
+#include "io/fprintf.h"
 #ifdef USE_PAM
 #include "pam_defs.h"
 #endif				/* USE_PAM */
@@ -294,9 +295,7 @@ static void prepare_pam_close_session (void)
 	sigemptyset (&action.sa_mask);
 	action.sa_flags = 0;
 	if (0 == caught && sigaction (SIGCHLD, &action, NULL) != 0) {
-		fprintf (stderr,
-		         _("%s: signal masking malfunction\n"),
-		         Prog);
+		eprintf(_("%s: signal masking malfunction\n"), Prog);
 		SYSLOG(LOG_WARN, "Will not execute %s", shellstr);
 		closelog ();
 		exit (1);
@@ -307,9 +306,7 @@ static void prepare_pam_close_session (void)
 	if (pid_child == 0) {	/* child shell */
 		return; /* Only the child will return from pam_create_session */
 	} else if ((pid_t)-1 == pid_child) {
-		(void) fprintf (stderr,
-		                _("%s: Cannot fork user shell\n"),
-		                Prog);
+		(void) eprintf(_("%s: Cannot fork user shell\n"), Prog);
 		SYSLOG(LOG_WARN, "Cannot execute %s", shellstr);
 		closelog ();
 		exit (1);
@@ -319,9 +316,7 @@ static void prepare_pam_close_session (void)
 	/* parent only */
 	sigfillset (&ourset);
 	if (sigprocmask (SIG_BLOCK, &ourset, NULL) != 0) {
-		(void) fprintf (stderr,
-		                _("%s: signal malfunction\n"),
-		                Prog);
+		(void) eprintf(_("%s: signal malfunction\n"), Prog);
 		caught = SIGTERM;
 	}
 	if (0 == caught) {
@@ -344,9 +339,7 @@ static void prepare_pam_close_session (void)
 		            || (sigaction (SIGTSTP,  &action, NULL) != 0)))
 		    || (sigprocmask (SIG_UNBLOCK, &ourset, NULL) != 0)
 		    ) {
-			fprintf (stderr,
-			         _("%s: signal masking malfunction\n"),
-			         Prog);
+			eprintf(_("%s: signal masking malfunction\n"), Prog);
 			caught = SIGTERM;
 		}
 	}
@@ -401,7 +394,7 @@ static void prepare_pam_close_session (void)
 		 * so it's time to block all of them. */
 		sigfillset (&ourset);
 		if (sigprocmask (SIG_BLOCK, &ourset, NULL) != 0) {
-			fprintf (stderr, _("%s: signal masking malfunction\n"), Prog);
+			eprintf(_("%s: signal masking malfunction\n"), Prog);
 			kill_child(pid_child);
 			/* Never reached (exit called). */
 		}
@@ -430,7 +423,7 @@ static void prepare_pam_close_session (void)
 	ret = pam_close_session (pamh, 0);
 	if (PAM_SUCCESS != ret) {
 		SYSLOG(LOG_ERR, "pam_close_session: %s", pam_strerror(pamh, ret));
-		fprintf (stderr, _("%s: %s\n"), Prog, pam_strerror (pamh, ret));
+		eprintf(_("%s: %s\n"), Prog, pam_strerror(pamh, ret));
 	}
 
 	(void) pam_setcred (pamh, PAM_DELETE_CRED);
@@ -475,7 +468,7 @@ static void check_perms_pam (const struct passwd *pw)
 	if (PAM_SUCCESS != ret) {
 		SYSLOG(pw->pw_uid ? LOG_NOTICE : LOG_WARN, "pam_authenticate: %s",
 		       pam_strerror(pamh, ret));
-		fprintf (stderr, _("%s: %s\n"), Prog, pam_strerror (pamh, ret));
+		eprintf(_("%s: %s\n"), Prog, pam_strerror(pamh, ret));
 		(void) pam_end (pamh, ret);
 		su_failure (caller_tty, 0 == pw->pw_uid);
 	}
@@ -483,25 +476,21 @@ static void check_perms_pam (const struct passwd *pw)
 	ret = pam_acct_mgmt (pamh, 0);
 	if (PAM_SUCCESS != ret) {
 		if (caller_is_root) {
-			fprintf (stderr,
-			         _("%s: %s\n(Ignored)\n"),
+			eprintf(_("%s: %s\n(Ignored)\n"),
 			         Prog, pam_strerror (pamh, ret));
 		} else if (PAM_NEW_AUTHTOK_REQD == ret) {
 			ret = pam_chauthtok (pamh, PAM_CHANGE_EXPIRED_AUTHTOK);
 			if (PAM_SUCCESS != ret) {
 				SYSLOG(LOG_ERR, "pam_chauthtok: %s",
 				       pam_strerror(pamh, ret));
-				fprintf (stderr,
-				         _("%s: %s\n"),
+				eprintf(_("%s: %s\n"),
 				         Prog, pam_strerror (pamh, ret));
 				(void) pam_end (pamh, ret);
 				su_failure (caller_tty, 0 == pw->pw_uid);
 			}
 		} else {
 			SYSLOG(LOG_ERR, "pam_acct_mgmt: %s", pam_strerror(pamh, ret));
-			fprintf (stderr,
-			         _("%s: %s\n"),
-			         Prog, pam_strerror (pamh, ret));
+			eprintf(_("%s: %s\n"), Prog, pam_strerror(pamh, ret));
 			(void) pam_end (pamh, ret);
 			su_failure (caller_tty, 0 == pw->pw_uid);
 		}
@@ -525,11 +514,11 @@ static void check_perms_nopam (const struct passwd *pw)
 			prevent_no_auth = "superuser";
 		}
 		if (streq(prevent_no_auth, "yes")) {
-			fprintf(stderr, _("Password field is empty, this is forbidden for all accounts.\n"));
+			eprintf(_("Password field is empty, this is forbidden for all accounts.\n"));
 			exit(1);
 		} else if ((pw->pw_uid == 0)
 				&& streq(prevent_no_auth, "superuser")) {
-			fprintf(stderr, _("Password field is empty, this is forbidden for super-user.\n"));
+			eprintf(_("Password field is empty, this is forbidden for super-user.\n"));
 			exit(1);
 		}
 	}
@@ -555,9 +544,7 @@ static void check_perms_nopam (const struct passwd *pw)
 	if (   (0 == pw->pw_uid)
 	    && getdef_bool ("SU_WHEEL_ONLY")
 	    && !iswheel (caller_name)) {
-		fprintf (stderr,
-		         _("You are not authorized to su %s\n"),
-		         name);
+		eprintf(_("You are not authorized to su %s\n"), name);
 		exit (1);
 	}
 	spwd = getspnam (name); /* !USE_PAM, no need for xgetspnam */
@@ -579,9 +566,7 @@ static void check_perms_nopam (const struct passwd *pw)
 		password = caller_pass;
 		break;
 	default:	/* access denied (-1) or unexpected value */
-		fprintf (stderr,
-		         _("You are not authorized to su %s\n"),
-		         name);
+		eprintf(_("You are not authorized to su %s\n"), name);
 		exit (1);
 	}
 #endif				/* SU_ACCESS */
@@ -599,7 +584,7 @@ static void check_perms_nopam (const struct passwd *pw)
 	if (pw_auth(password, name) != 0) {
 		SYSLOG(pw->pw_uid ? LOG_NOTICE : LOG_WARN,
 		       "Authentication failed for %s", name);
-		fprintf(stderr, _("%s: Authentication failure\n"), Prog);
+		eprintf(_("%s: Authentication failure\n"), Prog);
 		su_failure (caller_tty, 0 == pw->pw_uid);
 	}
 	(void) signal (SIGQUIT, oldsig);
@@ -622,8 +607,7 @@ static void check_perms_nopam (const struct passwd *pw)
 	if (!isttytime (name, "SU", time (NULL))) {
 		SYSLOG(pw->pw_uid ? LOG_WARN : LOG_CRIT,
 		       "SU by %s to restricted account %s", caller_name, name);
-		fprintf (stderr,
-		         _("%s: You are not authorized to su at that time\n"),
+		eprintf(_("%s: You are not authorized to su at that time\n"),
 		         Prog);
 		su_failure (caller_tty, 0 == pw->pw_uid);
 	}
@@ -664,8 +648,7 @@ static /*@only@*/struct passwd * do_check_perms (void)
 	 */
 	struct passwd *pw = xgetpwnam (name);
 	if (NULL == pw) {
-		(void) fprintf (stderr,
-		                _("No passwd entry for user '%s'\n"), name);
+		(void) eprintf(_("No passwd entry for user '%s'\n"), name);
 		SYSLOG(LOG_NOTICE, "No passwd entry for user '%s'", name);
 		su_failure (caller_tty, true);
 	}
@@ -679,8 +662,7 @@ static /*@only@*/struct passwd * do_check_perms (void)
 	ret = pam_get_item(pamh, PAM_USER, &item);
 	if (ret != PAM_SUCCESS) {
 		SYSLOG(LOG_ERR, "pam_get_item: internal PAM error\n");
-		(void) fprintf (stderr,
-		                "%s: Internal PAM error retrieving username\n",
+		(void) eprintf("%s: Internal PAM error retrieving username\n",
 		                Prog);
 		(void) pam_end (pamh, ret);
 		su_failure (caller_tty, 0 == pw->pw_uid);
@@ -691,15 +673,13 @@ static /*@only@*/struct passwd * do_check_perms (void)
 		       "Change user from '%s' to '%s' as requested by PAM",
 		       name, tmp_name);
 		if (strtcpy_a(name, tmp_name) == -1) {
-			fprintf (stderr, _("Overlong user name '%s'\n"),
-			         tmp_name);
+			eprintf(_("Overlong user name '%s'\n"), tmp_name);
 			SYSLOG(LOG_NOTICE, "Overlong user name '%s'", tmp_name);
 			su_failure (caller_tty, true);
 		}
 		pw = xgetpwnam (name);
 		if (NULL == pw) {
-			(void) fprintf (stderr,
-			                _("No passwd entry for user '%s'\n"),
+			(void) eprintf(_("No passwd entry for user '%s'\n"),
 			                name);
 			SYSLOG(LOG_NOTICE, "No passwd entry for user '%s'", name);
 			su_failure (caller_tty, true);
@@ -766,9 +746,7 @@ save_caller_context(void)
 		 * Be more paranoid, like su from SimplePAMApps.  --marekm
 		 */
 		if (!caller_is_root) {
-			fprintf (stderr,
-			         _("%s: must be run from a terminal\n"),
-			         Prog);
+			eprintf(_("%s: must be run from a terminal\n"), Prog);
 			exit (1);
 		}
 		caller_tty = "???";
@@ -780,9 +758,7 @@ save_caller_context(void)
 	 */
 	pw = get_my_pwent ();
 	if (NULL == pw) {
-		fprintf (stderr,
-		         _("%s: Cannot determine your user name.\n"),
-		         Prog);
+		eprintf(_("%s: Cannot determine your user name.\n"), Prog);
 		SYSLOG(LOG_WARN, "Cannot determine the user name of the caller (UID %lu)",
 		       (unsigned long) caller_uid);
 		su_failure (caller_tty, true); /* unknown target UID*/
@@ -1055,7 +1031,7 @@ int main (int argc, char **argv)
 	ret = pam_start (Prog, name, &conv, &pamh);
 	if (PAM_SUCCESS != ret) {
 		SYSLOG(LOG_ERR, "pam_start: error %d", ret);
-		fprintf(stderr, _("%s: pam_start: error %d\n"), Prog, ret);
+		eprintf(_("%s: pam_start: error %d\n"), Prog, ret);
 		exit (1);
 	}
 
@@ -1065,7 +1041,7 @@ int main (int argc, char **argv)
 	}
 	if (PAM_SUCCESS != ret) {
 		SYSLOG(LOG_ERR, "pam_set_item: %s", pam_strerror(pamh, ret));
-		fprintf (stderr, _("%s: %s\n"), Prog, pam_strerror (pamh, ret));
+		eprintf(_("%s: %s\n"), Prog, pam_strerror(pamh, ret));
 		pam_end (pamh, ret);
 		exit (1);
 	}
@@ -1126,7 +1102,7 @@ int main (int argc, char **argv)
 	ret = pam_setcred (pamh, PAM_ESTABLISH_CRED);
 	if (PAM_SUCCESS != ret) {
 		SYSLOG(LOG_ERR, "pam_setcred: %s", pam_strerror(pamh, ret));
-		fprintf (stderr, _("%s: %s\n"), Prog, pam_strerror (pamh, ret));
+		eprintf(_("%s: %s\n"), Prog, pam_strerror(pamh, ret));
 		(void) pam_end (pamh, ret);
 		exit (1);
 	}
@@ -1134,7 +1110,7 @@ int main (int argc, char **argv)
 	ret = pam_open_session (pamh, 0);
 	if (PAM_SUCCESS != ret) {
 		SYSLOG(LOG_ERR, "pam_open_session: %s", pam_strerror(pamh, ret));
-		fprintf (stderr, _("%s: %s\n"), Prog, pam_strerror (pamh, ret));
+		eprintf(_("%s: %s\n"), Prog, pam_strerror(pamh, ret));
 		pam_setcred (pamh, PAM_DELETE_CRED);
 		(void) pam_end (pamh, ret);
 		exit (1);
@@ -1197,8 +1173,7 @@ int main (int argc, char **argv)
 #endif				/* USE_PAM */
 
 		if (-1 == err) {
-			(void) fprintf (stderr,
-			                _("%s: Cannot drop the controlling terminal\n"),
+			(void) eprintf(_("%s: Cannot drop the controlling terminal\n"),
 			                Prog);
 			exit (1);
 		}
@@ -1250,8 +1225,7 @@ int main (int argc, char **argv)
 		argv[-1] = const_cast(char *, cp);
 		execve_shell (shellstr, &argv[-1], environ);
 		err = errno;
-		(void) fprintf (stderr,
-		                _("Cannot execute %s\n"), shellstr);
+		(void) eprintf(_("Cannot execute %s\n"), shellstr);
 		errno = err;
 	} else {
 		(void) shell (shellstr, cp, environ);

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -267,42 +267,41 @@ static void fail_exit (int code, bool process_selinux)
 #endif
 
 	if (home_added && rmdir(prefix_user_home) != 0) {
-		fprintf(stderr,
-		        _("%s: %s was created, but could not be removed\n"),
+		eprintf(_("%s: %s was created, but could not be removed\n"),
 		        Prog, prefix_user_home);
 		SYSLOG(LOG_ERR, "failed to remove %s", prefix_user_home);
 	}
 
 	if (spw_locked && spw_unlock(process_selinux) == 0) {
-		fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, spw_dbname());
+		eprintf(_("%s: failed to unlock %s\n"), Prog, spw_dbname());
 		SYSLOG(LOG_ERR, "failed to unlock %s", spw_dbname());
 		/* continue */
 	}
 	if (pw_locked && pw_unlock(process_selinux) == 0) {
-		fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, pw_dbname());
+		eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
 		SYSLOG(LOG_ERR, "failed to unlock %s", pw_dbname());
 		/* continue */
 	}
 	if (gr_locked && gr_unlock(process_selinux) == 0) {
-		fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, gr_dbname());
+		eprintf(_("%s: failed to unlock %s\n"), Prog, gr_dbname());
 		SYSLOG(LOG_ERR, "failed to unlock %s", gr_dbname());
 		/* continue */
 	}
 #ifdef SHADOWGRP
 	if (sgr_locked && sgr_unlock(process_selinux) == 0) {
-		fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, sgr_dbname());
+		eprintf(_("%s: failed to unlock %s\n"), Prog, sgr_dbname());
 		SYSLOG(LOG_ERR, "failed to unlock %s", sgr_dbname());
 		/* continue */
 	}
 #endif
 #ifdef ENABLE_SUBIDS
 	if (sub_uid_locked && sub_uid_unlock(process_selinux) == 0) {
-		fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, sub_uid_dbname());
+		eprintf(_("%s: failed to unlock %s\n"), Prog, sub_uid_dbname());
 		SYSLOG(LOG_ERR, "failed to unlock %s", sub_uid_dbname());
 		/* continue */
 	}
 	if (sub_gid_locked && sub_gid_unlock(process_selinux) == 0) {
-		fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, sub_gid_dbname());
+		eprintf(_("%s: failed to unlock %s\n"), Prog, sub_gid_dbname());
 		SYSLOG(LOG_ERR, "failed to unlock %s", sub_gid_dbname());
 		/* continue */
 	}
@@ -370,11 +369,9 @@ get_defaults(const struct option_flags *flags)
 		if (streq(buf, DGROUP)) {
 			const struct group *grp = prefix_getgr_nam_gid (cp);
 			if (NULL == grp) {
-				fprintf (stderr,
-				         _("%s: group '%s' does not exist\n"),
+				eprintf(_("%s: group '%s' does not exist\n"),
 				         Prog, cp);
-				fprintf (stderr,
-				         _("%s: the %s= configuration in %s will be ignored\n"),
+				eprintf(_("%s: the %s= configuration in %s will be ignored\n"),
 				         Prog, DGROUP, default_file);
 			} else {
 				def_group = grp->gr_gid;
@@ -386,8 +383,7 @@ get_defaults(const struct option_flags *flags)
 
 		if (streq(buf, DGROUPS)) {
 			if (get_groups (cp, flags) != 0) {
-				fprintf (stderr,
-				         _("%s: the '%s=' configuration in %s has an invalid group, ignoring the bad group\n"),
+				eprintf(_("%s: the '%s=' configuration in %s has an invalid group, ignoring the bad group\n"),
 				         Prog, DGROUPS, default_file);
 			}
 			if (user_groups[0] != NULL) {
@@ -414,11 +410,9 @@ get_defaults(const struct option_flags *flags)
 		 */
 		else if (streq(buf, DINACT)) {
 			if (a2sl(&def_inactive, ccp, NULL, 0, -1, LONG_MAX) == -1) {
-				fprintf (stderr,
-				         _("%s: invalid numeric argument '%s'\n"),
+				eprintf(_("%s: invalid numeric argument '%s'\n"),
 				         Prog, ccp);
-				fprintf (stderr,
-				         _("%s: the %s= configuration in %s will be ignored\n"),
+				eprintf(_("%s: the %s= configuration in %s will be ignored\n"),
 				         Prog, DINACT, default_file);
 				def_inactive = -1;
 			}
@@ -561,8 +555,7 @@ set_defaults(void)
 
 	new_file_dup = strdup(new_file);
 	if (new_file_dup == NULL) {
-		fprintf (stderr,
-			_("%s: cannot create directory for defaults file\n"),
+		eprintf(_("%s: cannot create directory for defaults file\n"),
 			Prog);
 		goto err_free_def;
 	}
@@ -570,8 +563,7 @@ set_defaults(void)
 	ret = mkdir(dirname(new_file_dup), 0755);
 	free(new_file_dup);
 	if (-1 == ret && EEXIST != errno) {
-		fprintf (stderr,
-			_("%s: cannot create directory for defaults file\n"),
+		eprintf(_("%s: cannot create directory for defaults file\n"),
 			Prog);
 		goto err_free_def;
 	}
@@ -581,8 +573,7 @@ set_defaults(void)
 	 */
 	ofp = fmkomstemp(new_file, 0, 0644);
 	if (NULL == ofp) {
-		fprintf (stderr,
-		         _("%s: cannot open new defaults file\n"),
+		eprintf(_("%s: cannot open new defaults file\n"),
 		         Prog);
 		goto err_free_def;
 	}
@@ -606,8 +597,7 @@ set_defaults(void)
 			 * at the end of the file.
 			 */
 			if (feof (ifp) == 0) {
-				fprintf (stderr,
-				         _("%s: line too long in %s: %s..."),
+				eprintf(_("%s: line too long in %s: %s..."),
 				         Prog, default_file, buf);
 				fclose(ifp);
 				fclose(ofp);
@@ -802,9 +792,7 @@ static int get_groups(char *list, const struct option_flags *flags)
 		 *        otherwise, we can't change its members
 		 */
 		if (NULL == grp) {
-			fprintf (stderr,
-			         _("%s: group '%s' does not exist\n"),
-			         Prog, g);
+			eprintf(_("%s: group '%s' does not exist\n"), Prog, g);
 			errors = true;
 		}
 
@@ -817,8 +805,7 @@ static int get_groups(char *list, const struct option_flags *flags)
 		}
 
 		if (ngroups == sys_ngroups) {
-			fprintf (stderr,
-			         _("%s: too many groups specified (max %zu).\n"),
+			eprintf(_("%s: too many groups specified (max %zu).\n"),
 			         Prog, ngroups);
 			gr_free(grp);
 			break;
@@ -867,8 +854,7 @@ static struct group * get_local_group(char * grp_name, bool process_selinux)
 	if (grp != NULL) {
 		result_grp = __gr_dup (grp);
 		if (NULL == result_grp) {
-			fprintf (stderr,
-					_("%s: Out of memory. Cannot find group '%s'.\n"),
+			eprintf(_("%s: Out of memory. Cannot find group '%s'.\n"),
 					Prog, grp_name);
 			fail_exit (E_GRP_UPDATE, process_selinux);
 		}
@@ -1033,8 +1019,7 @@ static void grp_update (bool process_selinux)
 		 */
 		ngrp = __gr_dup (grp);
 		if (NULL == ngrp) {
-			fprintf (stderr,
-			         _("%s: Out of memory. Cannot update %s.\n"),
+			eprintf(_("%s: Out of memory. Cannot update %s.\n"),
 			         Prog, gr_dbname ());
 			SYSLOG(LOG_ERR, "failed to prepare the new %s entry '%s'", gr_dbname(), user_name);
 			fail_exit (E_GRP_UPDATE, process_selinux);	/* XXX */
@@ -1046,8 +1031,7 @@ static void grp_update (bool process_selinux)
 		 */
 		ngrp->gr_mem = add_list (ngrp->gr_mem, user_name);
 		if (gr_update (ngrp) == 0) {
-			fprintf (stderr,
-			         _("%s: failed to prepare the new %s entry '%s'\n"),
+			eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
 			         Prog, gr_dbname (), ngrp->gr_name);
 			SYSLOG(LOG_ERR, "failed to prepare the new %s entry '%s'", gr_dbname(), user_name);
 			fail_exit (E_GRP_UPDATE, process_selinux);
@@ -1094,8 +1078,7 @@ static void grp_update (bool process_selinux)
 		 */
 		nsgrp = __sgr_dup (sgrp);
 		if (NULL == nsgrp) {
-			fprintf (stderr,
-			         _("%s: Out of memory. Cannot update %s.\n"),
+			eprintf(_("%s: Out of memory. Cannot update %s.\n"),
 			         Prog, sgr_dbname ());
 			SYSLOG(LOG_ERR, "failed to prepare the new %s entry '%s'", sgr_dbname(), user_name);
 			fail_exit (E_GRP_UPDATE, process_selinux);	/* XXX */
@@ -1107,8 +1090,7 @@ static void grp_update (bool process_selinux)
 		 */
 		nsgrp->sg_mem = add_list (nsgrp->sg_mem, user_name);
 		if (sgr_update (nsgrp) == 0) {
-			fprintf (stderr,
-			         _("%s: failed to prepare the new %s entry '%s'\n"),
+			eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
 			         Prog, sgr_dbname (), nsgrp->sg_namp);
 			SYSLOG(LOG_ERR, "failed to prepare the new %s entry '%s'", sgr_dbname(), user_name);
 
@@ -1196,8 +1178,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 			case 'b':
 				if (   ( !VALID (optarg) )
 				    || ( optarg[0] != '/' )) {
-					fprintf (stderr,
-					         _("%s: invalid base directory '%s'\n"),
+					eprintf(_("%s: invalid base directory '%s'\n"),
 					         Prog, optarg);
 					exit (E_BAD_ARG);
 				}
@@ -1212,8 +1193,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 				break;
 			case 'c':
 				if (!VALID (optarg)) {
-					fprintf (stderr,
-					         _("%s: invalid comment '%s'\n"),
+					eprintf(_("%s: invalid comment '%s'\n"),
 					         Prog, optarg);
 					exit (E_BAD_ARG);
 				}
@@ -1223,8 +1203,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 			case 'd':
 				if (   ( !VALID (optarg) )
 				    || ( optarg[0] != '/' )) {
-					fprintf (stderr,
-					         _("%s: invalid home directory '%s'\n"),
+					eprintf(_("%s: invalid home directory '%s'\n"),
 					         Prog, optarg);
 					exit (E_BAD_ARG);
 				}
@@ -1241,8 +1220,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 				if (!streq(optarg, "")) {
 					user_expire = strtoday (optarg);
 					if (user_expire < -1) {
-						fprintf (stderr,
-						         _("%s: invalid date '%s'\n"),
+						eprintf(_("%s: invalid date '%s'\n"),
 						         Prog, optarg);
 						exit (E_BAD_ARG);
 					}
@@ -1255,8 +1233,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 				 * (it's a no-op in such case)
 				 */
 				if ((-1 != user_expire) && !is_shadow_pwd) {
-					fprintf (stderr,
-					         _("%s: shadow passwords required for -e\n"),
+					eprintf(_("%s: shadow passwords required for -e\n"),
 					         Prog);
 					exit (E_USAGE);
 				}
@@ -1269,8 +1246,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 				if (a2sl(&def_inactive, optarg, NULL, 0, -1, LONG_MAX)
 				    == -1)
 				{
-					fprintf (stderr,
-					         _("%s: invalid numeric argument '%s'\n"),
+					eprintf(_("%s: invalid numeric argument '%s'\n"),
 					         Prog, optarg);
 					exit (E_BAD_ARG);
 				}
@@ -1279,8 +1255,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 				 * it's a no-op without /etc/shadow
 				 */
 				if ((-1 != def_inactive) && !is_shadow_pwd) {
-					fprintf (stderr,
-					         _("%s: shadow passwords required for -f\n"),
+					eprintf(_("%s: shadow passwords required for -f\n"),
 					         Prog);
 					exit (E_USAGE);
 				}
@@ -1294,8 +1269,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 			case 'g':
 				grp = prefix_getgr_nam_gid (optarg);
 				if (NULL == grp) {
-					fprintf (stderr,
-					         _("%s: group '%s' does not exist\n"),
+					eprintf(_("%s: group '%s' does not exist\n"),
 					         Prog, optarg);
 					exit (E_NOTFOUND);
 				}
@@ -1331,8 +1305,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 				 */
 				cp = stpsep(optarg, "=");
 				if (NULL == cp) {
-					fprintf (stderr,
-					         _("%s: -K requires KEY=VALUE\n"),
+					eprintf(_("%s: -K requires KEY=VALUE\n"),
 					         Prog);
 					exit (E_BAD_ARG);
 				}
@@ -1357,8 +1330,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 				break;
 			case 'p':	/* set encrypted password */
 				if (!VALID (optarg)) {
-					fprintf (stderr,
-					         _("%s: invalid field '%s'\n"),
+					eprintf(_("%s: invalid field '%s'\n"),
 					         Prog, optarg);
 					exit (E_BAD_ARG);
 				}
@@ -1378,8 +1350,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 				    || (   !streq(optarg, "")
 				        && ('/'  != optarg[0])
 				        && ('*'  != optarg[0]) )) {
-					fprintf (stderr,
-					         _("%s: invalid shell '%s'\n"),
+					eprintf(_("%s: invalid shell '%s'\n"),
 					         Prog, optarg);
 					exit (E_BAD_ARG);
 				}
@@ -1390,8 +1361,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 				     && (   stat(optarg, &st) != 0
 				         || S_ISDIR(st.st_mode)
 				         || access(optarg, X_OK) != 0)) {
-					fprintf (stderr,
-					         _("%s: Warning: missing or non-executable shell '%s'\n"),
+					eprintf(_("%s: Warning: missing or non-executable shell '%s'\n"),
 					         Prog, optarg);
 				}
 				user_shell = optarg;
@@ -1401,8 +1371,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 			case 'u':
 				if (   (get_uid(optarg, &user_id) == -1)
 				    || (user_id == (gid_t)-1)) {
-					fprintf (stderr,
-					         _("%s: invalid user ID '%s'\n"),
+					eprintf(_("%s: invalid user ID '%s'\n"),
 					         Prog, optarg);
 					exit (E_BAD_ARG);
 				}
@@ -1414,16 +1383,14 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 #ifdef WITH_SELINUX
 			case 'Z':
 				if (prefix[0]) {
-					fprintf (stderr,
-					         _("%s: -Z cannot be used with --prefix\n"),
+					eprintf(_("%s: -Z cannot be used with --prefix\n"),
 					         Prog);
 					exit (E_BAD_ARG);
 				}
 				if (is_selinux_enabled () > 0) {
 					user_selinux = optarg;
 				} else {
-					fprintf (stderr,
-					         _("%s: -Z requires SELinux enabled kernel\n"),
+					eprintf(_("%s: -Z requires SELinux enabled kernel\n"),
 					         Prog);
 
 					exit (E_BAD_ARG);
@@ -1453,39 +1420,33 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 	 * Check it here so that they can be specified in any order.
 	 */
 	if (oflg && !uflg) {
-		fprintf (stderr,
-		         _("%s: %s flag is only allowed with the %s flag\n"),
+		eprintf(_("%s: %s flag is only allowed with the %s flag\n"),
 		         Prog, "-o", "-u");
 		usage (E_USAGE);
 	}
 	if (kflg && !mflg) {
-		fprintf (stderr,
-		         _("%s: %s flag is only allowed with the %s flag\n"),
+		eprintf(_("%s: %s flag is only allowed with the %s flag\n"),
 		         Prog, "-k", "-m");
 		usage (E_USAGE);
 	}
 	if (Uflg && gflg) {
-		fprintf (stderr,
-		         _("%s: options %s and %s conflict\n"),
+		eprintf(_("%s: options %s and %s conflict\n"),
 		         Prog, "-U", "-g");
 		usage (E_USAGE);
 	}
 	if (Uflg && Nflg) {
-		fprintf (stderr,
-		         _("%s: options %s and %s conflict\n"),
+		eprintf(_("%s: options %s and %s conflict\n"),
 		         Prog, "-U", "-N");
 		usage (E_USAGE);
 	}
 	if (mflg && Mflg) {
-		fprintf (stderr,
-		         _("%s: options %s and %s conflict\n"),
+		eprintf(_("%s: options %s and %s conflict\n"),
 		         Prog, "-m", "-M");
 		usage (E_USAGE);
 	}
 #ifdef WITH_SELINUX
 	if (user_selinux_range && !Zflg) {
-		fprintf (stderr,
-		         _("%s: %s flag is only allowed with the %s flag\n"),
+		eprintf(_("%s: %s flag is only allowed with the %s flag\n"),
 		         Prog, "--selinux-range", "--selinux-user");
 		usage (E_USAGE);
 	}
@@ -1511,12 +1472,10 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 		user_name = argv[optind];
 		if (!is_valid_user_name(user_name, badnameflg)) {
 			if (errno == EILSEQ) {
-				fprintf(stderr,
-				        _("%s: invalid user name '%s': use --badname to ignore\n"),
+				eprintf(_("%s: invalid user name '%s': use --badname to ignore\n"),
 				        Prog, user_name);
 			} else {
-				fprintf(stderr,
-				        _("%s: invalid user name '%s'\n"),
+				eprintf(_("%s: invalid user name '%s'\n"),
 				        Prog, user_name);
 			}
 #ifdef WITH_AUDIT
@@ -1592,13 +1551,12 @@ static void close_files(const struct option_flags *flags)
 	process_selinux = !flags->chroot && !flags->prefix;
 
 	if (pw_close (process_selinux) == 0) {
-		fprintf (stderr, _("%s: failure while writing changes to %s\n"), Prog, pw_dbname ());
+		eprintf(_("%s: failure while writing changes to %s\n"), Prog, pw_dbname());
 		SYSLOG(LOG_ERR, "failure while writing changes to %s", pw_dbname());
 		fail_exit (E_PW_UPDATE, process_selinux);
 	}
 	if (is_shadow_pwd && (spw_close (process_selinux) == 0)) {
-		fprintf (stderr,
-		         _("%s: failure while writing changes to %s\n"), Prog, spw_dbname ());
+		eprintf(_("%s: failure while writing changes to %s\n"), Prog, spw_dbname());
 		SYSLOG(LOG_ERR, "failure while writing changes to %s", spw_dbname());
 		fail_exit (E_PW_UPDATE, process_selinux);
 	}
@@ -1607,21 +1565,19 @@ static void close_files(const struct option_flags *flags)
 
 #ifdef ENABLE_SUBIDS
 	if (is_sub_uid  && (sub_uid_close (process_selinux) == 0)) {
-		fprintf (stderr,
-		         _("%s: failure while writing changes to %s\n"), Prog, sub_uid_dbname ());
+		eprintf(_("%s: failure while writing changes to %s\n"), Prog, sub_uid_dbname());
 		SYSLOG(LOG_ERR, "failure while writing changes to %s", sub_uid_dbname());
 		fail_exit (E_SUB_UID_UPDATE, process_selinux);
 	}
 	if (is_sub_gid  && (sub_gid_close (process_selinux) == 0)) {
-		fprintf (stderr,
-		         _("%s: failure while writing changes to %s\n"), Prog, sub_gid_dbname ());
+		eprintf(_("%s: failure while writing changes to %s\n"), Prog, sub_gid_dbname());
 		SYSLOG(LOG_ERR, "failure while writing changes to %s", sub_gid_dbname());
 		fail_exit (E_SUB_GID_UPDATE, process_selinux);
 	}
 #endif				/* ENABLE_SUBIDS */
 	if (is_shadow_pwd) {
 		if (spw_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, spw_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, spw_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", spw_dbname());
 #ifdef WITH_AUDIT
 			audit_logger (AUDIT_ADD_USER,
@@ -1634,7 +1590,7 @@ static void close_files(const struct option_flags *flags)
 		spw_locked = false;
 	}
 	if (pw_unlock (process_selinux) == 0) {
-		fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, pw_dbname ());
+		eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
 		SYSLOG(LOG_ERR, "failed to unlock %s", pw_dbname());
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_ADD_USER,
@@ -1651,7 +1607,7 @@ static void close_files(const struct option_flags *flags)
 #ifdef ENABLE_SUBIDS
 	if (is_sub_uid) {
 		if (sub_uid_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, sub_uid_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, sub_uid_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sub_uid_dbname());
 #ifdef WITH_AUDIT
 			audit_logger (AUDIT_ADD_USER,
@@ -1665,7 +1621,7 @@ static void close_files(const struct option_flags *flags)
 	}
 	if (is_sub_gid) {
 		if (sub_gid_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, sub_gid_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, sub_gid_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sub_gid_dbname());
 #ifdef WITH_AUDIT
 			audit_logger (AUDIT_ADD_USER,
@@ -1692,16 +1648,14 @@ static void close_group_files (bool process_selinux)
 		return;
 
 	if (gr_close(process_selinux) == 0) {
-		fprintf(stderr,
-		        _("%s: failure while writing changes to %s\n"),
+		eprintf(_("%s: failure while writing changes to %s\n"),
 		        Prog, gr_dbname());
 		SYSLOG(LOG_ERR, "failure while writing changes to %s", gr_dbname());
 		fail_exit(E_GRP_UPDATE, process_selinux);
 	}
 #ifdef	SHADOWGRP
 	if (is_shadow_grp && sgr_close(process_selinux) == 0) {
-		fprintf(stderr,
-		        _("%s: failure while writing changes to %s\n"),
+		eprintf(_("%s: failure while writing changes to %s\n"),
 		        Prog, sgr_dbname());
 		SYSLOG(LOG_ERR, "failure while writing changes to %s", sgr_dbname());
 		fail_exit(E_GRP_UPDATE, process_selinux);
@@ -1718,7 +1672,7 @@ static void close_group_files (bool process_selinux)
 static void unlock_group_files (bool process_selinux)
 {
 	if (gr_unlock (process_selinux) == 0) {
-		fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, gr_dbname ());
+		eprintf(_("%s: failed to unlock %s\n"), Prog, gr_dbname());
 		SYSLOG(LOG_ERR, "failed to unlock %s", gr_dbname());
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_ADD_USER,
@@ -1732,7 +1686,7 @@ static void unlock_group_files (bool process_selinux)
 #ifdef	SHADOWGRP
 	if (is_shadow_grp) {
 		if (sgr_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, sgr_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, sgr_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sgr_dbname());
 #ifdef WITH_AUDIT
 			audit_logger (AUDIT_ADD_USER,
@@ -1755,14 +1709,13 @@ static void unlock_group_files (bool process_selinux)
 static void open_files (bool process_selinux)
 {
 	if (pw_lock () == 0) {
-		fprintf (stderr,
-		         _("%s: cannot lock %s; try again later.\n"),
+		eprintf(_("%s: cannot lock %s; try again later.\n"),
 		         Prog, pw_dbname ());
 		exit (E_PW_UPDATE);
 	}
 	pw_locked = true;
 	if (pw_open (O_CREAT | O_RDWR) == 0) {
-		fprintf (stderr, _("%s: cannot open %s\n"), Prog, pw_dbname ());
+		eprintf(_("%s: cannot open %s\n"), Prog, pw_dbname());
 		fail_exit (E_PW_UPDATE, process_selinux);
 	}
 
@@ -1776,30 +1729,26 @@ static void open_subid_files (bool process_selinux)
 {
 	if (is_sub_uid) {
 		if (sub_uid_lock () == 0) {
-			fprintf (stderr,
-			         _("%s: cannot lock %s; try again later.\n"),
+			eprintf(_("%s: cannot lock %s; try again later.\n"),
 			         Prog, sub_uid_dbname ());
 			fail_exit (E_SUB_UID_UPDATE, process_selinux);
 		}
 		sub_uid_locked = true;
 		if (sub_uid_open (O_CREAT | O_RDWR) == 0) {
-			fprintf (stderr,
-			         _("%s: cannot open %s\n"),
+			eprintf(_("%s: cannot open %s\n"),
 			         Prog, sub_uid_dbname ());
 			fail_exit (E_SUB_UID_UPDATE, process_selinux);
 		}
 	}
 	if (is_sub_gid) {
 		if (sub_gid_lock () == 0) {
-			fprintf (stderr,
-			         _("%s: cannot lock %s; try again later.\n"),
+			eprintf(_("%s: cannot lock %s; try again later.\n"),
 			         Prog, sub_gid_dbname ());
 			fail_exit (E_SUB_GID_UPDATE, process_selinux);
 		}
 		sub_gid_locked = true;
 		if (sub_gid_open (O_CREAT | O_RDWR) == 0) {
-			fprintf (stderr,
-			         _("%s: cannot open %s\n"),
+			eprintf(_("%s: cannot open %s\n"),
 			         Prog, sub_gid_dbname ());
 			fail_exit (E_SUB_GID_UPDATE, process_selinux);
 		}
@@ -1810,30 +1759,26 @@ static void open_subid_files (bool process_selinux)
 static void open_group_files (bool process_selinux)
 {
 	if (gr_lock () == 0) {
-		fprintf (stderr,
-		         _("%s: cannot lock %s; try again later.\n"),
+		eprintf(_("%s: cannot lock %s; try again later.\n"),
 		         Prog, gr_dbname ());
 		fail_exit (E_GRP_UPDATE, process_selinux);
 	}
 	gr_locked = true;
 	if (gr_open (O_CREAT | O_RDWR) == 0) {
-		fprintf (stderr, _("%s: cannot open %s\n"), Prog, gr_dbname ());
+		eprintf(_("%s: cannot open %s\n"), Prog, gr_dbname());
 		fail_exit (E_GRP_UPDATE, process_selinux);
 	}
 
 #ifdef  SHADOWGRP
 	if (is_shadow_grp) {
 		if (sgr_lock () == 0) {
-			fprintf (stderr,
-			         _("%s: cannot lock %s; try again later.\n"),
+			eprintf(_("%s: cannot lock %s; try again later.\n"),
 			         Prog, sgr_dbname ());
 			fail_exit (E_GRP_UPDATE, process_selinux);
 		}
 		sgr_locked = true;
 		if (sgr_open (O_CREAT | O_RDWR) == 0) {
-			fprintf (stderr,
-			         _("%s: cannot open %s\n"),
-			         Prog, sgr_dbname ());
+			eprintf(_("%s: cannot open %s\n"), Prog, sgr_dbname());
 			fail_exit (E_GRP_UPDATE, process_selinux);
 		}
 	}
@@ -1846,16 +1791,13 @@ static void open_shadow (bool process_selinux)
 		return;
 	}
 	if (spw_lock () == 0) {
-		fprintf (stderr,
-		         _("%s: cannot lock %s; try again later.\n"),
+		eprintf(_("%s: cannot lock %s; try again later.\n"),
 		         Prog, spw_dbname ());
 		fail_exit (E_PW_UPDATE, process_selinux);
 	}
 	spw_locked = true;
 	if (spw_open (O_CREAT | O_RDWR) == 0) {
-		fprintf (stderr,
-		         _("%s: cannot open %s\n"),
-		         Prog, spw_dbname ());
+		eprintf(_("%s: cannot open %s\n"), Prog, spw_dbname());
 		fail_exit (E_PW_UPDATE, process_selinux);
 	}
 }
@@ -1930,8 +1872,7 @@ static void grp_add (bool process_selinux)
 	 * Write out the new group file entry.
 	 */
 	if (gr_update (&grp) == 0) {
-		fprintf (stderr,
-		         _("%s: failed to prepare the new %s entry '%s'\n"),
+		eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
 		         Prog, gr_dbname (), grp.gr_name);
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_ADD_GROUP,
@@ -1946,8 +1887,7 @@ static void grp_add (bool process_selinux)
 	 * Write out the new shadow group entries as well.
 	 */
 	if (is_shadow_grp && (sgr_update (&sgrp) == 0)) {
-		fprintf (stderr,
-		         _("%s: failed to prepare the new %s entry '%s'\n"),
+		eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
 		         Prog, sgr_dbname (), sgrp.sg_namp);
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_ADD_GROUP,
@@ -2083,8 +2023,7 @@ static void tallylog_reset (const char *user_name)
 
 	if (failed)
 	{
-		fprintf (stderr,
-		         _("%s: failed to reset the tallylog entry of user \"%s\"\n"),
+		eprintf(_("%s: failed to reset the tallylog entry of user \"%s\"\n"),
 		         Prog, user_name);
 		SYSLOG(LOG_WARN, "failed to reset the tallylog entry of user \"%s\"", user_name);
 	}
@@ -2145,8 +2084,7 @@ usr_update (unsigned long subuid_count, unsigned long subgid_count,
 	 * Put the new (struct passwd) in the table.
 	 */
 	if (pw_update (&pwent) == 0) {
-		fprintf (stderr,
-		         _("%s: failed to prepare the new %s entry '%s'\n"),
+		eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
 		         Prog, pw_dbname (), pwent.pw_name);
 		fail_exit (E_PW_UPDATE, process_selinux);
 	}
@@ -2155,23 +2093,20 @@ usr_update (unsigned long subuid_count, unsigned long subgid_count,
 	 * Put the new (struct spwd) in the table.
 	 */
 	if (is_shadow_pwd && (spw_update (&spent) == 0)) {
-		fprintf (stderr,
-		         _("%s: failed to prepare the new %s entry '%s'\n"),
+		eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
 		         Prog, spw_dbname (), spent.sp_namp);
 		fail_exit (E_PW_UPDATE, process_selinux);
 	}
 #ifdef ENABLE_SUBIDS
 	if (is_sub_uid && !local_sub_uid_assigned(user_name) &&
 	    (sub_uid_add(user_name, sub_uid_start, subuid_count) == 0)) {
-		fprintf (stderr,
-		         _("%s: failed to prepare the new %s entry\n"),
+		eprintf(_("%s: failed to prepare the new %s entry\n"),
 		         Prog, sub_uid_dbname ());
 		fail_exit (E_SUB_UID_UPDATE, process_selinux);
 	}
 	if (is_sub_gid && !local_sub_gid_assigned(user_name) &&
 	    (sub_gid_add(user_name, sub_gid_start, subgid_count) == 0)) {
-		fprintf (stderr,
-		         _("%s: failed to prepare the new %s entry\n"),
+		eprintf(_("%s: failed to prepare the new %s entry\n"),
 		         Prog, sub_uid_dbname ());
 		fail_exit (E_SUB_GID_UPDATE, process_selinux);
 	}
@@ -2218,8 +2153,7 @@ static void create_home(const struct option_flags *flags)
 	strcpy(path, "");
 	bhome = strdup(prefix_user_home);
 	if (!bhome) {
-		fprintf(stderr,
-			_("%s: error while duplicating string %s\n"),
+		eprintf(_("%s: error while duplicating string %s\n"),
 			Prog, user_home);
 		fail_exit(E_HOMEDIR, process_selinux);
 	}
@@ -2227,8 +2161,7 @@ static void create_home(const struct option_flags *flags)
 #ifdef WITH_SELINUX
 	if (process_selinux) {
 		if (set_selinux_file_context(prefix_user_home, S_IFDIR) != 0) {
-			fprintf(stderr,
-				_("%s: cannot set SELinux context for home directory %s\n"),
+			eprintf(_("%s: cannot set SELinux context for home directory %s\n"),
 				Prog, user_home);
 			fail_exit(E_HOMEDIR, process_selinux);
 		}
@@ -2258,8 +2191,7 @@ static void create_home(const struct option_flags *flags)
 			struct statfs  sfs;
 
 			if (!btrfs_check) {
-				fprintf(stderr,
-					_("%s: error while duplicating string in BTRFS check %s\n"),
+				eprintf(_("%s: error while duplicating string in BTRFS check %s\n"),
 					Prog, path);
 				fail_exit(E_HOMEDIR, process_selinux);
 			}
@@ -2270,13 +2202,11 @@ static void create_home(const struct option_flags *flags)
 			}
 			free(btrfs_check);
 			if (!is_btrfs(&sfs)) {
-				fprintf(stderr,
-				        _("%s: warning: \"%s\" is not on BTRFS; creating regular directory instead of subvolume\n"),
+				eprintf(_("%s: warning: \"%s\" is not on BTRFS; creating regular directory instead of subvolume\n"),
 				        Prog, prefix_user_home);
 			} else {
 				if (btrfs_create_subvolume(path)) {
-					fprintf(stderr,
-					        _("%s: failed to create BTRFS subvolume: %s\n"),
+					eprintf(_("%s: failed to create BTRFS subvolume: %s\n"),
 						Prog, path);
 					fail_exit(E_HOMEDIR, process_selinux);
 				}
@@ -2286,7 +2216,7 @@ static void create_home(const struct option_flags *flags)
 #endif
 		if (!dir_created) {
 			if (mkdir(path, 0) != 0) {
-				fprintf(stderr, _("%s: cannot create directory %s\n"),
+				eprintf(_("%s: cannot create directory %s\n"),
 					Prog, path);
 				fail_exit(E_HOMEDIR, process_selinux);
 			}
@@ -2317,8 +2247,7 @@ static void create_home(const struct option_flags *flags)
 	if (process_selinux) {
 		/* Reset SELinux to create files with default contexts */
 		if (reset_selinux_file_context() != 0) {
-			fprintf(stderr,
-				_("%s: cannot reset SELinux file creation context\n"),
+			eprintf(_("%s: cannot reset SELinux file creation context\n"),
 				Prog);
 			fail_exit(E_HOMEDIR, process_selinux);
 		}
@@ -2365,9 +2294,8 @@ static void create_mail(const struct option_flags *flags)
 #ifdef WITH_SELINUX
 	if (process_selinux) {
 		if (set_selinux_file_context(file, S_IFREG) != 0) {
-			fprintf(stderr,
-					_("%s: cannot set SELinux context for mailbox file %s\n"),
-					Prog, file);
+			eprintf(_("%s: cannot set SELinux context for mailbox file %s\n"),
+				Prog, file);
 			fail_exit(E_MAILBOXFILE, process_selinux);
 		}
 	}
@@ -2408,9 +2336,8 @@ static void create_mail(const struct option_flags *flags)
 	if (process_selinux) {
 		/* Reset SELinux to create files with default contexts */
 		if (reset_selinux_file_context() != 0) {
-			fprintf(stderr,
-					_("%s: cannot reset SELinux file creation context\n"),
-					Prog);
+			eprintf(_("%s: cannot reset SELinux file creation context\n"),
+				Prog);
 			fail_exit(E_MAILBOXFILE, process_selinux);
 		}
 	}
@@ -2424,14 +2351,14 @@ static void check_uid_range(int rflg, uid_t user_id)
 	if (rflg) {
 		uid_max = getdef_ulong("SYS_UID_MAX",getdef_ulong("UID_MIN",1000UL)-1);
 		if (user_id > uid_max) {
-			fprintf(stderr, _("%s warning: %s's uid %d is greater than SYS_UID_MAX %d\n"), Prog, user_name, user_id, uid_max);
+			eprintf(_("%s warning: %s's uid %d is greater than SYS_UID_MAX %d\n"), Prog, user_name, user_id, uid_max);
 		}
 	}else{
 		uid_min = getdef_ulong("UID_MIN", 1000UL);
 		uid_max = getdef_ulong("UID_MAX", 6000UL);
 		if (uid_min <= uid_max) {
 			if (user_id < uid_min || user_id >uid_max)
-				fprintf(stderr, _("%s warning: %s's uid %d outside of the UID_MIN %d and UID_MAX %d range.\n"), Prog, user_name, user_id, uid_min, uid_max);
+				eprintf(_("%s warning: %s's uid %d outside of the UID_MIN %d and UID_MAX %d range.\n"), Prog, user_name, user_id, uid_min, uid_max);
 		}
 	}
 
@@ -2563,7 +2490,7 @@ int main (int argc, char **argv)
 	 * Start with a quick check to see if the user exists.
 	 */
 	if (prefix_getpwnam (user_name) != NULL) { /* local, no need for xgetpwnam */
-		fprintf (stderr, _("%s: user '%s' already exists\n"), Prog, user_name);
+		eprintf(_("%s: user '%s' already exists\n"), Prog, user_name);
 		fail_exit (E_NAME_IN_USE, process_selinux);
 	}
 
@@ -2576,8 +2503,7 @@ int main (int argc, char **argv)
 	if (Uflg) {
 		/* local, no need for xgetgrnam */
 		if (prefix_getgrnam (user_name) != NULL) {
-			fprintf (stderr,
-			         _("%s: group %s exists - if you want to add this user to that group, use -g.\n"),
+			eprintf(_("%s: group %s exists - if you want to add this user to that group, use -g.\n"),
 			         Prog, user_name);
 			fail_exit (E_NAME_IN_USE, process_selinux);
 		}
@@ -2600,13 +2526,12 @@ int main (int argc, char **argv)
 		 * gid too ... --gafton */
 		if (!uflg) {
 			if (find_new_uid (rflg, &user_id, NULL) < 0) {
-				fprintf (stderr, _("%s: can't create user\n"), Prog);
+				eprintf(_("%s: can't create user\n"), Prog);
 				fail_exit (E_UID_IN_USE, process_selinux);
 			}
 		} else {
 			if (prefix_getpwuid (user_id) != NULL) {
-				fprintf (stderr,
-				         _("%s: UID %lu is not unique\n"),
+				eprintf(_("%s: UID %lu is not unique\n"),
 				         Prog, (unsigned long) user_id);
 				fail_exit (E_UID_IN_USE, process_selinux);
 			}
@@ -2627,8 +2552,7 @@ int main (int argc, char **argv)
 #ifdef WITH_TCB
 	if (getdef_bool ("USE_TCB")) {
 		if (shadowtcb_create (user_name, user_id) == SHADOWTCB_FAILURE) {
-			fprintf (stderr,
-			         _("%s: Failed to create tcb directory for %s\n"),
+			eprintf(_("%s: Failed to create tcb directory for %s\n"),
 			         Prog, user_name);
 			fail_exit (E_UID_IN_USE, process_selinux);
 		}
@@ -2640,9 +2564,7 @@ int main (int argc, char **argv)
 	 * open the group files in the open_files() function  --gafton */
 	if (Uflg) {
 		if (find_new_gid (rflg, &user_gid, &user_id) < 0) {
-			fprintf (stderr,
-			         _("%s: can't create group\n"),
-			         Prog);
+			eprintf(_("%s: can't create group\n"), Prog);
 			fail_exit (4, process_selinux);
 		}
 		grp_add (process_selinux);
@@ -2651,18 +2573,14 @@ int main (int argc, char **argv)
 #ifdef ENABLE_SUBIDS
 	if (is_sub_uid && subuid_count != 0) {
 		if (find_new_sub_uids(user_id, &sub_uid_start, &subuid_count) < 0) {
-			fprinte(stderr,
-			        _("%s: can't create subordinate user IDs"),
-			        Prog);
+			eprinte(_("%s: can't create subordinate user IDs"), Prog);
 			SYSLOGE(LOG_WARN, "can't create subordinate user IDs");
 			fail_exit(E_SUB_UID_UPDATE, process_selinux);
 		}
 	}
 	if (is_sub_gid && subgid_count != 0) {
 		if (find_new_sub_gids(user_id, &sub_gid_start, &subgid_count) < 0) {
-			fprinte(stderr,
-			        _("%s: can't create subordinate group IDs"),
-			        Prog);
+			eprinte(_("%s: can't create subordinate group IDs"), Prog);
 			SYSLOGE(LOG_WARN, "can't create subordinate group IDs");
 			fail_exit(E_SUB_GID_UPDATE, process_selinux);
 		}
@@ -2689,8 +2607,7 @@ int main (int argc, char **argv)
 #ifdef WITH_SELINUX
 	if (Zflg) {
 		if (set_seuser (user_name, user_selinux, user_selinux_range) != 0) {
-			fprintf (stderr,
-			         _("%s: warning: the user name %s to %s SELinux user mapping failed.\n"),
+			eprintf(_("%s: warning: the user name %s to %s SELinux user mapping failed.\n"),
 			         Prog, user_name, user_selinux);
 #ifdef WITH_AUDIT
 			audit_logger (AUDIT_ROLE_ASSIGN,
@@ -2710,9 +2627,8 @@ int main (int argc, char **argv)
 			copy_tree (def_usrtemplate, prefix_user_home, false,
 			           (uid_t)-1, user_id, (gid_t)-1, user_gid);
 		} else {
-			fprintf (stderr,
-			         _("%s: warning: the home directory %s already exists.\n"
-			           "%s: Not copying any file from skel directory into it.\n"),
+			eprintf(_("%s: warning: the home directory %s already exists.\n"
+			          "%s: Not copying any file from skel directory into it.\n"),
 			         Prog, user_home, Prog);
 		}
 

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -541,14 +541,14 @@ set_defaults(void)
 
 	new_file = aprintf("%s%s%s", prefix, prefix[0]?"/":"", NEW_USER_FILE);
 	if (new_file == NULL) {
-		fprinte(stderr, _("%s: cannot create new defaults file"), Prog);
+		eprinte(_("%s: cannot create new defaults file"), Prog);
 		return -1;
 	}
 
 	if (prefix[0]) {
 		default_file = aprintf("%s/%s", prefix, USER_DEFAULTS_FILE);
 		if (default_file == NULL) {
-			fprinte(stderr, _("%s: cannot create new defaults file"), Prog);
+			eprinte(_("%s: cannot create new defaults file"), Prog);
 			goto err_free_new;
 		}
 	}
@@ -701,7 +701,7 @@ set_defaults(void)
 	assert(stprintf_a(buf, "%s-", default_file) != -1);
 	unlink (buf);
 	if ((link (default_file, buf) != 0) && (ENOENT != errno)) {
-		fprinte(stderr, _("%s: Cannot create backup file (%s)"), Prog, buf);
+		eprinte(_("%s: Cannot create backup file (%s)"), Prog, buf);
 		unlink (new_file);
 		goto err_free_def;
 	}
@@ -710,7 +710,7 @@ set_defaults(void)
 	 * Rename the new default file to its correct name.
 	 */
 	if (rename (new_file, default_file) != 0) {
-		fprinte(stderr, _("%s: rename: %s"), Prog, new_file);
+		eprinte("%s: rename: %s", Prog, new_file);
 		goto err_free_def;
 	}
 #ifdef WITH_AUDIT
@@ -1923,7 +1923,7 @@ static void faillog_reset (uid_t uid)
 
 	fd = open (FAILLOG_FILE, O_RDWR);
 	if (-1 == fd) {
-		fprinte(stderr, _("%s: failed to open the faillog file for UID %lu"),
+		eprinte(_("%s: failed to open the faillog file for UID %lu"),
 		        Prog, (unsigned long) uid);
 		SYSLOG(LOG_WARN, "failed to open the faillog file for UID %lu", (unsigned long) uid);
 		return;
@@ -1931,12 +1931,12 @@ static void faillog_reset (uid_t uid)
 	if (   (lseek (fd, offset_uid, SEEK_SET) != offset_uid)
 	    || (write_full(fd, &fl, sizeof(fl)) == -1)
 	    || (fsync (fd) != 0)) {
-		fprinte(stderr, _("%s: failed to reset the faillog entry of UID %lu"),
+		eprinte(_("%s: failed to reset the faillog entry of UID %lu"),
 		        Prog, (unsigned long) uid);
 		SYSLOG(LOG_WARN, "failed to reset the faillog entry of UID %lu", (unsigned long) uid);
 	}
 	if (close (fd) != 0 && errno != EINTR) {
-		fprinte(stderr, _("%s: failed to close the faillog file for UID %lu"),
+		eprinte(_("%s: failed to close the faillog file for UID %lu"),
 		        Prog, (unsigned long) uid);
 		SYSLOG(LOG_WARN, "failed to close the faillog file for UID %lu", (unsigned long) uid);
 	}
@@ -1965,7 +1965,7 @@ static void lastlog_reset (uid_t uid)
 
 	fd = open(_PATH_LASTLOG, O_RDWR);
 	if (-1 == fd) {
-		fprinte(stderr, _("%s: failed to open the lastlog file for UID %lu"),
+		eprinte(_("%s: failed to open the lastlog file for UID %lu"),
 		        Prog, (unsigned long) uid);
 		SYSLOG(LOG_WARN, "failed to open the lastlog file for UID %lu", (unsigned long) uid);
 		return;
@@ -1973,13 +1973,13 @@ static void lastlog_reset (uid_t uid)
 	if (   (lseek (fd, offset_uid, SEEK_SET) != offset_uid)
 	    || (write_full(fd, &ll, sizeof(ll)) == -1)
 	    || (fsync (fd) != 0)) {
-		fprinte(stderr, _("%s: failed to reset the lastlog entry of UID %lu"),
+		eprinte(_("%s: failed to reset the lastlog entry of UID %lu"),
 		        Prog, (unsigned long) uid);
 		SYSLOG(LOG_WARN, "failed to reset the lastlog entry of UID %lu", (unsigned long) uid);
 		/* continue */
 	}
 	if (close (fd) != 0 && errno != EINTR) {
-		fprinte(stderr, _("%s: failed to close the lastlog file for UID %lu"),
+		eprinte(_("%s: failed to close the lastlog file for UID %lu"),
 		        Prog, (unsigned long) uid);
 		SYSLOG(LOG_WARN, "failed to close the lastlog file for UID %lu", (unsigned long) uid);
 		/* continue */
@@ -2196,8 +2196,7 @@ static void create_home(const struct option_flags *flags)
 				fail_exit(E_HOMEDIR, process_selinux);
 			}
 			if (statfs(dirname(btrfs_check), &sfs) == -1) {
-				fprinte(stderr, "%s: statfs(dirname(\"%s\"))",
-					Prog, path);
+				eprinte("%s: statfs(dirname(\"%s\"))", Prog, path);
 				fail_exit(E_HOMEDIR, process_selinux);
 			}
 			free(btrfs_check);
@@ -2221,14 +2220,10 @@ static void create_home(const struct option_flags *flags)
 				fail_exit(E_HOMEDIR, process_selinux);
 			}
 		}
-		if (chown(path, 0, 0) < 0) {
-			fprinte(stderr,
-				"%s: %s: chown(%s)", Prog, _("warning"), path);
-		}
-		if (chmod(path, 0755) < 0) {
-			fprinte(stderr,
-				"%s: %s: chmod(%s)", Prog, _("warning"), path);
-		}
+		if (chown(path, 0, 0) < 0)
+			eprinte("%s: %s: chown(%s)", Prog, _("warning"), path);
+		if (chmod(path, 0755) < 0)
+			eprinte("%s: %s: chmod(%s)", Prog, _("warning"), path);
 	}
 	free(bhome);
 
@@ -2236,7 +2231,7 @@ static void create_home(const struct option_flags *flags)
 	mode = getdef_num("HOME_MODE",
 			  0777 & ~getdef_num("UMASK", GETDEF_DEFAULT_UMASK));
 	if (chmod(prefix_user_home, mode))
-		fprinte(stderr, "%s: %s: chmod(%s)", Prog, _("warning"), path);
+		eprinte("%s: %s: chmod(%s)", Prog, _("warning"), path);
 
 	home_added = true;
 #ifdef WITH_AUDIT

--- a/src/userdel.c
+++ b/src/userdel.c
@@ -197,15 +197,13 @@ static void update_groups (bool process_selinux)
 		 */
 		ngrp = __gr_dup (grp);
 		if (NULL == ngrp) {
-			fprintf (stderr,
-			         _("%s: Out of memory. Cannot update %s.\n"),
+			eprintf(_("%s: Out of memory. Cannot update %s.\n"),
 			         Prog, gr_dbname ());
 			exit (13);	/* XXX */
 		}
 		ngrp->gr_mem = del_list (ngrp->gr_mem, user_name);
 		if (gr_update (ngrp) == 0) {
-			fprintf (stderr,
-			         _("%s: failed to prepare the new %s entry '%s'\n"),
+			eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
 			         Prog, gr_dbname (), ngrp->gr_name);
 			exit (E_GRP_UPDATE);
 		}
@@ -255,8 +253,7 @@ static void update_groups (bool process_selinux)
 
 		nsgrp = __sgr_dup (sgrp);
 		if (NULL == nsgrp) {
-			fprintf (stderr,
-			         _("%s: Out of memory. Cannot update %s.\n"),
+			eprintf(_("%s: Out of memory. Cannot update %s.\n"),
 			         Prog, sgr_dbname ());
 			exit (13);	/* XXX */
 		}
@@ -270,8 +267,7 @@ static void update_groups (bool process_selinux)
 		}
 
 		if (sgr_update (nsgrp) == 0) {
-			fprintf (stderr,
-			         _("%s: failed to prepare the new %s entry '%s'\n"),
+			eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
 			         Prog, sgr_dbname (), nsgrp->sg_namp);
 			exit (E_GRP_UPDATE);
 		}
@@ -308,16 +304,14 @@ static void remove_usergroup (bool process_selinux)
 	}
 
 	if (grp->gr_gid != user_gid) {
-		fprintf (stderr,
-		         _("%s: group %s not removed because it is not the primary group of user %s.\n"),
+		eprintf(_("%s: group %s not removed because it is not the primary group of user %s.\n"),
 		         Prog, grp->gr_name, user_name);
 		return;
 	}
 
 	if (NULL != grp->gr_mem[0]) {
 		/* The usergroup has other members. */
-		fprintf (stderr,
-		         _("%s: group %s not removed because it has other members.\n"),
+		eprintf(_("%s: group %s not removed because it has other members.\n"),
 		         Prog, grp->gr_name);
 		return;
 	}
@@ -333,8 +327,7 @@ static void remove_usergroup (bool process_selinux)
 				continue;
 			}
 			if (pwd->pw_gid == grp->gr_gid) {
-				fprintf (stderr,
-				         _("%s: group %s is the primary group of another user and is not removed.\n"),
+				eprintf(_("%s: group %s is the primary group of another user and is not removed.\n"),
 				         Prog, grp->gr_name);
 				break;
 			}
@@ -348,8 +341,7 @@ static void remove_usergroup (bool process_selinux)
 		 * group of any remaining user.
 		 */
 		if (gr_remove (user_name) == 0) {
-			fprintf (stderr,
-			         _("%s: cannot remove entry '%s' from %s\n"),
+			eprintf(_("%s: cannot remove entry '%s' from %s\n"),
 			         Prog, user_name, gr_dbname ());
 			fail_exit (E_GRP_UPDATE, process_selinux);
 		}
@@ -366,8 +358,7 @@ static void remove_usergroup (bool process_selinux)
 #ifdef	SHADOWGRP
 		if (sgr_locate (user_name) != NULL) {
 			if (sgr_remove (user_name) == 0) {
-				fprintf (stderr,
-				         _("%s: cannot remove entry '%s' from %s\n"),
+				eprintf(_("%s: cannot remove entry '%s' from %s\n"),
 				         Prog, user_name, sgr_dbname ());
 				fail_exit (E_GRP_UPDATE, process_selinux);
 			}
@@ -398,12 +389,12 @@ static void close_files(const struct option_flags *flags)
 	process_selinux = !flags->chroot && !flags->prefix;
 
 	if (pw_close (process_selinux) == 0) {
-		fprintf (stderr, _("%s: failure while writing changes to %s\n"), Prog, pw_dbname ());
+		eprintf(_("%s: failure while writing changes to %s\n"), Prog, pw_dbname());
 		SYSLOG(LOG_ERR, "failure while writing changes to %s", pw_dbname());
 		fail_exit (E_PW_UPDATE, process_selinux);
 	}
 	if (pw_unlock (process_selinux) == 0) {
-		fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, pw_dbname ());
+		eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
 		SYSLOG(LOG_ERR, "failed to unlock %s", pw_dbname());
 		/* continue */
 	}
@@ -411,13 +402,12 @@ static void close_files(const struct option_flags *flags)
 
 	if (is_shadow_pwd) {
 		if (spw_close (process_selinux) == 0) {
-			fprintf (stderr,
-			         _("%s: failure while writing changes to %s\n"), Prog, spw_dbname ());
+			eprintf(_("%s: failure while writing changes to %s\n"), Prog, spw_dbname());
 			SYSLOG(LOG_ERR, "failure while writing changes to %s", spw_dbname());
 			fail_exit (E_PW_UPDATE, process_selinux);
 		}
 		if (spw_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, spw_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, spw_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", spw_dbname());
 			/* continue */
 		}
@@ -425,12 +415,12 @@ static void close_files(const struct option_flags *flags)
 	}
 
 	if (gr_close (process_selinux) == 0) {
-		fprintf (stderr, _("%s: failure while writing changes to %s\n"), Prog, gr_dbname ());
+		eprintf(_("%s: failure while writing changes to %s\n"), Prog, gr_dbname());
 		SYSLOG(LOG_ERR, "failure while writing changes to %s", gr_dbname());
 		fail_exit (E_GRP_UPDATE, process_selinux);
 	}
 	if (gr_unlock (process_selinux) == 0) {
-		fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, gr_dbname ());
+		eprintf(_("%s: failed to unlock %s\n"), Prog, gr_dbname());
 		SYSLOG(LOG_ERR, "failed to unlock %s", gr_dbname());
 		/* continue */
 	}
@@ -439,14 +429,13 @@ static void close_files(const struct option_flags *flags)
 #ifdef	SHADOWGRP
 	if (is_shadow_grp) {
 		if (sgr_close (process_selinux) == 0) {
-			fprintf (stderr,
-			         _("%s: failure while writing changes to %s\n"), Prog, sgr_dbname ());
+			eprintf(_("%s: failure while writing changes to %s\n"), Prog, sgr_dbname());
 			SYSLOG(LOG_ERR, "failure while writing changes to %s", sgr_dbname());
 			fail_exit (E_GRP_UPDATE, process_selinux);
 		}
 
 		if (sgr_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, sgr_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, sgr_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sgr_dbname());
 			/* continue */
 		}
@@ -457,12 +446,12 @@ static void close_files(const struct option_flags *flags)
 #ifdef ENABLE_SUBIDS
 	if (is_sub_uid) {
 		if (sub_uid_close (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failure while writing changes to %s\n"), Prog, sub_uid_dbname ());
+			eprintf(_("%s: failure while writing changes to %s\n"), Prog, sub_uid_dbname());
 			SYSLOG(LOG_ERR, "failure while writing changes to %s", sub_uid_dbname());
 			fail_exit (E_SUB_UID_UPDATE, process_selinux);
 		}
 		if (sub_uid_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, sub_uid_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, sub_uid_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sub_uid_dbname());
 			/* continue */
 		}
@@ -471,12 +460,12 @@ static void close_files(const struct option_flags *flags)
 
 	if (is_sub_gid) {
 		if (sub_gid_close (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failure while writing changes to %s\n"), Prog, sub_gid_dbname ());
+			eprintf(_("%s: failure while writing changes to %s\n"), Prog, sub_gid_dbname());
 			SYSLOG(LOG_ERR, "failure while writing changes to %s", sub_gid_dbname());
 			fail_exit (E_SUB_GID_UPDATE, process_selinux);
 		}
 		if (sub_gid_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, sub_gid_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, sub_gid_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sub_gid_dbname());
 			/* continue */
 		}
@@ -492,21 +481,21 @@ static void fail_exit (int code, bool process_selinux)
 {
 	if (pw_locked) {
 		if (pw_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, pw_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", pw_dbname());
 			/* continue */
 		}
 	}
 	if (gr_locked) {
 		if (gr_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, gr_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, gr_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", gr_dbname());
 			/* continue */
 		}
 	}
 	if (spw_locked) {
 		if (spw_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, spw_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, spw_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", spw_dbname());
 			/* continue */
 		}
@@ -514,7 +503,7 @@ static void fail_exit (int code, bool process_selinux)
 #ifdef	SHADOWGRP
 	if (sgr_locked) {
 		if (sgr_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, sgr_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, sgr_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sgr_dbname());
 			/* continue */
 		}
@@ -523,14 +512,14 @@ static void fail_exit (int code, bool process_selinux)
 #ifdef ENABLE_SUBIDS
 	if (sub_uid_locked) {
 		if (sub_uid_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, sub_uid_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, sub_uid_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sub_uid_dbname());
 			/* continue */
 		}
 	}
 	if (sub_gid_locked) {
 		if (sub_gid_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, sub_gid_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, sub_gid_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sub_gid_dbname());
 			/* continue */
 		}
@@ -555,55 +544,47 @@ static void fail_exit (int code, bool process_selinux)
 static void open_files (bool process_selinux)
 {
 	if (pw_lock () == 0) {
-		fprintf (stderr,
-		         _("%s: cannot lock %s; try again later.\n"),
+		eprintf(_("%s: cannot lock %s; try again later.\n"),
 		         Prog, pw_dbname ());
 		fail_exit (E_PW_UPDATE, process_selinux);
 	}
 	pw_locked = true;
 	if (pw_open (O_CREAT | O_RDWR) == 0) {
-		fprintf (stderr,
-		         _("%s: cannot open %s\n"), Prog, pw_dbname ());
+		eprintf(_("%s: cannot open %s\n"), Prog, pw_dbname());
 		fail_exit (E_PW_UPDATE, process_selinux);
 	}
 	if (is_shadow_pwd) {
 		if (spw_lock () == 0) {
-			fprintf (stderr,
-			         _("%s: cannot lock %s; try again later.\n"),
+			eprintf(_("%s: cannot lock %s; try again later.\n"),
 			         Prog, spw_dbname ());
 			fail_exit (E_PW_UPDATE, process_selinux);
 		}
 		spw_locked = true;
 		if (spw_open (O_CREAT | O_RDWR) == 0) {
-			fprintf (stderr,
-			         _("%s: cannot open %s\n"),
-			         Prog, spw_dbname ());
+			eprintf(_("%s: cannot open %s\n"), Prog, spw_dbname());
 			fail_exit (E_PW_UPDATE, process_selinux);
 		}
 	}
 	if (gr_lock () == 0) {
-		fprintf (stderr,
-		         _("%s: cannot lock %s; try again later.\n"),
+		eprintf(_("%s: cannot lock %s; try again later.\n"),
 		         Prog, gr_dbname ());
 		fail_exit (E_GRP_UPDATE, process_selinux);
 	}
 	gr_locked = true;
 	if (gr_open (O_CREAT | O_RDWR) == 0) {
-		fprintf (stderr, _("%s: cannot open %s\n"), Prog, gr_dbname ());
+		eprintf(_("%s: cannot open %s\n"), Prog, gr_dbname());
 		fail_exit (E_GRP_UPDATE, process_selinux);
 	}
 #ifdef	SHADOWGRP
 	if (is_shadow_grp) {
 		if (sgr_lock () == 0) {
-			fprintf (stderr,
-			         _("%s: cannot lock %s; try again later.\n"),
+			eprintf(_("%s: cannot lock %s; try again later.\n"),
 			         Prog, sgr_dbname ());
 			fail_exit (E_GRP_UPDATE, process_selinux);
 		}
 		sgr_locked= true;
 		if (sgr_open (O_CREAT | O_RDWR) == 0) {
-			fprintf (stderr, _("%s: cannot open %s\n"),
-			         Prog, sgr_dbname ());
+			eprintf(_("%s: cannot open %s\n"), Prog, sgr_dbname());
 			fail_exit (E_GRP_UPDATE, process_selinux);
 		}
 	}
@@ -611,29 +592,25 @@ static void open_files (bool process_selinux)
 #ifdef ENABLE_SUBIDS
 	if (is_sub_uid) {
 		if (sub_uid_lock () == 0) {
-			fprintf (stderr,
-				_("%s: cannot lock %s; try again later.\n"),
+			eprintf(_("%s: cannot lock %s; try again later.\n"),
 				Prog, sub_uid_dbname ());
 			fail_exit (E_SUB_UID_UPDATE, process_selinux);
 		}
 		sub_uid_locked = true;
 		if (sub_uid_open (O_CREAT | O_RDWR) == 0) {
-			fprintf (stderr,
-				_("%s: cannot open %s\n"), Prog, sub_uid_dbname ());
+			eprintf(_("%s: cannot open %s\n"), Prog, sub_uid_dbname());
 			fail_exit (E_SUB_UID_UPDATE, process_selinux);
 		}
 	}
 	if (is_sub_gid) {
 		if (sub_gid_lock () == 0) {
-			fprintf (stderr,
-				_("%s: cannot lock %s; try again later.\n"),
+			eprintf(_("%s: cannot lock %s; try again later.\n"),
 				Prog, sub_gid_dbname ());
 			fail_exit (E_SUB_GID_UPDATE, process_selinux);
 		}
 		sub_gid_locked = true;
 		if (sub_gid_open (O_CREAT | O_RDWR) == 0) {
-			fprintf (stderr,
-				_("%s: cannot open %s\n"), Prog, sub_gid_dbname ());
+			eprintf(_("%s: cannot open %s\n"), Prog, sub_gid_dbname());
 			fail_exit (E_SUB_GID_UPDATE, process_selinux);
 		}
 	}
@@ -649,29 +626,25 @@ static void open_files (bool process_selinux)
 static void update_user (bool process_selinux)
 {
 	if (pw_remove (user_name) == 0) {
-		fprintf (stderr,
-		         _("%s: cannot remove entry '%s' from %s\n"),
+		eprintf(_("%s: cannot remove entry '%s' from %s\n"),
 		         Prog, user_name, pw_dbname ());
 		fail_exit (E_PW_UPDATE, process_selinux);
 	}
 	if (   is_shadow_pwd
 	    && (spw_locate (user_name) != NULL)
 	    && (spw_remove (user_name) == 0)) {
-		fprintf (stderr,
-		         _("%s: cannot remove entry '%s' from %s\n"),
+		eprintf(_("%s: cannot remove entry '%s' from %s\n"),
 		         Prog, user_name, spw_dbname ());
 		fail_exit (E_PW_UPDATE, process_selinux);
 	}
 #ifdef ENABLE_SUBIDS
 	if (is_sub_uid && sub_uid_remove(user_name, 0, ULONG_MAX) == 0) {
-		fprintf (stderr,
-			_("%s: cannot remove entry %lu from %s\n"),
+		eprintf(_("%s: cannot remove entry %lu from %s\n"),
 			Prog, (unsigned long)user_id, sub_uid_dbname ());
 		fail_exit (E_SUB_UID_UPDATE, process_selinux);
 	}
 	if (is_sub_gid && sub_gid_remove(user_name, 0, ULONG_MAX) == 0) {
-		fprintf (stderr,
-			_("%s: cannot remove entry %lu from %s\n"),
+		eprintf(_("%s: cannot remove entry %lu from %s\n"),
 			Prog, (unsigned long)user_id, sub_gid_dbname ());
 		fail_exit (E_SUB_GID_UPDATE, process_selinux);
 	}
@@ -765,8 +738,7 @@ static bool remove_mailbox (void)
 
 	if (access (mailfile, F_OK) != 0) {
 		if (ENOENT == errno) {
-			fprintf (stderr,
-			         _("%s: %s mail spool (%s) not found\n"),
+			eprintf(_("%s: %s mail spool (%s) not found\n"),
 			         Prog, user_name, mailfile);
 			free(mailfile);
 			return 0;
@@ -808,8 +780,7 @@ static bool remove_mailbox (void)
 	}
 	i = is_owner (user_id, mailfile);
 	if (i == 0) {
-		fprintf (stderr,
-		         _("%s: %s not owned by %s, not removing\n"),
+		eprintf(_("%s: %s not owned by %s, not removing\n"),
 		         Prog, mailfile, user_name);
 		SYSLOG(LOG_ERR, "%s not owned by %s, not removed", mailfile, user_name);
 #ifdef WITH_AUDIT
@@ -858,8 +829,7 @@ static int remove_tcbdir (const char *user_name, uid_t user_id)
 
 	buf = aprintf(TCB_DIR "/%s", user_name);
 	if (buf == NULL) {
-		fprintf(stderr,
-		        _("%s: Can't allocate memory, tcb entry for %s not removed.\n"),
+		eprintf(_("%s: Can't allocate memory, tcb entry for %s not removed.\n"),
 		        Prog, user_name);
 		return 1;
 	}
@@ -954,16 +924,14 @@ int main (int argc, char **argv)
 #ifdef WITH_SELINUX
 			case 'Z':
 				if (prefix[0]) {
-					fprintf (stderr,
-					         _("%s: -Z cannot be used with --prefix\n"),
+					eprintf(_("%s: -Z cannot be used with --prefix\n"),
 					         Prog);
 					exit (E_BAD_ARG);
 				}
 				if (is_selinux_enabled () > 0) {
 					Zflg = true;
 				} else {
-					fprintf (stderr,
-					         _("%s: -Z requires SELinux enabled kernel\n"),
+					eprintf(_("%s: -Z requires SELinux enabled kernel\n"),
 					         Prog);
 
 					exit (E_BAD_ARG);
@@ -1005,7 +973,7 @@ int main (int argc, char **argv)
 		pwd = pw_locate (user_name); /* we care only about local users */
 		if (NULL == pwd) {
 			pw_close(process_selinux);
-			fprintf (stderr, _("%s: user '%s' does not exist\n"),
+			eprintf(_("%s: user '%s' does not exist\n"),
 				 Prog, user_name);
 #ifdef WITH_AUDIT
 			audit_logger (AUDIT_DEL_USER,
@@ -1063,13 +1031,11 @@ int main (int argc, char **argv)
 	if (rflg) {
 		int home_owned = is_owner (user_id, user_home);
 		if (-1 == home_owned) {
-			fprintf (stderr,
-			         _("%s: %s home directory (%s) not found\n"),
+			eprintf(_("%s: %s home directory (%s) not found\n"),
 			         Prog, user_name, user_home);
 			rflg = 0;
 		} else if ((0 == home_owned) && !fflg) {
-			fprintf (stderr,
-			         _("%s: %s not owned by %s, not removing\n"),
+			eprintf(_("%s: %s not owned by %s, not removing\n"),
 			         Prog, user_home, user_name);
 			rflg = 0;
 			errors = true;
@@ -1094,8 +1060,7 @@ int main (int argc, char **argv)
 				continue;
 			}
 			if (path_prefix (user_home, pwd->pw_dir)) {
-				fprintf (stderr,
-				         _("%s: not removing directory %s (would remove home of user %s)\n"),
+				eprintf(_("%s: not removing directory %s (would remove home of user %s)\n"),
 				         Prog, user_home, pwd->pw_name);
 				rflg = false;
 				errors = true;
@@ -1116,8 +1081,7 @@ int main (int argc, char **argv)
 		}
 		else if (is_subvolume > 0) {
 			if (btrfs_remove_subvolume (user_home)) {
-				fprintf (stderr,
-				         _("%s: error removing subvolume %s\n"),
+				eprintf(_("%s: error removing subvolume %s\n"),
 				         Prog, user_home);
 				errors = true;
 				/* continue */
@@ -1126,8 +1090,7 @@ int main (int argc, char **argv)
 		else
 #endif
 		if (remove_tree (user_home, true) != 0) {
-			fprintf (stderr,
-			         _("%s: error removing directory %s\n"),
+			eprintf(_("%s: error removing directory %s\n"),
 			         Prog, user_home);
 			errors = true;
 			/* continue */
@@ -1153,8 +1116,7 @@ int main (int argc, char **argv)
 #ifdef WITH_SELINUX
 	if (Zflg) {
 		if (del_seuser (user_name) != 0) {
-			fprintf (stderr,
-			         _("%s: warning: the user name %s to SELinux user mapping removal failed.\n"),
+			eprintf(_("%s: warning: the user name %s to SELinux user mapping removal failed.\n"),
 			         Prog, user_name);
 #ifdef WITH_AUDIT
 			audit_logger (AUDIT_ROLE_REMOVE,

--- a/src/userdel.c
+++ b/src/userdel.c
@@ -743,7 +743,7 @@ static bool remove_mailbox (void)
 			free(mailfile);
 			return 0;
 		} else {
-			fprinte(stderr, _("%s: warning: can't remove %s"), Prog, mailfile);
+			eprinte(_("%s: warning: can't remove %s"), Prog, mailfile);
 			SYSLOGE(LOG_ERR, "Cannot remove %s", mailfile);
 #ifdef WITH_AUDIT
 			audit_logger (AUDIT_DEL_USER,
@@ -757,7 +757,7 @@ static bool remove_mailbox (void)
 
 	if (fflg) {
 		if (unlink (mailfile) != 0) {
-			fprinte(stderr, _("%s: warning: can't remove %s"), Prog, mailfile);
+			eprinte(_("%s: warning: can't remove %s"), Prog, mailfile);
 			SYSLOGE(LOG_ERR, "Cannot remove %s", mailfile);
 #ifdef WITH_AUDIT
 			audit_logger (AUDIT_DEL_USER,
@@ -795,7 +795,7 @@ static bool remove_mailbox (void)
 		return 0;		/* mailbox doesn't exist */
 	}
 	if (unlink (mailfile) != 0) {
-		fprinte(stderr, _("%s: warning: can't remove %s"), Prog, mailfile);
+		eprinte(_("%s: warning: can't remove %s"), Prog, mailfile);
 		SYSLOGE(LOG_ERR, "Cannot remove %s", mailfile);
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_DEL_USER,
@@ -834,7 +834,7 @@ static int remove_tcbdir (const char *user_name, uid_t user_id)
 		return 1;
 	}
 	if (shadowtcb_drop_priv () == SHADOWTCB_FAILURE) {
-		fprinte(stderr, _("%s: Cannot drop privileges"), Prog);
+		eprinte(_("%s: Cannot drop privileges"), Prog);
 		shadowtcb_gain_priv ();
 		free (buf);
 		return 1;
@@ -843,7 +843,7 @@ static int remove_tcbdir (const char *user_name, uid_t user_id)
 	 * We will regain them and remove the user's tcb directory afterwards.
 	 */
 	if (remove_tree (buf, false) != 0) {
-		fprinte(stderr, _("%s: Cannot remove the content of %s"), Prog, buf);
+		eprinte(_("%s: Cannot remove the content of %s"), Prog, buf);
 		shadowtcb_gain_priv ();
 		free (buf);
 		return 1;
@@ -851,7 +851,7 @@ static int remove_tcbdir (const char *user_name, uid_t user_id)
 	shadowtcb_gain_priv ();
 	free (buf);
 	if (shadowtcb_remove (user_name) == SHADOWTCB_FAILURE) {
-		fprinte(stderr, _("%s: Cannot remove tcb files for %s"), Prog, user_name);
+		eprinte(_("%s: Cannot remove tcb files for %s"), Prog, user_name);
 		ret = 1;
 	}
 	return ret;

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -274,8 +274,7 @@ static int get_groups (char *list)
 		 * string name.
 		 */
 		if (NULL == grp) {
-			fprintf (stderr, _("%s: group '%s' does not exist\n"),
-			         Prog, g);
+			eprintf(_("%s: group '%s' does not exist\n"), Prog, g);
 			errors = true;
 		}
 
@@ -288,8 +287,7 @@ static int get_groups (char *list)
 		}
 
 		if (ngroups == sys_ngroups) {
-			fprintf (stderr,
-			         _("%s: too many groups specified (max %zu).\n"),
+			eprintf(_("%s: too many groups specified (max %zu).\n"),
 			         Prog, ngroups);
 			gr_free (grp);
 			break;
@@ -480,9 +478,8 @@ new_pw_passwd(char *pw_pass, bool process_selinux)
 		pw_pass = xaprintf("!%s", pw_pass);
 	} else if (Uflg && strprefix(pw_pass, "!")) {
 		if (pw_pass[1] == '\0') {
-			fprintf (stderr,
-			         _("%s: unlocking the user's password would result in a passwordless account.\n"
-			           "You should set a password with usermod -p to unlock this user's password.\n"),
+			eprintf(_("%s: unlocking the user's password would result in a passwordless account.\n"
+			          "You should set a password with usermod -p to unlock this user's password.\n"),
 			         Prog);
 			fail_exit(E_PASSWORDLESS, process_selinux);
 		}
@@ -518,8 +515,7 @@ static void new_pwent (struct passwd *pwent, bool process_selinux)
 			 * It was already checked that the user doesn't
 			 * exist on the system.
 			 */
-			fprintf (stderr,
-			         _("%s: user '%s' already exists in %s\n"),
+			eprintf(_("%s: user '%s' already exists in %s\n"),
 			         Prog, user_newname, pw_dbname ());
 			fail_exit (E_NAME_IN_USE, process_selinux);
 		}
@@ -604,8 +600,7 @@ static void new_spent (struct spwd *spent, bool process_selinux)
 {
 	if (lflg) {
 		if (spw_locate (user_newname) != NULL) {
-			fprintf (stderr,
-			         _("%s: user '%s' already exists in %s\n"),
+			eprintf(_("%s: user '%s' already exists in %s\n"),
 			         Prog, user_newname, spw_dbname ());
 			fail_exit (E_NAME_IN_USE, process_selinux);
 		}
@@ -669,14 +664,14 @@ fail_exit (int code, bool process_selinux)
 #ifdef ENABLE_SUBIDS
 	if (sub_gid_locked) {
 		if (sub_gid_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, sub_gid_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, sub_gid_dbname ());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sub_gid_dbname());
 			/* continue */
 		}
 	}
 	if (sub_uid_locked) {
 		if (sub_uid_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, sub_uid_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, sub_uid_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sub_uid_dbname());
 			/* continue */
 		}
@@ -685,7 +680,7 @@ fail_exit (int code, bool process_selinux)
 #ifdef	SHADOWGRP
 	if (sgr_locked) {
 		if (sgr_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, sgr_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, sgr_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sgr_dbname());
 			/* continue */
 		}
@@ -693,21 +688,21 @@ fail_exit (int code, bool process_selinux)
 #endif
 	if (gr_locked) {
 		if (gr_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, gr_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, gr_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", gr_dbname());
 			/* continue */
 		}
 	}
 	if (spw_locked) {
 		if (spw_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, spw_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, spw_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", spw_dbname());
 			/* continue */
 		}
 	}
 	if (pw_locked) {
 		if (pw_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, pw_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", pw_dbname());
 			/* continue */
 		}
@@ -767,8 +762,7 @@ update_group(const struct group *grp, bool process_selinux)
 
 	ngrp = __gr_dup (grp);
 	if (NULL == ngrp) {
-		fprintf (stderr,
-			 _("%s: Out of memory. Cannot update %s.\n"),
+		eprintf(_("%s: Out of memory. Cannot update %s.\n"),
 			 Prog, gr_dbname ());
 		fail_exit (E_GRP_UPDATE, process_selinux);
 	}
@@ -834,8 +828,7 @@ update_group(const struct group *grp, bool process_selinux)
 		goto free_ngrp;
 
 	if (gr_update (ngrp) == 0) {
-		fprintf (stderr,
-			 _("%s: failed to prepare the new %s entry '%s'\n"),
+		eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
 			 Prog, gr_dbname (), ngrp->gr_name);
 		SYSLOG(LOG_WARN, "failed to prepare the new %s entry '%s'", gr_dbname(), ngrp->gr_name);
 		fail_exit (E_GRP_UPDATE, process_selinux);
@@ -904,8 +897,7 @@ update_gshadow(const struct sgrp *sgrp, bool process_selinux)
 
 	nsgrp = __sgr_dup (sgrp);
 	if (NULL == nsgrp) {
-		fprintf (stderr,
-			 _("%s: Out of memory. Cannot update %s.\n"),
+		eprintf(_("%s: Out of memory. Cannot update %s.\n"),
 			 Prog, sgr_dbname ());
 		fail_exit (E_GRP_UPDATE, process_selinux);
 	}
@@ -986,8 +978,7 @@ update_gshadow(const struct sgrp *sgrp, bool process_selinux)
 	 * Update the group entry to reflect the changes.
 	 */
 	if (sgr_update (nsgrp) == 0) {
-		fprintf (stderr,
-			 _("%s: failed to prepare the new %s entry '%s'\n"),
+		eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
 			 Prog, sgr_dbname (), nsgrp->sg_namp);
 		SYSLOG(LOG_WARN, "failed to prepare the new %s entry '%s'",
 			sgr_dbname(), nsgrp->sg_namp);
@@ -1087,8 +1078,7 @@ process_flags(int argc, char **argv, struct option_flags *flags)
 				break;
 			case 'c':
 				if (!VALID (optarg)) {
-					fprintf (stderr,
-					         _("%s: invalid field '%s'\n"),
+					eprintf(_("%s: invalid field '%s'\n"),
 					         Prog, optarg);
 					exit (E_BAD_ARG);
 				}
@@ -1097,16 +1087,14 @@ process_flags(int argc, char **argv, struct option_flags *flags)
 				break;
 			case 'd':
 				if (!VALID (optarg)) {
-					fprintf (stderr,
-					         _("%s: invalid field '%s'\n"),
+					eprintf(_("%s: invalid field '%s'\n"),
 					         Prog, optarg);
 					exit (E_BAD_ARG);
 				}
 				dflg = true;
 				user_newhome = optarg;
 				if ((user_newhome[0] != '/') && !streq(user_newhome, "")) {
-					fprintf (stderr,
-					         _("%s: homedir must be an absolute path\n"),
+					eprintf(_("%s: homedir must be an absolute path\n"),
 					         Prog);
 					exit (E_BAD_ARG);
 				}
@@ -1114,8 +1102,7 @@ process_flags(int argc, char **argv, struct option_flags *flags)
 			case 'e':
 				user_newexpire = strtoday (optarg);
 				if (user_newexpire < -1) {
-					fprintf (stderr,
-						 _("%s: invalid date '%s'\n"),
+					eprintf(_("%s: invalid date '%s'\n"),
 						 Prog, optarg);
 					exit (E_BAD_ARG);
 				}
@@ -1125,8 +1112,7 @@ process_flags(int argc, char **argv, struct option_flags *flags)
 				if (a2sl(&user_newinactive, optarg, NULL, 0, -1, LONG_MAX)
 				    == -1)
 				{
-					fprintf (stderr,
-					         _("%s: invalid numeric argument '%s'\n"),
+					eprintf(_("%s: invalid numeric argument '%s'\n"),
 					         Prog, optarg);
 					exit (E_BAD_ARG);
 				}
@@ -1138,8 +1124,7 @@ process_flags(int argc, char **argv, struct option_flags *flags)
 
 				grp = prefix_getgr_nam_gid (optarg);
 				if (NULL == grp) {
-					fprintf (stderr,
-					         _("%s: group '%s' does not exist\n"),
+					eprintf(_("%s: group '%s' does not exist\n"),
 					         Prog, optarg);
 					exit (E_NOTFOUND);
 				}
@@ -1160,12 +1145,10 @@ process_flags(int argc, char **argv, struct option_flags *flags)
 			case 'l':
 				if (!is_valid_user_name(optarg, bflg)) {
 					if (errno == EILSEQ) {
-						fprintf(stderr,
-						        _("%s: invalid user name '%s': use --badname to ignore\n"),
+						eprintf(_("%s: invalid user name '%s': use --badname to ignore\n"),
 						        Prog, optarg);
 					} else {
-						fprintf(stderr,
-						        _("%s: invalid user name '%s'\n"),
+						eprintf(_("%s: invalid user name '%s'\n"),
 						        Prog, optarg);
 					}
 					exit (E_BAD_ARG);
@@ -1200,8 +1183,7 @@ process_flags(int argc, char **argv, struct option_flags *flags)
 				    || (   !streq(optarg, "")
 				        && ('/'  != optarg[0])
 				        && ('*'  != optarg[0]) )) {
-					fprintf (stderr,
-					         _("%s: invalid shell '%s'\n"),
+					eprintf(_("%s: invalid shell '%s'\n"),
 					         Prog, optarg);
 					exit (E_BAD_ARG);
 				}
@@ -1212,8 +1194,7 @@ process_flags(int argc, char **argv, struct option_flags *flags)
 				     && (   stat(optarg, &st) != 0
 				         || S_ISDIR(st.st_mode)
 				         || access(optarg, X_OK) != 0)) {
-					fprintf (stderr,
-					         _("%s: Warning: missing or non-executable shell '%s'\n"),
+					eprintf(_("%s: Warning: missing or non-executable shell '%s'\n"),
 					         Prog, optarg);
 				}
 				user_newshell = optarg;
@@ -1222,8 +1203,7 @@ process_flags(int argc, char **argv, struct option_flags *flags)
 			case 'u':
 				if (   (get_uid(optarg, &user_newid) == -1)
 				    || (user_newid == (uid_t)-1)) {
-					fprintf (stderr,
-					         _("%s: invalid user ID '%s'\n"),
+					eprintf(_("%s: invalid user ID '%s'\n"),
 					         Prog, optarg);
 					exit (E_BAD_ARG);
 				}
@@ -1235,8 +1215,7 @@ process_flags(int argc, char **argv, struct option_flags *flags)
 #ifdef ENABLE_SUBIDS
 			case 'v':
 				if (prepend_range (optarg, &add_sub_uids) == 0) {
-					fprintf (stderr,
-						_("%s: invalid subordinate uid range '%s'\n"),
+					eprintf(_("%s: invalid subordinate uid range '%s'\n"),
 						Prog, optarg);
 					exit(E_BAD_ARG);
 				}
@@ -1244,8 +1223,7 @@ process_flags(int argc, char **argv, struct option_flags *flags)
 				break;
 			case 'V':
 				if (prepend_range (optarg, &del_sub_uids) == 0) {
-					fprintf (stderr,
-						_("%s: invalid subordinate uid range '%s'\n"),
+					eprintf(_("%s: invalid subordinate uid range '%s'\n"),
 						Prog, optarg);
 					exit(E_BAD_ARG);
 				}
@@ -1253,8 +1231,7 @@ process_flags(int argc, char **argv, struct option_flags *flags)
 				break;
 			case 'w':
 				if (prepend_range (optarg, &add_sub_gids) == 0) {
-					fprintf (stderr,
-						_("%s: invalid subordinate gid range '%s'\n"),
+					eprintf(_("%s: invalid subordinate gid range '%s'\n"),
 						Prog, optarg);
 					exit(E_BAD_ARG);
 				}
@@ -1262,8 +1239,7 @@ process_flags(int argc, char **argv, struct option_flags *flags)
 				break;
 			case 'W':
 				if (prepend_range (optarg, &del_sub_gids) == 0) {
-					fprintf (stderr,
-						_("%s: invalid subordinate gid range '%s'\n"),
+					eprintf(_("%s: invalid subordinate gid range '%s'\n"),
 						Prog, optarg);
 					exit(E_BAD_ARG);
 				}
@@ -1279,8 +1255,7 @@ process_flags(int argc, char **argv, struct option_flags *flags)
 #ifdef WITH_SELINUX
 			case 'Z':
 				if (prefix[0]) {
-					fprintf (stderr,
-					         _("%s: -Z cannot be used with --prefix\n"),
+					eprintf(_("%s: -Z cannot be used with --prefix\n"),
 					         Prog);
 					exit (E_BAD_ARG);
 				}
@@ -1288,8 +1263,7 @@ process_flags(int argc, char **argv, struct option_flags *flags)
 					user_selinux = optarg;
 					Zflg = true;
 				} else {
-					fprintf (stderr,
-					         _("%s: -Z requires SELinux enabled kernel\n"),
+					eprintf(_("%s: -Z requires SELinux enabled kernel\n"),
 					         Prog);
 					exit (E_BAD_ARG);
 				}
@@ -1316,8 +1290,7 @@ process_flags(int argc, char **argv, struct option_flags *flags)
 		/* local, no need for xgetpwnam */
 		pwd = prefix_getpwnam (user_name);
 		if (NULL == pwd) {
-			fprintf (stderr,
-			         _("%s: user '%s' does not exist\n"),
+			eprintf(_("%s: user '%s' does not exist\n"),
 			         Prog, user_name);
 			exit (E_NOTFOUND);
 		}
@@ -1361,56 +1334,49 @@ process_flags(int argc, char **argv, struct option_flags *flags)
 	}
 
 	if (!anyflag) {
-		fprintf (stderr, _("%s: no options\n"), Prog);
+		eprintf(_("%s: no options\n"), Prog);
 		usage (E_USAGE);
 	}
 
 	if (aflg && (!Gflg)) {
-		fprintf (stderr,
-		         _("%s: %s flag is only allowed with the %s flag\n"),
+		eprintf(_("%s: %s flag is only allowed with the %s flag\n"),
 		         Prog, "-a", "-G");
 		usage (E_USAGE);
 	}
 
 	if (rflg && (!Gflg)) {
-		fprintf (stderr,
-		         _("%s: %s flag is only allowed with the %s flag\n"),
+		eprintf(_("%s: %s flag is only allowed with the %s flag\n"),
 		         Prog, "-r", "-G");
 		usage (E_USAGE);
 	}
 
 	if (rflg && aflg) {
-		fprintf (stderr,
-		         _("%s: %s and %s are mutually exclusive flags\n"),
+		eprintf(_("%s: %s and %s are mutually exclusive flags\n"),
 		         Prog, "-r", "-a");
 		usage (E_USAGE);
 	}
 
 	if ((Lflg && (pflg || Uflg)) || (pflg && Uflg)) {
-		fprintf (stderr,
-		         _("%s: the -L, -p, and -U flags are exclusive\n"),
+		eprintf(_("%s: the -L, -p, and -U flags are exclusive\n"),
 		         Prog);
 		usage (E_USAGE);
 	}
 
 	if (oflg && !uflg) {
-		fprintf (stderr,
-		         _("%s: %s flag is only allowed with the %s flag\n"),
+		eprintf(_("%s: %s flag is only allowed with the %s flag\n"),
 		         Prog, "-o", "-u");
 		usage (E_USAGE);
 	}
 
 	if (mflg && !dflg) {
-		fprintf (stderr,
-		         _("%s: %s flag is only allowed with the %s flag\n"),
+		eprintf(_("%s: %s flag is only allowed with the %s flag\n"),
 		         Prog, "-m", "-d");
 		usage (E_USAGE);
 	}
 
 #ifdef WITH_SELINUX
 	if (user_selinux_range && !Zflg) {
-		fprintf (stderr,
-		         _("%s: %s flag is only allowed with the %s flag\n"),
+		eprintf(_("%s: %s flag is only allowed with the %s flag\n"),
 		         Prog, "--selinux-range", "--selinux-user");
 		usage (E_USAGE);
 	}
@@ -1459,24 +1425,19 @@ process_flags(int argc, char **argv, struct option_flags *flags)
 	}
 
 	if (!is_shadow_pwd && (eflg || fflg)) {
-		fprintf (stderr,
-		         _("%s: shadow passwords required for -e and -f\n"),
-		         Prog);
+		eprintf(_("%s: shadow passwords required for -e and -f\n"), Prog);
 		exit (E_USAGE);
 	}
 
 	/* local, no need for xgetpwnam */
 	if (lflg && (prefix_getpwnam (user_newname) != NULL)) {
-		fprintf (stderr,
-		         _("%s: user '%s' already exists\n"),
-		         Prog, user_newname);
+		eprintf(_("%s: user '%s' already exists\n"), Prog, user_newname);
 		exit (E_NAME_IN_USE);
 	}
 
 	/* local, no need for xgetpwuid */
 	if (uflg && !oflg && (prefix_getpwuid (user_newid) != NULL)) {
-		fprintf (stderr,
-		         _("%s: UID '%lu' already exists\n"),
+		eprintf(_("%s: UID '%lu' already exists\n"),
 		         Prog, (unsigned long) user_newid);
 		exit (E_UID_IN_USE);
 	}
@@ -1484,16 +1445,14 @@ process_flags(int argc, char **argv, struct option_flags *flags)
 #ifdef ENABLE_SUBIDS
 	if (   (vflg || Vflg)
 	    && !is_sub_uid) {
-		fprintf (stderr,
-		         _("%s: %s does not exist, you cannot use the flags %s or %s\n"),
+		eprintf(_("%s: %s does not exist, you cannot use the flags %s or %s\n"),
 		         Prog, sub_uid_dbname (), "-v", "-V");
 		exit (E_USAGE);
 	}
 
 	if (   (wflg || Wflg)
 	    && !is_sub_gid) {
-		fprintf (stderr,
-		         _("%s: %s does not exist, you cannot use the flags %s or %s\n"),
+		eprintf(_("%s: %s does not exist, you cannot use the flags %s or %s\n"),
 		         Prog, sub_gid_dbname (), "-w", "-W");
 		exit (E_USAGE);
 	}
@@ -1515,12 +1474,12 @@ static void close_files(const struct option_flags *flags)
 #ifdef ENABLE_SUBIDS
 	if (sub_gid_locked) {
 		if (sub_gid_close (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failure while writing changes to %s\n"), Prog, sub_gid_dbname ());
+			eprintf(_("%s: failure while writing changes to %s\n"), Prog, sub_gid_dbname());
 			SYSLOG(LOG_ERR, "failure while writing changes to %s", sub_gid_dbname());
 			fail_exit (E_SUB_GID_UPDATE, process_selinux);
 		}
 		if (sub_gid_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, sub_gid_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, sub_gid_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sub_gid_dbname());
 			/* continue */
 		}
@@ -1528,12 +1487,12 @@ static void close_files(const struct option_flags *flags)
 	}
 	if (sub_uid_locked) {
 		if (sub_uid_close (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failure while writing changes to %s\n"), Prog, sub_uid_dbname ());
+			eprintf(_("%s: failure while writing changes to %s\n"), Prog, sub_uid_dbname());
 			SYSLOG(LOG_ERR, "failure while writing changes to %s", sub_uid_dbname());
 			fail_exit (E_SUB_UID_UPDATE, process_selinux);
 		}
 		if (sub_uid_unlock (process_selinux) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, sub_uid_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, sub_uid_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sub_uid_dbname());
 			/* continue */
 		}
@@ -1545,17 +1504,14 @@ static void close_files(const struct option_flags *flags)
 #ifdef SHADOWGRP
 		if (is_shadow_grp) {
 			if (sgr_close (process_selinux) == 0) {
-				fprintf (stderr,
-				         _("%s: failure while writing changes to %s\n"),
+				eprintf(_("%s: failure while writing changes to %s\n"),
 				         Prog, sgr_dbname ());
 				SYSLOG(LOG_ERR, "failure while writing changes to %s",
 				       sgr_dbname());
 				fail_exit (E_GRP_UPDATE, process_selinux);
 			}
 			if (sgr_unlock (process_selinux) == 0) {
-				fprintf (stderr,
-				         _("%s: failed to unlock %s\n"),
-				         Prog, sgr_dbname ());
+				eprintf(_("%s: failed to unlock %s\n"), Prog, sgr_dbname());
 				SYSLOG(LOG_ERR, "failed to unlock %s", sgr_dbname());
 				/* continue */
 			}
@@ -1563,17 +1519,14 @@ static void close_files(const struct option_flags *flags)
 		}
 #endif
 		if (gr_close (process_selinux) == 0) {
-			fprintf (stderr,
-			         _("%s: failure while writing changes to %s\n"),
+			eprintf(_("%s: failure while writing changes to %s\n"),
 			         Prog, gr_dbname ());
 			SYSLOG(LOG_ERR, "failure while writing changes to %s",
 			       gr_dbname());
 			fail_exit (E_GRP_UPDATE, process_selinux);
 		}
 		if (gr_unlock (process_selinux) == 0) {
-			fprintf (stderr,
-			         _("%s: failed to unlock %s\n"),
-			         Prog, gr_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, gr_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", gr_dbname());
 			/* continue */
 		}
@@ -1581,32 +1534,25 @@ static void close_files(const struct option_flags *flags)
 	}
 	if (spw_locked) {
 		if (spw_close (process_selinux) == 0) {
-			fprintf (stderr,
-				_("%s: failure while writing changes to %s\n"),
+			eprintf(_("%s: failure while writing changes to %s\n"),
 				Prog, spw_dbname ());
 			SYSLOG(LOG_ERR, "failure while writing changes to %s", spw_dbname());
 			fail_exit (E_PW_UPDATE, process_selinux);
 		}
 		if (spw_unlock (process_selinux) == 0) {
-			fprintf (stderr,
-			         _("%s: failed to unlock %s\n"),
-			         Prog, spw_dbname ());
+			eprintf(_("%s: failed to unlock %s\n"), Prog, spw_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", spw_dbname());
 			/* continue */
 		}
 		spw_locked = false;
 	}
 	if (pw_close (process_selinux) == 0) {
-		fprintf (stderr,
-		         _("%s: failure while writing changes to %s\n"),
-		         Prog, pw_dbname ());
+		eprintf(_("%s: failure while writing changes to %s\n"), Prog, pw_dbname());
 		SYSLOG(LOG_ERR, "failure while writing changes to %s", pw_dbname());
 		fail_exit (E_PW_UPDATE, process_selinux);
 	}
 	if (pw_unlock (process_selinux) == 0) {
-		fprintf (stderr,
-		         _("%s: failed to unlock %s\n"),
-		         Prog, pw_dbname ());
+		eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
 		SYSLOG(LOG_ERR, "failed to unlock %s", pw_dbname());
 		/* continue */
 	}
@@ -1631,30 +1577,24 @@ static void close_files(const struct option_flags *flags)
 static void open_files (bool process_selinux)
 {
 	if (pw_lock () == 0) {
-		fprintf (stderr,
-		         _("%s: cannot lock %s; try again later.\n"),
+		eprintf(_("%s: cannot lock %s; try again later.\n"),
 		         Prog, pw_dbname ());
 		fail_exit (E_PW_UPDATE, process_selinux);
 	}
 	pw_locked = true;
 	if (pw_open (O_CREAT | O_RDWR) == 0) {
-		fprintf (stderr,
-		         _("%s: cannot open %s\n"),
-		         Prog, pw_dbname ());
+		eprintf(_("%s: cannot open %s\n"), Prog, pw_dbname());
 		fail_exit (E_PW_UPDATE, process_selinux);
 	}
 	if (is_shadow_pwd && (lflg || pflg || eflg || fflg || Lflg || Uflg)) {
 		if (spw_lock () == 0) {
-			fprintf (stderr,
-				_("%s: cannot lock %s; try again later.\n"),
+			eprintf(_("%s: cannot lock %s; try again later.\n"),
 				Prog, spw_dbname ());
 			fail_exit (E_PW_UPDATE, process_selinux);
 		}
 		spw_locked = true;
 		if (is_shadow_pwd && (spw_open (O_CREAT | O_RDWR) == 0)) {
-			fprintf (stderr,
-				_("%s: cannot open %s\n"),
-				Prog, spw_dbname ());
+			eprintf(_("%s: cannot open %s\n"), Prog, spw_dbname());
 			fail_exit (E_PW_UPDATE, process_selinux);
 		}
 	}
@@ -1665,30 +1605,24 @@ static void open_files (bool process_selinux)
 		 * group entries.
 		 */
 		if (gr_lock () == 0) {
-			fprintf (stderr,
-			         _("%s: cannot lock %s; try again later.\n"),
+			eprintf(_("%s: cannot lock %s; try again later.\n"),
 			         Prog, gr_dbname ());
 			fail_exit (E_GRP_UPDATE, process_selinux);
 		}
 		gr_locked = true;
 		if (gr_open (O_CREAT | O_RDWR) == 0) {
-			fprintf (stderr,
-			         _("%s: cannot open %s\n"),
-			         Prog, gr_dbname ());
+			eprintf(_("%s: cannot open %s\n"), Prog, gr_dbname());
 			fail_exit (E_GRP_UPDATE, process_selinux);
 		}
 #ifdef SHADOWGRP
 		if (is_shadow_grp && (sgr_lock () == 0)) {
-			fprintf (stderr,
-			         _("%s: cannot lock %s; try again later.\n"),
+			eprintf(_("%s: cannot lock %s; try again later.\n"),
 			         Prog, sgr_dbname ());
 			fail_exit (E_GRP_UPDATE, process_selinux);
 		}
 		sgr_locked = true;
 		if (is_shadow_grp && (sgr_open (O_CREAT | O_RDWR) == 0)) {
-			fprintf (stderr,
-			         _("%s: cannot open %s\n"),
-			         Prog, sgr_dbname ());
+			eprintf(_("%s: cannot open %s\n"), Prog, sgr_dbname());
 			fail_exit (E_GRP_UPDATE, process_selinux);
 		}
 #endif
@@ -1696,31 +1630,25 @@ static void open_files (bool process_selinux)
 #ifdef ENABLE_SUBIDS
 	if (vflg || Vflg) {
 		if (sub_uid_lock () == 0) {
-			fprintf (stderr,
-			         _("%s: cannot lock %s; try again later.\n"),
+			eprintf(_("%s: cannot lock %s; try again later.\n"),
 			         Prog, sub_uid_dbname ());
 			fail_exit (E_SUB_UID_UPDATE, process_selinux);
 		}
 		sub_uid_locked = true;
 		if (sub_uid_open (O_CREAT | O_RDWR) == 0) {
-			fprintf (stderr,
-			         _("%s: cannot open %s\n"),
-			         Prog, sub_uid_dbname ());
+			eprintf(_("%s: cannot open %s\n"), Prog, sub_uid_dbname());
 			fail_exit (E_SUB_UID_UPDATE, process_selinux);
 		}
 	}
 	if (wflg || Wflg) {
 		if (sub_gid_lock () == 0) {
-			fprintf (stderr,
-			         _("%s: cannot lock %s; try again later.\n"),
+			eprintf(_("%s: cannot lock %s; try again later.\n"),
 			         Prog, sub_gid_dbname ());
 			fail_exit (E_SUB_GID_UPDATE, process_selinux);
 		}
 		sub_gid_locked = true;
 		if (sub_gid_open (O_CREAT | O_RDWR) == 0) {
-			fprintf (stderr,
-			         _("%s: cannot open %s\n"),
-			         Prog, sub_gid_dbname ());
+			eprintf(_("%s: cannot open %s\n"), Prog, sub_gid_dbname());
 			fail_exit (E_SUB_GID_UPDATE, process_selinux);
 		}
 	}
@@ -1748,8 +1676,7 @@ static void usr_update(const struct option_flags *flags)
 	 */
 	pwd = pw_locate (user_name);
 	if (NULL == pwd) {
-		fprintf (stderr,
-		         _("%s: user '%s' does not exist in %s\n"),
+		eprintf(_("%s: user '%s' does not exist in %s\n"),
 		         Prog, user_name, pw_dbname ());
 		fail_exit (E_NOTFOUND, process_selinux);
 	}
@@ -1802,28 +1729,24 @@ static void usr_update(const struct option_flags *flags)
 	if (lflg || uflg || gflg || cflg || dflg || sflg || pflg
 	    || Lflg || Uflg || spwd == &spent) {
 		if (pw_update (&pwent) == 0) {
-			fprintf (stderr,
-			         _("%s: failed to prepare the new %s entry '%s'\n"),
+			eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
 			         Prog, pw_dbname (), pwent.pw_name);
 			fail_exit (E_PW_UPDATE, process_selinux);
 		}
 		if (lflg && (pw_remove (user_name) == 0)) {
-			fprintf (stderr,
-			         _("%s: cannot remove entry '%s' from %s\n"),
+			eprintf(_("%s: cannot remove entry '%s' from %s\n"),
 			         Prog, user_name, pw_dbname ());
 			fail_exit (E_PW_UPDATE, process_selinux);
 		}
 	}
 	if ((NULL != spwd) && (lflg || eflg || fflg || pflg || Lflg || Uflg)) {
 		if (spw_update (&spent) == 0) {
-			fprintf (stderr,
-			         _("%s: failed to prepare the new %s entry '%s'\n"),
+			eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
 			         Prog, spw_dbname (), spent.sp_namp);
 			fail_exit (E_PW_UPDATE, process_selinux);
 		}
 		if (lflg && (spw_remove (user_name) == 0)) {
-			fprintf (stderr,
-			         _("%s: cannot remove entry '%s' from %s\n"),
+			eprintf(_("%s: cannot remove entry '%s' from %s\n"),
 			         Prog, user_name, spw_dbname ());
 			fail_exit (E_PW_UPDATE, process_selinux);
 		}
@@ -1845,9 +1768,7 @@ static void move_home (bool process_selinux)
 		 * If the new home directory already exists, the user
 		 * should not use -m.
 		 */
-		fprintf (stderr,
-		         _("%s: directory %s exists\n"),
-		         Prog, user_newhome);
+		eprintf(_("%s: directory %s exists\n"), Prog, user_newhome);
 		fail_exit (E_HOMEDIR, process_selinux);
 	}
 
@@ -1857,10 +1778,9 @@ static void move_home (bool process_selinux)
 		 * (but /dev/null for example).  --marekm
 		 */
 		if (!S_ISDIR (sb.st_mode)) {
-			fprintf (stderr,
-			         _("%s: The previous home directory (%s) was "
-			           "not a directory. It is not removed and no "
-			           "home directories are created.\n"),
+			eprintf(_("%s: The previous home directory (%s) was "
+			          "not a directory. It is not removed and no "
+			          "home directories are created.\n"),
 			         Prog, user_home);
 			fail_exit (E_HOMEDIR, process_selinux);
 		}
@@ -1880,8 +1800,7 @@ static void move_home (bool process_selinux)
 			if (chown_tree (prefix_user_newhome,
 			                user_id,  uflg ? user_newid  : (uid_t)-1,
 			                user_gid, gflg ? user_newgid : (gid_t)-1) != 0) {
-				fprintf (stderr,
-				         _("%s: Failed to change ownership of the home directory"),
+				eprintf(_("%s: Failed to change ownership of the home directory"),
 				         Prog);
 				fail_exit (E_HOMEDIR, process_selinux);
 			}
@@ -1895,8 +1814,7 @@ static void move_home (bool process_selinux)
 			if (EXDEV == errno) {
 #ifdef WITH_BTRFS
 				if (btrfs_is_subvolume (prefix_user_home) > 0) {
-					fprintf (stderr,
-					        _("%s: error: cannot move subvolume from %s to %s - different device\n"),
+					eprintf(_("%s: error: cannot move subvolume from %s to %s - different device\n"),
 					        Prog, prefix_user_home, prefix_user_newhome);
 					fail_exit (E_HOMEDIR, process_selinux);
 				}
@@ -1908,8 +1826,7 @@ static void move_home (bool process_selinux)
 				               user_gid,
 				               gflg ? user_newgid : (gid_t)-1) == 0) {
 					if (remove_tree (prefix_user_home, true) != 0) {
-						fprintf (stderr,
-						         _("%s: warning: failed to completely remove old home directory %s"),
+						eprintf(_("%s: warning: failed to completely remove old home directory %s"),
 						         Prog, prefix_user_home);
 					}
 #ifdef WITH_AUDIT
@@ -1924,15 +1841,13 @@ static void move_home (bool process_selinux)
 
 				(void) remove_tree (prefix_user_newhome, true);
 			}
-			fprintf (stderr,
-			         _("%s: cannot rename directory %s to %s\n"),
+			eprintf(_("%s: cannot rename directory %s to %s\n"),
 			         Prog, prefix_user_home, prefix_user_newhome);
 			fail_exit (E_HOMEDIR, process_selinux);
 		}
 	} else {
-		fprintf (stderr,
-		         _("%s: The previous home directory (%s) does not "
-		           "exist or is inaccessible. Move cannot be completed.\n"),
+		eprintf(_("%s: The previous home directory (%s) does not "
+		          "exist or is inaccessible. Move cannot be completed.\n"),
 		         Prog, prefix_user_home);
 	}
 }
@@ -2118,7 +2033,7 @@ static void move_mailbox (void)
 	}
 	if (st.st_uid != user_id) {
 		/* better leave it alone */
-		fprintf (stderr, _("%s: warning: %s not owned by %s\n"),
+		eprintf(_("%s: warning: %s not owned by %s\n"),
 		         Prog, mailfile, user_name);
 		(void) close (fd);
 		free(mailfile);
@@ -2241,16 +2156,12 @@ int main (int argc, char **argv)
 #ifdef ENABLE_SUBIDS
 	if (Sflg) {
 		if (find_range (&add_sub_uids, user_id, find_new_sub_uids) == 0) {
-			fprinte(stderr,
-				_("%s: unable to find new subordinate uid range"),
-				Prog);
+			eprinte(_("%s: unable to find new subordinate uid range"), Prog);
 			SYSLOGE(LOG_WARN, "unable to find new subordinate uid range");
 			fail_exit (E_SUB_UID_UPDATE, process_selinux);
 		}
 		if (find_range (&add_sub_gids, user_id, find_new_sub_gids) == 0) {
-			fprinte(stderr,
-				_("%s: unable to find new subordinate gid range"),
-				Prog);
+			eprinte(_("%s: unable to find new subordinate gid range"), Prog);
 			SYSLOGE(LOG_WARN, "unable to find new subordinate gid range");
 			fail_exit (E_SUB_GID_UPDATE, process_selinux);
 		}
@@ -2263,8 +2174,7 @@ int main (int argc, char **argv)
 			id_t  count = ptr->range.last - ptr->range.first + 1;
 
 			if (sub_uid_remove(user_name, ptr->range.first, count) == 0) {
-				fprintf(stderr,
-				        _("%s: failed to remove uid range %ju-%ju from '%s'\n"),
+				eprintf(_("%s: failed to remove uid range %ju-%ju from '%s'\n"),
 				        Prog,
 				        (uintmax_t) ptr->range.first,
 				        (uintmax_t) ptr->range.last,
@@ -2280,8 +2190,7 @@ int main (int argc, char **argv)
 			id_t  count = ptr->range.last - ptr->range.first + 1;
 
 			if (sub_uid_add(user_name, ptr->range.first, count) == 0) {
-				fprintf(stderr,
-				        _("%s: failed to add uid range %ju-%ju to '%s'\n"),
+				eprintf(_("%s: failed to add uid range %ju-%ju to '%s'\n"),
 				        Prog,
 				        (uintmax_t) ptr->range.first,
 				        (uintmax_t) ptr->range.last,
@@ -2297,8 +2206,7 @@ int main (int argc, char **argv)
 			id_t  count = ptr->range.last - ptr->range.first + 1;
 
 			if (sub_gid_remove(user_name, ptr->range.first, count) == 0) {
-				fprintf(stderr,
-				        _("%s: failed to remove gid range %ju-%ju from '%s'\n"),
+				eprintf(_("%s: failed to remove gid range %ju-%ju from '%s'\n"),
 				        Prog,
 				        (uintmax_t) ptr->range.first,
 				        (uintmax_t) ptr->range.last,
@@ -2314,8 +2222,7 @@ int main (int argc, char **argv)
 			id_t  count = ptr->range.last - ptr->range.first + 1;
 
 			if (sub_gid_add(user_name, ptr->range.first, count) == 0) {
-				fprintf(stderr,
-				        _("%s: failed to add gid range %ju-%ju to '%s'\n"),
+				eprintf(_("%s: failed to add gid range %ju-%ju to '%s'\n"),
 				        Prog,
 				        (uintmax_t) ptr->range.first,
 				        (uintmax_t) ptr->range.last,
@@ -2342,8 +2249,7 @@ int main (int argc, char **argv)
 	if (Zflg) {
 		if (!streq(user_selinux, "")) {
 			if (set_seuser (user_name, user_selinux, user_selinux_range) != 0) {
-				fprintf (stderr,
-				         _("%s: warning: the user name %s to %s SELinux user mapping failed.\n"),
+				eprintf(_("%s: warning: the user name %s to %s SELinux user mapping failed.\n"),
 				         Prog, user_name, user_selinux);
 #ifdef WITH_AUDIT
 				audit_logger (AUDIT_ROLE_ASSIGN,
@@ -2355,8 +2261,7 @@ int main (int argc, char **argv)
 			}
 		} else {
 			if (del_seuser (user_name) != 0) {
-				fprintf (stderr,
-				         _("%s: warning: the user name %s to SELinux user mapping removal failed.\n"),
+				eprintf(_("%s: warning: the user name %s to SELinux user mapping removal failed.\n"),
 				         Prog, user_name);
 #ifdef WITH_AUDIT
 				audit_logger (AUDIT_ROLE_REMOVE,
@@ -2413,8 +2318,7 @@ int main (int argc, char **argv)
 			                uflg ? user_newid  : (uid_t)-1,
 			                user_gid,
 			                gflg ? user_newgid : (gid_t)-1) != 0) {
-				fprintf (stderr,
-				         _("%s: Failed to change ownership of the home directory"),
+				eprintf(_("%s: Failed to change ownership of the home directory"),
 				         Prog);
 				fail_exit (E_HOMEDIR, process_selinux);
 			}

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -372,7 +372,7 @@ prepend_range(const char *str, struct id_range_list_entry **head)
 
 	entry = malloc_T(1, struct id_range_list_entry);
 	if (!entry) {
-		fprinte(stderr, _("%s: failed to allocate memory"), Prog);
+		eprinte(_("%s: failed to allocate memory"), Prog);
 		return 0;
 	}
 	entry->next = *head;
@@ -396,7 +396,7 @@ find_range(struct id_range_list_entry **head, uid_t uid,
 
 	entry = malloc_T(1, struct id_range_list_entry);
 	if (entry == NULL) {
-		fprinte(stderr, "%s: malloc", Prog);
+		eprinte("%s: malloc", Prog);
 		return 0;
 	}
 
@@ -1881,7 +1881,7 @@ static void update_lastlog (void)
 	fd = open(_PATH_LASTLOG, O_RDWR);
 
 	if (-1 == fd) {
-		fprinte(stderr, _("%s: failed to copy the lastlog entry of user %lu to user %lu"),
+		eprinte(_("%s: failed to copy the lastlog entry of user %lu to user %lu"),
 		        Prog, (unsigned long) user_id, (unsigned long) user_newid);
 		return;
 	}
@@ -1892,7 +1892,7 @@ static void update_lastlog (void)
 		if (   (lseek (fd, off_newuid, SEEK_SET) != off_newuid)
 		    || (write_full(fd, &ll, sizeof(ll)) == -1)
 		    || (fsync (fd) != 0)) {
-			fprinte(stderr, _("%s: failed to copy the lastlog entry of user %lu to user %lu"),
+			eprinte(_("%s: failed to copy the lastlog entry of user %lu to user %lu"),
 			        Prog, (unsigned long) user_id, (unsigned long) user_newid);
 		}
 	} else {
@@ -1907,14 +1907,14 @@ static void update_lastlog (void)
 			if (   (lseek (fd, off_newuid, SEEK_SET) != off_newuid)
 			    || (write_full(fd, &ll, sizeof(ll)) == -1)
 			    || (fsync (fd) != 0)) {
-				fprinte(stderr, _("%s: failed to copy the lastlog entry of user %lu to user %lu"),
+				eprinte(_("%s: failed to copy the lastlog entry of user %lu to user %lu"),
 				        Prog, (unsigned long) user_id, (unsigned long) user_newid);
 			}
 		}
 	}
 
 	if (close (fd) != 0 && errno != EINTR) {
-		fprinte(stderr, _("%s: failed to copy the lastlog entry of user %ju to user %ju"),
+		eprinte(_("%s: failed to copy the lastlog entry of user %ju to user %ju"),
 		        Prog, (uintmax_t) user_id, (uintmax_t) user_newid);
 	}
 }
@@ -1941,7 +1941,7 @@ static void update_faillog (void)
 	fd = open (FAILLOG_FILE, O_RDWR);
 
 	if (-1 == fd) {
-		fprinte(stderr, _("%s: failed to copy the faillog entry of user %lu to user %lu"),
+		eprinte(_("%s: failed to copy the faillog entry of user %lu to user %lu"),
 		        Prog, (unsigned long) user_id, (unsigned long) user_newid);
 		return;
 	}
@@ -1952,7 +1952,7 @@ static void update_faillog (void)
 		if (   (lseek (fd, off_newuid, SEEK_SET) != off_newuid)
 		    || (write_full(fd, &fl, sizeof(fl)) == -1)
 		    || (fsync (fd) != 0)) {
-			fprinte(stderr, _("%s: failed to copy the faillog entry of user %lu to user %lu"),
+			eprinte(_("%s: failed to copy the faillog entry of user %lu to user %lu"),
 			        Prog, (unsigned long) user_id, (unsigned long) user_newid);
 		}
 	} else {
@@ -1967,14 +1967,14 @@ static void update_faillog (void)
 			if (   (lseek (fd, off_newuid, SEEK_SET) != off_newuid)
 			    || (write_full(fd, &fl, sizeof(fl)) == -1))
 			{
-				fprinte(stderr, _("%s: failed to copy the faillog entry of user %lu to user %lu"),
+				eprinte(_("%s: failed to copy the faillog entry of user %lu to user %lu"),
 				        Prog, (unsigned long) user_id, (unsigned long) user_newid);
 			}
 		}
 	}
 
 	if (close (fd) != 0 && errno != EINTR) {
-		fprinte(stderr, _("%s: failed to copy the faillog entry of user %ju to user %ju"),
+		eprinte(_("%s: failed to copy the faillog entry of user %ju to user %ju"),
 		        Prog, (uintmax_t) user_id, (uintmax_t) user_newid);
 	}
 }

--- a/src/vipw.c
+++ b/src/vipw.c
@@ -314,7 +314,7 @@ vipwedit (const char *file, int (*file_lock) (void), int (*file_unlock) (bool))
 
 		status = system (buf);
 		if (-1 == status) {
-			fprinte(stderr, "%s: %s", Prog, editor);
+			eprinte("%s: %s", Prog, editor);
 			exit (1);
 		} else if (   WIFEXITED (status)
 		           && (WEXITSTATUS (status) != 0)) {
@@ -349,17 +349,17 @@ vipwedit (const char *file, int (*file_lock) (void), int (*file_unlock) (bool))
 			if (orig_pgrp != -1) {
 				editor_pgrp = tcgetpgrp(STDIN_FILENO);
 				if (editor_pgrp == -1) {
-					fprinte(stderr, "%s: %s", Prog, "tcgetpgrp");
+					eprinte("%s: %s", Prog, "tcgetpgrp");
 				}
 				if (tcsetpgrp(STDIN_FILENO, orig_pgrp) == -1) {
-					fprinte(stderr, "%s: %s", Prog, "tcsetpgrp");
+					eprinte("%s: %s", Prog, "tcsetpgrp");
 				}
 			}
 			kill (getpid (), SIGSTOP);
 			/* wake child when resumed */
 			if (editor_pgrp != -1) {
 				if (tcsetpgrp(STDIN_FILENO, editor_pgrp) == -1) {
-					fprinte(stderr, "%s: %s", Prog, "tcsetpgrp");
+					eprinte("%s: %s", Prog, "tcsetpgrp");
 				}
 			}
 			killpg (pid, SIGCONT);
@@ -371,7 +371,7 @@ vipwedit (const char *file, int (*file_lock) (void), int (*file_unlock) (bool))
 	if (orig_pgrp != -1) {
 		 /* Restore terminal pgrp after editing. */
 		if (tcsetpgrp(STDIN_FILENO, orig_pgrp) == -1) {
-			fprinte(stderr, "%s: %s", Prog, "tcsetpgrp");
+			eprinte("%s: %s", Prog, "tcsetpgrp");
 		}
 		sigprocmask(SIG_SETMASK, &omask, NULL);
 	}
@@ -441,7 +441,7 @@ vipwedit (const char *file, int (*file_lock) (void), int (*file_unlock) (bool))
 	unlink (filebackup);
 	link (file, filebackup);
 	if (rename (to_rename, file) == -1) {
-		fprinte(stderr, _("%s: can't restore %s (your changes are in %s)"),
+		eprinte(_("%s: can't restore %s (your changes are in %s)"),
 		        Prog, file, to_rename);
 #ifdef WITH_TCB
 		if (tcb_mode) {

--- a/src/vipw.c
+++ b/src/vipw.c
@@ -159,22 +159,22 @@ static void vipwexit (const char *msg, int syserr, int ret)
 
 	if (createedit) {
 		if (unlink (fileeditname) != 0) {
-			fprintf (stderr, _("%s: failed to remove %s\n"), Prog, fileeditname);
+			eprintf(_("%s: failed to remove %s\n"), Prog, fileeditname);
 			/* continue */
 		}
 	}
 	if (filelocked) {
 		if ((*unlock) (true) == 0) {
-			fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, fileeditname);
+			eprintf(_("%s: failed to unlock %s\n"), Prog, fileeditname);
 			SYSLOG(LOG_ERR, "failed to unlock %s", fileeditname);
 			/* continue */
 		}
 	}
 	if (NULL != msg) {
-		fprintf (stderr, "%s: %s", Prog, msg);
+		eprintf("%s: %s", Prog, msg);
 	}
 	if (0 != syserr) {
-		fprintf (stderr, ": %s", strerror (err));
+		eprintf(": %s", strerror(err));
 	}
 	if (   (NULL != msg)
 	    || (0 != syserr)) {
@@ -318,12 +318,12 @@ vipwedit (const char *file, int (*file_lock) (void), int (*file_unlock) (bool))
 			exit (1);
 		} else if (   WIFEXITED (status)
 		           && (WEXITSTATUS (status) != 0)) {
-			fprintf(stderr, "%s: %s: WEXITSTATUS(): %d\n",
-			         Prog, editor, WEXITSTATUS (status));
+			eprintf("%s: %s: WEXITSTATUS(): %d\n",
+			        Prog, editor, WEXITSTATUS(status));
 			exit (WEXITSTATUS (status));
 		} else if (WIFSIGNALED (status)) {
-			fprintf(stderr, "%s: %s: WTERMSIG(): %d\n",
-			         Prog, editor, WTERMSIG (status));
+			eprintf("%s: %s: WTERMSIG(): %d\n",
+			        Prog, editor, WTERMSIG(status));
 			exit (1);
 		} else {
 			exit (0);
@@ -382,7 +382,7 @@ vipwedit (const char *file, int (*file_lock) (void), int (*file_unlock) (bool))
 	           && (WEXITSTATUS (status) != 0)) {
 		vipwexit (NULL, 0, WEXITSTATUS (status));
 	} else if (WIFSIGNALED (status)) {
-		fprintf (stderr, _("%s: %s killed by signal %d\n"),
+		eprintf(_("%s: %s killed by signal %d\n"),
 		         Prog, editor, WTERMSIG(status));
 		vipwexit (NULL, 0, 1);
 	}
@@ -461,7 +461,7 @@ vipwedit (const char *file, int (*file_lock) (void), int (*file_unlock) (bool))
 #endif				/* WITH_TCB */
 
 	if ((*file_unlock) (true) == 0) {
-		fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, fileeditname);
+		eprintf(_("%s: failed to unlock %s\n"), Prog, fileeditname);
 		SYSLOG(LOG_ERR, "failed to unlock %s", fileeditname);
 		/* continue */
 	}
@@ -569,8 +569,7 @@ int main (int argc, char **argv)
 #ifdef WITH_TCB
 			if (getdef_bool ("USE_TCB") && (NULL != user)) {
 				if (shadowtcb_set_user (user) == SHADOWTCB_FAILURE) {
-					fprintf (stderr,
-					         _("%s: failed to find tcb directory for %s\n"),
+					eprintf(_("%s: failed to find tcb directory for %s\n"),
 					         Prog, user);
 					return E_SHADOW_NOTFOUND;
 				}


### PR DESCRIPTION
This allows compacting a lot of code.  It also makes it easier to discern lines that print to actual files, from those that print to stderr/stdout.

---

Revisions:

<details>
<summary>v2</summary>

-  Drop patches 3 and 4 (they're now in #1299 ).
-  `#include "config.h"` with quotes.

```
$ git range-diff f6e676334455^..gh/eprintf shadow/master..eprintf 
1:  f6e67633 ! 1:  302aae32 lib/io/fprintf/: eprintf(): Add function to print to stderr
    @@ lib/io/fprintf/eprintf.c (new)
     +// SPDX-License-Identifier: BSD-3-Clause
     +
     +
    -+#include <config.h>
    ++#include "config.h"
     +
     +#include "io/fprintf/eprintf.h"
     +
    @@ lib/io/fprintf/eprintf.h (new)
     +#define SHADOW_INCLUDE_LIB_IO_FPRINTF_EPRINTF_H_
     +
     +
    -+#include <config.h>
    ++#include "config.h"
     +
     +#include <stdarg.h>
     +#include <stdio.h>
2:  1c1568e1 = 2:  a3ed1da0 lib/, src/: Use eprintf() instead of its pattern
3:  be83d1b4 < -:  -------- src/vipw.c: usage(): Print everything to the same stream
4:  c3af808a < -:  -------- lib/, src/: Use printf(3) instead of its pattern
```
</details>

<details>
<summary>v2b</summary>

-  Rebase

```
$ git rd 
1:  302aae32 = 1:  da4c7959 lib/io/fprintf/: eprintf(): Add function to print to stderr
2:  a3ed1da0 ! 2:  13a80305 lib/, src/: Use eprintf() instead of its pattern
    @@ src/login.c: int main (int argc, char **argv)
                exit (0);
        } else if (child != 0) {
     @@ src/login.c: int main (int argc, char **argv)
    -   if (getppid() == 1) {
    +   if (1 == initial_pid) {
                setsid();
                if (ioctl(0, TIOCSCTTY, 1) != 0) {
     -                  fprintf (stderr, _("TIOCSCTTY failed on %s"), tty);
```
</details>

<details>
<summary>v3</summary>

-  Add and use strerrno().  This compacts some lines further.

```
$ git rd
1:  da4c7959 = 1:  da4c7959 lib/io/fprintf/: eprintf(): Add function to print to stderr
2:  13a80305 = 2:  13a80305 lib/, src/: Use eprintf() instead of its pattern
-:  -------- > 3:  e1cddf24 lib/string/: strerrno(): Add function
-:  -------- > 4:  767c2377 lib/, src/: Use strerrno() instead of its pattern
```
</details>

<details>
<summary>v4</summary>

-  Fix definition of SYSLOG() to remove the weird double parentheses.
-  Fix non-matching parentheses in SYSLOG() call.

```
$ git rd 
1:  da4c7959 = 1:  da4c7959 lib/io/fprintf/: eprintf(): Add function to print to stderr
2:  13a80305 = 2:  13a80305 lib/, src/: Use eprintf() instead of its pattern
3:  e1cddf24 = 3:  e1cddf24 lib/string/: strerrno(): Add function
4:  767c2377 = 4:  767c2377 lib/, src/: Use strerrno() instead of its pattern
-:  -------- > 5:  7e6bef2e src/su.c: Fix incorrect (non-matching) parentheses
-:  -------- > 6:  a9900489 lib/defines.h, lib/, src/: Redefine SYSLOG() as a variadic macro
```
</details>

<details>
<summary>v5</summary>

-  Add moar wrappers, fix moar bugs, make code moar readable.

```
$ git rd 
 1:  da4c7959 =  1:  da4c7959 lib/io/fprintf/: eprintf(): Add function to print to stderr
 2:  13a80305 =  2:  13a80305 lib/, src/: Use eprintf() instead of its pattern
 3:  e1cddf24 =  3:  e1cddf24 lib/string/: strerrno(): Add function
 4:  767c2377 =  4:  767c2377 lib/, src/: Use strerrno() instead of its pattern
 5:  7e6bef2e =  5:  7e6bef2e src/su.c: Fix incorrect (non-matching) parentheses
 6:  a9900489 =  6:  a9900489 lib/defines.h, lib/, src/: Redefine SYSLOG() as a variadic macro
 -:  -------- >  7:  ca6382ba lib/: Move <syslog.h> wrappers to "io/syslog.h"
 -:  -------- >  8:  eb3b2517 lib/io/: syslog_c(): Implement SYSLOG() with a helper function
 -:  -------- >  9:  82cf1bd0 lib/io/syslog.h: Call setlocale(3) and free(3) unconditionally
 -:  -------- > 10:  67826ff5 lib/io/fprintf/: [v]fprinte(): Add function
 -:  -------- > 11:  53eaccf5 lib/io/fprintf/: [v]eprinte(): Add function
 -:  -------- > 12:  a7e0a585 lib/, src/: Use eprinte() instead of its pattern
 -:  -------- > 13:  ec4bcad1 lib/: Use [v]fprinte() instead of its pattern
 -:  -------- > 14:  15c8269f lib/io/syslog.h: SYSLOGE(): Add macro
 -:  -------- > 15:  73f63bd4 src/userdel.c: Fix error message
 -:  -------- > 16:  2c45897a lib/, src/: Use SYSLOGE() instead of its pattern
```
</details>

<details>
<summary>v5b</summary>

-  tfix

```
$ git rd 
 1:  da4c7959 =  1:  da4c7959 lib/io/fprintf/: eprintf(): Add function to print to stderr
 2:  13a80305 =  2:  13a80305 lib/, src/: Use eprintf() instead of its pattern
 3:  e1cddf24 =  3:  e1cddf24 lib/string/: strerrno(): Add function
 4:  767c2377 =  4:  767c2377 lib/, src/: Use strerrno() instead of its pattern
 5:  7e6bef2e =  5:  7e6bef2e src/su.c: Fix incorrect (non-matching) parentheses
 6:  a9900489 =  6:  a9900489 lib/defines.h, lib/, src/: Redefine SYSLOG() as a variadic macro
 7:  ca6382ba =  7:  ca6382ba lib/: Move <syslog.h> wrappers to "io/syslog.h"
 8:  eb3b2517 =  8:  eb3b2517 lib/io/: syslog_c(): Implement SYSLOG() with a helper function
 9:  82cf1bd0 =  9:  82cf1bd0 lib/io/syslog.h: Call setlocale(3) and free(3) unconditionally
10:  67826ff5 ! 10:  9ad98eef lib/io/fprintf/: [v]fprinte(): Add function
    @@ lib/io/fprintf/fprinte.h (new)
     +#include "attr.h"
     +
     +
    -+format_attr(printf, 2, 2)
    ++format_attr(printf, 2, 3)
     +inline int fprinte(FILE *restrict stream, const char *restrict fmt, ...);
     +format_attr(printf, 2, 0)
     +inline int vfprinte(FILE *restrict stream, const char *restrict fmt, va_list ap);
11:  53eaccf5 = 11:  ff79b1d7 lib/io/fprintf/: [v]eprinte(): Add function
12:  a7e0a585 = 12:  79ce27b7 lib/, src/: Use eprinte() instead of its pattern
13:  ec4bcad1 = 13:  adf040bd lib/: Use [v]fprinte() instead of its pattern
14:  15c8269f = 14:  3c56b00e lib/io/syslog.h: SYSLOGE(): Add macro
15:  73f63bd4 = 15:  215bfe62 src/userdel.c: Fix error message
16:  2c45897a = 16:  2e8be431 lib/, src/: Use SYSLOGE() instead of its pattern
```
</details>

<details>
<summary>v6</summary>

-  SYSLOG_C() must be a macro.  It does some interesting magic!

```
$ git rd 
 1:  da4c7959 =  1:  da4c7959 lib/io/fprintf/: eprintf(): Add function to print to stderr
 2:  13a80305 =  2:  13a80305 lib/, src/: Use eprintf() instead of its pattern
 3:  e1cddf24 =  3:  e1cddf24 lib/string/: strerrno(): Add function
 4:  767c2377 =  4:  767c2377 lib/, src/: Use strerrno() instead of its pattern
 5:  7e6bef2e =  5:  7e6bef2e src/su.c: Fix incorrect (non-matching) parentheses
 6:  a9900489 =  6:  a9900489 lib/defines.h, lib/, src/: Redefine SYSLOG() as a variadic macro
 7:  ca6382ba =  7:  ca6382ba lib/: Move <syslog.h> wrappers to "io/syslog.h"
 8:  eb3b2517 !  8:  d9cb90ca lib/io/: syslog_c(): Implement SYSLOG() with a helper function
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/io/: syslog_c(): Implement SYSLOG() with a helper function
    +    lib/io/syslog.h: SYSLOG_C(): Split code to helper macro
    +
    +    The name of this macro makes it more evident what it does.  It's a
    +    C-locale version of syslog(3).  We need to implement it as a macro
    +    so that arguments such as strerror(3) are evaluated after setting
    +    the C locale.  This would be impossible with a function.
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    - ## lib/io/syslog.c ##
    -@@
    - #include "config.h"
    - 
    - #include "io/syslog.h"
    -+
    -+#include <stdarg.h>
    -+
    -+
    -+extern inline void syslog_c(int priority, const char *restrict fmt, ...);
    -+extern inline void vsyslog_c(int priority, const char *restrict fmt, va_list ap);
    -
      ## lib/io/syslog.h ##
    -@@
    - #include "config.h"
    - 
    - #include <locale.h>
    -+#include <stdarg.h>
    - #include <stddef.h>
    - #include <stdlib.h>
    - #include <string.h>
     @@
      #define LOG_AUTHPRIV LOG_AUTH
      #endif
    @@ lib/io/syslog.h
     -          }                                                       \
     -  } while (false)
     -#else                             /* !ENABLE_NLS */
    -+#define SYSLOG(...)  syslog_c(__VA_ARGS__)
    ++#define SYSLOG(...)  SYSLOG_C(__VA_ARGS__)
     +#else
      #define SYSLOG(...)  syslog(__VA_ARGS__)
     -#endif                            /* !ENABLE_NLS */
    @@ lib/io/syslog.h
      #define OPENLOG(progname) openlog(progname, SYSLOG_OPTIONS, SYSLOG_FACILITY)
      
      
    -+inline void syslog_c(int priority, const char *restrict fmt, ...);
    -+inline void vsyslog_c(int priority, const char *restrict fmt, va_list ap);
    -+
    -+
     +// system log C-locale
    -+inline void
    -+syslog_c(int priority, const char *restrict fmt, ...)
    -+{
    -+  va_list  ap;
    -+
    -+  va_start(ap, fmt);
    -+  vsyslog_c(priority, fmt, ap);
    -+  va_end(ap);
    -+}
    -+
    -+
    -+// va_list system log C-locale
    -+inline void
    -+vsyslog_c(int priority, const char *restrict fmt, va_list ap)
    -+{
    -+  char *old_locale;
    -+  char *saved_locale;
    -+
    -+  old_locale = setlocale(LC_ALL, NULL);
    -+  saved_locale = NULL;
    -+
    -+  if (NULL != old_locale)
    -+          saved_locale = strdup(old_locale);
    -+
    -+  if (NULL != saved_locale)
    -+          setlocale(LC_ALL, "C");
    -+
    -+  vsyslog(priority, fmt, ap);
    -+
    -+  if (NULL != saved_locale) {
    -+          setlocale(LC_ALL, saved_locale);
    -+          free(saved_locale);
    -+  }
    -+}
    ++#define SYSLOG_C(...)  do                                             \
    ++{                                                                     \
    ++  char  *old_locale;                                            \
    ++  char  *saved_locale;                                          \
    ++                                                                      \
    ++  old_locale = setlocale(LC_ALL, NULL);                         \
    ++  saved_locale = NULL;                                          \
    ++                                                                      \
    ++  if (NULL != old_locale)                                       \
    ++          saved_locale = strdup(old_locale);                    \
    ++                                                                      \
    ++  if (NULL != saved_locale) {                                   \
    ++          setlocale(LC_ALL, "C");                               \
    ++                                                                      \
    ++  syslog(__VA_ARGS__);                                          \
    ++  if (NULL != saved_locale) {                                   \
    ++          setlocale(LC_ALL, saved_locale);                      \
    ++          free(saved_locale);                                   \
    ++  }                                                             \
    ++} while (0)
     +
     +
      #endif  // include guard
 9:  82cf1bd0 <  -:  -------- lib/io/syslog.h: Call setlocale(3) and free(3) unconditionally
 -:  -------- >  9:  1f0531b1 lib/io/syslog.h: Rename local variable
 -:  -------- > 10:  41bd7c81 lib/io/syslog.h: SYSLOG_C(): Use a single local variable
 -:  -------- > 11:  163ebeea lib/io/syslog.h: SYSLOG_C(): Call setlocale(3) and free(3) unconditionally
10:  9ad98eef = 12:  95463ee9 lib/io/fprintf/: [v]fprinte(): Add function
11:  ff79b1d7 = 13:  1c37648a lib/io/fprintf/: [v]eprinte(): Add function
12:  79ce27b7 = 14:  d45e1fee lib/, src/: Use eprinte() instead of its pattern
13:  adf040bd = 15:  cfecd5ca lib/: Use [v]fprinte() instead of its pattern
14:  3c56b00e ! 16:  3caa45d7 lib/io/syslog.h: SYSLOGE(): Add macro
    @@ lib/io/syslog.h
     +)
     +
     +
    - inline void syslog_c(int priority, const char *restrict fmt, ...);
    - inline void vsyslog_c(int priority, const char *restrict fmt, va_list ap);
    - 
    + // system log C-locale
    + #define SYSLOG_C(...)  do                                             \
    + {                                                                     \
15:  215bfe62 = 17:  eaed086d src/userdel.c: Fix error message
16:  2e8be431 = 18:  5b44ec25 lib/, src/: Use SYSLOGE() instead of its pattern
```
</details>

<details>
<summary>v6b</summary>

-  fix braces

```
$ git rd 
 1:  da4c7959 =  1:  da4c7959 lib/io/fprintf/: eprintf(): Add function to print to stderr
 2:  13a80305 =  2:  13a80305 lib/, src/: Use eprintf() instead of its pattern
 3:  e1cddf24 =  3:  e1cddf24 lib/string/: strerrno(): Add function
 4:  767c2377 =  4:  767c2377 lib/, src/: Use strerrno() instead of its pattern
 5:  7e6bef2e =  5:  7e6bef2e src/su.c: Fix incorrect (non-matching) parentheses
 6:  a9900489 =  6:  a9900489 lib/defines.h, lib/, src/: Redefine SYSLOG() as a variadic macro
 7:  ca6382ba =  7:  ca6382ba lib/: Move <syslog.h> wrappers to "io/syslog.h"
 8:  d9cb90ca !  8:  73336b3f lib/io/syslog.h: SYSLOG_C(): Split code to helper macro
    @@ lib/io/syslog.h
     +  if (NULL != old_locale)                                       \
     +          saved_locale = strdup(old_locale);                    \
     +                                                                      \
    -+  if (NULL != saved_locale) {                                   \
    ++  if (NULL != saved_locale)                                     \
     +          setlocale(LC_ALL, "C");                               \
     +                                                                      \
     +  syslog(__VA_ARGS__);                                          \
 9:  1f0531b1 !  9:  063966cc lib/io/syslog.h: Rename local variable
    @@ lib/io/syslog.h
     +  if (NULL != l_)                                               \
     +          saved_locale = strdup(l_);                            \
                                                                            \
    -   if (NULL != saved_locale) {                                   \
    +   if (NULL != saved_locale)                                     \
                setlocale(LC_ALL, "C");                               \
10:  41bd7c81 ! 10:  ab24ab95 lib/io/syslog.h: SYSLOG_C(): Use a single local variable
    @@ lib/io/syslog.h
     -          saved_locale = strdup(l_);                            \
     +          l_ = strdup(l_);                                      \
                                                                            \
    --  if (NULL != saved_locale) {                                   \
    -+  if (NULL != l_) {                                             \
    +-  if (NULL != saved_locale)                                     \
    ++  if (NULL != l_)                                               \
                setlocale(LC_ALL, "C");                               \
                                                                            \
        syslog(__VA_ARGS__);                                          \
11:  163ebeea = 11:  07f77ecf lib/io/syslog.h: SYSLOG_C(): Call setlocale(3) and free(3) unconditionally
12:  95463ee9 = 12:  4d3b887d lib/io/fprintf/: [v]fprinte(): Add function
13:  1c37648a = 13:  e2e2c4fd lib/io/fprintf/: [v]eprinte(): Add function
14:  d45e1fee = 14:  058f311a lib/, src/: Use eprinte() instead of its pattern
15:  cfecd5ca = 15:  3b1c3231 lib/: Use [v]fprinte() instead of its pattern
16:  3caa45d7 = 16:  955ab8bf lib/io/syslog.h: SYSLOGE(): Add macro
17:  eaed086d = 17:  7be1c698 src/userdel.c: Fix error message
18:  5b44ec25 = 18:  2e1ee543 lib/, src/: Use SYSLOGE() instead of its pattern
```
</details>

<details>
<summary>v6c</summary>

-  Use do-while(0) to implement SYSLOGE()

```
$ git rd 
 1:  da4c7959 =  1:  da4c7959 lib/io/fprintf/: eprintf(): Add function to print to stderr
 2:  13a80305 =  2:  13a80305 lib/, src/: Use eprintf() instead of its pattern
 3:  e1cddf24 =  3:  e1cddf24 lib/string/: strerrno(): Add function
 4:  767c2377 =  4:  767c2377 lib/, src/: Use strerrno() instead of its pattern
 5:  7e6bef2e =  5:  7e6bef2e src/su.c: Fix incorrect (non-matching) parentheses
 6:  a9900489 =  6:  a9900489 lib/defines.h, lib/, src/: Redefine SYSLOG() as a variadic macro
 7:  ca6382ba =  7:  ca6382ba lib/: Move <syslog.h> wrappers to "io/syslog.h"
 8:  73336b3f =  8:  73336b3f lib/io/syslog.h: SYSLOG_C(): Split code to helper macro
 9:  063966cc =  9:  063966cc lib/io/syslog.h: Rename local variable
10:  ab24ab95 = 10:  ab24ab95 lib/io/syslog.h: SYSLOG_C(): Use a single local variable
11:  07f77ecf = 11:  07f77ecf lib/io/syslog.h: SYSLOG_C(): Call setlocale(3) and free(3) unconditionally
12:  4d3b887d = 12:  4d3b887d lib/io/fprintf/: [v]fprinte(): Add function
13:  e2e2c4fd = 13:  e2e2c4fd lib/io/fprintf/: [v]eprinte(): Add function
14:  058f311a = 14:  058f311a lib/, src/: Use eprinte() instead of its pattern
15:  3b1c3231 = 15:  3b1c3231 lib/: Use [v]fprinte() instead of its pattern
16:  955ab8bf ! 16:  47cf544a lib/io/syslog.h: SYSLOGE(): Add macro
    @@ lib/io/syslog.h
      
      
     +// system log errno
    -+#define SYSLOGE(prio, fmt, ...)                                       \
    -+(                                                                     \
    ++#define SYSLOGE(prio, fmt, ...)  do                                   \
    ++{                                                                     \
     +  SYSLOG(prio, "" fmt ": %s" __VA_OPT__(,) __VA_ARGS__, strerrno()) \
    -+)
    ++} while (0)
     +
     +
      // system log C-locale
17:  7be1c698 = 17:  9faad6e1 src/userdel.c: Fix error message
18:  2e1ee543 = 18:  e0290fcb lib/, src/: Use SYSLOGE() instead of its pattern
```
</details>

<details>
<summary>v6d</summary>

-  Fix semicolons.

```
$ git rd
 1:  da4c7959 =  1:  da4c7959 lib/io/fprintf/: eprintf(): Add function to print to stderr
 2:  13a80305 =  2:  13a80305 lib/, src/: Use eprintf() instead of its pattern
 3:  e1cddf24 =  3:  e1cddf24 lib/string/: strerrno(): Add function
 4:  767c2377 =  4:  767c2377 lib/, src/: Use strerrno() instead of its pattern
 5:  7e6bef2e =  5:  7e6bef2e src/su.c: Fix incorrect (non-matching) parentheses
 6:  a9900489 =  6:  a9900489 lib/defines.h, lib/, src/: Redefine SYSLOG() as a variadic macro
 7:  ca6382ba =  7:  ca6382ba lib/: Move <syslog.h> wrappers to "io/syslog.h"
 8:  73336b3f =  8:  73336b3f lib/io/syslog.h: SYSLOG_C(): Split code to helper macro
 9:  063966cc =  9:  063966cc lib/io/syslog.h: Rename local variable
10:  ab24ab95 = 10:  ab24ab95 lib/io/syslog.h: SYSLOG_C(): Use a single local variable
11:  07f77ecf = 11:  07f77ecf lib/io/syslog.h: SYSLOG_C(): Call setlocale(3) and free(3) unconditionally
12:  4d3b887d = 12:  4d3b887d lib/io/fprintf/: [v]fprinte(): Add function
13:  e2e2c4fd = 13:  e2e2c4fd lib/io/fprintf/: [v]eprinte(): Add function
14:  058f311a = 14:  058f311a lib/, src/: Use eprinte() instead of its pattern
15:  3b1c3231 = 15:  3b1c3231 lib/: Use [v]fprinte() instead of its pattern
16:  47cf544a ! 16:  d94ded03 lib/io/syslog.h: SYSLOGE(): Add macro
    @@ lib/io/syslog.h
     +// system log errno
     +#define SYSLOGE(prio, fmt, ...)  do                                   \
     +{                                                                     \
    -+  SYSLOG(prio, "" fmt ": %s" __VA_OPT__(,) __VA_ARGS__, strerrno()) \
    ++  SYSLOG(prio, "" fmt ": %s" __VA_OPT__(,) __VA_ARGS__, strerrno()); \
     +} while (0)
     +
     +
17:  9faad6e1 = 17:  a16468a1 src/userdel.c: Fix error message
18:  e0290fcb = 18:  97d74781 lib/, src/: Use SYSLOGE() instead of its pattern
```
</details>

<details>
<summary>v6e</summary>

-  Add missing includes

```
$ git rd 
 -:  -------- >  1:  453bb132 lib/getdef.h: Add missing includes
 1:  da4c7959 =  2:  1aa42283 lib/io/fprintf/: eprintf(): Add function to print to stderr
 2:  13a80305 =  3:  e0f12df3 lib/, src/: Use eprintf() instead of its pattern
 3:  e1cddf24 =  4:  9478a434 lib/string/: strerrno(): Add function
 4:  767c2377 =  5:  7d03b42e lib/, src/: Use strerrno() instead of its pattern
 5:  7e6bef2e =  6:  869d2b44 src/su.c: Fix incorrect (non-matching) parentheses
 6:  a9900489 =  7:  96049602 lib/defines.h, lib/, src/: Redefine SYSLOG() as a variadic macro
 7:  ca6382ba =  8:  e542800a lib/: Move <syslog.h> wrappers to "io/syslog.h"
 8:  73336b3f =  9:  59a7bd7a lib/io/syslog.h: SYSLOG_C(): Split code to helper macro
 9:  063966cc = 10:  df5826c0 lib/io/syslog.h: Rename local variable
10:  ab24ab95 = 11:  7508615d lib/io/syslog.h: SYSLOG_C(): Use a single local variable
11:  07f77ecf = 12:  20a4f244 lib/io/syslog.h: SYSLOG_C(): Call setlocale(3) and free(3) unconditionally
12:  4d3b887d = 13:  7b2ce1f1 lib/io/fprintf/: [v]fprinte(): Add function
13:  e2e2c4fd = 14:  5b13bfba lib/io/fprintf/: [v]eprinte(): Add function
14:  058f311a = 15:  da1c2aac lib/, src/: Use eprinte() instead of its pattern
15:  3b1c3231 = 16:  1004d7e8 lib/: Use [v]fprinte() instead of its pattern
16:  d94ded03 = 17:  fa4d663d lib/io/syslog.h: SYSLOGE(): Add macro
17:  a16468a1 = 18:  42ff49da src/userdel.c: Fix error message
18:  97d74781 = 19:  68dfb3ae lib/, src/: Use SYSLOGE() instead of its pattern
```
</details>

<details>
<summary>v6f</summary>

-  Rebase

```
$ git rd 
 1:  453bb132 =  1:  0ac2e68c lib/getdef.h: Add missing includes
 2:  1aa42283 =  2:  acc8238c lib/io/fprintf/: eprintf(): Add function to print to stderr
 3:  e0f12df3 !  3:  4ebb63c2 lib/, src/: Use eprintf() instead of its pattern
    @@ src/chfn.c: int main (int argc, char **argv)
                        SYSLOG ((LOG_WARN, "Cannot determine the user name of the caller (UID %lu)",
                                 (unsigned long) getuid ()));
     @@ src/chfn.c: int main (int argc, char **argv)
    -    */
    -   if ((strlen (fullnm) + strlen (roomno) + strlen (workph) +
    -        strlen (homeph) + strlen (slop)) > (unsigned int) 80) {
    +           p = stpeprintf(p, e, ",%s", slop);
    + 
    +   if (p == e || p == NULL) {
     -          fprintf (stderr, _("%s: fields too long\n"), Prog);
     +          eprintf(_("%s: fields too long\n"), Prog);
                fail_exit (E_NOPERM);
        }
    -   SNPRINTF(new_gecos, "%s,%s,%s,%s%s%s",
    + 
     
      ## src/chgpasswd.c ##
     @@
 4:  9478a434 =  4:  2a615806 lib/string/: strerrno(): Add function
 5:  7d03b42e =  5:  fae8b792 lib/, src/: Use strerrno() instead of its pattern
 6:  869d2b44 =  6:  bdbe3523 src/su.c: Fix incorrect (non-matching) parentheses
 7:  96049602 =  7:  b170a21d lib/defines.h, lib/, src/: Redefine SYSLOG() as a variadic macro
 8:  e542800a =  8:  abdabe26 lib/: Move <syslog.h> wrappers to "io/syslog.h"
 9:  59a7bd7a =  9:  feda6e03 lib/io/syslog.h: SYSLOG_C(): Split code to helper macro
10:  df5826c0 = 10:  75cd1347 lib/io/syslog.h: Rename local variable
11:  7508615d = 11:  71818a6f lib/io/syslog.h: SYSLOG_C(): Use a single local variable
12:  20a4f244 = 12:  02ce55c6 lib/io/syslog.h: SYSLOG_C(): Call setlocale(3) and free(3) unconditionally
13:  7b2ce1f1 = 13:  c77c1be8 lib/io/fprintf/: [v]fprinte(): Add function
14:  5b13bfba = 14:  3a5f8825 lib/io/fprintf/: [v]eprinte(): Add function
15:  da1c2aac = 15:  a1a173d4 lib/, src/: Use eprinte() instead of its pattern
16:  1004d7e8 = 16:  17c5083e lib/: Use [v]fprinte() instead of its pattern
17:  fa4d663d = 17:  51640f21 lib/io/syslog.h: SYSLOGE(): Add macro
18:  42ff49da = 18:  3fb3b4c8 src/userdel.c: Fix error message
19:  68dfb3ae = 19:  55cd6cbc lib/, src/: Use SYSLOGE() instead of its pattern
```
</details>

<details>
<summary>v6g</summary>

-  Rebase

```
$ git rd 
 1:  0ac2e68c =  1:  6bc39aba lib/getdef.h: Add missing includes
 2:  acc8238c =  2:  4a57daa1 lib/io/fprintf/: eprintf(): Add function to print to stderr
 3:  4ebb63c2 =  3:  e75c9ff3 lib/, src/: Use eprintf() instead of its pattern
 4:  2a615806 =  4:  a46a8a0e lib/string/: strerrno(): Add function
 5:  fae8b792 =  5:  98555258 lib/, src/: Use strerrno() instead of its pattern
 6:  bdbe3523 =  6:  ad63c9e1 src/su.c: Fix incorrect (non-matching) parentheses
 7:  b170a21d =  7:  f56b7440 lib/defines.h, lib/, src/: Redefine SYSLOG() as a variadic macro
 8:  abdabe26 =  8:  d688bdb1 lib/: Move <syslog.h> wrappers to "io/syslog.h"
 9:  feda6e03 =  9:  4b42ef08 lib/io/syslog.h: SYSLOG_C(): Split code to helper macro
10:  75cd1347 = 10:  31706a0b lib/io/syslog.h: Rename local variable
11:  71818a6f = 11:  bd960db3 lib/io/syslog.h: SYSLOG_C(): Use a single local variable
12:  02ce55c6 = 12:  5164c736 lib/io/syslog.h: SYSLOG_C(): Call setlocale(3) and free(3) unconditionally
13:  c77c1be8 = 13:  c3e54019 lib/io/fprintf/: [v]fprinte(): Add function
14:  3a5f8825 = 14:  854399af lib/io/fprintf/: [v]eprinte(): Add function
15:  a1a173d4 = 15:  9d17e83b lib/, src/: Use eprinte() instead of its pattern
16:  17c5083e = 16:  f773e997 lib/: Use [v]fprinte() instead of its pattern
17:  51640f21 = 17:  93b6a5fc lib/io/syslog.h: SYSLOGE(): Add macro
18:  3fb3b4c8 = 18:  dc366523 src/userdel.c: Fix error message
19:  55cd6cbc = 19:  0a20d7bf lib/, src/: Use SYSLOGE() instead of its pattern
```
</details>

<details>
<summary>v7</summary>

-  Rebase

```
$ git rd 
 1:  6bc39aba =  1:  4c7cdd81 lib/getdef.h: Add missing includes
 2:  4a57daa1 =  2:  c5f7d1ba lib/io/fprintf/: eprintf(): Add function to print to stderr
 3:  e75c9ff3 !  3:  e9de5767 lib/, src/: Use eprintf() instead of its pattern
    @@ src/chpasswd.c: static void close_files (void)
                /* continue */
        }
     @@ src/chpasswd.c: int main (int argc, char **argv)
    -                                   }
    +                                           break;
                                }
      
     -                          fprintf (stderr,
    @@ src/lastlog.c: int main (int argc, char **argv)
     -          fprintf (stderr,
     -                   _("%s: Cannot get the size of %s: %s\n"),
     +          eprintf(_("%s: Cannot get the size of %s: %s\n"),
    -                    Prog, LASTLOG_FILE, strerror (errno));
    +                    Prog, _PATH_LASTLOG, strerror(errno));
                exit (EXIT_FAILURE);
        }
     
    @@ src/newgidmap.c: int main(int argc, char **argv)
     @@ src/newgidmap.c: int main(int argc, char **argv)
        }
      
    -   if (!sub_gid_open(O_RDONLY)) {
    +   if (want_subgid_file() && !sub_gid_open(O_RDONLY)) {
     -          fprintf (stderr,
     -                   _("%s: cannot open %s: %s\n"),
     +          eprintf(_("%s: cannot open %s: %s\n"),
    @@ src/newuidmap.c: int main(int argc, char **argv)
     @@ src/newuidmap.c: int main(int argc, char **argv)
        }
      
    -   if (!sub_uid_open(O_RDONLY)) {
    +   if (want_subuid_file() && !sub_uid_open(O_RDONLY)) {
     -          fprintf (stderr,
     -                   _("%s: cannot open %s: %s\n"),
     +          eprintf(_("%s: cannot open %s: %s\n"),
    @@ src/su.c: save_caller_context(void)
     @@ src/su.c: int main (int argc, char **argv)
        ret = pam_start (Prog, name, &conv, &pamh);
        if (PAM_SUCCESS != ret) {
    -           SYSLOG ((LOG_ERR, "pam_start: error %d", ret);
    --          fprintf (stderr,
    --                   _("%s: pam_start: error %d\n"),
    --                   Prog, ret));
    -+          eprintf(_("%s: pam_start: error %d\n"), Prog, ret));
    +           SYSLOG((LOG_ERR, "pam_start: error %d", ret));
    +-          fprintf(stderr, _("%s: pam_start: error %d\n"), Prog, ret);
    ++          eprintf(_("%s: pam_start: error %d\n"), Prog, ret);
                exit (1);
        }
      
    @@ src/useradd.c: static void faillog_reset (uid_t uid)
        }
     @@ src/useradd.c: static void lastlog_reset (uid_t uid)
      
    -   fd = open (LASTLOG_FILE, O_RDWR);
    +   fd = open(_PATH_LASTLOG, O_RDWR);
        if (-1 == fd) {
     -          fprintf (stderr,
     -                   _("%s: failed to open the lastlog file for UID %lu: %s\n"),
    @@ src/usermod.c: static void move_home (void)
        }
      }
     @@ src/usermod.c: static void update_lastlog (void)
    -   fd = open (LASTLOG_FILE, O_RDWR);
    +   fd = open(_PATH_LASTLOG, O_RDWR);
      
        if (-1 == fd) {
     -          fprintf (stderr,
 4:  a46a8a0e =  4:  c303977c lib/string/: strerrno(): Add function
 5:  98555258 !  5:  05f95c6f lib/, src/: Use strerrno() instead of its pattern
    @@ lib/tcbfuncs.c: static shadowtcb_status mkdir_leading (const char *name, uid_t u
     +                   shadow_progname, TCB_DIR, strerrno());
                goto out_free_path;
        }
    -   while ((ind = strchr (ptr, '/'))) {
    +   while (NULL != (ind = strchr(ptr, '/'))) {
     @@ lib/tcbfuncs.c: static shadowtcb_status mkdir_leading (const char *name, uid_t uid)
                if ((mkdir (dir, 0700) != 0) && (errno != EEXIST)) {
                        fprintf (shadow_logfd,
    @@ src/lastlog.c: int main (int argc, char **argv)
        /* Get the lastlog size */
        if (fstat (fileno (lastlogfile), &statbuf) != 0) {
                eprintf(_("%s: Cannot get the size of %s: %s\n"),
    --                   Prog, LASTLOG_FILE, strerror (errno));
    -+                  Prog, LASTLOG_FILE, strerrno());
    +-                   Prog, _PATH_LASTLOG, strerror(errno));
    ++                  Prog, _PATH_LASTLOG, strerrno());
                exit (EXIT_FAILURE);
        }
      
    @@ src/newgidmap.c: int main(int argc, char **argv)
     @@ src/newgidmap.c: int main(int argc, char **argv)
        }
      
    -   if (!sub_gid_open(O_RDONLY)) {
    +   if (want_subgid_file() && !sub_gid_open(O_RDONLY)) {
     -          eprintf(_("%s: cannot open %s: %s\n"),
     -                   Prog, sub_gid_dbname (), strerror (errno));
     +          eprintf(_("%s: cannot open %s: %s\n"), Prog, sub_gid_dbname(), strerrno());
    @@ src/newuidmap.c: int main(int argc, char **argv)
      
     @@ src/newuidmap.c: int main(int argc, char **argv)
      
    -   if (!sub_uid_open(O_RDONLY)) {
    +   if (want_subuid_file() && !sub_uid_open(O_RDONLY)) {
                eprintf(_("%s: cannot open %s: %s\n"),
     -                   Prog, sub_uid_dbname (), strerror (errno));
     +                  Prog, sub_uid_dbname(), strerrno());
    @@ src/useradd.c: static void faillog_reset (uid_t uid)
        }
      }
     @@ src/useradd.c: static void lastlog_reset (uid_t uid)
    -   fd = open (LASTLOG_FILE, O_RDWR);
    +   fd = open(_PATH_LASTLOG, O_RDWR);
        if (-1 == fd) {
                eprintf(_("%s: failed to open the lastlog file for UID %lu: %s\n"),
     -                   Prog, (unsigned long) uid, strerror (errno));
 6:  ad63c9e1 <  -:  -------- src/su.c: Fix incorrect (non-matching) parentheses
 7:  f56b7440 !  6:  5a448c24 lib/defines.h, lib/, src/: Redefine SYSLOG() as a variadic macro
    @@ lib/log.c: void dolastlog (
        if (lseek (fd, offset, SEEK_SET) != offset) {
     -          SYSLOG ((LOG_WARN,
     -                   "Can't read last lastlog entry for UID %lu in %s. Entry not updated.",
    --                   (unsigned long) pw->pw_uid, LASTLOG_FILE));
    +-                   (unsigned long) pw->pw_uid, _PATH_LASTLOG));
     +          SYSLOG(LOG_WARN,
     +                 "Can't read last lastlog entry for UID %lu in %s. Entry not updated.",
    -+                 (unsigned long) pw->pw_uid, LASTLOG_FILE);
    ++                 (unsigned long) pw->pw_uid, _PATH_LASTLOG);
                (void) close (fd);
                return;
        }
    @@ lib/log.c: err_write:
      err_close:
     -  SYSLOG ((LOG_WARN,
     -           "Can't write lastlog entry for UID %lu in %s: %m",
    --           (unsigned long) pw->pw_uid, LASTLOG_FILE));
    +-           (unsigned long) pw->pw_uid, _PATH_LASTLOG));
     +  SYSLOG(LOG_WARN,
     +         "Can't write lastlog entry for UID %lu in %s: %m",
    -+         (unsigned long) pw->pw_uid, LASTLOG_FILE);
    ++         (unsigned long) pw->pw_uid, _PATH_LASTLOG);
      }
     
      ## lib/pwdcheck.c ##
 8:  d688bdb1 =  7:  89a68bba lib/: Move <syslog.h> wrappers to "io/syslog.h"
 9:  4b42ef08 =  8:  de8b9cd4 lib/io/syslog.h: SYSLOG_C(): Split code to helper macro
10:  31706a0b =  9:  5cbca3af lib/io/syslog.h: Rename local variable
11:  bd960db3 = 10:  91bbde22 lib/io/syslog.h: SYSLOG_C(): Use a single local variable
12:  5164c736 = 11:  e32447c6 lib/io/syslog.h: SYSLOG_C(): Call setlocale(3) and free(3) unconditionally
13:  c3e54019 = 12:  fa2d4762 lib/io/fprintf/: [v]fprinte(): Add function
14:  854399af = 13:  d36ed519 lib/io/fprintf/: [v]eprinte(): Add function
15:  9d17e83b ! 14:  0a0f2c23 lib/, src/: Use eprinte() instead of its pattern
    @@ src/lastlog.c: int main (int argc, char **argv)
        /* Get the lastlog size */
        if (fstat (fileno (lastlogfile), &statbuf) != 0) {
     -          eprintf(_("%s: Cannot get the size of %s: %s\n"),
    --                  Prog, LASTLOG_FILE, strerrno());
    -+          eprinte(_("%s: Cannot get the size of %s"), Prog, LASTLOG_FILE);
    +-                  Prog, _PATH_LASTLOG, strerrno());
    ++          eprinte(_("%s: Cannot get the size of %s"), Prog, _PATH_LASTLOG);
                exit (EXIT_FAILURE);
        }
      
    @@ src/newgidmap.c: int main(int argc, char **argv)
     @@ src/newgidmap.c: int main(int argc, char **argv)
        }
      
    -   if (!sub_gid_open(O_RDONLY)) {
    +   if (want_subgid_file() && !sub_gid_open(O_RDONLY)) {
     -          eprintf(_("%s: cannot open %s: %s\n"), Prog, sub_gid_dbname(), strerrno());
     +          eprinte(_("%s: cannot open %s"), Prog, sub_gid_dbname());
                return EXIT_FAILURE;
    @@ src/newuidmap.c: int main(int argc, char **argv)
     @@ src/newuidmap.c: int main(int argc, char **argv)
        }
      
    -   if (!sub_uid_open(O_RDONLY)) {
    +   if (want_subuid_file() && !sub_uid_open(O_RDONLY)) {
     -          eprintf(_("%s: cannot open %s: %s\n"),
     -                  Prog, sub_uid_dbname(), strerrno());
     +          eprinte(_("%s: cannot open %s"), Prog, sub_uid_dbname());
    @@ src/useradd.c: static void faillog_reset (uid_t uid)
      }
     @@ src/useradd.c: static void lastlog_reset (uid_t uid)
      
    -   fd = open (LASTLOG_FILE, O_RDWR);
    +   fd = open(_PATH_LASTLOG, O_RDWR);
        if (-1 == fd) {
     -          eprintf(_("%s: failed to open the lastlog file for UID %lu: %s\n"),
     -                  Prog, (unsigned long) uid, strerrno());
    @@ src/usermod.c: prepend_range(const char *str, struct id_range_list_entry **head)
        }
        entry->next = *head;
     @@ src/usermod.c: static void update_lastlog (void)
    -   fd = open (LASTLOG_FILE, O_RDWR);
    +   fd = open(_PATH_LASTLOG, O_RDWR);
      
        if (-1 == fd) {
     -          eprintf(_("%s: failed to copy the lastlog entry of user %lu to user %lu: %s\n"),
16:  f773e997 ! 15:  350da966 lib/: Use [v]fprinte() instead of its pattern
    @@ lib/tcbfuncs.c: static shadowtcb_status mkdir_leading (const char *name, uid_t u
     +                  shadow_progname, TCB_DIR);
                goto out_free_path;
        }
    -   while ((ind = strchr (ptr, '/'))) {
    +   while (NULL != (ind = strchr(ptr, '/'))) {
     @@ lib/tcbfuncs.c: static shadowtcb_status mkdir_leading (const char *name, uid_t uid)
                        return SHADOWTCB_FAILURE;
                }
17:  93b6a5fc = 16:  64d4993c lib/io/syslog.h: SYSLOGE(): Add macro
18:  dc366523 = 17:  dfb25c6c src/userdel.c: Fix error message
19:  0a20d7bf = 18:  3b1b87e4 lib/, src/: Use SYSLOGE() instead of its pattern
```
</details>

v8: <https://github.com/shadow-maint/shadow/pull/1289#issuecomment-3419613758>

<details>
<summary>v8b</summary>

-  Fix previous rebase (v8).

```
$ git range-diff shadow/master gh/eprintf eprintf 
 1:  093ab3f0 =  1:  093ab3f0 lib/getdef.h: Add missing includes
 2:  5f2879a5 =  2:  5f2879a5 lib/io/fprintf/: eprintf(): Add function to print to stderr
 3:  224ebc52 =  3:  224ebc52 lib/, src/: Use eprintf() instead of its pattern
 4:  86d632c8 =  4:  86d632c8 lib/string/: strerrno(): Add function
 5:  931f9e4b =  5:  931f9e4b lib/, src/: Use strerrno() instead of its pattern
 6:  2e5885c8 !  6:  89e91e48 lib/defines.h, lib/, src/: Redefine SYSLOG() as a variadic macro
    @@ src/grpunconv.c: int main (int argc, char **argv)
        if (unlink(_PATH_GSHADOW) != 0) {
                eprintf(_("%s: cannot delete %s\n"), Prog, _PATH_GSHADOW);
     -          SYSLOG((LOG_ERR, "cannot delete %s", _PATH_GSHADOW));
    -+          SYSLOG(LOG_ERR, "cannot delete %s", SGROUP_FILE);
    ++          SYSLOG(LOG_ERR, "cannot delete %s", _PATH_GSHADOW);
                fail_exit (3, process_selinux);
        }
      
 7:  0d4af870 =  7:  6b17f1be lib/: Move <syslog.h> wrappers to "io/syslog.h"
 8:  d22e486c =  8:  0807708a lib/io/syslog.h: SYSLOG_C(): Split code to helper macro
 9:  aace99d5 =  9:  92d14578 lib/io/syslog.h: Rename local variable
10:  0d718f3b = 10:  928b2285 lib/io/syslog.h: SYSLOG_C(): Use a single local variable
11:  2d142ecf = 11:  78571ba2 lib/io/syslog.h: SYSLOG_C(): Call setlocale(3) and free(3) unconditionally
12:  17a5a34a = 12:  8df579dd lib/io/fprintf/: [v]fprinte(): Add function
13:  af7f8cb6 = 13:  7bf404c5 lib/io/fprintf/: [v]eprinte(): Add function
14:  9ae067f8 = 14:  d9fc1d94 lib/, src/: Use eprinte() instead of its pattern
15:  85698a10 = 15:  78cccbd7 lib/: Use [v]fprinte() instead of its pattern
16:  69dbc822 = 16:  171454ec lib/io/syslog.h: SYSLOGE(): Add macro
17:  300e074d = 17:  db55a04a src/userdel.c: Fix error message
18:  65c2e9cc = 18:  86ca0d69 lib/, src/: Use SYSLOGE() instead of its pattern
```
</details>

<details>
<summary>v9</summary>

-  Rebase on top of #1375 .

```
$ git range-diff shadow/master..gh/eprintf gh/strerrno..eprintf 
 1:  093ab3f0 <  -:  -------- lib/getdef.h: Add missing includes
 2:  5f2879a5 =  1:  f311d59c lib/io/fprintf/: eprintf(): Add function to print to stderr
 3:  224ebc52 !  2:  e3a68500 lib/, src/: Use eprintf() instead of its pattern
    @@ lib/get_pid.c
     +#include "io/fprintf/eprintf.h"
      #include "prototypes.h"
      #include "string/sprintf/snprintf.h"
    - 
    + #include "string/strerrno.h"
     @@ lib/get_pid.c: int open_pidfd(const char *pidstr)
                return -ENOENT;
      
        if (SNPRINTF(proc_dir_name, "/proc/%d/", target) == -1) {
     -          fprintf(stderr, "snprintf of proc path failed for %d: %s\n",
     +          eprintf("snprintf of proc path failed for %d: %s\n",
    -                   target, strerror(errno));
    +                   target, strerrno());
                return -EINVAL;
        }
      
    @@ lib/get_pid.c: int open_pidfd(const char *pidstr)
        if (proc_dir_fd < 0) {
     -          fprintf(stderr, _("Could not open proc directory for target %d: %s\n"),
     +          eprintf(_("Could not open proc directory for target %d: %s\n"),
    -                   target, strerror(errno));
    +                   target, strerrno());
                return -EINVAL;
        }
     
    @@ src/chage.c: int main (int argc, char **argv)
                     || (setreuid (ruid, ruid) != 0))) {
     -          fprintf (stderr, _("%s: failed to drop privileges (%s)\n"),
     +          eprintf(_("%s: failed to drop privileges (%s)\n"),
    -                    Prog, strerror (errno));
    +                    Prog, strerrno());
                fail_exit (E_NOPERM, process_selinux);
        }
      
    @@ src/chgpasswd.c: int main (int argc, char **argv)
     -                          fprintf (stderr,
     -                                   _("%s: failed to crypt password with salt '%s': %s\n"),
     +                          eprintf(_("%s: failed to crypt password with salt '%s': %s\n"),
    -                                    Prog, salt, strerror (errno));
    +                                   Prog, salt, strerrno());
                                fail_exit (1, process_selinux);
                        }
     @@ src/chgpasswd.c: int main (int argc, char **argv)
    @@ src/chpasswd.c: int main (int argc, char **argv)
     -                          fprintf (stderr,
     -                                   _("%s: failed to crypt password with salt '%s': %s\n"),
     +                          eprintf(_("%s: failed to crypt password with salt '%s': %s\n"),
    -                                    Prog, salt, strerror (errno));
    +                                   Prog, salt, strerrno());
                                fail_exit (1, process_selinux);
                        }
     @@ src/chpasswd.c: int main (int argc, char **argv)
    @@ src/faillog.c: int main (int argc, char **argv)
     -          fprintf (stderr,
     -                   _("%s: Cannot open %s: %s\n"),
     +          eprintf(_("%s: Cannot open %s: %s\n"),
    -                    Prog, FAILLOG_FILE, strerror (errno));
    +                   Prog, FAILLOG_FILE, strerrno());
                exit (E_NOPERM);
        }
      
    @@ src/faillog.c: int main (int argc, char **argv)
     -          fprintf (stderr,
     -                   _("%s: Cannot get the size of %s: %s\n"),
     +          eprintf(_("%s: Cannot get the size of %s: %s\n"),
    -                    Prog, FAILLOG_FILE, strerror (errno));
    +                   Prog, FAILLOG_FILE, strerrno());
                exit (E_NOPERM);
        }
     @@ src/faillog.c: int main (int argc, char **argv)
    @@ src/faillog.c: int main (int argc, char **argv)
     -                  fprintf (stderr,
     -                           _("%s: Failed to write %s: %s\n"),
     +                  eprintf(_("%s: Failed to write %s: %s\n"),
    -                            Prog, FAILLOG_FILE, strerror (errno));
    +                           Prog, FAILLOG_FILE, strerrno());
                        (void) fclose (fail);
                        errors = true;
     
    @@ src/gpasswd.c: static void change_passwd (struct group *gr)
     -          fprintf (stderr,
     -                   _("%s: failed to crypt password with salt '%s': %s\n"),
     +          eprintf(_("%s: failed to crypt password with salt '%s': %s\n"),
    -                    Prog, salt, strerror (errno));
    +                   Prog, salt, strerrno());
                exit (1);
        }
     @@ src/gpasswd.c: int main (int argc, char **argv)
    @@ src/groupadd.c: static void open_files (struct option_flags *flags)
      
        /* And now open the databases */
        if (gr_open (O_CREAT | O_RDWR) == 0) {
    --          fprintf (stderr, _("%s: cannot open %s: %s\n"), Prog, gr_dbname (), strerror(errno));
    -+          eprintf(_("%s: cannot open %s: %s\n"), Prog, gr_dbname(), strerror(errno));
    -           SYSLOG ((LOG_WARN, "cannot open %s: %s", gr_dbname (), strerror(errno)));
    +-          fprintf(stderr, _("%s: cannot open %s: %s\n"), Prog, gr_dbname(), strerrno());
    ++          eprintf(_("%s: cannot open %s: %s\n"), Prog, gr_dbname(), strerrno());
    +           SYSLOG((LOG_WARN, "cannot open %s: %s", gr_dbname(), strerrno()));
                fail_exit (E_GRP_UPDATE);
        }
     @@ src/groupadd.c: static void open_files (struct option_flags *flags)
    @@ src/groupadd.c: static void open_files (struct option_flags *flags)
                if (sgr_open (O_CREAT | O_RDWR) == 0) {
     -                  fprintf (stderr,
     -                           _("%s: cannot open %s: %s\n"),
    -+                  eprintf(_("%s: cannot open %s: %s\n"),
    -                            Prog, sgr_dbname (), strerror(errno));
    -                   SYSLOG ((LOG_WARN, "cannot open %s: %s", sgr_dbname (), strerror(errno)));
    +-                           Prog, sgr_dbname(), strerrno());
    ++                  eprintf(_("%s: cannot open %s: %s\n"), Prog, sgr_dbname(), strerrno());
    +                   SYSLOG((LOG_WARN, "cannot open %s: %s", sgr_dbname(), strerrno()));
                        fail_exit (E_GRP_UPDATE);
    +           }
     @@ src/groupadd.c: static void process_flags (int argc, char **argv, struct option_flags *flags)
                        gflg = true;
                        if (   (get_gid(optarg, &group_id) == -1)
    @@ src/lastlog.c: int main (int argc, char **argv)
     -          fprintf (stderr,
     -                   _("%s: Cannot get the size of %s: %s\n"),
     +          eprintf(_("%s: Cannot get the size of %s: %s\n"),
    -                    Prog, _PATH_LASTLOG, strerror(errno));
    +                   Prog, _PATH_LASTLOG, strerrno());
                exit (EXIT_FAILURE);
        }
     
    @@ src/login.c: int main (int argc, char **argv)
        child = fork ();
        if (child < 0) {
                /* error in fork() */
    --          fprintf (stderr, _("%s: failure forking: %s"),
    --                   Prog, strerror (errno));
    -+          eprintf(_("%s: failure forking: %s"), Prog, strerror(errno));
    +-          fprintf(stderr, _("%s: failure forking: %s"), Prog, strerrno());
    ++          eprintf(_("%s: failure forking: %s"), Prog, strerrno());
                PAM_END;
                exit (0);
        } else if (child != 0) {
    @@ src/newgidmap.c: static void write_setgroups(int proc_dir_fd, bool allow_setgrou
                        goto out;
                }
     -          fprintf(stderr, _("%s: couldn't open process setgroups: %s\n"),
    -+          eprintf(_("%s: couldn't open process setgroups: %s\n"),
    -                   Prog,
    -                   strerror(errno));
    +-                  Prog, strerrno());
    ++          eprintf(_("%s: couldn't open process setgroups: %s\n"), Prog, strerrno());
                exit(EXIT_FAILURE);
    +   }
    + 
     @@ src/newgidmap.c: static void write_setgroups(int proc_dir_fd, bool allow_setgroups)
         * fail.
         */
        if (read(setgroups_fd, policy_buffer, sizeof(policy_buffer)) < 0) {
     -          fprintf(stderr, _("%s: failed to read setgroups: %s\n"),
    -+          eprintf(_("%s: failed to read setgroups: %s\n"),
    -                   Prog,
    -                   strerror(errno));
    +-                  Prog, strerrno());
    ++          eprintf(_("%s: failed to read setgroups: %s\n"), Prog, strerrno());
                exit(EXIT_FAILURE);
    +   }
    +   if (strprefix(policy_buffer, policy))
     @@ src/newgidmap.c: static void write_setgroups(int proc_dir_fd, bool allow_setgroups)
      
        /* Write the policy. */
        if (lseek(setgroups_fd, 0, SEEK_SET) < 0) {
     -          fprintf(stderr, _("%s: failed to seek setgroups: %s\n"),
    -+          eprintf(_("%s: failed to seek setgroups: %s\n"),
    -                   Prog,
    -                   strerror(errno));
    +-                  Prog, strerrno());
    ++          eprintf(_("%s: failed to seek setgroups: %s\n"), Prog, strerrno());
                exit(EXIT_FAILURE);
        }
        if (dprintf(setgroups_fd, "%s", policy) < 0) {
     -          fprintf(stderr, _("%s: failed to setgroups %s policy: %s\n"),
     +          eprintf(_("%s: failed to setgroups %s policy: %s\n"),
    -                   Prog,
    -                   policy,
    -                   strerror(errno));
    +                   Prog, policy, strerrno());
    +           exit(EXIT_FAILURE);
    +   }
     @@ src/newgidmap.c: int main(int argc, char **argv)
        /* Who am I? */
        pw = get_my_pwent ();
    @@ src/newgidmap.c: int main(int argc, char **argv)
     -          fprintf(stderr,
     -                  _("%s: Could not stat directory for target process: %s\n"),
     +          eprintf(_("%s: Could not stat directory for target process: %s\n"),
    -                   Prog, strerror (errno));
    +                   Prog, strerrno());
                return EXIT_FAILURE;
        }
     @@ src/newgidmap.c: int main(int argc, char **argv)
    @@ src/newgidmap.c: int main(int argc, char **argv)
        if (want_subgid_file() && !sub_gid_open(O_RDONLY)) {
     -          fprintf (stderr,
     -                   _("%s: cannot open %s: %s\n"),
    -+          eprintf(_("%s: cannot open %s: %s\n"),
    -                    Prog, sub_gid_dbname (), strerror (errno));
    +-                   Prog, sub_gid_dbname(), strerrno());
    ++          eprintf(_("%s: cannot open %s: %s\n"), Prog, sub_gid_dbname(), strerrno());
                return EXIT_FAILURE;
        }
    + 
     
      ## src/newgrp.c ##
     @@
    @@ src/newgrp.c: static void check_perms (const struct group *grp,
     -                  fprintf (stderr,
     -                           _("%s: failed to crypt password with previous salt: %s\n"),
     +                  eprintf(_("%s: failed to crypt password with previous salt: %s\n"),
    -                            Prog, strerror (errno));
    +                           Prog, strerrno());
                        SYSLOG ((LOG_INFO,
                                 "Failed to crypt password with previous salt of group '%s'",
     @@ src/newgrp.c: static void syslog_sg (const char *name, const char *group)
    @@ src/newgrp.c: static void syslog_sg (const char *name, const char *group)
                        /* error in fork() */
     -                  fprintf (stderr, _("%s: failure forking: %s\n"),
     +                  eprintf(_("%s: failure forking: %s\n"),
    -                            is_newgrp ? "newgrp" : "sg", strerror (errno));
    +                           is_newgrp ? "newgrp" : "sg", strerrno());
      #ifdef WITH_AUDIT
                        if (group) {
     @@ src/newgrp.c: int main (int argc, char **argv)
    @@ src/newuidmap.c: int main(int argc, char **argv)
     -          fprintf(stderr,
     -                  _("%s: Could not stat directory for target process: %s\n"),
     +          eprintf(_("%s: Could not stat directory for target process: %s\n"),
    -                   Prog, strerror (errno));
    +                   Prog, strerrno());
                return EXIT_FAILURE;
        }
     @@ src/newuidmap.c: int main(int argc, char **argv)
    @@ src/newuidmap.c: int main(int argc, char **argv)
     -          fprintf (stderr,
     -                   _("%s: cannot open %s: %s\n"),
     +          eprintf(_("%s: cannot open %s: %s\n"),
    -                    Prog, sub_uid_dbname (), strerror (errno));
    +                   Prog, sub_uid_dbname(), strerrno());
                return EXIT_FAILURE;
        }
     
    @@ src/newusers.c: static int update_passwd (struct passwd *pwd, const char *passwo
     -                  fprintf (stderr,
     -                           _("%s: failed to crypt password with salt '%s': %s\n"),
     +                  eprintf(_("%s: failed to crypt password with salt '%s': %s\n"),
    -                            Prog, salt, strerror (errno));
    +                           Prog, salt, strerrno());
                        return 1;
                }
     @@ src/newusers.c: static int add_passwd (struct passwd *pwd, const char *password)
    @@ src/newusers.c: static int add_passwd (struct passwd *pwd, const char *password)
     -                          fprintf (stderr,
     -                                   _("%s: failed to crypt password with salt '%s': %s\n"),
     +                          eprintf(_("%s: failed to crypt password with salt '%s': %s\n"),
    -                                    Prog, salt, strerror (errno));
    +                                   Prog, salt, strerrno());
                                return 1;
                        }
     @@ src/newusers.c: static int add_passwd (struct passwd *pwd, const char *password)
    @@ src/newusers.c: static int add_passwd (struct passwd *pwd, const char *password)
     -                  fprintf (stderr,
     -                           _("%s: failed to crypt password with salt '%s': %s\n"),
     +                  eprintf(_("%s: failed to crypt password with salt '%s': %s\n"),
    -                            Prog, salt, strerror (errno));
    +                           Prog, salt, strerrno());
                        return 1;
                }
     @@ src/newusers.c: static void process_flags (int argc, char **argv, struct option_flags *flags)
    @@ src/newusers.c: int main (int argc, char **argv)
                usernames = REALLOCF(usernames, nusers, char *);
                passwords = REALLOCF(passwords, nusers, char *);
                if (lines == NULL || usernames == NULL || passwords == NULL) {
    --                  fprintf (stderr,
    --                           _("%s: line %jd: %s\n"),
    --                           Prog, line, strerror(errno));
    -+                  eprintf(_("%s: line %jd: %s\n"), Prog, line, strerror(errno));
    +-                  fprintf(stderr, _("%s: line %jd: %s\n"), Prog, line, strerrno());
    ++                  eprintf(_("%s: line %jd: %s\n"), Prog, line, strerrno());
                        fail_exit (EXIT_FAILURE, process_selinux);
                }
                lines[nusers-1]     = line;
    @@ src/newusers.c: int main (int argc, char **argv)
     -                          fprintf (stderr,
     -                                   _("%s: line %jd: mkdir %s failed: %s\n"),
     +                          eprintf(_("%s: line %jd: mkdir %s failed: %s\n"),
    -                                    Prog, line, newpw.pw_dir,
    -                                    strerror (errno));
    +                                   Prog, line, newpw.pw_dir, strerrno());
                                if (errno != EEXIST) {
    +                                   fail_exit (EXIT_FAILURE, process_selinux);
     @@ src/newusers.c: int main (int argc, char **argv)
                        }
                        if (chown(newpw.pw_dir, newpw.pw_uid, newpw.pw_gid) != 0)
    @@ src/newusers.c: int main (int argc, char **argv)
     -                          fprintf (stderr,
     -                                   _("%s: line %jd: chown %s failed: %s\n"),
     +                          eprintf(_("%s: line %jd: chown %s failed: %s\n"),
    -                                    Prog, line, newpw.pw_dir,
    -                                    strerror (errno));
    +                                   Prog, line, newpw.pw_dir, strerrno());
                                fail_exit (EXIT_FAILURE, process_selinux);
    +                   }
     @@ src/newusers.c: int main (int argc, char **argv)
                 * Update the password entry with the new changes made.
                 */
    @@ src/passwd.c: static int new_password (const struct passwd *pw)
     -                  fprintf (stderr,
     -                           _("%s: failed to crypt password with previous salt: %s\n"),
     +                  eprintf(_("%s: failed to crypt password with previous salt: %s\n"),
    -                            Prog, strerror (errno));
    +                            Prog, strerrno());
                        SYSLOG ((LOG_INFO,
                                 "Failed to crypt password with previous salt of user '%s'",
     @@ src/passwd.c: static int new_password (const struct passwd *pw)
    @@ src/passwd.c: static int new_password (const struct passwd *pw)
     -          fprintf (stderr,
     -                   _("%s: failed to crypt password with salt '%s': %s\n"),
     +          eprintf(_("%s: failed to crypt password with salt '%s': %s\n"),
    -                    Prog, salt, strerror (errno));
    +                    Prog, salt, strerrno());
                return -1;
        }
     @@ src/passwd.c: static void check_password (const struct passwd *pw, const struct spwd *sp)
    @@ src/useradd.c: set_defaults(void)
        if (new_file == NULL) {
     -          fprintf(stderr, _("%s: cannot create new defaults file: %s\n"),
     +          eprintf(_("%s: cannot create new defaults file: %s\n"),
    -                   Prog, strerror(errno));
    +                   Prog, strerrno());
                return -1;
              }
     @@ src/useradd.c: set_defaults(void)
    @@ src/useradd.c: set_defaults(void)
     -                  fprintf(stderr,
     -                          _("%s: cannot create new defaults file: %s\n"),
     +                  eprintf(_("%s: cannot create new defaults file: %s\n"),
    -                           Prog, strerror(errno));
    +                           Prog, strerrno());
                        goto err_free_new;
                }
     @@ src/useradd.c: set_defaults(void)
    @@ src/useradd.c: static void faillog_reset (uid_t uid)
     -          fprintf (stderr,
     -                   _("%s: failed to open the faillog file for UID %lu: %s\n"),
     +          eprintf(_("%s: failed to open the faillog file for UID %lu: %s\n"),
    -                    Prog, (unsigned long) uid, strerror (errno));
    +                   Prog, (unsigned long) uid, strerrno());
                SYSLOG ((LOG_WARN, "failed to open the faillog file for UID %lu", (unsigned long) uid));
                return;
     @@ src/useradd.c: static void faillog_reset (uid_t uid)
    @@ src/useradd.c: static void faillog_reset (uid_t uid)
     -          fprintf (stderr,
     -                   _("%s: failed to reset the faillog entry of UID %lu: %s\n"),
     +          eprintf(_("%s: failed to reset the faillog entry of UID %lu: %s\n"),
    -                    Prog, (unsigned long) uid, strerror (errno));
    +                   Prog, (unsigned long) uid, strerrno());
                SYSLOG ((LOG_WARN, "failed to reset the faillog entry of UID %lu", (unsigned long) uid));
        }
        if (close (fd) != 0 && errno != EINTR) {
     -          fprintf (stderr,
     -                   _("%s: failed to close the faillog file for UID %lu: %s\n"),
     +          eprintf(_("%s: failed to close the faillog file for UID %lu: %s\n"),
    -                    Prog, (unsigned long) uid, strerror (errno));
    +                   Prog, (unsigned long) uid, strerrno());
                SYSLOG ((LOG_WARN, "failed to close the faillog file for UID %lu", (unsigned long) uid));
        }
     @@ src/useradd.c: static void lastlog_reset (uid_t uid)
    @@ src/useradd.c: static void lastlog_reset (uid_t uid)
     -          fprintf (stderr,
     -                   _("%s: failed to open the lastlog file for UID %lu: %s\n"),
     +          eprintf(_("%s: failed to open the lastlog file for UID %lu: %s\n"),
    -                    Prog, (unsigned long) uid, strerror (errno));
    +                   Prog, (unsigned long) uid, strerrno());
                SYSLOG ((LOG_WARN, "failed to open the lastlog file for UID %lu", (unsigned long) uid));
                return;
     @@ src/useradd.c: static void lastlog_reset (uid_t uid)
    @@ src/useradd.c: static void lastlog_reset (uid_t uid)
     -          fprintf (stderr,
     -                   _("%s: failed to reset the lastlog entry of UID %lu: %s\n"),
     +          eprintf(_("%s: failed to reset the lastlog entry of UID %lu: %s\n"),
    -                    Prog, (unsigned long) uid, strerror (errno));
    +                   Prog, (unsigned long) uid, strerrno());
                SYSLOG ((LOG_WARN, "failed to reset the lastlog entry of UID %lu", (unsigned long) uid));
                /* continue */
        }
    @@ src/useradd.c: static void lastlog_reset (uid_t uid)
     -          fprintf (stderr,
     -                   _("%s: failed to close the lastlog file for UID %lu: %s\n"),
     +          eprintf(_("%s: failed to close the lastlog file for UID %lu: %s\n"),
    -                    Prog, (unsigned long) uid, strerror (errno));
    +                   Prog, (unsigned long) uid, strerrno());
                SYSLOG ((LOG_WARN, "failed to close the lastlog file for UID %lu", (unsigned long) uid));
                /* continue */
     @@ src/useradd.c: static void tallylog_reset (const char *user_name)
    @@ src/userdel.c: static bool remove_mailbox (void)
     -                  fprintf (stderr,
     -                           _("%s: warning: can't remove %s: %s\n"),
     +                  eprintf(_("%s: warning: can't remove %s: %s\n"),
    -                            Prog, mailfile, strerror (errno));
    -                   SYSLOG ((LOG_ERR, "Cannot remove %s: %s", mailfile, strerror (errno)));
    +                           Prog, mailfile, strerrno());
    +                   SYSLOG((LOG_ERR, "Cannot remove %s: %s", mailfile, strerrno()));
      #ifdef WITH_AUDIT
     @@ src/userdel.c: static bool remove_mailbox (void)
      
    @@ src/userdel.c: static bool remove_mailbox (void)
     -                  fprintf (stderr,
     -                           _("%s: warning: can't remove %s: %s\n"),
     +                  eprintf(_("%s: warning: can't remove %s: %s\n"),
    -                            Prog, mailfile, strerror (errno));
    -                   SYSLOG ((LOG_ERR, "Cannot remove %s: %s", mailfile, strerror (errno)));
    +                           Prog, mailfile, strerrno());
    +                   SYSLOG((LOG_ERR, "Cannot remove %s: %s", mailfile, strerrno()));
      #ifdef WITH_AUDIT
     @@ src/userdel.c: static bool remove_mailbox (void)
        }
    @@ src/userdel.c: static bool remove_mailbox (void)
     -                   _("%s: %s not owned by %s, not removing\n"),
     +          eprintf(_("%s: %s not owned by %s, not removing\n"),
                         Prog, mailfile, user_name);
    -           SYSLOG ((LOG_ERR,
    -                    "%s not owned by %s, not removed",
    +           SYSLOG((LOG_ERR, "%s not owned by %s, not removed", mailfile, strerrno()));
    + #ifdef WITH_AUDIT
     @@ src/userdel.c: static bool remove_mailbox (void)
                return 0;               /* mailbox doesn't exist */
        }
        if (unlink (mailfile) != 0) {
     -          fprintf (stderr,
     -                   _("%s: warning: can't remove %s: %s\n"),
    -+          eprintf(_("%s: warning: can't remove %s: %s\n"),
    -                    Prog, mailfile, strerror (errno));
    -           SYSLOG ((LOG_ERR, "Cannot remove %s: %s", mailfile, strerror (errno)));
    +-                   Prog, mailfile, strerrno());
    ++          eprintf(_("%s: warning: can't remove %s: %s\n"), Prog, mailfile, strerrno());
    +           SYSLOG((LOG_ERR, "Cannot remove %s: %s", mailfile, strerrno()));
      #ifdef WITH_AUDIT
    +           audit_logger (AUDIT_DEL_USER, Prog,
     @@ src/userdel.c: static int remove_tcbdir (const char *user_name, uid_t user_id)
      
        buf = aprintf(TCB_DIR "/%s", user_name);
    @@ src/userdel.c: static int remove_tcbdir (const char *user_name, uid_t user_id)
        }
        if (shadowtcb_drop_priv () == SHADOWTCB_FAILURE) {
     -          fprintf (stderr, _("%s: Cannot drop privileges: %s\n"),
    -+          eprintf(_("%s: Cannot drop privileges: %s\n"),
    -                    Prog, strerror (errno));
    +-                   Prog, strerrno());
    ++          eprintf(_("%s: Cannot drop privileges: %s\n"), Prog, strerrno());
                shadowtcb_gain_priv ();
                free (buf);
    +           return 1;
     @@ src/userdel.c: static int remove_tcbdir (const char *user_name, uid_t user_id)
         * We will regain them and remove the user's tcb directory afterwards.
         */
        if (remove_tree (buf, false) != 0) {
     -          fprintf (stderr, _("%s: Cannot remove the content of %s: %s\n"),
     +          eprintf(_("%s: Cannot remove the content of %s: %s\n"),
    -                    Prog, buf, strerror (errno));
    +                   Prog, buf, strerrno());
                shadowtcb_gain_priv ();
                free (buf);
     @@ src/userdel.c: static int remove_tcbdir (const char *user_name, uid_t user_id)
    @@ src/userdel.c: static int remove_tcbdir (const char *user_name, uid_t user_id)
        if (shadowtcb_remove (user_name) == SHADOWTCB_FAILURE) {
     -          fprintf (stderr, _("%s: Cannot remove tcb files for %s: %s\n"),
     +          eprintf(_("%s: Cannot remove tcb files for %s: %s\n"),
    -                    Prog, user_name, strerror (errno));
    +                   Prog, user_name, strerrno());
                ret = 1;
        }
     @@ src/userdel.c: int main (int argc, char **argv)
    @@ src/usermod.c: prepend_range(const char *str, struct id_range_list_entry **head)
        if (!entry) {
     -          fprintf (stderr,
     -                  _("%s: failed to allocate memory: %s\n"),
    -+          eprintf(_("%s: failed to allocate memory: %s\n"),
    -                   Prog, strerror (errno));
    +-                  Prog, strerrno());
    ++          eprintf(_("%s: failed to allocate memory: %s\n"), Prog, strerrno());
                return 0;
        }
    +   entry->next = *head;
     @@ src/usermod.c: static char *new_pw_passwd (char *pw_pass)
                pw_pass = xaprintf("!%s", pw_pass);
        } else if (Uflg && strprefix(pw_pass, "!")) {
    @@ src/usermod.c: static void update_lastlog (void)
     -          fprintf (stderr,
     -                   _("%s: failed to copy the lastlog entry of user %lu to user %lu: %s\n"),
     +          eprintf(_("%s: failed to copy the lastlog entry of user %lu to user %lu: %s\n"),
    -                    Prog, (unsigned long) user_id, (unsigned long) user_newid, strerror (errno));
    +                   Prog, (unsigned long) user_id, (unsigned long) user_newid, strerrno());
                return;
        }
     @@ src/usermod.c: static void update_lastlog (void)
    @@ src/usermod.c: static void update_lastlog (void)
     -                  fprintf (stderr,
     -                           _("%s: failed to copy the lastlog entry of user %lu to user %lu: %s\n"),
     +                  eprintf(_("%s: failed to copy the lastlog entry of user %lu to user %lu: %s\n"),
    -                            Prog, (unsigned long) user_id, (unsigned long) user_newid, strerror (errno));
    +                           Prog, (unsigned long) user_id, (unsigned long) user_newid, strerrno());
                }
        } else {
     @@ src/usermod.c: static void update_lastlog (void)
    @@ src/usermod.c: static void update_lastlog (void)
     -                          fprintf (stderr,
     -                                   _("%s: failed to copy the lastlog entry of user %lu to user %lu: %s\n"),
     +                          eprintf(_("%s: failed to copy the lastlog entry of user %lu to user %lu: %s\n"),
    -                                    Prog, (unsigned long) user_id, (unsigned long) user_newid, strerror (errno));
    +                                   Prog, (unsigned long) user_id, (unsigned long) user_newid, strerrno());
                        }
                }
        }
    @@ src/usermod.c: static void update_lastlog (void)
     -          fprintf (stderr,
     -                   _("%s: failed to copy the lastlog entry of user %ju to user %ju: %s\n"),
     +          eprintf(_("%s: failed to copy the lastlog entry of user %ju to user %ju: %s\n"),
    -                    Prog, (uintmax_t) user_id, (uintmax_t) user_newid, strerror (errno));
    +                   Prog, (uintmax_t) user_id, (uintmax_t) user_newid, strerrno());
        }
      }
     @@ src/usermod.c: static void update_faillog (void)
    @@ src/usermod.c: static void update_faillog (void)
     -          fprintf (stderr,
     -                   _("%s: failed to copy the faillog entry of user %lu to user %lu: %s\n"),
     +          eprintf(_("%s: failed to copy the faillog entry of user %lu to user %lu: %s\n"),
    -                    Prog, (unsigned long) user_id, (unsigned long) user_newid, strerror (errno));
    +                   Prog, (unsigned long) user_id, (unsigned long) user_newid, strerrno());
                return;
        }
     @@ src/usermod.c: static void update_faillog (void)
    @@ src/usermod.c: static void update_faillog (void)
     -                  fprintf (stderr,
     -                           _("%s: failed to copy the faillog entry of user %lu to user %lu: %s\n"),
     +                  eprintf(_("%s: failed to copy the faillog entry of user %lu to user %lu: %s\n"),
    -                            Prog, (unsigned long) user_id, (unsigned long) user_newid, strerror (errno));
    +                           Prog, (unsigned long) user_id, (unsigned long) user_newid, strerrno());
                }
        } else {
     @@ src/usermod.c: static void update_faillog (void)
    @@ src/usermod.c: static void update_faillog (void)
     -                          fprintf (stderr,
     -                                   _("%s: failed to copy the faillog entry of user %lu to user %lu: %s\n"),
     +                          eprintf(_("%s: failed to copy the faillog entry of user %lu to user %lu: %s\n"),
    -                                    Prog, (unsigned long) user_id, (unsigned long) user_newid, strerror (errno));
    +                                   Prog, (unsigned long) user_id, (unsigned long) user_newid, strerrno());
                        }
                }
        }
    @@ src/usermod.c: static void update_faillog (void)
     -          fprintf (stderr,
     -                   _("%s: failed to copy the faillog entry of user %ju to user %ju: %s\n"),
     +          eprintf(_("%s: failed to copy the faillog entry of user %ju to user %ju: %s\n"),
    -                    Prog, (uintmax_t) user_id, (uintmax_t) user_newid, strerror (errno));
    +                   Prog, (uintmax_t) user_id, (uintmax_t) user_newid, strerrno());
        }
      }
     @@ src/usermod.c: static void move_mailbox (void)
    @@ src/vipw.c: vipwedit (const char *file, int (*file_lock) (void), int (*file_unlo
      
                status = system (buf);
                if (-1 == status) {
    --                  fprintf (stderr, _("%s: %s: %s\n"), Prog, editor,
    -+                  eprintf(_("%s: %s: %s\n"), Prog, editor,
    -                            strerror (errno));
    +-                  fprintf(stderr, _("%s: %s: %s\n"), Prog, editor, strerrno());
    ++                  eprintf(_("%s: %s: %s\n"), Prog, editor, strerrno());
                        exit (1);
                } else if (   WIFEXITED (status)
                           && (WEXITSTATUS (status) != 0)) {
    @@ src/vipw.c: vipwedit (const char *file, int (*file_lock) (void), int (*file_unlo
                                if (editor_pgrp == -1) {
     -                                  fprintf (stderr, "%s: %s: %s", Prog,
     +                                  eprintf("%s: %s: %s", Prog,
    -                                            "tcgetpgrp", strerror (errno));
    +                                           "tcgetpgrp", strerrno());
                                }
                                if (tcsetpgrp(STDIN_FILENO, orig_pgrp) == -1) {
     -                                  fprintf (stderr, "%s: %s: %s", Prog,
     +                                  eprintf("%s: %s: %s", Prog,
    -                                            "tcsetpgrp", strerror (errno));
    +                                           "tcsetpgrp", strerrno());
                                }
                        }
     @@ src/vipw.c: vipwedit (const char *file, int (*file_lock) (void), int (*file_unlock) (bool))
    @@ src/vipw.c: vipwedit (const char *file, int (*file_lock) (void), int (*file_unlo
                                if (tcsetpgrp(STDIN_FILENO, editor_pgrp) == -1) {
     -                                  fprintf (stderr, "%s: %s: %s", Prog,
     +                                  eprintf("%s: %s: %s", Prog,
    -                                            "tcsetpgrp", strerror (errno));
    +                                           "tcsetpgrp", strerrno());
                                }
                        }
     @@ src/vipw.c: vipwedit (const char *file, int (*file_lock) (void), int (*file_unlock) (bool))
        if (orig_pgrp != -1) {
                 /* Restore terminal pgrp after editing. */
                if (tcsetpgrp(STDIN_FILENO, orig_pgrp) == -1) {
    --                  fprintf(stderr, "%s: %s: %s", Prog,
    -+                  eprintf("%s: %s: %s", Prog,
    -                           "tcsetpgrp", strerror(errno));
    +-                  fprintf(stderr, "%s: %s: %s", Prog, "tcsetpgrp", strerrno());
    ++                  eprintf("%s: %s: %s", Prog, "tcsetpgrp", strerrno());
                }
                sigprocmask(SIG_SETMASK, &omask, NULL);
    +   }
     @@ src/vipw.c: vipwedit (const char *file, int (*file_lock) (void), int (*file_unlock) (bool))
                   && (WEXITSTATUS (status) != 0)) {
                vipwexit (NULL, 0, WEXITSTATUS (status));
    @@ src/vipw.c: vipwedit (const char *file, int (*file_lock) (void), int (*file_unlo
     -          fprintf (stderr,
     -                   _("%s: can't restore %s: %s (your changes are in %s)\n"),
     +          eprintf(_("%s: can't restore %s: %s (your changes are in %s)\n"),
    -                    Prog, file, strerror (errno), to_rename);
    +                   Prog, file, strerrno(), to_rename);
      #ifdef WITH_TCB
                if (tcb_mode) {
     @@ src/vipw.c: vipwedit (const char *file, int (*file_lock) (void), int (*file_unlock) (bool))
 4:  86d632c8 <  -:  -------- lib/string/: strerrno(): Add function
 5:  931f9e4b <  -:  -------- lib/, src/: Use strerrno() instead of its pattern
 6:  89e91e48 =  3:  e2e8c983 lib/defines.h, lib/, src/: Redefine SYSLOG() as a variadic macro
 7:  6b17f1be =  4:  b182024c lib/: Move <syslog.h> wrappers to "io/syslog.h"
 8:  0807708a =  5:  03a3d05c lib/io/syslog.h: SYSLOG_C(): Split code to helper macro
 9:  92d14578 =  6:  c9e628dd lib/io/syslog.h: Rename local variable
10:  928b2285 =  7:  447e46ee lib/io/syslog.h: SYSLOG_C(): Use a single local variable
11:  78571ba2 =  8:  d9e9dffb lib/io/syslog.h: SYSLOG_C(): Call setlocale(3) and free(3) unconditionally
12:  8df579dd =  9:  511051c3 lib/io/fprintf/: [v]fprinte(): Add function
13:  7bf404c5 = 10:  b89bee67 lib/io/fprintf/: [v]eprinte(): Add function
14:  d9fc1d94 = 11:  c8d5afba lib/, src/: Use eprinte() instead of its pattern
15:  78cccbd7 = 12:  e212bedc lib/: Use [v]fprinte() instead of its pattern
16:  171454ec = 13:  74a354bb lib/io/syslog.h: SYSLOGE(): Add macro
17:  db55a04a = 14:  a2dcdc97 src/userdel.c: Fix error message
18:  86ca0d69 = 15:  b3f573b1 lib/, src/: Use SYSLOGE() instead of its pattern
```
</details>

<details>
<summary>v9b</summary>

-  Rebase

```
$ git range-diff gh/strerrno..gh/eprintf strerrno..eprintf 
 1:  f311d59c =  1:  32d6cd8d lib/io/fprintf/: eprintf(): Add function to print to stderr
 2:  e3a68500 !  2:  12360771 lib/, src/: Use eprintf() instead of its pattern
    @@ src/groupdel.c: int main (int argc, char **argv)
     
      ## src/groupmems.c ##
     @@
    - #include "alloc/x/xmalloc.h"
    + #include "alloc/malloc.h"
      #include "defines.h"
      #include "groupio.h"
     +#include "io/fprintf/eprintf.h"
 3:  e2e8c983 =  3:  54a071ad lib/defines.h, lib/, src/: Redefine SYSLOG() as a variadic macro
 4:  b182024c =  4:  058dddb6 lib/: Move <syslog.h> wrappers to "io/syslog.h"
 5:  03a3d05c =  5:  3e3f1c12 lib/io/syslog.h: SYSLOG_C(): Split code to helper macro
 6:  c9e628dd =  6:  c9001a70 lib/io/syslog.h: Rename local variable
 7:  447e46ee =  7:  56aade53 lib/io/syslog.h: SYSLOG_C(): Use a single local variable
 8:  d9e9dffb =  8:  5b720d6d lib/io/syslog.h: SYSLOG_C(): Call setlocale(3) and free(3) unconditionally
 9:  511051c3 =  9:  e9fc6219 lib/io/fprintf/: [v]fprinte(): Add function
10:  b89bee67 = 10:  745e0633 lib/io/fprintf/: [v]eprinte(): Add function
11:  c8d5afba ! 11:  7ad63296 lib/, src/: Use eprinte() instead of its pattern
    @@ src/chage.c
      #include "io/fprintf/eprintf.h"
      #include "prototypes.h"
      #include "pwio.h"
    -@@
    - #include "string/strcmp/streq.h"
    - #include "string/strcpy/strtcpy.h"
    - #include "string/strdup/xstrdup.h"
    --#include "string/strerrno.h"
    - #include "string/strftime.h"
    - #include "time/day_to_str.h"
    - /*@-exitarg@*/
     @@ src/chage.c: int main (int argc, char **argv)
        /* Drop privileges */
        if (lflg && (   (setregid (rgid, rgid) != 0)
    @@ src/gpasswd.c
      #include "io/fprintf/eprintf.h"
      #include "nscd.h"
      #include "prototypes.h"
    -@@
    - #include "string/strcmp/streq.h"
    - #include "string/strcpy/strtcpy.h"
    - #include "string/strdup/xstrdup.h"
    --#include "string/strerrno.h"
    - 
    - struct option_flags {
    -   bool chroot;
     @@ src/gpasswd.c: static void change_passwd (struct group *gr)
        cp = pw_encrypt (pass, salt);
        MEMZERO(pass);
    @@ src/login.c
      #include "io/fprintf/eprintf.h"
      #include "prototypes.h"
      #include "pwauth.h"
    -@@
    - #include "string/strcmp/strprefix.h"
    - #include "string/strcpy/strtcpy.h"
    - #include "string/strdup/xstrdup.h"
    --#include "string/strerrno.h"
    - #include "string/strftime.h"
    - 
    - 
     @@ src/login.c: int main (int argc, char **argv)
        child = fork ();
        if (child < 0) {
    @@ src/newgrp.c
      #include "io/fprintf/eprintf.h"
      #include "prototypes.h"
      #include "search/l/lfind.h"
    -@@
    - #include "string/strcmp/streq.h"
    - #include "string/strcmp/strprefix.h"
    - #include "string/strdup/xstrdup.h"
    --#include "string/strerrno.h"
    - 
    - #include <assert.h>
    - 
     @@ src/newgrp.c: static void check_perms (const struct group *grp,
                erase_pass (cp);
      
    @@ src/newusers.c
      #include "io/fprintf/eprintf.h"
      #include "nscd.h"
      #include "prototypes.h"
    -@@
    - #include "string/sprintf/snprintf.h"
    - #include "string/strcmp/streq.h"
    - #include "string/strdup/xstrdup.h"
    --#include "string/strerrno.h"
    - #include "string/strtok/stpsep.h"
    - #include "string/strtok/strsep2arr.h"
    - 
     @@ src/newusers.c: static int update_passwd (struct passwd *pwd, const char *password)
                const char *salt = crypt_make_salt (crypt_method, crypt_arg);
                cp = pw_encrypt (password, salt);
    @@ src/passwd.c
      #include "io/fprintf/eprintf.h"
      #include "nscd.h"
      #include "prototypes.h"
    -@@
    - #include "string/strcmp/strprefix.h"
    - #include "string/strcpy/strtcpy.h"
    - #include "string/strdup/xstrdup.h"
    --#include "string/strerrno.h"
    - #include "time/day_to_str.h"
    - 
    - 
     @@ src/passwd.c: static int new_password (const struct passwd *pw)
      
                if (NULL == cipher) {
    @@ src/useradd.c
      #include "io/fprintf/eprintf.h"
      #include "nscd.h"
      #include "prototypes.h"
    -@@
    - #include "string/strcmp/streq.h"
    - #include "string/strcmp/strprefix.h"
    - #include "string/strdup/xstrdup.h"
    --#include "string/strerrno.h"
    - #include "string/strtok/stpsep.h"
    - 
    - 
     @@ src/useradd.c: set_defaults(void)
      
        new_file = aprintf("%s%s%s", prefix, prefix[0]?"/":"", NEW_USER_FILE);
    @@ src/usermod.c
      #include "io/fprintf/eprintf.h"
      #include "nscd.h"
      #include "prototypes.h"
    -@@
    - #include "string/strcmp/streq.h"
    - #include "string/strcmp/strprefix.h"
    - #include "string/strdup/xstrdup.h"
    --#include "string/strerrno.h"
    - #include "time/day_to_str.h"
    - #include "typetraits.h"
    - 
     @@ src/usermod.c: prepend_range(const char *str, struct id_range_list_entry **head)
      
        entry = MALLOC(1, struct id_range_list_entry);
    @@ src/vipw.c
      #include "nscd.h"
      #include "prototypes.h"
     @@
    + #include "string/sprintf/aprintf.h"
      #include "string/sprintf/snprintf.h"
    - #include "string/sprintf/xaprintf.h"
      #include "string/strcmp/streq.h"
     -#include "string/strerrno.h"
      
12:  e212bedc ! 12:  96a193a7 lib/: Use [v]fprinte() instead of its pattern
    @@ lib/addgrps.c: add_groups(const char *list)
        }
      
     
    - ## lib/alloc/x/xcalloc.c ##
    -@@
    - #include <string.h>
    - 
    - #include "defines.h"
    -+#include "io/fprintf/fprinte.h"
    - #include "shadowlog.h"
    --#include "string/strerrno.h"
    - 
    - 
    - void *
    -@@ lib/alloc/x/xcalloc.c: xcalloc(size_t nmemb, size_t size)
    -   return p;
    - 
    - x:
    --  fprintf(log_get_logfd(), _("%s: %s\n"), log_get_progname(), strerrno());
    -+  fprinte(log_get_logfd(), "%s", log_get_progname());
    -   exit(13);
    - }
    -
    - ## lib/alloc/x/xrealloc.c ##
    -@@
    - 
    - #include "alloc/reallocf.h"
    - #include "defines.h"
    -+#include "io/fprintf/fprinte.h"
    - #include "shadowlog.h"
    --#include "string/strerrno.h"
    - 
    - 
    - void *
    -@@ lib/alloc/x/xrealloc.c: xreallocarray(void *p, size_t nmemb, size_t size)
    -   return p;
    - 
    - x:
    --  fprintf(log_get_logfd(), _("%s: %s\n"), log_get_progname(), strerrno());
    -+  fprinte(log_get_logfd(), "%s", log_get_progname());
    -   exit(13);
    - }
    -
      ## lib/chowntty.c ##
     @@
      #include <stdio.h>
    @@ lib/commonio.c: static int do_lock_file (const char *file, const char *lock, boo
     
      ## lib/copydir.c ##
     @@
    - #include "alloc/x/xmalloc.h"
    + #include "alloc/malloc.h"
      #include "attr.h"
      #include "fs/readlink/areadlink.h"
     +#include "io/fprintf/fprinte.h"
    @@ lib/copydir.c
      #include "defines.h"
      #ifdef WITH_SELINUX
     @@
    - #include "string/sprintf/xaprintf.h"
    + #include "string/sprintf/aprintf.h"
      #include "string/strcmp/streq.h"
      #include "string/strcmp/strprefix.h"
     -#include "string/strerrno.h"
    @@ lib/copydir.c: static void error_acl (MAYBE_UNUSED struct error_context *ctx, co
      }
      
     
    + ## lib/exit_if_null.h ##
    +@@
    + #include <stdio.h>
    + #include <stdlib.h>
    + 
    ++#include "io/fprintf/fprinte.h"
    + #include "shadowlog.h"
    +-#include "string/strerrno.h"
    + 
    + 
    + /*
    +@@ lib/exit_if_null.h: inline void
    + exit_if_null_(void *p)
    + {
    +   if (p == NULL) {
    +-          fprintf(log_get_logfd(), "%s: %s\n", log_get_progname(), strerrno());
    ++          fprinte(log_get_logfd(), "%s", log_get_progname());
    +           exit(13);
    +   }
    + }
    +
      ## lib/find_new_gid.c ##
     @@
      #include <errno.h>
    @@ lib/gettime.c: gettime(void)
     
      ## lib/idmapping.c ##
     @@
    - #include "alloc/x/xmalloc.h"
    + #include "alloc/malloc.h"
      #include "atoi/a2i/a2u.h"
      #include "idmapping.h"
     +#include "io/fprintf/fprinte.h"
    @@ lib/prefix_flag.c
      #ifdef    SHADOWGRP
      #include "sgroupio.h"
     @@
    - #include "string/sprintf/xaprintf.h"
    + #include "string/sprintf/aprintf.h"
      #include "string/strcmp/streq.h"
      #include "string/strcmp/strprefix.h"
     -#include "string/strerrno.h"
    @@ lib/spawn.c: run_command(const char *cmd, const char *argv[],
        }
      
     
    - ## lib/string/strtok/xastrsep2ls.h ##
    -@@
    - #include <string.h>
    - 
    - #include "attr.h"
    -+#include "io/fprintf/fprinte.h"
    - #include "shadowlog.h"
    - #include "string/strtok/astrsep2ls.h"
    --#include "string/strerrno.h"
    - 
    - 
    - ATTR_ACCESS(read_write, 1) ATTR_ACCESS(write_only, 3)
    -@@ lib/string/strtok/xastrsep2ls.h: xastrsep2ls(char *s, const char *restrict delim, size_t *restrict np)
    - 
    -   return ls;
    - x:
    --  fprintf(log_get_logfd(), "%s: %s\n", log_get_progname(), strerrno());
    -+  fprinte(log_get_logfd(), "%s", log_get_progname());
    -   exit(13);
    - }
    - 
    -
      ## lib/tcbfuncs.c ##
     @@
      #include "defines.h"
13:  74a354bb = 13:  b0555c70 lib/io/syslog.h: SYSLOGE(): Add macro
14:  a2dcdc97 = 14:  9ea01862 src/userdel.c: Fix error message
15:  b3f573b1 = 15:  b70f3d85 lib/, src/: Use SYSLOGE() instead of its pattern
```
</details>

<details>
<summary>v9c</summary>

-  Rebase

```
$ git range-diff gh/strerrno..gh/eprintf strerrno..eprintf 
 1:  32d6cd8da =  1:  02d908010 lib/io/fprintf/: eprintf(): Add function to print to stderr
 2:  123607716 =  2:  e12c346ac lib/, src/: Use eprintf() instead of its pattern
 3:  54a071ada =  3:  4aa7af55d lib/defines.h, lib/, src/: Redefine SYSLOG() as a variadic macro
 4:  058dddb6c =  4:  2c1ddba14 lib/: Move <syslog.h> wrappers to "io/syslog.h"
 5:  3e3f1c121 =  5:  05a2edec1 lib/io/syslog.h: SYSLOG_C(): Split code to helper macro
 6:  c9001a701 =  6:  46c76c318 lib/io/syslog.h: Rename local variable
 7:  56aade53d =  7:  a575498c1 lib/io/syslog.h: SYSLOG_C(): Use a single local variable
 8:  5b720d6d7 =  8:  82c19e705 lib/io/syslog.h: SYSLOG_C(): Call setlocale(3) and free(3) unconditionally
 9:  e9fc62191 =  9:  ecc37d893 lib/io/fprintf/: [v]fprinte(): Add function
10:  745e0633c = 10:  c863844f9 lib/io/fprintf/: [v]eprinte(): Add function
11:  7ad632968 = 11:  1e9a50f84 lib/, src/: Use eprinte() instead of its pattern
12:  96a193a78 = 12:  55430e2a4 lib/: Use [v]fprinte() instead of its pattern
13:  b0555c707 = 13:  3ae20d047 lib/io/syslog.h: SYSLOGE(): Add macro
14:  9ea018620 = 14:  68d8690f6 src/userdel.c: Fix error message
15:  b70f3d857 = 15:  5f726c811 lib/, src/: Use SYSLOGE() instead of its pattern
```
</details>

<details>
<summary>v9d</summary>

-  Rebase

```
$ git range-diff gh/strerrno..gh/eprintf strerrno..eprintf 
 1:  02d908010 =  1:  cbafb3c7a lib/io/fprintf/: eprintf(): Add function to print to stderr
 2:  e12c346ac =  2:  74020b9af lib/, src/: Use eprintf() instead of its pattern
 3:  4aa7af55d =  3:  cf954ecaa lib/defines.h, lib/, src/: Redefine SYSLOG() as a variadic macro
 4:  2c1ddba14 =  4:  837b982ed lib/: Move <syslog.h> wrappers to "io/syslog.h"
 5:  05a2edec1 =  5:  455888065 lib/io/syslog.h: SYSLOG_C(): Split code to helper macro
 6:  46c76c318 =  6:  b68d049f8 lib/io/syslog.h: Rename local variable
 7:  a575498c1 =  7:  960680cb7 lib/io/syslog.h: SYSLOG_C(): Use a single local variable
 8:  82c19e705 =  8:  e9b79a845 lib/io/syslog.h: SYSLOG_C(): Call setlocale(3) and free(3) unconditionally
 9:  ecc37d893 =  9:  936cc98ea lib/io/fprintf/: [v]fprinte(): Add function
10:  c863844f9 = 10:  390ba8cd0 lib/io/fprintf/: [v]eprinte(): Add function
11:  1e9a50f84 = 11:  391403416 lib/, src/: Use eprinte() instead of its pattern
12:  55430e2a4 = 12:  d0bbfdb43 lib/: Use [v]fprinte() instead of its pattern
13:  3ae20d047 = 13:  e3bd861f6 lib/io/syslog.h: SYSLOGE(): Add macro
14:  68d8690f6 = 14:  850e7c0dd src/userdel.c: Fix error message
15:  5f726c811 = 15:  9c8c33d07 lib/, src/: Use SYSLOGE() instead of its pattern
```
</details>

<details>
<summary>v9e</summary>

-  Rebase

```
$ git range-diff gh/strerrno..gh/eprintf strerrno..eprintf 
 1:  cbafb3c7a =  1:  0b062b7ab lib/io/fprintf/: eprintf(): Add function to print to stderr
 2:  74020b9af =  2:  fc83647ee lib/, src/: Use eprintf() instead of its pattern
 3:  cf954ecaa =  3:  2fa5ec3af lib/defines.h, lib/, src/: Redefine SYSLOG() as a variadic macro
 4:  837b982ed =  4:  bef3c7b3e lib/: Move <syslog.h> wrappers to "io/syslog.h"
 5:  455888065 =  5:  589ecf478 lib/io/syslog.h: SYSLOG_C(): Split code to helper macro
 6:  b68d049f8 =  6:  2582d6fd5 lib/io/syslog.h: Rename local variable
 7:  960680cb7 =  7:  fc508610d lib/io/syslog.h: SYSLOG_C(): Use a single local variable
 8:  e9b79a845 =  8:  99033cfa3 lib/io/syslog.h: SYSLOG_C(): Call setlocale(3) and free(3) unconditionally
 9:  936cc98ea =  9:  7fc6f4f8d lib/io/fprintf/: [v]fprinte(): Add function
10:  390ba8cd0 = 10:  137e9e6b5 lib/io/fprintf/: [v]eprinte(): Add function
11:  391403416 = 11:  abf5cf226 lib/, src/: Use eprinte() instead of its pattern
12:  d0bbfdb43 = 12:  d6fc5087f lib/: Use [v]fprinte() instead of its pattern
13:  e3bd861f6 = 13:  9e78e35a3 lib/io/syslog.h: SYSLOGE(): Add macro
14:  850e7c0dd = 14:  b64a7c895 src/userdel.c: Fix error message
15:  9c8c33d07 = 15:  42e67581b lib/, src/: Use SYSLOGE() instead of its pattern
```
</details>

<details>
<summary>v9f</summary>

-  Rebase

```
$ git range-diff gh/strerrno..gh/eprintf strerrno..eprintf 
 1:  0b062b7ab =  1:  9f8e483ca lib/io/fprintf/: eprintf(): Add function to print to stderr
 2:  fc83647ee =  2:  700943415 lib/, src/: Use eprintf() instead of its pattern
 3:  2fa5ec3af =  3:  2233e855c lib/defines.h, lib/, src/: Redefine SYSLOG() as a variadic macro
 4:  bef3c7b3e =  4:  b60d327c0 lib/: Move <syslog.h> wrappers to "io/syslog.h"
 5:  589ecf478 =  5:  96cbea968 lib/io/syslog.h: SYSLOG_C(): Split code to helper macro
 6:  2582d6fd5 =  6:  14d733842 lib/io/syslog.h: Rename local variable
 7:  fc508610d =  7:  421ede5c2 lib/io/syslog.h: SYSLOG_C(): Use a single local variable
 8:  99033cfa3 =  8:  e163f529c lib/io/syslog.h: SYSLOG_C(): Call setlocale(3) and free(3) unconditionally
 9:  7fc6f4f8d =  9:  3e61317ec lib/io/fprintf/: [v]fprinte(): Add function
10:  137e9e6b5 = 10:  94bcd9cf8 lib/io/fprintf/: [v]eprinte(): Add function
11:  abf5cf226 = 11:  48efa1f24 lib/, src/: Use eprinte() instead of its pattern
12:  d6fc5087f = 12:  c868ea466 lib/: Use [v]fprinte() instead of its pattern
13:  9e78e35a3 = 13:  dfc65a8c0 lib/io/syslog.h: SYSLOGE(): Add macro
14:  b64a7c895 = 14:  ed7db160a src/userdel.c: Fix error message
15:  42e67581b = 15:  da27e3c62 lib/, src/: Use SYSLOGE() instead of its pattern
```
</details>

<details>
<summary>v9g</summary>

-  Rebase

```
$ git range-diff gh/strerrno..gh/eprintf strerrno..eprintf 
 1:  9f8e483ca =  1:  f56341565 lib/io/fprintf/: eprintf(): Add function to print to stderr
 2:  700943415 =  2:  aec585294 lib/, src/: Use eprintf() instead of its pattern
 3:  2233e855c =  3:  7dddf5f6a lib/defines.h, lib/, src/: Redefine SYSLOG() as a variadic macro
 4:  b60d327c0 =  4:  153e846e5 lib/: Move <syslog.h> wrappers to "io/syslog.h"
 5:  96cbea968 =  5:  9540ad6b0 lib/io/syslog.h: SYSLOG_C(): Split code to helper macro
 6:  14d733842 =  6:  1098d5a3e lib/io/syslog.h: Rename local variable
 7:  421ede5c2 =  7:  43211534d lib/io/syslog.h: SYSLOG_C(): Use a single local variable
 8:  e163f529c =  8:  be07d8008 lib/io/syslog.h: SYSLOG_C(): Call setlocale(3) and free(3) unconditionally
 9:  3e61317ec =  9:  7ee12ae26 lib/io/fprintf/: [v]fprinte(): Add function
10:  94bcd9cf8 = 10:  597c3a530 lib/io/fprintf/: [v]eprinte(): Add function
11:  48efa1f24 = 11:  97463e4c1 lib/, src/: Use eprinte() instead of its pattern
12:  c868ea466 = 12:  f52b801f6 lib/: Use [v]fprinte() instead of its pattern
13:  dfc65a8c0 = 13:  1aa7d44ee lib/io/syslog.h: SYSLOGE(): Add macro
14:  ed7db160a = 14:  54d5bb3b0 src/userdel.c: Fix error message
15:  da27e3c62 = 15:  ed333898f lib/, src/: Use SYSLOGE() instead of its pattern
```
</details>

v10: <https://github.com/shadow-maint/shadow/pull/1289#issuecomment-3480387114>

<details>
<summary>v10b</summary>

-  Reorder commits, to allow splitting some to a separate PR.

```
$ git range-diff gh/strerrno gh/eprintf eprintf 
 1:  98037675f =  1:  98037675f lib/defines.h, lib/, src/: Redefine SYSLOG() as a variadic macro
 4:  195845666 !  2:  165b4829c lib/: Move <syslog.h> wrappers to "io/syslog.h"
    @@ Commit message
     
      ## lib/Makefile.am ##
     @@ lib/Makefile.am: libshadow_la_SOURCES = \
    +   hushed.c \
    +   idmapping.h \
        idmapping.c \
    -   io/fprintf/eprintf.c \
    -   io/fprintf/eprintf.h \
     +  io/syslog.c \
     +  io/syslog.h \
        isexpired.c \
 5:  a01badd0c =  3:  da9c94103 lib/io/syslog.h: SYSLOG_C(): Split code to helper macro
 6:  eebd42541 =  4:  85f5dc585 lib/io/syslog.h: Rename local variable
 7:  fbfc7f153 =  5:  76c47f951 lib/io/syslog.h: SYSLOG_C(): Use a single local variable
 8:  0d5c45361 =  6:  a81bb672d lib/io/syslog.h: SYSLOG_C(): Call setlocale(3) and free(3) unconditionally
 2:  e1bcd94ab !  7:  c52eb077a lib/io/fprintf/: eprintf(): Add function to print to stderr
    @@ lib/Makefile.am: libshadow_la_SOURCES = \
        idmapping.c \
     +  io/fprintf/eprintf.c \
     +  io/fprintf/eprintf.h \
    +   io/syslog.c \
    +   io/syslog.h \
        isexpired.c \
    -   limits.c \
    -   list.c \
     
      ## lib/io/fprintf/eprintf.c (new) ##
     @@
 3:  11e991ed7 =  8:  96059fad4 lib/, src/: Use eprintf() instead of its pattern
 9:  f9da6bae3 =  9:  167e37962 lib/io/fprintf/: [v]fprinte(): Add function
10:  f7ae0caaa = 10:  822fd0b48 lib/io/fprintf/: [v]eprinte(): Add function
11:  bc9967364 = 11:  d0d4efc55 lib/, src/: Use eprinte() instead of its pattern
12:  add0f7870 = 12:  631c5be81 lib/: Use [v]fprinte() instead of its pattern
13:  7a4d5bed0 = 13:  2030ded26 lib/io/syslog.h: SYSLOGE(): Add macro
14:  957e9ab3e = 14:  413c1dfc0 src/userdel.c: Fix error message
15:  6a4975da0 = 15:  870c5c7cb lib/, src/: Use SYSLOGE() instead of its pattern
```
</details>

<details>
<summary>v11</summary>

-  Rebase on top of #1380.
-  Reorder commits.  This will allow splitting a few commits into a separate PR.

```diff
$ git diff gh/eprintf..eprintf
$
```
```
$ git range-diff gh/strerrno..gh/eprintf gh/syslog_c..eprintf 
 1:  98037675f <  -:  --------- lib/defines.h, lib/, src/: Redefine SYSLOG() as a variadic macro
 2:  165b4829c <  -:  --------- lib/: Move <syslog.h> wrappers to "io/syslog.h"
 3:  da9c94103 <  -:  --------- lib/io/syslog.h: SYSLOG_C(): Split code to helper macro
 4:  85f5dc585 <  -:  --------- lib/io/syslog.h: Rename local variable
 5:  76c47f951 <  -:  --------- lib/io/syslog.h: SYSLOG_C(): Use a single local variable
 6:  a81bb672d <  -:  --------- lib/io/syslog.h: SYSLOG_C(): Call setlocale(3) and free(3) unconditionally
 9:  167e37962 !  1:  f9a2c5170 lib/io/fprintf/: [v]fprinte(): Add function
    @@ Commit message
     
      ## lib/Makefile.am ##
     @@ lib/Makefile.am: libshadow_la_SOURCES = \
    +   hushed.c \
    +   idmapping.h \
        idmapping.c \
    -   io/fprintf/eprintf.c \
    -   io/fprintf/eprintf.h \
     +  io/fprintf/fprinte.c \
     +  io/fprintf/fprinte.h \
        io/syslog.c \
12:  631c5be81 =  2:  cd56367d3 lib/: Use [v]fprinte() instead of its pattern
13:  2030ded26 =  3:  3bf242849 lib/io/syslog.h: SYSLOGE(): Add macro
15:  870c5c7cb !  4:  ae21a2a32 lib/, src/: Use SYSLOGE() instead of its pattern
    @@ lib/setugid.c: int change_uid (const struct passwd *info)
     
      ## src/groupadd.c ##
     @@
    + #include "defines.h"
    + #include "getdef.h"
      #include "groupio.h"
    - #include "io/fprintf/eprinte.h"
    - #include "io/fprintf/eprintf.h"
     +#include "io/syslog.h"
      #include "nscd.h"
      #include "sssd.h"
    @@ src/groupadd.c
     @@ src/groupadd.c: static void open_files (struct option_flags *flags)
        /* And now open the databases */
        if (gr_open (O_CREAT | O_RDWR) == 0) {
    -           eprinte(_("%s: cannot open %s"), Prog, gr_dbname());
    +           fprintf(stderr, _("%s: cannot open %s: %s\n"), Prog, gr_dbname(), strerrno());
     -          SYSLOG(LOG_WARN, "cannot open %s: %s", gr_dbname(), strerrno());
     +          SYSLOGE(LOG_WARN, "cannot open %s", gr_dbname());
                fail_exit (E_GRP_UPDATE);
        }
      
     @@ src/groupadd.c: static void open_files (struct option_flags *flags)
    -   if (is_shadow_grp) {
    -           if (sgr_open (O_CREAT | O_RDWR) == 0) {
    -                   eprinte(_("%s: cannot open %s"), Prog, sgr_dbname());
    +                   fprintf (stderr,
    +                            _("%s: cannot open %s: %s\n"),
    +                            Prog, sgr_dbname(), strerrno());
     -                  SYSLOG(LOG_WARN, "cannot open %s: %s", sgr_dbname(), strerrno());
     +                  SYSLOGE(LOG_WARN, "cannot open %s", sgr_dbname());
                        fail_exit (E_GRP_UPDATE);
    @@ src/suauth.c: check_su_auth(const char *actual_id, const char *wanted_id, bool s
     
      ## src/userdel.c ##
     @@
    + #include "defines.h"
    + #include "getdef.h"
      #include "groupio.h"
    - #include "io/fprintf/eprinte.h"
    - #include "io/fprintf/eprintf.h"
     +#include "io/syslog.h"
      #include "nscd.h"
      #include "sssd.h"
      #include "prototypes.h"
     @@ src/userdel.c: static bool remove_mailbox (void)
    -                   return 0;
    -           } else {
    -                   eprinte(_("%s: warning: can't remove %s"), Prog, mailfile);
    +                   fprintf (stderr,
    +                            _("%s: warning: can't remove %s: %s\n"),
    +                           Prog, mailfile, strerrno());
     -                  SYSLOG(LOG_ERR, "Cannot remove %s: %s", mailfile, strerrno());
     +                  SYSLOGE(LOG_ERR, "Cannot remove %s", mailfile);
      #ifdef WITH_AUDIT
                        audit_logger (AUDIT_DEL_USER, Prog,
                                      "delete-mail-file",
     @@ src/userdel.c: static bool remove_mailbox (void)
    -   if (fflg) {
    -           if (unlink (mailfile) != 0) {
    -                   eprinte(_("%s: warning: can't remove %s"), Prog, mailfile);
    +                   fprintf (stderr,
    +                            _("%s: warning: can't remove %s: %s\n"),
    +                           Prog, mailfile, strerrno());
     -                  SYSLOG(LOG_ERR, "Cannot remove %s: %s", mailfile, strerrno());
     +                  SYSLOGE(LOG_ERR, "Cannot remove %s", mailfile);
      #ifdef WITH_AUDIT
                        audit_logger (AUDIT_DEL_USER, Prog,
                                      "delete-mail-file",
     @@ src/userdel.c: static bool remove_mailbox (void)
    -   }
    -   if (unlink (mailfile) != 0) {
    -           eprinte(_("%s: warning: can't remove %s"), Prog, mailfile);
    +           fprintf (stderr,
    +                    _("%s: warning: can't remove %s: %s\n"),
    +                    Prog, mailfile, strerrno());
     -          SYSLOG(LOG_ERR, "Cannot remove %s: %s", mailfile, strerrno());
     +          SYSLOGE(LOG_ERR, "Cannot remove %s", mailfile);
      #ifdef WITH_AUDIT
 7:  c52eb077a !  5:  5380dd557 lib/io/fprintf/: eprintf(): Add function to print to stderr
    @@ lib/Makefile.am: libshadow_la_SOURCES = \
        idmapping.c \
     +  io/fprintf/eprintf.c \
     +  io/fprintf/eprintf.h \
    +   io/fprintf/fprinte.c \
    +   io/fprintf/fprinte.h \
        io/syslog.c \
    -   io/syslog.h \
    -   isexpired.c \
     
      ## lib/io/fprintf/eprintf.c (new) ##
     @@
 8:  96059fad4 !  6:  57af7fdc3 lib/, src/: Use eprintf() instead of its pattern
    @@ src/groupadd.c
      #include "getdef.h"
      #include "groupio.h"
     +#include "io/fprintf/eprintf.h"
    + #include "io/syslog.h"
      #include "nscd.h"
      #include "sssd.h"
    - #include "prototypes.h"
     @@ src/groupadd.c: grp_update(void)
                ul = user_list;
                while (NULL != (u = strsep(&ul, ","))) {
    @@ src/groupadd.c: static void open_files (struct option_flags *flags)
        if (gr_open (O_CREAT | O_RDWR) == 0) {
     -          fprintf(stderr, _("%s: cannot open %s: %s\n"), Prog, gr_dbname(), strerrno());
     +          eprintf(_("%s: cannot open %s: %s\n"), Prog, gr_dbname(), strerrno());
    -           SYSLOG(LOG_WARN, "cannot open %s: %s", gr_dbname(), strerrno());
    +           SYSLOGE(LOG_WARN, "cannot open %s", gr_dbname());
                fail_exit (E_GRP_UPDATE);
        }
     @@ src/groupadd.c: static void open_files (struct option_flags *flags)
    @@ src/groupadd.c: static void open_files (struct option_flags *flags)
     -                           _("%s: cannot open %s: %s\n"),
     -                           Prog, sgr_dbname(), strerrno());
     +                  eprintf(_("%s: cannot open %s: %s\n"), Prog, sgr_dbname(), strerrno());
    -                   SYSLOG(LOG_WARN, "cannot open %s: %s", sgr_dbname(), strerrno());
    +                   SYSLOGE(LOG_WARN, "cannot open %s", sgr_dbname());
                        fail_exit (E_GRP_UPDATE);
                }
     @@ src/groupadd.c: static void process_flags (int argc, char **argv, struct option_flags *flags)
    @@ src/userdel.c
      #include "getdef.h"
      #include "groupio.h"
     +#include "io/fprintf/eprintf.h"
    + #include "io/syslog.h"
      #include "nscd.h"
      #include "sssd.h"
    - #include "prototypes.h"
     @@ src/userdel.c: static void update_groups (bool process_selinux)
                 */
                ngrp = __gr_dup (grp);
    @@ src/userdel.c: static bool remove_mailbox (void)
     -                           _("%s: warning: can't remove %s: %s\n"),
     +                  eprintf(_("%s: warning: can't remove %s: %s\n"),
                                Prog, mailfile, strerrno());
    -                   SYSLOG(LOG_ERR, "Cannot remove %s: %s", mailfile, strerrno());
    +                   SYSLOGE(LOG_ERR, "Cannot remove %s", mailfile);
      #ifdef WITH_AUDIT
     @@ src/userdel.c: static bool remove_mailbox (void)
      
    @@ src/userdel.c: static bool remove_mailbox (void)
     -                           _("%s: warning: can't remove %s: %s\n"),
     +                  eprintf(_("%s: warning: can't remove %s: %s\n"),
                                Prog, mailfile, strerrno());
    -                   SYSLOG(LOG_ERR, "Cannot remove %s: %s", mailfile, strerrno());
    +                   SYSLOGE(LOG_ERR, "Cannot remove %s", mailfile);
      #ifdef WITH_AUDIT
     @@ src/userdel.c: static bool remove_mailbox (void)
        }
    @@ src/userdel.c: static bool remove_mailbox (void)
     -                   _("%s: warning: can't remove %s: %s\n"),
     -                   Prog, mailfile, strerrno());
     +          eprintf(_("%s: warning: can't remove %s: %s\n"), Prog, mailfile, strerrno());
    -           SYSLOG(LOG_ERR, "Cannot remove %s: %s", mailfile, strerrno());
    +           SYSLOGE(LOG_ERR, "Cannot remove %s", mailfile);
      #ifdef WITH_AUDIT
                audit_logger (AUDIT_DEL_USER, Prog,
     @@ src/userdel.c: static int remove_tcbdir (const char *user_name, uid_t user_id)
10:  822fd0b48 =  7:  591a84760 lib/io/fprintf/: [v]eprinte(): Add function
11:  d0d4efc55 !  8:  0c9e404a3 lib/, src/: Use eprinte() instead of its pattern
    @@ src/groupadd.c
      #include "groupio.h"
     +#include "io/fprintf/eprinte.h"
      #include "io/fprintf/eprintf.h"
    + #include "io/syslog.h"
      #include "nscd.h"
    - #include "sssd.h"
     @@ src/groupadd.c: static void open_files (struct option_flags *flags)
      
        /* And now open the databases */
        if (gr_open (O_CREAT | O_RDWR) == 0) {
     -          eprintf(_("%s: cannot open %s: %s\n"), Prog, gr_dbname(), strerrno());
     +          eprinte(_("%s: cannot open %s"), Prog, gr_dbname());
    -           SYSLOG(LOG_WARN, "cannot open %s: %s", gr_dbname(), strerrno());
    +           SYSLOGE(LOG_WARN, "cannot open %s", gr_dbname());
                fail_exit (E_GRP_UPDATE);
        }
     @@ src/groupadd.c: static void open_files (struct option_flags *flags)
    @@ src/groupadd.c: static void open_files (struct option_flags *flags)
                if (sgr_open (O_CREAT | O_RDWR) == 0) {
     -                  eprintf(_("%s: cannot open %s: %s\n"), Prog, sgr_dbname(), strerrno());
     +                  eprinte(_("%s: cannot open %s"), Prog, sgr_dbname());
    -                   SYSLOG(LOG_WARN, "cannot open %s: %s", sgr_dbname(), strerrno());
    +                   SYSLOGE(LOG_WARN, "cannot open %s", sgr_dbname());
                        fail_exit (E_GRP_UPDATE);
                }
     
    @@ src/userdel.c
      #include "groupio.h"
     +#include "io/fprintf/eprinte.h"
      #include "io/fprintf/eprintf.h"
    + #include "io/syslog.h"
      #include "nscd.h"
    - #include "sssd.h"
     @@ src/userdel.c: static bool remove_mailbox (void)
                        free(mailfile);
                        return 0;
    @@ src/userdel.c: static bool remove_mailbox (void)
     -                  eprintf(_("%s: warning: can't remove %s: %s\n"),
     -                          Prog, mailfile, strerrno());
     +                  eprinte(_("%s: warning: can't remove %s"), Prog, mailfile);
    -                   SYSLOG(LOG_ERR, "Cannot remove %s: %s", mailfile, strerrno());
    +                   SYSLOGE(LOG_ERR, "Cannot remove %s", mailfile);
      #ifdef WITH_AUDIT
                        audit_logger (AUDIT_DEL_USER, Prog,
     @@ src/userdel.c: static bool remove_mailbox (void)
    @@ src/userdel.c: static bool remove_mailbox (void)
     -                  eprintf(_("%s: warning: can't remove %s: %s\n"),
     -                          Prog, mailfile, strerrno());
     +                  eprinte(_("%s: warning: can't remove %s"), Prog, mailfile);
    -                   SYSLOG(LOG_ERR, "Cannot remove %s: %s", mailfile, strerrno());
    +                   SYSLOGE(LOG_ERR, "Cannot remove %s", mailfile);
      #ifdef WITH_AUDIT
                        audit_logger (AUDIT_DEL_USER, Prog,
     @@ src/userdel.c: static bool remove_mailbox (void)
    @@ src/userdel.c: static bool remove_mailbox (void)
        if (unlink (mailfile) != 0) {
     -          eprintf(_("%s: warning: can't remove %s: %s\n"), Prog, mailfile, strerrno());
     +          eprinte(_("%s: warning: can't remove %s"), Prog, mailfile);
    -           SYSLOG(LOG_ERR, "Cannot remove %s: %s", mailfile, strerrno());
    +           SYSLOGE(LOG_ERR, "Cannot remove %s", mailfile);
      #ifdef WITH_AUDIT
                audit_logger (AUDIT_DEL_USER, Prog,
     @@ src/userdel.c: static int remove_tcbdir (const char *user_name, uid_t user_id)
14:  413c1dfc0 =  9:  4ae6b0399 src/userdel.c: Fix error message
```
</details>

v12: <https://github.com/shadow-maint/shadow/pull/1289#issuecomment-3481561353>

<details>
<summary>v12b</summary>

-  Rebase.

```
$ git range-diff f9a2c5170^..59c9d208b se2..c0483feb0
 1:  f9a2c5170 =  1:  c9324c952 lib/io/fprintf/: [v]fprinte(): Add function
 2:  22d737344 =  2:  e1cb59b9e lib/: Use [v]fprinte() instead of its pattern
 3:  a79ac3072 =  3:  14f2b7c9f lib/io/syslog.h: SYSLOGE(): Add macro
 4:  9f5390550 =  4:  0bf285d61 lib/, src/: Use SYSLOGE() instead of its pattern
 5:  5013dd39b =  5:  f12cfbb6b lib/io/fprintf/: eprintf(): Add function to print to stderr
 6:  682f10445 =  6:  82135db03 lib/, src/: Use eprintf() instead of its pattern
 7:  71e868fd2 =  7:  2562ce8de lib/io/fprintf/: eprinte(): Add macro
 8:  c1249764e =  8:  ad4b855dd lib/, src/: Use eprinte() instead of its pattern
 9:  59c9d208b =  9:  c0483feb0 src/userdel.c: Fix error message
```
</details>

<details>
<summary>v12c</summary>

-  Rebase of top of #1381 

```
$ git range-diff se2..gh/eprintf  e..eprintf 
 1:  c9324c952 <  -:  --------- lib/io/fprintf/: [v]fprinte(): Add function
 2:  e1cb59b9e <  -:  --------- lib/: Use [v]fprinte() instead of its pattern
 3:  14f2b7c9f <  -:  --------- lib/io/syslog.h: SYSLOGE(): Add macro
 4:  0bf285d61 <  -:  --------- lib/, src/: Use SYSLOGE() instead of its pattern
 5:  f12cfbb6b =  1:  f12cfbb6b lib/io/fprintf/: eprintf(): Add function to print to stderr
 6:  82135db03 =  2:  82135db03 lib/, src/: Use eprintf() instead of its pattern
 7:  2562ce8de =  3:  2562ce8de lib/io/fprintf/: eprinte(): Add macro
 8:  ad4b855dd =  4:  ad4b855dd lib/, src/: Use eprinte() instead of its pattern
 9:  c0483feb0 =  5:  c0483feb0 src/userdel.c: Fix error message
```
</details>

<details>
<summary>v12d</summary>

-  Rebase

```
$ git range-diff gh/e..gh/eprintf e..eprintf 
1:  f12cfbb6b = 1:  af91e3e35 lib/io/fprintf/: eprintf(): Add function to print to stderr
2:  82135db03 = 2:  f2ed153b7 lib/, src/: Use eprintf() instead of its pattern
3:  2562ce8de = 3:  017690e14 lib/io/fprintf/: eprinte(): Add macro
4:  ad4b855dd = 4:  2bb6eb674 lib/, src/: Use eprinte() instead of its pattern
5:  c0483feb0 = 5:  99c0a3a6a src/userdel.c: Fix error message
```
</details>

<details>
<summary>v13</summary>

-  Rebase
-  Implement APIs as macros.
-  Reduce header fields.

```
$ git range-diff gh/e..gh/eprintf e..eprintf 
1:  af91e3e35 < -:  --------- lib/io/fprintf/: eprintf(): Add function to print to stderr
-:  --------- > 1:  d23dfbd64 lib/io/fprintf/: eprintf(): Add macro to print to stderr
2:  f2ed153b7 ! 2:  60238f9c0 lib/, src/: Use eprintf() instead of its pattern
    @@ Commit message
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## src/chage.c ##
    -@@
    - #include "atoi/a2i/a2s.h"
    - #include "defines.h"
    - #include "fields.h"
    -+#include "io/fprintf/eprintf.h"
    - #include "io/fprintf/fprinte.h"
    - #include "prototypes.h"
    - #include "pwio.h"
     @@ src/chage.c: fail_exit (int code, bool process_selinux)
      {
        if (spw_locked) {
    @@ src/chfn.c: int main (int argc, char **argv)
      
     
      ## src/chgpasswd.c ##
    -@@
    - #include "atoi/str2i.h"
    - #include "defines.h"
    - #include "groupio.h"
    -+#include "io/fprintf/eprintf.h"
    - #include "io/fprintf/fprinte.h"
    - #include "nscd.h"
    - #include "sssd.h"
     @@ src/chgpasswd.c: static void fail_exit (int code, bool process_selinux)
      {
        if (gr_locked) {
    @@ src/chgpasswd.c: int main (int argc, char **argv)
      
     
      ## src/chpasswd.c ##
    -@@
    - #include "chkhash.h"
    - #include "defines.h"
    - #include "getdef.h"
    -+#include "io/fprintf/eprintf.h"
    - #include "io/fprintf/fprinte.h"
    - #include "nscd.h"
    - #include "sssd.h"
     @@ src/chpasswd.c: static void fail_exit (int code, bool process_selinux)
      {
        if (pw_locked) {
    @@ src/expiry.c: int main (int argc, char **argv)
                exit (10);
     
      ## src/faillog.c ##
    -@@
    - /*@-exitarg@*/
    - #include "exitcodes.h"
    - #include "faillog.h"
    -+#include "io/fprintf/eprintf.h"
    - #include "io/fprintf/fprinte.h"
    - #include "prototypes.h"
    - #include "shadowlog.h"
     @@ src/faillog.c: static off_t lookup_faillog(struct faillog *fl, uid_t uid)
      
        /* Ensure multiplication does not overflow and retrieving a wrong entry */
    @@ src/getsubids.c: int main(int argc, char *argv[])
        for (i = 0; i < count; i++) {
     
      ## src/gpasswd.c ##
    -@@
    - /*@-exitarg@*/
    - #include "exitcodes.h"
    - #include "groupio.h"
    -+#include "io/fprintf/eprintf.h"
    - #include "io/fprintf/fprinte.h"
    - #include "nscd.h"
    - #include "prototypes.h"
     @@ src/gpasswd.c: static bool is_valid_user_list (const char *users)
      
                /* local, no need for xgetpwnam */
    @@ src/gpasswd.c: int main (int argc, char **argv)
      
     
      ## src/groupadd.c ##
    -@@
    - #include "defines.h"
    - #include "getdef.h"
    - #include "groupio.h"
    -+#include "io/fprintf/eprintf.h"
    - #include "io/fprintf/fprinte.h"
    - #include "io/syslog.h"
    - #include "nscd.h"
     @@ src/groupadd.c: grp_update(void)
                ul = user_list;
                while (NULL != (u = strsep(&ul, ","))) {
    @@ src/grpunconv.c: int main (int argc, char **argv)
      #endif                            /* !SHADOWGRP */
     
      ## src/lastlog.c ##
    -@@
    - /*@-exitarg@*/
    - #include "exitcodes.h"
    - #include "getdef.h"
    -+#include "io/fprintf/eprintf.h"
    - #include "io/fprintf/fprinte.h"
    - #include "prototypes.h"
    - #include "shadowlog.h"
     @@ src/lastlog.c: static void print_one (/*@null@*/const struct passwd *pw)
                 * empty entry in this case.
                 */
    @@ src/lastlog.c: int main (int argc, char **argv)
                }
     
      ## src/login.c ##
    -@@
    - #include "faillog.h"
    - #include "failure.h"
    - #include "getdef.h"
    -+#include "io/fprintf/eprintf.h"
    - #include "io/fprintf/fprinte.h"
    - #include "prototypes.h"
    - #include "pwauth.h"
     @@
      static pam_handle_t *pamh = NULL;
      
    @@ src/new_subid_range.c: int main(int argc, char *argv[])
        printf("Subuid range %lu:%lu\n", range.start, range.count);
     
      ## src/newgidmap.c ##
    -@@
    - #include "defines.h"
    - #include "getdef.h"
    - #include "idmapping.h"
    -+#include "io/fprintf/eprintf.h"
    - #include "io/fprintf/fprinte.h"
    - #include "prototypes.h"
    - #include "shadowlog.h"
     @@ src/newgidmap.c: static void verify_ranges(struct passwd *pw, int ranges,
        mapping = mappings;
        for (idx = 0; idx < ranges; idx++, mapping++) {
    @@ src/newgidmap.c: int main(int argc, char **argv)
                        (unsigned long)getgid(), (unsigned long)pw->pw_gid, (unsigned long)st.st_gid);
     
      ## src/newgrp.c ##
    -@@
    - /*@-exitarg@*/
    - #include "exitcodes.h"
    - #include "getdef.h"
    -+#include "io/fprintf/eprintf.h"
    - #include "io/fprintf/fprinte.h"
    - #include "prototypes.h"
    - #include "search/l/lfind.h"
     @@ src/newgrp.c: int main (int argc, char **argv)
      
        pwd = get_my_pwent ();
    @@ src/newgrp.c: int main (int argc, char **argv)
      
     
      ## src/newuidmap.c ##
    -@@
    - #include "defines.h"
    - #include "getdef.h"
    - #include "idmapping.h"
    -+#include "io/fprintf/eprintf.h"
    - #include "io/fprintf/fprinte.h"
    - #include "prototypes.h"
    - #include "shadowlog.h"
     @@ src/newuidmap.c: static void verify_ranges(struct passwd *pw, int ranges,
        mapping = mappings;
        for (idx = 0; idx < ranges; idx++, mapping++) {
    @@ src/newuidmap.c: int main(int argc, char **argv)
                        (unsigned long)getgid(), (unsigned long)pw->pw_gid, (unsigned long)st.st_gid);
     
      ## src/newusers.c ##
    -@@
    - #include "defines.h"
    - #include "getdef.h"
    - #include "groupio.h"
    -+#include "io/fprintf/eprintf.h"
    - #include "io/fprintf/fprinte.h"
    - #include "nscd.h"
    - #include "prototypes.h"
     @@ src/newusers.c: static void fail_exit (int code, bool process_selinux)
      {
        if (spw_locked) {
    @@ src/newusers.c: int main (int argc, char **argv)
                }
     
      ## src/passwd.c ##
    -@@
    - #include "chkname.h"
    - #include "defines.h"
    - #include "getdef.h"
    -+#include "io/fprintf/eprintf.h"
    - #include "io/fprintf/fprinte.h"
    - #include "nscd.h"
    - #include "prototypes.h"
     @@ src/passwd.c: static int new_password (const struct passwd *pw)
                        strzero (cipher);
                        SYSLOG(LOG_WARN, "incorrect password for %s", pw->pw_name);
    @@ src/su.c: int main (int argc, char **argv)
                (void) shell (shellstr, cp, environ);
     
      ## src/useradd.c ##
    -@@
    - #include "fs/mkstemp/fmkomstemp.h"
    - #include "getdef.h"
    - #include "groupio.h"
    -+#include "io/fprintf/eprintf.h"
    - #include "io/fprintf/fprinte.h"
    - #include "nscd.h"
    - #include "prototypes.h"
     @@ src/useradd.c: static void fail_exit (int code, bool process_selinux)
      #endif
      
    @@ src/useradd.c: int main (int argc, char **argv)
      
     
      ## src/userdel.c ##
    -@@
    - #include "defines.h"
    - #include "getdef.h"
    - #include "groupio.h"
    -+#include "io/fprintf/eprintf.h"
    - #include "io/fprintf/fprinte.h"
    - #include "io/syslog.h"
    - #include "nscd.h"
     @@ src/userdel.c: static void update_groups (bool process_selinux)
                 */
                ngrp = __gr_dup (grp);
    @@ src/userdel.c: int main (int argc, char **argv)
                        audit_logger (AUDIT_ROLE_REMOVE, Prog,
     
      ## src/usermod.c ##
    -@@
    - #include "faillog.h"
    - #include "getdef.h"
    - #include "groupio.h"
    -+#include "io/fprintf/eprintf.h"
    - #include "io/fprintf/fprinte.h"
    - #include "nscd.h"
    - #include "prototypes.h"
     @@ src/usermod.c: static int get_groups (char *list)
                 * string name.
                 */
    @@ src/usermod.c: int main (int argc, char **argv)
                        }
     
      ## src/vipw.c ##
    -@@
    - #include "defines.h"
    - #include "getdef.h"
    - #include "groupio.h"
    -+#include "io/fprintf/eprintf.h"
    - #include "io/fprintf/fprinte.h"
    - #include "nscd.h"
    - #include "prototypes.h"
     @@ src/vipw.c: static void vipwexit (const char *msg, int syserr, int ret)
      
        if (createedit) {
3:  017690e14 ! 3:  b3aba13f2 lib/io/fprintf/: eprinte(): Add macro
    @@ Commit message
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    - ## lib/io/fprintf/fprinte.h ##
    + ## lib/io/fprintf.h ##
     @@
    - #include "attr.h"
    + // eprintf - stderr print formatted
    + #define eprintf(...)  fprintf(stderr, __VA_ARGS__)
      
    - 
    -+// eprinte - stderr print error
    ++// eprinte - stderr print errno
     +#define eprinte(...)  fprinte(stderr, __VA_ARGS__)
     +
    -+
    - format_attr(printf, 2, 3)
    - inline int fprinte(FILE *restrict stream, const char *restrict fmt, ...);
    - format_attr(printf, 2, 0)
    + // fprinte - FILE print errno
    + #define fprinte(stream, ...)       fprintec(stream, errno, __VA_ARGS__)
    + // vfprinte - va_list FILE print errno
4:  2bb6eb674 = 4:  bfac0a7f9 lib/, src/: Use eprinte() instead of its pattern
5:  99c0a3a6a = 5:  16cc12078 src/userdel.c: Fix error message
```

</details>

<details>
<summary>v13b</summary>

-  Rebase

```
$ git range-diff gh/e..gh/eprintf e..eprintf 
1:  d23dfbd64 = 1:  4fb6a85fe lib/io/fprintf/: eprintf(): Add macro to print to stderr
2:  60238f9c0 = 2:  a2bfb923f lib/, src/: Use eprintf() instead of its pattern
3:  b3aba13f2 = 3:  1ca3010ac lib/io/fprintf/: eprinte(): Add macro
4:  bfac0a7f9 = 4:  321f3110d lib/, src/: Use eprinte() instead of its pattern
5:  16cc12078 = 5:  85e28e216 src/userdel.c: Fix error message
```
</details>

<details>
<summary>v14</summary>

-  Rebase

```
$ git range-diff gh/e..gh/eprintf e..eprintf 
1:  4fb6a85fe = 1:  f2da3fd7a lib/io/fprintf/: eprintf(): Add macro to print to stderr
2:  a2bfb923f ! 2:  51fdf6f9c lib/, src/: Use eprintf() instead of its pattern
    @@ src/newgrp.c: int main (int argc, char **argv)
     -                   Prog);
     +          eprintf(_("%s: Cannot determine your user name.\n"), Prog);
      #ifdef WITH_AUDIT
    -           audit_logger (AUDIT_CHGRP_ID, Prog,
    +           audit_logger (AUDIT_CHGRP_ID,
                              "changing", NULL, getuid (), SHADOW_AUDIT_FAILURE);
     @@ src/newgrp.c: int main (int argc, char **argv)
                 */
    @@ src/useradd.c: static void close_files (struct option_flags *flags)
     +                  eprintf(_("%s: failed to unlock %s\n"), Prog, spw_dbname());
                        SYSLOG(LOG_ERR, "failed to unlock %s", spw_dbname());
      #ifdef WITH_AUDIT
    -                   audit_logger (AUDIT_ADD_USER, Prog,
    +                   audit_logger (AUDIT_ADD_USER,
     @@ src/useradd.c: static void close_files (struct option_flags *flags)
                spw_locked = false;
        }
    @@ src/useradd.c: static void close_files (struct option_flags *flags)
     +          eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
                SYSLOG(LOG_ERR, "failed to unlock %s", pw_dbname());
      #ifdef WITH_AUDIT
    -           audit_logger (AUDIT_ADD_USER, Prog,
    +           audit_logger (AUDIT_ADD_USER,
     @@ src/useradd.c: static void close_files (struct option_flags *flags)
      #ifdef ENABLE_SUBIDS
        if (is_sub_uid) {
    @@ src/useradd.c: static void close_files (struct option_flags *flags)
     +                  eprintf(_("%s: failed to unlock %s\n"), Prog, sub_uid_dbname());
                        SYSLOG(LOG_ERR, "failed to unlock %s", sub_uid_dbname());
      #ifdef WITH_AUDIT
    -                   audit_logger (AUDIT_ADD_USER, Prog,
    +                   audit_logger (AUDIT_ADD_USER,
     @@ src/useradd.c: static void close_files (struct option_flags *flags)
        }
        if (is_sub_gid) {
    @@ src/useradd.c: static void close_files (struct option_flags *flags)
     +                  eprintf(_("%s: failed to unlock %s\n"), Prog, sub_gid_dbname());
                        SYSLOG(LOG_ERR, "failed to unlock %s", sub_gid_dbname());
      #ifdef WITH_AUDIT
    -                   audit_logger (AUDIT_ADD_USER, Prog,
    +                   audit_logger (AUDIT_ADD_USER,
     @@ src/useradd.c: static void close_group_files (bool process_selinux)
                return;
      
    @@ src/useradd.c: static void close_group_files (bool process_selinux)
     +          eprintf(_("%s: failed to unlock %s\n"), Prog, gr_dbname());
                SYSLOG(LOG_ERR, "failed to unlock %s", gr_dbname());
      #ifdef WITH_AUDIT
    -           audit_logger (AUDIT_ADD_USER, Prog,
    +           audit_logger (AUDIT_ADD_USER,
     @@ src/useradd.c: static void unlock_group_files (bool process_selinux)
      #ifdef    SHADOWGRP
        if (is_shadow_grp) {
    @@ src/useradd.c: static void unlock_group_files (bool process_selinux)
     +                  eprintf(_("%s: failed to unlock %s\n"), Prog, sgr_dbname());
                        SYSLOG(LOG_ERR, "failed to unlock %s", sgr_dbname());
      #ifdef WITH_AUDIT
    -                   audit_logger (AUDIT_ADD_USER, Prog,
    +                   audit_logger (AUDIT_ADD_USER,
     @@ src/useradd.c: static void unlock_group_files (bool process_selinux)
      static void open_files (bool process_selinux)
      {
    @@ src/useradd.c: static void grp_add (bool process_selinux)
     +          eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
                         Prog, gr_dbname (), grp.gr_name);
      #ifdef WITH_AUDIT
    -           audit_logger (AUDIT_ADD_GROUP, Prog,
    +           audit_logger (AUDIT_ADD_GROUP,
     @@ src/useradd.c: static void grp_add (bool process_selinux)
         * Write out the new shadow group entries as well.
         */
    @@ src/useradd.c: static void grp_add (bool process_selinux)
     +          eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
                         Prog, sgr_dbname (), sgrp.sg_namp);
      #ifdef WITH_AUDIT
    -           audit_logger (AUDIT_ADD_GROUP, Prog,
    +           audit_logger (AUDIT_ADD_GROUP,
     @@ src/useradd.c: static void tallylog_reset (const char *user_name)
      
        if (failed)
    @@ src/useradd.c: int main (int argc, char **argv)
     +                  eprintf(_("%s: warning: the user name %s to %s SELinux user mapping failed.\n"),
                                 Prog, user_name, user_selinux);
      #ifdef WITH_AUDIT
    -                   audit_logger (AUDIT_ROLE_ASSIGN, Prog,
    +                   audit_logger (AUDIT_ROLE_ASSIGN,
     @@ src/useradd.c: int main (int argc, char **argv)
                        copy_tree (def_usrtemplate, prefix_user_home, false, true,
                                   (uid_t)-1, user_id, (gid_t)-1, user_gid);
    @@ src/userdel.c: int main (int argc, char **argv)
     +                  eprintf(_("%s: user '%s' does not exist\n"),
                                 Prog, user_name);
      #ifdef WITH_AUDIT
    -                   audit_logger (AUDIT_DEL_USER, Prog,
    +                   audit_logger (AUDIT_DEL_USER,
     @@ src/userdel.c: int main (int argc, char **argv)
        if (rflg) {
                int home_owned = is_owner (user_id, user_home);
    @@ src/userdel.c: int main (int argc, char **argv)
     +                  eprintf(_("%s: warning: the user name %s to SELinux user mapping removal failed.\n"),
                                 Prog, user_name);
      #ifdef WITH_AUDIT
    -                   audit_logger (AUDIT_ROLE_REMOVE, Prog,
    +                   audit_logger (AUDIT_ROLE_REMOVE,
     
      ## src/usermod.c ##
     @@ src/usermod.c: static int get_groups (char *list)
    @@ src/usermod.c: int main (int argc, char **argv)
     +                          eprintf(_("%s: warning: the user name %s to %s SELinux user mapping failed.\n"),
                                         Prog, user_name, user_selinux);
      #ifdef WITH_AUDIT
    -                           audit_logger (AUDIT_ROLE_ASSIGN, Prog,
    +                           audit_logger (AUDIT_ROLE_ASSIGN,
     @@ src/usermod.c: int main (int argc, char **argv)
                        }
                } else {
    @@ src/usermod.c: int main (int argc, char **argv)
     +                          eprintf(_("%s: warning: the user name %s to SELinux user mapping removal failed.\n"),
                                         Prog, user_name);
      #ifdef WITH_AUDIT
    -                           audit_logger (AUDIT_ROLE_REMOVE, Prog,
    +                           audit_logger (AUDIT_ROLE_REMOVE,
     @@ src/usermod.c: int main (int argc, char **argv)
                                        uflg ? user_newid  : (uid_t)-1,
                                        user_gid,
3:  1ca3010ac = 3:  d2d388352 lib/io/fprintf/: eprinte(): Add macro
4:  321f3110d ! 4:  366e77d48 lib/, src/: Use eprinte() instead of its pattern
    @@ src/userdel.c: static bool remove_mailbox (void)
     +                  eprinte(_("%s: warning: can't remove %s"), Prog, mailfile);
                        SYSLOGE(LOG_ERR, "Cannot remove %s", mailfile);
      #ifdef WITH_AUDIT
    -                   audit_logger (AUDIT_DEL_USER, Prog,
    +                   audit_logger (AUDIT_DEL_USER,
     @@ src/userdel.c: static bool remove_mailbox (void)
      
        if (fflg) {
    @@ src/userdel.c: static bool remove_mailbox (void)
     +                  eprinte(_("%s: warning: can't remove %s"), Prog, mailfile);
                        SYSLOGE(LOG_ERR, "Cannot remove %s", mailfile);
      #ifdef WITH_AUDIT
    -                   audit_logger (AUDIT_DEL_USER, Prog,
    +                   audit_logger (AUDIT_DEL_USER,
     @@ src/userdel.c: static bool remove_mailbox (void)
                return 0;               /* mailbox doesn't exist */
        }
    @@ src/userdel.c: static bool remove_mailbox (void)
     +          eprinte(_("%s: warning: can't remove %s"), Prog, mailfile);
                SYSLOGE(LOG_ERR, "Cannot remove %s", mailfile);
      #ifdef WITH_AUDIT
    -           audit_logger (AUDIT_DEL_USER, Prog,
    +           audit_logger (AUDIT_DEL_USER,
     @@ src/userdel.c: static int remove_tcbdir (const char *user_name, uid_t user_id)
                return 1;
        }
5:  85e28e216 ! 5:  3214071d8 src/userdel.c: Fix error message
    @@ src/userdel.c: static bool remove_mailbox (void)
     -          SYSLOG(LOG_ERR, "%s not owned by %s, not removed", mailfile, strerrno());
     +          SYSLOG(LOG_ERR, "%s not owned by %s, not removed", mailfile, user_name);
      #ifdef WITH_AUDIT
    -           audit_logger (AUDIT_DEL_USER, Prog,
    +           audit_logger (AUDIT_DEL_USER,
                              "delete-mail-file",
```
</details>

v15: <https://github.com/shadow-maint/shadow/pull/1289#issuecomment-3589772915>

<details>
<summary>v15b</summary>

-  Rebase

```
$ git range-diff gh/e..gh/eprintf e..eprintf 
1:  937a956ee = 1:  dae375ee4 lib/io/fprintf/: eprintf(): Add macro to print to stderr
2:  771951419 = 2:  32262f123 lib/, src/: Use eprintf() instead of its pattern
3:  b5075839d = 3:  d32a24767 lib/io/fprintf/: eprinte(): Add macro
4:  734ef3b7a = 4:  d18c50838 lib/, src/: Use eprinte() instead of its pattern
5:  06ffd61b0 = 5:  185fd3505 src/userdel.c: Fix error message
```
</details>

<details>
<summary>v15c</summary>

-  Rebase

```
$ git range-diff -U0 gh/e..gh/eprintf e..eprintf 
1:  dae375ee4 = 1:  6bad4e73d lib/io/fprintf/: eprintf(): Add macro to print to stderr
2:  32262f123 ! 2:  d4b5c7577 lib/, src/: Use eprintf() instead of its pattern
    @@ src/chage.c: static void check_flags (int argc, int opt_index)
    -@@ src/chage.c: static void check_perms (struct option_flags *flags)
    +@@ src/chage.c: static void check_perms(const struct option_flags *flags)
    @@ src/chage.c: static void check_perms (struct option_flags *flags)
    -@@ src/chage.c: static void open_files (bool readonly, struct option_flags *flags)
    +@@ src/chage.c: static void open_files(bool readonly, const struct option_flags *flags)
    @@ src/chage.c: static void open_files (bool readonly, struct option_flags *flags)
    -@@ src/chage.c: static void open_files (bool readonly, struct option_flags *flags)
    +@@ src/chage.c: static void open_files(bool readonly, const struct option_flags *flags)
    @@ src/chage.c: static void open_files (bool readonly, struct option_flags *flags)
    -@@ src/chage.c: static void close_files (struct option_flags *flags)
    +@@ src/chage.c: static void close_files(const struct option_flags *flags)
    @@ src/chage.c: static void close_files (struct option_flags *flags)
    -@@ src/chage.c: static void close_files (struct option_flags *flags)
    +@@ src/chage.c: static void close_files(const struct option_flags *flags)
    @@ src/chfn.c: static void check_perms (const struct passwd *pw)
    -@@ src/chfn.c: static void update_gecos (const char *user, char *gecos, struct option_flags *fl
    +@@ src/chfn.c: static void update_gecos(const char *user, char *gecos, const struct option_flag
    @@ src/chfn.c: static void update_gecos (const char *user, char *gecos, struct opti
    -@@ src/chfn.c: static void update_gecos (const char *user, char *gecos, struct option_flags *fl
    +@@ src/chfn.c: static void update_gecos(const char *user, char *gecos, const struct option_flag
    @@ src/chfn.c: static void update_gecos (const char *user, char *gecos, struct opti
    -@@ src/chfn.c: static void update_gecos (const char *user, char *gecos, struct option_flags *fl
    +@@ src/chfn.c: static void update_gecos(const char *user, char *gecos, const struct option_flag
    @@ src/chfn.c: static void update_gecos (const char *user, char *gecos, struct opti
    -@@ src/chfn.c: static void update_gecos (const char *user, char *gecos, struct option_flags *fl
    +@@ src/chfn.c: static void update_gecos(const char *user, char *gecos, const struct option_flag
    @@ src/chgpasswd.c: static void open_files (bool process_selinux)
    -@@ src/chgpasswd.c: static void close_files (struct option_flags *flags)
    +@@ src/chgpasswd.c: static void close_files(const struct option_flags *flags)
    @@ src/chgpasswd.c: static void close_files (struct option_flags *flags)
    -@@ src/chgpasswd.c: static void close_files (struct option_flags *flags)
    +@@ src/chgpasswd.c: static void close_files(const struct option_flags *flags)
    @@ src/chpasswd.c: static void check_perms (void)
    -@@ src/chpasswd.c: static void open_files (struct option_flags *flags)
    +@@ src/chpasswd.c: static void open_files(const struct option_flags *flags)
    @@ src/chpasswd.c: static void open_files (struct option_flags *flags)
    -@@ src/chpasswd.c: static void close_files (struct option_flags *flags)
    +@@ src/chpasswd.c: static void close_files(const struct option_flags *flags)
    @@ src/chpasswd.c: static void close_files (struct option_flags *flags)
    -@@ src/chpasswd.c: static void close_files (struct option_flags *flags)
    +@@ src/chpasswd.c: static void close_files(const struct option_flags *flags)
    @@ src/chsh.c: static bool shell_is_listed (const char *sh)
    -@@ src/chsh.c: static void check_perms (const struct passwd *pw, struct option_flags *flags)
    +@@ src/chsh.c: static void check_perms(const struct passwd *pw, const struct option_flags *flag
    @@ src/chsh.c: static void check_perms (const struct passwd *pw, struct option_flag
    -@@ src/chsh.c: static void check_perms (const struct passwd *pw, struct option_flags *flags)
    +@@ src/chsh.c: static void check_perms(const struct passwd *pw, const struct option_flags *flag
    @@ src/chsh.c: static void check_perms (const struct passwd *pw, struct option_flag
    -@@ src/chsh.c: static void check_perms (const struct passwd *pw, struct option_flags *flags)
    +@@ src/chsh.c: static void check_perms(const struct passwd *pw, const struct option_flags *flag
    @@ src/chsh.c: static void check_perms (const struct passwd *pw, struct option_flag
    -@@ src/chsh.c: static void check_perms (const struct passwd *pw, struct option_flags *flags)
    +@@ src/chsh.c: static void check_perms(const struct passwd *pw, const struct option_flags *flag
    @@ src/chsh.c: static void check_perms (const struct passwd *pw, struct option_flag
    -@@ src/chsh.c: static void check_perms (const struct passwd *pw, struct option_flags *flags)
    +@@ src/chsh.c: static void check_perms(const struct passwd *pw, const struct option_flags *flag
    @@ src/chsh.c: static void check_perms (const struct passwd *pw, struct option_flag
    -@@ src/chsh.c: static void update_shell (const char *user, char *newshell, struct option_flags
    +@@ src/chsh.c: static void update_shell (const char *user, char *newshell, const struct option_
    @@ src/chsh.c: static void update_shell (const char *user, char *newshell, struct o
    -@@ src/chsh.c: static void update_shell (const char *user, char *newshell, struct option_flags
    +@@ src/chsh.c: static void update_shell (const char *user, char *newshell, const struct option_
    @@ src/chsh.c: static void update_shell (const char *user, char *newshell, struct o
    -@@ src/chsh.c: static void update_shell (const char *user, char *newshell, struct option_flags
    +@@ src/chsh.c: static void update_shell (const char *user, char *newshell, const struct option_
    @@ src/chsh.c: static void update_shell (const char *user, char *newshell, struct o
    -@@ src/chsh.c: static void update_shell (const char *user, char *newshell, struct option_flags
    +@@ src/chsh.c: static void update_shell (const char *user, char *newshell, const struct option_
    @@ src/gpasswd.c: static void open_files (void)
    -@@ src/gpasswd.c: static void close_files (struct option_flags *flags)
    +@@ src/gpasswd.c: static void close_files(const struct option_flags *flags)
    @@ src/gpasswd.c: static void close_files (struct option_flags *flags)
    -@@ src/gpasswd.c: static void close_files (struct option_flags *flags)
    +@@ src/gpasswd.c: static void close_files(const struct option_flags *flags)
    @@ src/gpasswd.c: static void update_group (struct group *gr)
    -@@ src/gpasswd.c: static void get_group (struct group *gr, struct option_flags *flags)
    +@@ src/gpasswd.c: static void get_group(struct group *gr, const struct option_flags *flags)
    @@ src/gpasswd.c: static void get_group (struct group *gr, struct option_flags *fla
    -@@ src/gpasswd.c: static void get_group (struct group *gr, struct option_flags *flags)
    +@@ src/gpasswd.c: static void get_group(struct group *gr, const struct option_flags *flags)
    @@ src/gpasswd.c: static void get_group (struct group *gr, struct option_flags *fla
    -@@ src/gpasswd.c: static void get_group (struct group *gr, struct option_flags *flags)
    +@@ src/gpasswd.c: static void get_group(struct group *gr, const struct option_flags *flags)
    @@ src/gpasswd.c: static void get_group (struct group *gr, struct option_flags *fla
    -@@ src/gpasswd.c: static void get_group (struct group *gr, struct option_flags *flags)
    +@@ src/gpasswd.c: static void get_group(struct group *gr, const struct option_flags *flags)
    @@ src/groupadd.c: static void
    -@@ src/groupadd.c: static void close_files (struct option_flags *flags)
    +@@ src/groupadd.c: static void close_files(const struct option_flags *flags)
    @@ src/groupadd.c: static void close_files (struct option_flags *flags)
    -@@ src/groupadd.c: static void close_files (struct option_flags *flags)
    +@@ src/groupadd.c: static void close_files(const struct option_flags *flags)
    @@ src/groupadd.c: static void close_files (struct option_flags *flags)
    -@@ src/groupadd.c: static void open_files (struct option_flags *flags)
    +@@ src/groupadd.c: static void open_files(const struct option_flags *flags)
    @@ src/groupadd.c: static void open_files (struct option_flags *flags)
    -@@ src/groupadd.c: static void open_files (struct option_flags *flags)
    +@@ src/groupadd.c: static void open_files(const struct option_flags *flags)
    @@ src/groupdel.c: static void grp_update (void)
    -@@ src/groupdel.c: static void close_files (struct option_flags *flags)
    +@@ src/groupdel.c: static void close_files(const struct option_flags *flags)
    @@ src/groupdel.c: static void close_files (struct option_flags *flags)
    -@@ src/groupdel.c: static void close_files (struct option_flags *flags)
    +@@ src/groupdel.c: static void close_files(const struct option_flags *flags)
    @@ src/groupdel.c: static void close_files (struct option_flags *flags)
    -@@ src/groupdel.c: static void open_files (struct option_flags *flags)
    +@@ src/groupdel.c: static void open_files(const struct option_flags *flags)
    @@ src/groupdel.c: static void open_files (struct option_flags *flags)
    -@@ src/groupdel.c: static void open_files (struct option_flags *flags)
    +@@ src/groupdel.c: static void open_files(const struct option_flags *flags)
    @@ src/groupdel.c: static void open_files (struct option_flags *flags)
    -@@ src/groupdel.c: static void open_files (struct option_flags *flags)
    +@@ src/groupdel.c: static void open_files(const struct option_flags *flags)
    @@ src/groupmems.c
    - #include "alloc/malloc.h"
    + #include "attr.h"
    @@ src/groupmems.c: static void process_flags (int argc, char **argv, struct option
    -@@ src/groupmems.c: static void check_perms (bool process_selinux)
    +@@ src/groupmems.c: check_perms(MAYBE_UNUSED bool process_selinux)
    @@ src/groupmems.c: static void check_perms (bool process_selinux)
    -@@ src/groupmems.c: static void check_perms (bool process_selinux)
    +@@ src/groupmems.c: check_perms(MAYBE_UNUSED bool process_selinux)
    @@ src/groupmems.c: static void open_files (bool process_selinux)
    -@@ src/groupmems.c: static void close_files (struct option_flags *flags)
    +@@ src/groupmems.c: static void close_files(const struct option_flags *flags)
    @@ src/groupmems.c: static void close_files (struct option_flags *flags)
    -@@ src/groupmems.c: static void close_files (struct option_flags *flags)
    +@@ src/groupmems.c: static void close_files(const struct option_flags *flags)
    @@ src/groupmod.c: static void process_flags (int argc, char **argv, struct option_
    -@@ src/groupmod.c: static void close_files (struct option_flags *flags)
    +@@ src/groupmod.c: static void close_files(const struct option_flags *flags)
    @@ src/groupmod.c: static void close_files (struct option_flags *flags)
    -@@ src/groupmod.c: static void close_files (struct option_flags *flags)
    +@@ src/groupmod.c: static void close_files(const struct option_flags *flags)
    @@ src/groupmod.c: static void close_files (struct option_flags *flags)
    -@@ src/groupmod.c: static void close_files (struct option_flags *flags)
    +@@ src/groupmod.c: static void close_files(const struct option_flags *flags)
    @@ src/groupmod.c: static void close_files (struct option_flags *flags)
    -@@ src/groupmod.c: static void lock_files (struct option_flags *flags)
    +@@ src/groupmod.c: static void lock_files(const struct option_flags *flags)
    @@ src/groupmod.c: static void lock_files (struct option_flags *flags)
    -@@ src/groupmod.c: static void lock_files (struct option_flags *flags)
    +@@ src/groupmod.c: static void lock_files(const struct option_flags *flags)
    @@ src/groupmod.c: static void lock_files (struct option_flags *flags)
    -@@ src/groupmod.c: static void lock_files (struct option_flags *flags)
    +@@ src/groupmod.c: static void lock_files(const struct option_flags *flags)
    @@ src/groupmod.c: static void lock_files (struct option_flags *flags)
    -@@ src/groupmod.c: static void lock_files (struct option_flags *flags)
    +@@ src/groupmod.c: static void lock_files(const struct option_flags *flags)
    @@ src/grpck.c: static void open_files (bool process_selinux)
    -@@ src/grpck.c: static void close_files (bool changed, struct option_flags *flags)
    +@@ src/grpck.c: static void close_files(bool changed, const struct option_flags *flags)
    @@ src/grpck.c: static void close_files (bool changed, struct option_flags *flags)
    -@@ src/grpck.c: static void close_files (bool changed, struct option_flags *flags)
    +@@ src/grpck.c: static void close_files(bool changed, const struct option_flags *flags)
    @@ src/grpck.c: static void close_files (bool changed, struct option_flags *flags)
    -@@ src/grpck.c: static void close_files (bool changed, struct option_flags *flags)
    +@@ src/grpck.c: static void close_files(bool changed, const struct option_flags *flags)
    @@ src/grpck.c: static void close_files (bool changed, struct option_flags *flags)
    -@@ src/grpck.c: static void check_grp_file (bool *errors, bool *changed, struct option_flags *fl
    +@@ src/grpck.c: static void check_grp_file(bool *errors, bool *changed, const struct option_flag
    @@ src/grpck.c: static void check_grp_file (bool *errors, bool *changed, struct opt
    -@@ src/grpck.c: static void check_grp_file (bool *errors, bool *changed, struct option_flags *fl
    +@@ src/grpck.c: static void check_grp_file(bool *errors, bool *changed, const struct option_flag
    @@ src/grpconv.c: int main (int argc, char **argv)
    - #else                             /* !SHADOWGRP */
    - int main (MAYBE_UNUSED int argc, char **argv)
    + int
    + main(int, char **argv)
    @@ src/grpunconv.c: int main (int argc, char **argv)
    - #else                             /* !SHADOWGRP */
    - int main (MAYBE_UNUSED int argc, char **argv)
    + int
    + main(int, char **argv)
    @@ src/newusers.c: static void check_flags (void)
    -@@ src/newusers.c: static void check_perms (struct option_flags *flags)
    +@@ src/newusers.c: check_perms(MAYBE_UNUSED const struct option_flags *flags)
    @@ src/newusers.c: static void check_perms (struct option_flags *flags)
    -@@ src/newusers.c: static void check_perms (struct option_flags *flags)
    +@@ src/newusers.c: check_perms(MAYBE_UNUSED const struct option_flags *flags)
    @@ src/newusers.c: static void open_files (bool process_selinux)
    -@@ src/newusers.c: static void close_files (struct option_flags *flags)
    +@@ src/newusers.c: static void close_files(const struct option_flags *flags)
    @@ src/newusers.c: static void close_files (struct option_flags *flags)
    -@@ src/newusers.c: static void close_files (struct option_flags *flags)
    +@@ src/newusers.c: static void close_files(const struct option_flags *flags)
    @@ src/newusers.c: static void close_files (struct option_flags *flags)
    -@@ src/newusers.c: static void close_files (struct option_flags *flags)
    +@@ src/newusers.c: static void close_files(const struct option_flags *flags)
    @@ src/newusers.c: static void close_files (struct option_flags *flags)
    -@@ src/newusers.c: static void close_files (struct option_flags *flags)
    +@@ src/newusers.c: static void close_files(const struct option_flags *flags)
    @@ src/newusers.c: static void close_files (struct option_flags *flags)
    -@@ src/newusers.c: static void close_files (struct option_flags *flags)
    +@@ src/newusers.c: static void close_files(const struct option_flags *flags)
    @@ src/newusers.c: static void close_files (struct option_flags *flags)
    -@@ src/newusers.c: static void close_files (struct option_flags *flags)
    +@@ src/newusers.c: static void close_files(const struct option_flags *flags)
    @@ src/newusers.c: int main (int argc, char **argv)
    -           if (add_passwd (&newpw, fields[1]) != 0) {
    +           if (!streq(fields[1], "") && add_passwd(&newpw, fields[1]) != 0) {
    @@ src/newusers.c: int main (int argc, char **argv)
    -   /* Now update the passwords using PAM */
    -   for (size_t i = 0; i < nusers; i++) {
    +           if (streq(passwords[i], ""))
    +                   continue;
    @@ src/passwd.c: static char *update_crypt_pw (char *cp, bool process_selinux)
    -@@ src/passwd.c: static void update_noshadow (struct option_flags *flags)
    +@@ src/passwd.c: static void update_noshadow(const struct option_flags *flags)
    @@ src/passwd.c: static void update_noshadow (struct option_flags *flags)
    -@@ src/passwd.c: static void update_noshadow (struct option_flags *flags)
    +@@ src/passwd.c: static void update_noshadow(const struct option_flags *flags)
    @@ src/passwd.c: static void update_noshadow (struct option_flags *flags)
    -@@ src/passwd.c: static void update_shadow (struct option_flags *flags)
    +@@ src/passwd.c: static void update_shadow(const struct option_flags *flags)
    @@ src/passwd.c: static void update_shadow (struct option_flags *flags)
    -@@ src/passwd.c: static void update_shadow (struct option_flags *flags)
    +@@ src/passwd.c: static void update_shadow(const struct option_flags *flags)
    @@ src/passwd.c: static void update_shadow (struct option_flags *flags)
    -@@ src/passwd.c: static void update_shadow (struct option_flags *flags)
    +@@ src/passwd.c: static void update_shadow(const struct option_flags *flags)
    @@ src/pwck.c: static void process_flags (int argc, char **argv, struct option_flag
    -@@ src/pwck.c: static void open_files (struct option_flags *flags)
    +@@ src/pwck.c: static void open_files(const struct option_flags *flags)
    @@ src/pwck.c: static void open_files (struct option_flags *flags)
    -@@ src/pwck.c: static void open_files (struct option_flags *flags)
    +@@ src/pwck.c: static void open_files(const struct option_flags *flags)
    @@ src/pwck.c: static void open_files (struct option_flags *flags)
    -@@ src/pwck.c: static void open_files (struct option_flags *flags)
    +@@ src/pwck.c: static void open_files(const struct option_flags *flags)
    @@ src/pwck.c: static void open_files (struct option_flags *flags)
    -@@ src/pwck.c: static void close_files (bool changed, struct option_flags *flags)
    +@@ src/pwck.c: static void close_files(bool changed, const struct option_flags *flags)
    @@ src/pwck.c: static void close_files (bool changed, struct option_flags *flags)
    -@@ src/pwck.c: static void close_files (bool changed, struct option_flags *flags)
    +@@ src/pwck.c: static void close_files(bool changed, const struct option_flags *flags)
    @@ src/pwck.c: static void close_files (bool changed, struct option_flags *flags)
    -@@ src/pwck.c: static void close_files (bool changed, struct option_flags *flags)
    +@@ src/pwck.c: static void close_files(bool changed, const struct option_flags *flags)
    @@ src/pwck.c: static void close_files (bool changed, struct option_flags *flags)
    -@@ src/pwck.c: static void close_files (bool changed, struct option_flags *flags)
    +@@ src/pwck.c: static void close_files(bool changed, const struct option_flags *flags)
    @@ src/pwck.c: static void close_files (bool changed, struct option_flags *flags)
    -@@ src/pwck.c: static void check_pw_file (bool *errors, bool *changed, struct option_flags *fla
    +@@ src/pwck.c: static void check_pw_file(bool *errors, bool *changed, const struct option_flags
    @@ src/pwck.c: static void check_pw_file (bool *errors, bool *changed, struct optio
    -@@ src/pwck.c: static void check_pw_file (bool *errors, bool *changed, struct option_flags *fla
    +@@ src/pwck.c: static void check_pw_file(bool *errors, bool *changed, const struct option_flags
    @@ src/pwck.c: static void check_pw_file (bool *errors, bool *changed, struct optio
    -@@ src/pwck.c: static void check_pw_file (bool *errors, bool *changed, struct option_flags *fla
    +@@ src/pwck.c: static void check_pw_file(bool *errors, bool *changed, const struct option_flags
    @@ src/pwck.c: static void check_pw_file (bool *errors, bool *changed, struct optio
    -@@ src/pwck.c: static void check_pw_file (bool *errors, bool *changed, struct option_flags *fla
    +@@ src/pwck.c: static void check_pw_file(bool *errors, bool *changed, const struct option_flags
    @@ src/pwck.c: static void check_pw_file (bool *errors, bool *changed, struct optio
    -@@ src/pwck.c: static void check_pw_file (bool *errors, bool *changed, struct option_flags *fla
    +@@ src/pwck.c: static void check_pw_file(bool *errors, bool *changed, const struct option_flags
    @@ src/useradd.c: static void fail_exit (int code, bool process_selinux)
    -@@ src/useradd.c: get_defaults(struct option_flags *flags)
    +@@ src/useradd.c: get_defaults(const struct option_flags *flags)
    @@ src/useradd.c: get_defaults(struct option_flags *flags)
    -@@ src/useradd.c: get_defaults(struct option_flags *flags)
    +@@ src/useradd.c: get_defaults(const struct option_flags *flags)
    @@ src/useradd.c: get_defaults(struct option_flags *flags)
    -@@ src/useradd.c: get_defaults(struct option_flags *flags)
    +@@ src/useradd.c: get_defaults(const struct option_flags *flags)
    @@ src/useradd.c: set_defaults(void)
    -@@ src/useradd.c: static int get_groups (char *list, struct option_flags *flags)
    +@@ src/useradd.c: static int get_groups(char *list, const struct option_flags *flags)
    @@ src/useradd.c: static int get_groups (char *list, struct option_flags *flags)
    -@@ src/useradd.c: static int get_groups (char *list, struct option_flags *flags)
    +@@ src/useradd.c: static int get_groups(char *list, const struct option_flags *flags)
    @@ src/useradd.c: static void process_flags (int argc, char **argv, struct option_f
    -@@ src/useradd.c: static void close_files (struct option_flags *flags)
    +@@ src/useradd.c: static void close_files(const struct option_flags *flags)
    @@ src/useradd.c: static void close_files (struct option_flags *flags)
    -@@ src/useradd.c: static void close_files (struct option_flags *flags)
    +@@ src/useradd.c: static void close_files(const struct option_flags *flags)
    @@ src/useradd.c: static void close_files (struct option_flags *flags)
    -@@ src/useradd.c: static void close_files (struct option_flags *flags)
    +@@ src/useradd.c: static void close_files(const struct option_flags *flags)
    @@ src/useradd.c: static void close_files (struct option_flags *flags)
    -@@ src/useradd.c: static void close_files (struct option_flags *flags)
    +@@ src/useradd.c: static void close_files(const struct option_flags *flags)
    @@ src/useradd.c: static void close_files (struct option_flags *flags)
    -@@ src/useradd.c: static void close_files (struct option_flags *flags)
    +@@ src/useradd.c: static void close_files(const struct option_flags *flags)
    @@ src/useradd.c: usr_update (unsigned long subuid_count, unsigned long subgid_coun
    -@@ src/useradd.c: static void create_home (struct option_flags *flags)
    +@@ src/useradd.c: static void create_home(const struct option_flags *flags)
    @@ src/useradd.c: static void create_home (struct option_flags *flags)
    -@@ src/useradd.c: static void create_home (struct option_flags *flags)
    +@@ src/useradd.c: static void create_home(const struct option_flags *flags)
    @@ src/useradd.c: static void create_home (struct option_flags *flags)
    -@@ src/useradd.c: static void create_home (struct option_flags *flags)
    +@@ src/useradd.c: static void create_home(const struct option_flags *flags)
    @@ src/useradd.c: static void create_home (struct option_flags *flags)
    -@@ src/useradd.c: static void create_home (struct option_flags *flags)
    +@@ src/useradd.c: static void create_home(const struct option_flags *flags)
    @@ src/useradd.c: static void create_home (struct option_flags *flags)
    -@@ src/useradd.c: static void create_home (struct option_flags *flags)
    +@@ src/useradd.c: static void create_home(const struct option_flags *flags)
    @@ src/useradd.c: static void create_home (struct option_flags *flags)
    -@@ src/useradd.c: static void create_home (struct option_flags *flags)
    +@@ src/useradd.c: static void create_home(const struct option_flags *flags)
    @@ src/useradd.c: static void create_home (struct option_flags *flags)
    -@@ src/useradd.c: static void create_mail (struct option_flags *flags)
    +@@ src/useradd.c: static void create_mail(const struct option_flags *flags)
    @@ src/useradd.c: static void create_mail (struct option_flags *flags)
    -@@ src/useradd.c: static void create_mail (struct option_flags *flags)
    +@@ src/useradd.c: static void create_mail(const struct option_flags *flags)
    @@ src/userdel.c: static void remove_usergroup (bool process_selinux)
    -@@ src/userdel.c: static void close_files (struct option_flags *flags)
    +@@ src/userdel.c: static void close_files(const struct option_flags *flags)
    @@ src/userdel.c: static void close_files (struct option_flags *flags)
    -@@ src/userdel.c: static void close_files (struct option_flags *flags)
    +@@ src/userdel.c: static void close_files(const struct option_flags *flags)
    @@ src/userdel.c: static void close_files (struct option_flags *flags)
    -@@ src/userdel.c: static void close_files (struct option_flags *flags)
    +@@ src/userdel.c: static void close_files(const struct option_flags *flags)
    @@ src/userdel.c: static void close_files (struct option_flags *flags)
    -@@ src/userdel.c: static void close_files (struct option_flags *flags)
    +@@ src/userdel.c: static void close_files(const struct option_flags *flags)
    @@ src/userdel.c: static void close_files (struct option_flags *flags)
    -@@ src/userdel.c: static void close_files (struct option_flags *flags)
    +@@ src/userdel.c: static void close_files(const struct option_flags *flags)
    @@ src/userdel.c: static void close_files (struct option_flags *flags)
    -@@ src/userdel.c: static void close_files (struct option_flags *flags)
    +@@ src/userdel.c: static void close_files(const struct option_flags *flags)
    @@ src/usermod.c: process_flags(int argc, char **argv, struct option_flags *flags)
    -@@ src/usermod.c: static void close_files (struct option_flags *flags)
    +@@ src/usermod.c: static void close_files(const struct option_flags *flags)
    @@ src/usermod.c: static void close_files (struct option_flags *flags)
    -@@ src/usermod.c: static void close_files (struct option_flags *flags)
    +@@ src/usermod.c: static void close_files(const struct option_flags *flags)
    @@ src/usermod.c: static void close_files (struct option_flags *flags)
    -@@ src/usermod.c: static void close_files (struct option_flags *flags)
    +@@ src/usermod.c: static void close_files(const struct option_flags *flags)
    @@ src/usermod.c: static void close_files (struct option_flags *flags)
    -@@ src/usermod.c: static void close_files (struct option_flags *flags)
    +@@ src/usermod.c: static void close_files(const struct option_flags *flags)
    @@ src/usermod.c: static void close_files (struct option_flags *flags)
    -@@ src/usermod.c: static void close_files (struct option_flags *flags)
    +@@ src/usermod.c: static void close_files(const struct option_flags *flags)
    @@ src/usermod.c: static void close_files (struct option_flags *flags)
    -@@ src/usermod.c: static void close_files (struct option_flags *flags)
    +@@ src/usermod.c: static void close_files(const struct option_flags *flags)
    @@ src/usermod.c: static void close_files (struct option_flags *flags)
    -@@ src/usermod.c: static void close_files (struct option_flags *flags)
    +@@ src/usermod.c: static void close_files(const struct option_flags *flags)
    @@ src/usermod.c: static void close_files (struct option_flags *flags)
    -@@ src/usermod.c: static void close_files (struct option_flags *flags)
    +@@ src/usermod.c: static void close_files(const struct option_flags *flags)
    @@ src/usermod.c: static void close_files (struct option_flags *flags)
    -@@ src/usermod.c: static void close_files (struct option_flags *flags)
    +@@ src/usermod.c: static void close_files(const struct option_flags *flags)
    @@ src/usermod.c: static void open_files (bool process_selinux)
    -@@ src/usermod.c: static void usr_update (struct option_flags *flags)
    +@@ src/usermod.c: static void usr_update(const struct option_flags *flags)
    @@ src/usermod.c: static void usr_update (struct option_flags *flags)
    -@@ src/usermod.c: static void usr_update (struct option_flags *flags)
    +@@ src/usermod.c: static void usr_update(const struct option_flags *flags)
3:  d32a24767 = 3:  1732745e1 lib/io/fprintf/: eprinte(): Add macro
4:  d18c50838 ! 4:  8e5dbae99 lib/, src/: Use eprinte() instead of its pattern
    @@ src/groupadd.c
    -@@ src/groupadd.c: static void open_files (struct option_flags *flags)
    +@@ src/groupadd.c: static void open_files(const struct option_flags *flags)
    @@ src/groupadd.c: static void open_files (struct option_flags *flags)
    -@@ src/groupadd.c: static void open_files (struct option_flags *flags)
    +@@ src/groupadd.c: static void open_files(const struct option_flags *flags)
    @@ src/newusers.c: static int update_passwd (struct passwd *pwd, const char *passwo
    -@@ src/newusers.c: static int add_passwd (struct passwd *pwd, const char *password)
    +@@ src/newusers.c: add_passwd(struct passwd *pwd, MAYBE_UNUSED const char *password)
    @@ src/newusers.c: static int add_passwd (struct passwd *pwd, const char *password)
    -@@ src/newusers.c: static int add_passwd (struct passwd *pwd, const char *password)
    +@@ src/newusers.c: add_passwd(struct passwd *pwd, MAYBE_UNUSED const char *password)
    @@ src/newusers.c: int main (int argc, char **argv)
    -           usernames = REALLOCF(usernames, nusers, char *);
    -           passwords = REALLOCF(passwords, nusers, char *);
    +           usernames = reallocf_T(usernames, nusers, char *);
    +           passwords = reallocf_T(passwords, nusers, char *);
    @@ src/usermod.c: prepend_range(const char *str, struct id_range_list_entry **head)
    -   entry = MALLOC(1, struct id_range_list_entry);
    +   entry = malloc_T(1, struct id_range_list_entry);
5:  185fd3505 = 5:  c1b93d2ec src/userdel.c: Fix error message
```
</details>

v16: <https://github.com/shadow-maint/shadow/pull/1289#issuecomment-3688213292>

<details>
<summary>v16b</summary>

-  Rebase

```
$ git range-diff gh/e..gh/eprintf e..eprintf 
1:  4353e9a7e ! 1:  5c89f0981 lib/io/fprintf/: eprintf(): Add macro to print to stderr
    @@ lib/io/fprintf.h
     +// eprintf - stderr print formatted
     +#define eprintf(...)  fprintf(stderr, __VA_ARGS__)
     +
    - // fprinte - FILE print errno
    - #define fprinte(stream, ...)       fprintec(stream, errno, __VA_ARGS__)
    - // vfprinte - va_list FILE print errno
    ++
    + // fprinte - FILE* print errno
    + #define fprinte(stream, ...)  do                                      \
    + {                                                                     \
2:  69edc43e8 = 2:  40a82ced1 lib/, src/: Use eprintf() instead of its pattern
3:  0938f9c97 ! 3:  593001d46 lib/io/fprintf/: eprinte(): Add macro
    @@ lib/io/fprintf.h
     +// eprinte - stderr print errno
     +#define eprinte(...)  fprinte(stderr, __VA_ARGS__)
     +
    - // fprinte - FILE print errno
    - #define fprinte(stream, ...)       fprintec(stream, errno, __VA_ARGS__)
    - // vfprinte - va_list FILE print errno
    + 
    + // fprinte - FILE* print errno
    + #define fprinte(stream, ...)  do                                      \
4:  57e0eafd6 = 4:  6e71c7410 lib/, src/: Use eprinte() instead of its pattern
5:  60a5920fd = 5:  08d4abe32 src/userdel.c: Fix error message
```
</details>

<details>
<summary>v17</summary>

-  Rebase.
-  Patch 5 is already in master through <https://github.com/shadow-maint/shadow/pull/1448>

```
$ git range-diff gh/e..gh/eprintf e..eprintf 
1:  5c89f0981 = 1:  7a87d6e0f lib/io/fprintf/: eprintf(): Add macro to print to stderr
2:  40a82ced1 ! 2:  67dad9455 lib/, src/: Use eprintf() instead of its pattern
    @@ src/newusers.c: static int get_user_id (const char *uid, uid_t *nuid) {
     @@ src/newusers.c: static int add_user (const char *name, uid_t uid, gid_t gid)
        /* Check if this is a valid user name */
        if (!is_valid_user_name(name)) {
    -           if (errno == EINVAL) {
    +           if (errno == EILSEQ) {
     -                  fprintf(stderr,
     -                          _("%s: invalid user name '%s': use --badname to ignore\n"),
     +                  eprintf(_("%s: invalid user name '%s': use --badname to ignore\n"),
    @@ src/useradd.c: static void process_flags (int argc, char **argv, struct option_f
     @@ src/useradd.c: static void process_flags (int argc, char **argv, struct option_flags *flags)
                user_name = argv[optind];
                if (!is_valid_user_name(user_name)) {
    -                   if (errno == EINVAL) {
    +                   if (errno == EILSEQ) {
     -                          fprintf(stderr,
     -                                  _("%s: invalid user name '%s': use --badname to ignore\n"),
     +                          eprintf(_("%s: invalid user name '%s': use --badname to ignore\n"),
    @@ src/userdel.c: static bool remove_mailbox (void)
     -                   _("%s: %s not owned by %s, not removing\n"),
     +          eprintf(_("%s: %s not owned by %s, not removing\n"),
                         Prog, mailfile, user_name);
    -           SYSLOG(LOG_ERR, "%s not owned by %s, not removed", mailfile, strerrno());
    +           SYSLOG(LOG_ERR, "%s not owned by %s, not removed", mailfile, user_name);
      #ifdef WITH_AUDIT
     @@ src/userdel.c: static int remove_tcbdir (const char *user_name, uid_t user_id)
      
    @@ src/usermod.c: process_flags(int argc, char **argv, struct option_flags *flags)
     @@ src/usermod.c: process_flags(int argc, char **argv, struct option_flags *flags)
                        case 'l':
                                if (!is_valid_user_name(optarg)) {
    -                                   if (errno == EINVAL) {
    +                                   if (errno == EILSEQ) {
     -                                          fprintf(stderr,
     -                                                  _("%s: invalid user name '%s': use --badname to ignore\n"),
     +                                          eprintf(_("%s: invalid user name '%s': use --badname to ignore\n"),
3:  593001d46 = 3:  490893350 lib/io/fprintf/: eprinte(): Add macro
4:  6e71c7410 = 4:  53f4dd852 lib/, src/: Use eprinte() instead of its pattern
5:  08d4abe32 < -:  --------- src/userdel.c: Fix error message
```
</details>

<details>
<summary>v17b</summary>

-  Rebase

```
$ git range-diff gh/e..gh/eprintf e..eprintf 
1:  7a87d6e0f = 1:  641af4f3e lib/io/fprintf/: eprintf(): Add macro to print to stderr
2:  67dad9455 ! 2:  5a6d9dfda lib/, src/: Use eprintf() instead of its pattern
    @@ src/groupmod.c: grp_update(void)
                exit (E_GRP_UPDATE);
        }
     @@ src/groupmod.c: grp_update(void)
    -           ul = user_list;
    -           while (NULL != (u = strsep(&ul, ","))) {
    -                   if (prefix_getpwnam(u) == NULL) {
    --                          fprintf(stderr, _("Invalid member username %s\n"), u);
    -+                          eprintf(_("Invalid member username %s\n"), u);
    -                           exit (E_GRP_UPDATE);
    -                   }
    +                   ul = user_list;
    +                   while (NULL != (u = strsep(&ul, ","))) {
    +                           if (prefix_getpwnam(u) == NULL) {
    +-                                  fprintf(stderr, _("Invalid member username %s\n"), u);
    ++                                  eprintf(_("Invalid member username %s\n"), u);
    +                                   exit(E_GRP_UPDATE);
    +                           }
      
     @@ src/groupmod.c: grp_update(void)
         * Write out the new group file entry.
3:  490893350 = 3:  8e6f0d68a lib/io/fprintf/: eprinte(): Add macro
4:  53f4dd852 = 4:  add48d7c8 lib/, src/: Use eprinte() instead of its pattern
```
</details>

v18: <https://github.com/shadow-maint/shadow/pull/1289#issuecomment-3911263315>

<details>
<summary>v18b</summary>

-  Rebase

```
$ git range-diff gh/e..gh/eprintf e..eprintf -U0
1:  54c59f1bea00 = 1:  2ee394f81e99 lib/io/fprintf/: eprintf(): Add macro to print to stderr
2:  ff9f2118bc9d ! 2:  45452098fa5f lib/, src/: Use eprintf() instead of its pattern
    @@ src/chgpasswd.c: static void process_flags (int argc, char **argv, struct option
    -@@ src/chgpasswd.c: static void check_flags (void)
    +@@ src/chgpasswd.c: static void process_flags (int argc, char **argv, struct option_flags *flags)
    + static void check_flags (void)
    @@ src/chgpasswd.c: static void check_flags (void)
    - #if defined(USE_SHA_CRYPT) || defined(USE_BCRYPT) || defined(USE_YESCRYPT)
    @@ src/chgpasswd.c: static void check_flags (void)
    -@@ src/chgpasswd.c: static void check_flags (void)
    @@ src/chpasswd.c: static void process_flags (int argc, char **argv, struct option_
    -@@ src/chpasswd.c: static void check_flags (void)
    +@@ src/chpasswd.c: static void process_flags (int argc, char **argv, struct option_flags *flags)
    + static void check_flags (void)
    @@ src/chpasswd.c: static void check_flags (void)
    - #if defined(USE_SHA_CRYPT) || defined(USE_BCRYPT) || defined(USE_YESCRYPT)
    @@ src/chpasswd.c: static void check_flags (void)
    -@@ src/chpasswd.c: static void check_flags (void)
    @@ src/chsh.c: int main (int argc, char **argv)
    - ## src/expiry.c ##
    -@@
    - 
    - #include "attr.h"
    - #include "defines.h"
    -+#include "io/fprintf/eprintf.h"
    - #include "prototypes.h"
    - /*@-exitarg@*/
    - #include "exitcodes.h"
    -@@ src/expiry.c: static void process_flags (int argc, char **argv)
    -   }
    - 
    -   if (cflg && fflg) {
    --          fprintf (stderr,
    --                   _("%s: options %s and %s conflict\n"),
    --                   Prog, "-c", "-f");
    -+          eprintf(_("%s: options %s and %s conflict\n"), Prog, "-c", "-f");
    -           usage (E_USAGE);
    -   }
    - 
    -   if (argc != optind) {
    --          fprintf (stderr,
    --                   _("%s: unexpected argument: %s\n"),
    --                   Prog, argv[optind]);
    -+          eprintf(_("%s: unexpected argument: %s\n"), Prog, argv[optind]);
    -           usage (E_USAGE);
    -   }
    - }
    -@@ src/expiry.c: int main (int argc, char **argv)
    -    */
    -   pwd = get_my_pwent ();
    -   if (NULL == pwd) {
    --          fprintf (stderr, _("%s: Cannot determine your user name.\n"),
    --                   Prog);
    -+          eprintf(_("%s: Cannot determine your user name.\n"), Prog);
    -           SYSLOG(LOG_WARN, "Cannot determine the user name of the caller (UID %lu)",
    -                  (unsigned long) getuid());
    -           exit (10);
    -
    @@ src/newusers.c: static void check_flags (void)
    + {
    @@ src/newusers.c: static void check_flags (void)
    - #if defined(USE_SHA_CRYPT) || defined(USE_BCRYPT) || defined(USE_YESCRYPT)
3:  e7b24668a628 = 3:  210a3d0fda0f lib/io/fprintf/: eprinte(): Add macro
4:  3fe3cb52fe8d = 4:  092aab765c66 lib/, src/: Use eprinte() instead of its pattern
```
</details>

<details>
<summary>v18c</summary>

-  Rebase

```
$ git range-diff gh/e..gh/eprintf e..eprintf 
1:  2ee394f8 = 1:  3de1fd9b lib/io/fprintf/: eprintf(): Add macro to print to stderr
2:  45452098 ! 2:  bd45072f lib/, src/: Use eprintf() instead of its pattern
    @@ src/chgpasswd.c: static void process_flags (int argc, char **argv, struct option
                usage (E_USAGE);
        }
      
    -   if ((eflg && (md5flg || cflg)) ||
    -       (md5flg && cflg)) {
    +   if (eflg && cflg) {
     -          fprintf (stderr,
    --                   _("%s: the -c, -e, and -m flags are exclusive\n"),
    -+          eprintf(_("%s: the -c, -e, and -m flags are exclusive\n"),
    -                    Prog);
    +-                   _("%s: the -c and -e flags are exclusive\n"),
    +-                   Prog);
    ++          eprintf(_("%s: the -c and -e flags are exclusive\n"), Prog);
                usage (E_USAGE);
        }
    + 
     @@ src/chgpasswd.c: static void check_flags (void)
                    && !streq(crypt_method, "YESCRYPT")
      #endif                            /* USE_YESCRYPT */
    @@ src/chpasswd.c: static void process_flags (int argc, char **argv, struct option_
                usage (E_USAGE);
        }
      
    -   if ((eflg && (md5flg || cflg)) ||
    -       (md5flg && cflg)) {
    +   if (eflg && cflg) {
     -          fprintf (stderr,
    --                   _("%s: the -c, -e, and -m flags are exclusive\n"),
    +-                   _("%s: the -c and -e flags are exclusive\n"),
     -                   Prog);
    -+          eprintf(_("%s: the -c, -e, and -m flags are exclusive\n"), Prog);
    ++          eprintf(_("%s: the -c and -e flags are exclusive\n"), Prog);
                usage (E_USAGE);
        }
      
3:  210a3d0f = 3:  919875ca lib/io/fprintf/: eprinte(): Add macro
4:  092aab76 = 4:  14f2f16b lib/, src/: Use eprinte() instead of its pattern
```
</details>

<details>
<summary>v18d</summary>

-  Rebase

```
$ git range-diff gh/e..gh/eprintf e..eprintf 
1:  3de1fd9b = 1:  bace42a0 lib/io/fprintf/: eprintf(): Add macro to print to stderr
2:  bd45072f = 2:  f5aa6f25 lib/, src/: Use eprintf() instead of its pattern
3:  919875ca = 3:  13f258a5 lib/io/fprintf/: eprinte(): Add macro
4:  14f2f16b = 4:  2a7ec929 lib/, src/: Use eprinte() instead of its pattern
```
</details>

<details>
<summary>v18e</summary>

-  Rebase

```
$ git range-diff gh/e..gh/eprintf e..eprintf 
1:  bace42a0 = 1:  e93c6045 lib/io/fprintf/: eprintf(): Add macro to print to stderr
2:  f5aa6f25 = 2:  31755bd5 lib/, src/: Use eprintf() instead of its pattern
3:  13f258a5 = 3:  313bd043 lib/io/fprintf/: eprinte(): Add macro
4:  2a7ec929 = 4:  2e794910 lib/, src/: Use eprinte() instead of its pattern
```
</details>

<details>
<summary>v18f</summary>

-  Rebase 

```
$ git range-diff gh/e..gh/eprintf e..eprintf 
1:  e93c6045 = 1:  7ded153c lib/io/fprintf/: eprintf(): Add macro to print to stderr
2:  31755bd5 ! 2:  ae604ba3 lib/, src/: Use eprintf() instead of its pattern
    @@ src/grpconv.c: int main (int argc, char **argv)
        }
     @@ src/grpconv.c: int main (int argc, char **argv)
      int
    - main(int, char **argv)
    + main(MAYBE_UNUSED int _1, char **argv)
      {
     -  fprintf (stderr,
     -           "%s: not configured for shadow group support.\n", argv[0]);
    @@ src/grpunconv.c: int main (int argc, char **argv)
        }
     @@ src/grpunconv.c: int main (int argc, char **argv)
      int
    - main(int, char **argv)
    + main(MAYBE_UNUSED int _1, char **argv)
      {
     -  fprintf (stderr,
     -           "%s: not configured for shadow group support.\n", argv[0]);
3:  313bd043 = 3:  08c5fef1 lib/io/fprintf/: eprinte(): Add macro
4:  2e794910 = 4:  485ecff1 lib/, src/: Use eprinte() instead of its pattern
```
</details>

<details>
<summary>v18g</summary>

-  Rebase

```
$ git range-diff gh/e..gh/eprintf e..eprintf 
1:  7ded153c = 1:  9d21e035 lib/io/fprintf/: eprintf(): Add macro to print to stderr
2:  ae604ba3 = 2:  953dab70 lib/, src/: Use eprintf() instead of its pattern
3:  08c5fef1 = 3:  36e78458 lib/io/fprintf/: eprinte(): Add macro
4:  485ecff1 = 4:  5dcc4918 lib/, src/: Use eprinte() instead of its pattern
```
</details>

<details>
<summary>v18h</summary>

-  Rebase

```
$ git range-diff gh/e..gh/eprintf e..eprintf 
1:  9d21e035 = 1:  fd89ce0b lib/io/fprintf/: eprintf(): Add macro to print to stderr
2:  953dab70 = 2:  73e9f5cc lib/, src/: Use eprintf() instead of its pattern
3:  36e78458 = 3:  4b16aeeb lib/io/fprintf/: eprinte(): Add macro
4:  5dcc4918 = 4:  92938a57 lib/, src/: Use eprinte() instead of its pattern
```
</details>

<details>
<summary>v18i</summary>

-  Rebase

```
$ git range-diff gh/e..gh/eprintf e..eprintf 
1:  fd89ce0b = 1:  fe70e787 lib/io/fprintf/: eprintf(): Add macro to print to stderr
2:  73e9f5cc = 2:  33766672 lib/, src/: Use eprintf() instead of its pattern
3:  4b16aeeb = 3:  4f52dd6d lib/io/fprintf/: eprinte(): Add macro
4:  92938a57 = 4:  18ea85dd lib/, src/: Use eprinte() instead of its pattern
```
</details>

<details>
<summary>v19</summary>

-  Rebase
-  Replace a few more cases I just found.

```
$ git range-diff gh/e..gh/eprintf e..eprintf 
1:  fe70e787 = 1:  3c6b089d lib/io/fprintf/: eprintf(): Add macro to print to stderr
2:  33766672 ! 2:  09180fa2 lib/, src/: Use eprintf() instead of its pattern
    @@ src/faillog.c: int main (int argc, char **argv)
                }
     
      ## src/free_subid_range.c ##
    -@@
    - #include <unistd.h>
    - 
    - #include "atoi/a2i.h"
    -+#include "io/fprintf/eprintf.h"
    - #include "string/strerrno.h"
    - #include "subid.h"
    - #include "stdlib.h"
     @@ src/free_subid_range.c: static const char Prog[] = "free_subid_range";
      
      static void usage(void)
    @@ src/free_subid_range.c: static const char Prog[] = "free_subid_range";
        exit(EXIT_FAILURE);
      }
      
    -@@ src/free_subid_range.c: int main(int argc, char *argv[])
    -   bool group = false;   // get subuids by default
    - 
    -   if (!subid_init(Prog, stderr))
    --          fprintf(stderr, "subid_init: %s\n", strerrno());
    -+          eprintf("subid_init: %s\n", strerrno());
    -   while ((c = getopt(argc, argv, "g")) != EOF) {
    -           switch(c) {
    -           case 'g': group = true; break;
     @@ src/free_subid_range.c: int main(int argc, char *argv[])
                ok = subid_ungrant_uid_range(&range);
      
    @@ src/free_subid_range.c: int main(int argc, char *argv[])
      
     
      ## src/get_subid_owners.c ##
    -@@
    - 
    - #include "atoi/getnum.h"
    - #include "attr.h"
    -+#include "io/fprintf/eprintf.h"
    - #include "prototypes.h"
    - #include "stdlib.h"
    - #include "string/strcmp/streq.h"
     @@ src/get_subid_owners.c: int main(int argc, char *argv[])
                n = subid_get_uid_owners(u, &uids);
        }
    @@ src/get_subid_owners.c: int main(int argc, char *argv[])
      }
     
      ## src/getsubids.c ##
    -@@
    - #include <string.h>
    - 
    - #include "attr.h"
    -+#include "io/fprintf/eprintf.h"
    - #include "prototypes.h"
    - #include "string/strcmp/streq.h"
    - #include "string/strerrno.h"
     @@ src/getsubids.c: int main(int argc, char *argv[])
                count = subid_get_uid_ranges(owner, &ranges);
        }
    @@ src/login.c: int main (int argc, char **argv)
      
     
      ## src/new_subid_range.c ##
    -@@
    - #include <unistd.h>
    - 
    - #include "atoi/a2i.h"
    -+#include "io/fprintf/eprintf.h"
    - #include "string/strerrno.h"
    - #include "subid.h"
    - #include "stdlib.h"
     @@ src/new_subid_range.c: static const char Prog[] = "new_subid_range";
      
      static void usage(void)
    @@ src/new_subid_range.c: static const char Prog[] = "new_subid_range";
        exit(EXIT_FAILURE);
      }
      
    -@@ src/new_subid_range.c: int main(int argc, char *argv[])
    -   bool ok;
    - 
    -   if (!subid_init(Prog, stderr))
    --          fprintf(stderr, "subid_init: %s\n", strerrno());
    -+          eprintf("subid_init: %s\n", strerrno());
    -   while ((c = getopt(argc, argv, "gn")) != EOF) {
    -           switch(c) {
    -           case 'n': makenew = true; break;
     @@ src/new_subid_range.c: int main(int argc, char *argv[])
                ok = subid_grant_uid_range(&range, !makenew);
      
3:  4f52dd6d = 3:  fdcbdc82 lib/io/fprintf/: eprinte(): Add macro
4:  18ea85dd ! 4:  a72d2593 lib/, src/: Use eprinte() instead of its pattern
    @@ src/faillog.c: int main (int argc, char **argv)
                        errors = true;
                }
     
    + ## src/free_subid_range.c ##
    +@@ src/free_subid_range.c: int main(int argc, char *argv[])
    +   bool group = false;   // get subuids by default
    + 
    +   if (!subid_init(Prog, stderr))
    +-          fprinte(stderr, "subid_init");
    ++          eprinte("subid_init");
    +   while ((c = getopt(argc, argv, "g")) != EOF) {
    +           switch(c) {
    +           case 'g': group = true; break;
    +
    + ## src/get_subid_owners.c ##
    +@@ src/get_subid_owners.c: int main(int argc, char *argv[])
    +   uid_t  *uids;
    + 
    +   if (!subid_init(Prog, stderr))
    +-          fprinte(stderr, "subid_init");
    ++          eprinte("subid_init");
    +   if (argc < 2) {
    +           usage();
    +   }
    +
    + ## src/getsubids.c ##
    +@@ src/getsubids.c: int main(int argc, char *argv[])
    +   const char *owner;
    + 
    +   if (!subid_init(Prog, stderr))
    +-          fprinte(stderr, "subid_init");
    ++          eprinte("subid_init");
    +   if (argc < 2)
    +           usage();
    +   owner = argv[1];
    +
      ## src/gpasswd.c ##
     @@ src/gpasswd.c: static void change_passwd (struct group *gr)
        cp = pw_encrypt (pass, salt);
    @@ src/login.c: int main (int argc, char **argv)
                exit (0);
        } else if (child != 0) {
     
    + ## src/new_subid_range.c ##
    +@@ src/new_subid_range.c: int main(int argc, char *argv[])
    +   bool ok;
    + 
    +   if (!subid_init(Prog, stderr))
    +-          fprinte(stderr, "subid_init");
    ++          eprinte("subid_init");
    +   while ((c = getopt(argc, argv, "gn")) != EOF) {
    +           switch(c) {
    +           case 'n': makenew = true; break;
    +
      ## src/newgidmap.c ##
     @@ src/newgidmap.c: static void write_setgroups(int proc_dir_fd, bool allow_setgroups)
                        eprintf(_("%s: kernel doesn't support setgroups restrictions\n"), Prog);
    @@ src/usermod.c: prepend_range(const char *str, struct id_range_list_entry **head)
                return 0;
        }
        entry->next = *head;
    +@@ src/usermod.c: find_range(struct id_range_list_entry **head,
    + 
    +   entry = malloc_T(1, struct id_range_list_entry);
    +   if (entry == NULL) {
    +-          fprinte(stderr, "%s: malloc", Prog);
    ++          eprinte("%s: malloc", Prog);
    +           return 0;
    +   }
    + 
     @@ src/usermod.c: static void update_lastlog (void)
        fd = open(_PATH_LASTLOG, O_RDWR);
      
```
</details>

<details>
<summary>v19b</summary>

-  Rebase

```
$ git range-diff gh/e..gh/eprintf e..eprintf 
1:  3c6b089d = 1:  9fdbf5fc lib/io/fprintf/: eprintf(): Add macro to print to stderr
2:  09180fa2 = 2:  3e22ffa7 lib/, src/: Use eprintf() instead of its pattern
3:  fdcbdc82 = 3:  f92197b4 lib/io/fprintf/: eprinte(): Add macro
4:  a72d2593 = 4:  6f6cf8b6 lib/, src/: Use eprinte() instead of its pattern
```
</details>

<details>
<summary>v19c</summary>

-  Rebase

```
$ git range-diff gh/e..gh/eprintf e..eprintf 
1:  9fdbf5fc = 1:  422109dd lib/io/fprintf/: eprintf(): Add macro to print to stderr
2:  3e22ffa7 = 2:  707e8d15 lib/, src/: Use eprintf() instead of its pattern
3:  f92197b4 = 3:  813d47f6 lib/io/fprintf/: eprinte(): Add macro
4:  6f6cf8b6 = 4:  3298dd92 lib/, src/: Use eprinte() instead of its pattern
```
</details>

<details>
<summary>v19d</summary>

-  Rebase

```
$ git range-diff gh/e..gh/eprintf e..eprintf 
1:  422109dd = 1:  b481298a lib/io/fprintf/: eprintf(): Add macro to print to stderr
2:  707e8d15 = 2:  08d7207e lib/, src/: Use eprintf() instead of its pattern
3:  813d47f6 = 3:  a74fc0de lib/io/fprintf/: eprinte(): Add macro
4:  3298dd92 = 4:  9a432e76 lib/, src/: Use eprinte() instead of its pattern
```
</details>

<details>
<summary>v19e</summary>

-  Rebase

```
$ git range-diff -U0 gh/e..gh/eprintf e..eprintf 
1:  b481298a = 1:  ca88b26b lib/io/fprintf/: eprintf(): Add macro to print to stderr
2:  08d7207e ! 2:  f49c8f8f lib/, src/: Use eprintf() instead of its pattern
    @@ src/chgpasswd.c: int main (int argc, char **argv)
    -   while (fgets(buf, sizeof(buf), stdin) != NULL) {
    +   while (fgets_a(buf, stdin) != NULL) {
    @@ src/newusers.c: int main (int argc, char **argv)
    -   while (fgets(buf, sizeof(buf), stdin) != NULL) {
    +   while (fgets_a(buf, stdin) != NULL) {
    @@ src/useradd.c: static int get_groups(char *list, const struct option_flags *flag
    --                           _("%s: too many groups specified (max %d).\n"),
    -+                  eprintf(_("%s: too many groups specified (max %d).\n"),
    +-                           _("%s: too many groups specified (max %zu).\n"),
    ++                  eprintf(_("%s: too many groups specified (max %zu).\n"),
    @@ src/usermod.c: static int get_groups (char *list)
    --                           _("%s: too many groups specified (max %d).\n"),
    -+                  eprintf(_("%s: too many groups specified (max %d).\n"),
    +-                           _("%s: too many groups specified (max %zu).\n"),
    ++                  eprintf(_("%s: too many groups specified (max %zu).\n"),
    @@ src/usermod.c: static void usr_update(const struct option_flags *flags)
    -       || Lflg || Uflg) {
    +       || Lflg || Uflg || spwd == &spent) {
3:  a74fc0de = 3:  a514c68b lib/io/fprintf/: eprinte(): Add macro
4:  9a432e76 = 4:  c840902e lib/, src/: Use eprinte() instead of its pattern
```
</details>

v20: <https://github.com/shadow-maint/shadow/pull/1289#issuecomment-4071415593>

<details>
<summary>v20b</summary>

-  Rebase

```
$ git range-diff -U0 gh/e..gh/eprintf e..eprintf
1:  481b958d = 1:  392b7d4d lib/io/fprintf/: eprintf(): Add macro to print to stderr
2:  1e528081 ! 2:  95c9c1c5 lib/, src/: Use eprintf() instead of its pattern
    @@ src/groupdel.c: int main (int argc, char **argv)
    - ## src/groupmems.c ##
    -@@
    - #include "attr.h"
    - #include "defines.h"
    - #include "groupio.h"
    -+#include "io/fprintf/eprintf.h"
    - #include "prototypes.h"
    - #ifdef SHADOWGRP
    - #include "sgroupio.h"
    -@@ src/groupmems.c: static void add_user (const char *user,
    - 
    -   /* Make sure the user is not already part of the group */
    -   if (is_on_list (grp->gr_mem, user)) {
    --          fprintf (stderr,
    --                   _("%s: user '%s' is already a member of '%s'\n"),
    -+          eprintf(_("%s: user '%s' is already a member of '%s'\n"),
    -                    Prog, user, grp->gr_name);
    -           fail_exit (EXIT_MEMBER_EXISTS, process_selinux);
    -   }
    - 
    -   newgrp = __gr_dup(grp);
    -   if (NULL == newgrp) {
    --          fprintf (stderr,
    --                   _("%s: Out of memory. Cannot update %s.\n"),
    -+          eprintf(_("%s: Out of memory. Cannot update %s.\n"),
    -                    Prog, gr_dbname ());
    -           fail_exit (13, process_selinux);
    -   }
    -@@ src/groupmems.c: static void add_user (const char *user,
    -           } else {
    -                   newsg = __sgr_dup (sg);
    -                   if (NULL == newsg) {
    --                          fprintf (stderr,
    --                                   _("%s: Out of memory. Cannot update %s.\n"),
    -+                          eprintf(_("%s: Out of memory. Cannot update %s.\n"),
    -                                    Prog, sgr_dbname ());
    -                           fail_exit (13, process_selinux);
    -                   }
    -@@ src/groupmems.c: static void add_user (const char *user,
    -           }
    - 
    -           if (sgr_update (newsg) == 0) {
    --                  fprintf (stderr,
    --                           _("%s: failed to prepare the new %s entry '%s'\n"),
    -+                  eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
    -                            Prog, sgr_dbname (), newsg->sg_namp);
    -                   fail_exit (13, process_selinux);
    -           }
    -@@ src/groupmems.c: static void add_user (const char *user,
    - #endif
    - 
    -   if (gr_update (newgrp) == 0) {
    --          fprintf (stderr,
    --                   _("%s: failed to prepare the new %s entry '%s'\n"),
    -+          eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
    -                    Prog, gr_dbname (), newgrp->gr_name);
    -           fail_exit (13, process_selinux);
    -   }
    -@@ src/groupmems.c: static void remove_user (const char *user,
    - 
    -   /* Check if the user is a member of the specified group */
    -   if (!is_on_list (grp->gr_mem, user)) {
    --          fprintf (stderr,
    --                   _("%s: user '%s' is not a member of '%s'\n"),
    -+          eprintf(_("%s: user '%s' is not a member of '%s'\n"),
    -                    Prog, user, grp->gr_name);
    -           fail_exit (EXIT_NOT_MEMBER, process_selinux);
    -   }
    - 
    -   newgrp = __gr_dup (grp);
    -   if (NULL == newgrp) {
    --          fprintf (stderr,
    --                   _("%s: Out of memory. Cannot update %s.\n"),
    -+          eprintf(_("%s: Out of memory. Cannot update %s.\n"),
    -                    Prog, gr_dbname ());
    -           fail_exit (13, process_selinux);
    -   }
    -@@ src/groupmems.c: static void remove_user (const char *user,
    -           } else {
    -                   newsg = __sgr_dup (sg);
    -                   if (NULL == newsg) {
    --                          fprintf (stderr,
    --                                   _("%s: Out of memory. Cannot update %s.\n"),
    -+                          eprintf(_("%s: Out of memory. Cannot update %s.\n"),
    -                                    Prog, sgr_dbname ());
    -                           fail_exit (13, process_selinux);
    -                   }
    -@@ src/groupmems.c: static void remove_user (const char *user,
    -           }
    - 
    -           if (sgr_update (newsg) == 0) {
    --                  fprintf (stderr,
    --                           _("%s: failed to prepare the new %s entry '%s'\n"),
    -+                  eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
    -                            Prog, sgr_dbname (), newsg->sg_namp);
    -                   fail_exit (13, process_selinux);
    -           }
    -@@ src/groupmems.c: static void remove_user (const char *user,
    - #endif
    - 
    -   if (gr_update (newgrp) == 0) {
    --          fprintf (stderr,
    --                   _("%s: failed to prepare the new %s entry '%s'\n"),
    -+          eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
    -                    Prog, gr_dbname (), newgrp->gr_name);
    -           fail_exit (13, process_selinux);
    -   }
    -@@ src/groupmems.c: static void purge_members (const struct group *grp, bool process_selinux)
    -   struct group *newgrp = __gr_dup (grp);
    - 
    -   if (NULL == newgrp) {
    --          fprintf (stderr,
    --                   _("%s: Out of memory. Cannot update %s.\n"),
    -+          eprintf(_("%s: Out of memory. Cannot update %s.\n"),
    -                    Prog, gr_dbname ());
    -           fail_exit (13, process_selinux);
    -   }
    -@@ src/groupmems.c: static void purge_members (const struct group *grp, bool process_selinux)
    -           } else {
    -                   newsg = __sgr_dup (sg);
    -                   if (NULL == newsg) {
    --                          fprintf (stderr,
    --                                   _("%s: Out of memory. Cannot update %s.\n"),
    -+                          eprintf(_("%s: Out of memory. Cannot update %s.\n"),
    -                                    Prog, sgr_dbname ());
    -                           fail_exit (13, process_selinux);
    -                   }
    -@@ src/groupmems.c: static void purge_members (const struct group *grp, bool process_selinux)
    -           }
    - 
    -           if (sgr_update (newsg) == 0) {
    --                  fprintf (stderr,
    --                           _("%s: failed to prepare the new %s entry '%s'\n"),
    -+                  eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
    -                            Prog, sgr_dbname (), newsg->sg_namp);
    -                   fail_exit (13, process_selinux);
    -           }
    -@@ src/groupmems.c: static void purge_members (const struct group *grp, bool process_selinux)
    - #endif
    - 
    -   if (gr_update (newgrp) == 0) {
    --          fprintf (stderr,
    --                   _("%s: failed to prepare the new %s entry '%s'\n"),
    -+          eprintf(_("%s: failed to prepare the new %s entry '%s'\n"),
    -                    Prog, gr_dbname (), newgrp->gr_name);
    -           fail_exit (13, process_selinux);
    -   }
    -@@ src/groupmems.c: static void process_flags (int argc, char **argv, struct option_flags *flags)
    -   /* local, no need for xgetpwnam */
    -   if (   (NULL != adduser)
    -       && (getpwnam (adduser) == NULL)) {
    --          fprintf (stderr, _("%s: user '%s' does not exist\n"),
    --                   Prog, adduser);
    -+          eprintf(_("%s: user '%s' does not exist\n"), Prog, adduser);
    -           fail_exit (EXIT_INVALID_USER, !flags->chroot);
    -   }
    - 
    -@@ src/groupmems.c: check_perms(MAYBE_UNUSED bool process_selinux)
    - 
    -           pampw = getpwuid (getuid ()); /* local, no need for xgetpwuid */
    -           if (NULL == pampw) {
    --                  fprintf (stderr,
    --                           _("%s: Cannot determine your user name.\n"),
    -+                  eprintf(_("%s: Cannot determine your user name.\n"),
    -                            Prog);
    -                   fail_exit (1, process_selinux);
    -           }
    -@@ src/groupmems.c: check_perms(MAYBE_UNUSED bool process_selinux)
    -           }
    - 
    -           if (PAM_SUCCESS != retval) {
    --                  fprintf (stderr, _("%s: PAM: %s\n"),
    -+                  eprintf(_("%s: PAM: %s\n"),
    -                            Prog, pam_strerror (pamh, retval));
    -                   SYSLOG(LOG_ERR, "%s", pam_strerror(pamh, retval));
    -                   if (NULL != pamh) {
    -@@ src/groupmems.c: static void fail_exit (int code, bool process_selinux)
    - {
    -   if (gr_locked) {
    -           if (gr_unlock (process_selinux) == 0) {
    --                  fprintf (stderr,
    --                           _("%s: failed to unlock %s\n"),
    --                           Prog, gr_dbname ());
    -+                  eprintf(_("%s: failed to unlock %s\n"), Prog, gr_dbname());
    -                   SYSLOG(LOG_ERR, "failed to unlock %s", gr_dbname());
    -                   /* continue */
    -           }
    -@@ src/groupmems.c: static void fail_exit (int code, bool process_selinux)
    - #ifdef SHADOWGRP
    -   if (sgr_locked) {
    -           if (sgr_unlock (process_selinux) == 0) {
    --                  fprintf (stderr,
    --                           _("%s: failed to unlock %s\n"),
    --                           Prog, sgr_dbname ());
    -+                  eprintf(_("%s: failed to unlock %s\n"), Prog, sgr_dbname());
    -                   SYSLOG(LOG_ERR, "failed to unlock %s", sgr_dbname());
    -                   /* continue */
    -           }
    -@@ src/groupmems.c: static void open_files (bool process_selinux)
    - {
    -   if (!list) {
    -           if (gr_lock () == 0) {
    --                  fprintf (stderr,
    --                           _("%s: cannot lock %s; try again later.\n"),
    -+                  eprintf(_("%s: cannot lock %s; try again later.\n"),
    -                            Prog, gr_dbname ());
    -                   fail_exit (EXIT_GROUP_FILE, process_selinux);
    -           }
    -@@ src/groupmems.c: static void open_files (bool process_selinux)
    - #ifdef SHADOWGRP
    -           if (is_shadowgrp) {
    -                   if (sgr_lock () == 0) {
    --                          fprintf (stderr,
    --                                   _("%s: cannot lock %s; try again later.\n"),
    -+                          eprintf(_("%s: cannot lock %s; try again later.\n"),
    -                                    Prog, sgr_dbname ());
    -                           fail_exit (EXIT_GROUP_FILE, process_selinux);
    -                   }
    -@@ src/groupmems.c: static void open_files (bool process_selinux)
    -   }
    - 
    -   if (gr_open (list ? O_RDONLY : O_CREAT | O_RDWR) == 0) {
    --          fprintf (stderr, _("%s: cannot open %s\n"), Prog, gr_dbname ());
    -+          eprintf(_("%s: cannot open %s\n"), Prog, gr_dbname());
    -           fail_exit (EXIT_GROUP_FILE, process_selinux);
    -   }
    - 
    - #ifdef SHADOWGRP
    -   if (is_shadowgrp) {
    -           if (sgr_open (list ? O_RDONLY : O_CREAT | O_RDWR) == 0) {
    --                  fprintf (stderr, _("%s: cannot open %s\n"), Prog, sgr_dbname ());
    -+                  eprintf(_("%s: cannot open %s\n"), Prog, sgr_dbname());
    -                   fail_exit (EXIT_GROUP_FILE, process_selinux);
    -           }
    -   }
    -@@ src/groupmems.c: static void close_files(const struct option_flags *flags)
    -   process_selinux = !flags->chroot;
    - 
    -   if ((gr_close (process_selinux) == 0) && !list) {
    --          fprintf (stderr, _("%s: failure while writing changes to %s\n"), Prog, gr_dbname ());
    -+          eprintf(_("%s: failure while writing changes to %s\n"), Prog, gr_dbname());
    -           SYSLOG(LOG_ERR, "failure while writing changes to %s", gr_dbname());
    -           fail_exit (EXIT_GROUP_FILE, process_selinux);
    -   }
    -   if (gr_locked) {
    -           if (gr_unlock (process_selinux) == 0) {
    --                  fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, gr_dbname ());
    -+                  eprintf(_("%s: failed to unlock %s\n"), Prog, gr_dbname());
    -                   SYSLOG(LOG_ERR, "failed to unlock %s", gr_dbname());
    -                   /* continue */
    -           }
    -@@ src/groupmems.c: static void close_files(const struct option_flags *flags)
    - #ifdef SHADOWGRP
    -   if (is_shadowgrp) {
    -           if ((sgr_close (process_selinux) == 0) && !list) {
    --                  fprintf (stderr, _("%s: failure while writing changes to %s\n"), Prog, sgr_dbname ());
    -+                  eprintf(_("%s: failure while writing changes to %s\n"), Prog, sgr_dbname());
    -                   SYSLOG(LOG_ERR, "failure while writing changes to %s", sgr_dbname());
    -                   fail_exit (EXIT_GROUP_FILE, process_selinux);
    -           }
    -           if (sgr_locked) {
    -                   if (sgr_unlock (process_selinux) == 0) {
    --                          fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, sgr_dbname ());
    -+                          eprintf(_("%s: failed to unlock %s\n"), Prog, sgr_dbname());
    -                           SYSLOG(LOG_ERR, "failed to unlock %s", sgr_dbname());
    -                           /* continue */
    -                   }
    -@@ src/groupmems.c: int main (int argc, char **argv)
    -   if (NULL == thisgroup) {
    -           name = whoami ();
    -           if (!list && (NULL == name)) {
    --                  fprintf (stderr, _("%s: your groupname does not match your username\n"), Prog);
    -+                  eprintf(_("%s: your groupname does not match your username\n"), Prog);
    -                   fail_exit (EXIT_NOT_PRIMARY, process_selinux);
    -           }
    -   } else {
    -           name = thisgroup;
    -           if (!list && !isroot ()) {
    --                  fprintf (stderr, _("%s: only root can use the -g/--group option\n"), Prog);
    -+                  eprintf(_("%s: only root can use the -g/--group option\n"), Prog);
    -                   fail_exit (EXIT_NOT_ROOT, process_selinux);
    -           }
    -   }
    -@@ src/groupmems.c: int main (int argc, char **argv)
    - 
    -   grp = gr_locate (name);
    -   if (NULL == grp) {
    --          fprintf (stderr, _("%s: group '%s' does not exist in %s\n"),
    -+          eprintf(_("%s: group '%s' does not exist in %s\n"),
    -                    Prog, name, gr_dbname ());
    -           fail_exit (EXIT_INVALID_GROUP, process_selinux);
    -   }
    -
3:  17bc7893 = 3:  9a81abf9 lib/io/fprintf/: eprinte(): Add macro
4:  31de827d = 4:  2c73c2f8 lib/, src/: Use eprinte() instead of its pattern
```
</details>

<details>
<summary>v20c</summary>

-  Rebase

```
$ git range-diff -U0 gh/e..gh/eprintf e..eprintf 
1:  392b7d4d = 1:  9e3cd89e lib/io/fprintf/: eprintf(): Add macro to print to stderr
2:  95c9c1c5 ! 2:  8c01a857 lib/, src/: Use eprintf() instead of its pattern
    @@ src/login.c: int main (int argc, char **argv)
    -                           PAM_END;
    +                           pam_end(pamh, retcode);
    @@ src/login.c: int main (int argc, char **argv)
    -                           PAM_END;
    +                           pam_end(pamh, retcode);
3:  9a81abf9 = 3:  a43bbf0f lib/io/fprintf/: eprinte(): Add macro
4:  2c73c2f8 ! 4:  adfa8566 lib/, src/: Use eprinte() instead of its pattern
    @@ src/login.c: int main (int argc, char **argv)
    -           PAM_END;
    +           retcode = pam_close_session(pamh, 0);
    +           pam_end(pamh, retcode);
    @@ src/login.c: int main (int argc, char **argv)
    -   } else if (child != 0) {
```
</details>

<details>
<summary>v21</summary>

-  Rebase
-  Remove bogus `\n` in f/eprinte() calls.

```
$ git range-diff gh/e..gh/eprintf e..eprintf 
1:  9e3cd89e = 1:  c3681663 lib/io/fprintf/: eprintf(): Add macro to print to stderr
2:  8c01a857 ! 2:  840eb551 lib/, src/: Use eprintf() instead of its pattern
    @@ src/newusers.c: int main (int argc, char **argv)
                }
     @@ src/newusers.c: int main (int argc, char **argv)
                        unsigned long sub_uid_count = 0;
    -                   if (find_new_sub_uids(&sub_uid_start, &sub_uid_count) != 0)
    +                   if (find_new_sub_uids(newpw.pw_uid, &sub_uid_start, &sub_uid_count) != 0)
                        {
    --                          fprintf (stderr,
    --                                  _("%s: can't find subordinate user range\n"),
    -+                          eprintf(_("%s: can't find subordinate user range\n"),
    -                                   Prog);
    +-                          fprinte(stderr,
    +-                                  _("%s: can't find subordinate user range"),
    +-                                  Prog);
    ++                          eprinte(_("%s: can't find subordinate user range"), Prog);
    +                           SYSLOGE(LOG_WARN, "can't find subordinate user range");
                                fail_exit (EXIT_FAILURE, process_selinux);
                        }
                        if (sub_uid_add(fields[0], sub_uid_start, sub_uid_count) == 0)
    @@ src/newusers.c: int main (int argc, char **argv)
     @@ src/newusers.c: int main (int argc, char **argv)
                        gid_t sub_gid_start = 0;
                        unsigned long sub_gid_count = 0;
    -                   if (find_new_sub_gids(&sub_gid_start, &sub_gid_count) != 0) {
    --                          fprintf (stderr,
    --                                  _("%s: can't find subordinate group range\n"),
    -+                          eprintf(_("%s: can't find subordinate group range\n"),
    -                                   Prog);
    +                   if (find_new_sub_gids(newpw.pw_uid, &sub_gid_start, &sub_gid_count) != 0) {
    +-                          fprinte(stderr,
    +-                                  _("%s: can't find subordinate group range"),
    +-                                  Prog);
    ++                          eprinte(_("%s: can't find subordinate group range"), Prog);
    +                           SYSLOGE(LOG_WARN, "can't find subordinate group range");
                                fail_exit (EXIT_FAILURE, process_selinux);
                        }
                        if (sub_gid_add(fields[0], sub_gid_start, sub_gid_count) == 0) {
    @@ src/useradd.c: int main (int argc, char **argv)
     @@ src/useradd.c: int main (int argc, char **argv)
      #ifdef ENABLE_SUBIDS
        if (is_sub_uid && subuid_count != 0) {
    -           if (find_new_sub_uids(&sub_uid_start, &subuid_count) < 0) {
    --                  fprintf (stderr,
    --                           _("%s: can't create subordinate user IDs\n"),
    -+                  eprintf(_("%s: can't create subordinate user IDs\n"),
    -                            Prog);
    +           if (find_new_sub_uids(user_id, &sub_uid_start, &subuid_count) < 0) {
    +-                  fprinte(stderr,
    +-                          _("%s: can't create subordinate user IDs"),
    +-                          Prog);
    ++                  eprinte(_("%s: can't create subordinate user IDs"), Prog);
    +                   SYSLOGE(LOG_WARN, "can't create subordinate user IDs");
                        fail_exit(E_SUB_UID_UPDATE, process_selinux);
                }
        }
        if (is_sub_gid && subgid_count != 0) {
    -           if (find_new_sub_gids(&sub_gid_start, &subgid_count) < 0) {
    --                  fprintf (stderr,
    --                           _("%s: can't create subordinate group IDs\n"),
    -+                  eprintf(_("%s: can't create subordinate group IDs\n"),
    -                            Prog);
    +           if (find_new_sub_gids(user_id, &sub_gid_start, &subgid_count) < 0) {
    +-                  fprinte(stderr,
    +-                          _("%s: can't create subordinate group IDs"),
    +-                          Prog);
    ++                  eprinte(_("%s: can't create subordinate group IDs"), Prog);
    +                   SYSLOGE(LOG_WARN, "can't create subordinate group IDs");
                        fail_exit(E_SUB_GID_UPDATE, process_selinux);
                }
     @@ src/useradd.c: int main (int argc, char **argv)
    @@ src/usermod.c: static void move_mailbox (void)
     @@ src/usermod.c: int main (int argc, char **argv)
      #ifdef ENABLE_SUBIDS
        if (Sflg) {
    -           if (find_range (&add_sub_uids, find_new_sub_uids) == 0) {
    --                  fprintf (stderr,
    --                          _("%s: unable to find new subordinate uid range\n"),
    +           if (find_range (&add_sub_uids, user_id, find_new_sub_uids) == 0) {
    +-                  fprinte(stderr,
    +-                          _("%s: unable to find new subordinate uid range"),
     -                          Prog);
    -+                  eprintf(_("%s: unable to find new subordinate uid range\n"), Prog);
    ++                  eprinte(_("%s: unable to find new subordinate uid range"), Prog);
    +                   SYSLOGE(LOG_WARN, "unable to find new subordinate uid range");
                        fail_exit (E_SUB_UID_UPDATE, process_selinux);
                }
    -           if (find_range (&add_sub_gids, find_new_sub_gids) == 0) {
    --                  fprintf (stderr,
    --                          _("%s: unable to find new subordinate gid range\n"),
    +           if (find_range (&add_sub_gids, user_id, find_new_sub_gids) == 0) {
    +-                  fprinte(stderr,
    +-                          _("%s: unable to find new subordinate gid range"),
     -                          Prog);
    -+                  eprintf(_("%s: unable to find new subordinate gid range\n"), Prog);
    ++                  eprinte(_("%s: unable to find new subordinate gid range"), Prog);
    +                   SYSLOGE(LOG_WARN, "unable to find new subordinate gid range");
                        fail_exit (E_SUB_GID_UPDATE, process_selinux);
                }
    -   }
     @@ src/usermod.c: int main (int argc, char **argv)
                        id_t  count = ptr->range.last - ptr->range.first + 1;
      
3:  a43bbf0f = 3:  4035a075 lib/io/fprintf/: eprinte(): Add macro
4:  adfa8566 ! 4:  48f0a9c5 lib/, src/: Use eprinte() instead of its pattern
    @@ src/usermod.c: prepend_range(const char *str, struct id_range_list_entry **head)
                return 0;
        }
        entry->next = *head;
    -@@ src/usermod.c: find_range(struct id_range_list_entry **head,
    +@@ src/usermod.c: find_range(struct id_range_list_entry **head, uid_t uid,
      
        entry = malloc_T(1, struct id_range_list_entry);
        if (entry == NULL) {
```
</details>

<details>
<summary>v22</summary>

-  Rebase

```
$ git range-diff c3681663^..48f0a9c5 HEAD..71e5184e
1:  c3681663 = 1:  7631ace4 lib/io/fprintf/: eprintf(): Add macro to print to stderr
2:  840eb551 ! 2:  f5c89f43 lib/, src/: Use eprintf() instead of its pattern
    @@ src/chfn.c: int main (int argc, char **argv)
                        SYSLOG(LOG_WARN, "Cannot determine the user name of the caller (UID %lu)",
                               (unsigned long) getuid());
     @@ src/chfn.c: int main (int argc, char **argv)
    -           p = stpeprintf(p, e, ",%s", slop);
    +           p = seprintf(p, e, ",%s", slop);
      
        if (p == e || p == NULL) {
     -          fprintf (stderr, _("%s: fields too long\n"), Prog);
    @@ src/useradd.c: static void create_home(const struct option_flags *flags)
                        fail_exit(E_HOMEDIR, process_selinux);
                }
     @@ src/useradd.c: static void create_home(const struct option_flags *flags)
    -                   char *btrfs_check = strdup(path);
    +                   struct statfs  sfs;
      
                        if (!btrfs_check) {
     -                          fprintf(stderr,
    @@ src/useradd.c: static void create_home(const struct option_flags *flags)
                                        Prog, path);
                                fail_exit(E_HOMEDIR, process_selinux);
                        }
    -                   stpcpy(&btrfs_check[strlen(path) - strlen(cp) - 1], "");
    -                   if (is_btrfs(btrfs_check) <= 0) {
    --                          fprintf(stderr,
    --                                  _("%s: home directory \"%s\" must be mounted on BTRFS\n"),
    -+                          eprintf(_("%s: home directory \"%s\" must be mounted on BTRFS\n"),
    -                                   Prog, path);
    +                   if (statfs(dirname(btrfs_check), &sfs) == -1) {
    +-                          fprintf(stderr, "%s: statfs(dirname(\"%s\")): %s\n",
    ++                          eprintf("%s: statfs(dirname(\"%s\")): %s\n",
    +                                   Prog, path, strerrno());
                                fail_exit(E_HOMEDIR, process_selinux);
                        }
                        free(btrfs_check);
    -                   // make subvolume to mount for user instead of directory
    -                   if (btrfs_create_subvolume(path)) {
    +                   if (!is_btrfs(&sfs)) {
     -                          fprintf(stderr,
    --                                  _("%s: failed to create BTRFS subvolume: %s\n"),
    -+                          eprintf(_("%s: failed to create BTRFS subvolume: %s\n"),
    +-                                  _("%s: warning: \"%s\" is not on BTRFS; creating regular directory instead of subvolume\n"),
    ++                          eprintf(_("%s: warning: \"%s\" is not on BTRFS; creating regular directory instead of subvolume\n"),
    +                                   Prog, prefix_user_home);
    +                   } else {
    +                           if (btrfs_create_subvolume(path)) {
    +-                                  fprintf(stderr,
    +-                                          _("%s: failed to create BTRFS subvolume: %s\n"),
    ++                                  eprintf(_("%s: failed to create BTRFS subvolume: %s\n"),
    +                                           Prog, path);
    +                                   fail_exit(E_HOMEDIR, process_selinux);
    +                           }
    +@@ src/useradd.c: static void create_home(const struct option_flags *flags)
    + #endif
    +           if (!dir_created) {
    +                   if (mkdir(path, 0) != 0) {
    +-                          fprintf(stderr, _("%s: cannot create directory %s\n"),
    ++                          eprintf(_("%s: cannot create directory %s\n"),
                                        Prog, path);
                                fail_exit(E_HOMEDIR, process_selinux);
                        }
    -@@ src/useradd.c: static void create_home(const struct option_flags *flags)
    -           else
    - #endif
    -           if (mkdir(path, 0) != 0) {
    --                  fprintf(stderr, _("%s: cannot create directory %s\n"),
    -+                  eprintf(_("%s: cannot create directory %s\n"),
    -                           Prog, path);
    -                   fail_exit(E_HOMEDIR, process_selinux);
                }
                if (chown(path, 0, 0) < 0) {
     -                  fprintf(stderr,
3:  4035a075 = 3:  ba991fc6 lib/io/fprintf/: eprinte(): Add macro
4:  48f0a9c5 = 4:  71e5184e lib/, src/: Use eprinte() instead of its pattern
```
</details>

<details>
<summary>v22b</summary>

-  Rebase

```
$ git range-diff gh/e..gh/eprintf e..eprintf 
1:  7631ace4 = 1:  561d192c lib/io/fprintf/: eprintf(): Add macro to print to stderr
2:  f5c89f43 ! 2:  7c2ed305 lib/, src/: Use eprintf() instead of its pattern
    @@ src/useradd.c: static void create_home(const struct option_flags *flags)
                                        Prog, path);
                                fail_exit(E_HOMEDIR, process_selinux);
                        }
    -                   if (statfs(dirname(btrfs_check), &sfs) == -1) {
    --                          fprintf(stderr, "%s: statfs(dirname(\"%s\")): %s\n",
    -+                          eprintf("%s: statfs(dirname(\"%s\")): %s\n",
    -                                   Prog, path, strerrno());
    -                           fail_exit(E_HOMEDIR, process_selinux);
    +@@ src/useradd.c: static void create_home(const struct option_flags *flags)
                        }
                        free(btrfs_check);
                        if (!is_btrfs(&sfs)) {
3:  ba991fc6 = 3:  7bd642eb lib/io/fprintf/: eprinte(): Add macro
4:  71e5184e ! 4:  310b9e2c lib/, src/: Use eprinte() instead of its pattern
    @@ src/useradd.c: static void lastlog_reset (uid_t uid)
                        Prog, (unsigned long) uid);
                SYSLOG(LOG_WARN, "failed to close the lastlog file for UID %lu", (unsigned long) uid);
                /* continue */
    +@@ src/useradd.c: static void create_home(const struct option_flags *flags)
    +                           fail_exit(E_HOMEDIR, process_selinux);
    +                   }
    +                   if (statfs(dirname(btrfs_check), &sfs) == -1) {
    +-                          fprinte(stderr, "%s: statfs(dirname(\"%s\"))",
    +-                                  Prog, path);
    ++                          eprinte("%s: statfs(dirname(\"%s\"))", Prog, path);
    +                           fail_exit(E_HOMEDIR, process_selinux);
    +                   }
    +                   free(btrfs_check);
     
      ## src/userdel.c ##
     @@ src/userdel.c: static bool remove_mailbox (void)
```
</details>

<details>
<summary>v22c</summary>

-  Rebase

```
$ git range-diff gh/e..gh/eprintf e..eprintf 
1:  561d192c8aab = 1:  ac0cb734281a lib/io/fprintf/: eprintf(): Add macro to print to stderr
2:  7c2ed30500e6 ! 2:  767346d93671 lib/, src/: Use eprintf() instead of its pattern
    @@ src/newusers.c: static int add_group (const char *name, const char *gid, gid_t *
                }
     @@ src/newusers.c: static int get_user_id (const char *uid, uid_t *nuid) {
         */
    -   if (isdigit (uid[0])) {
    +   if (isdigit_c(uid[0])) {
                if ((get_uid(uid, nuid) == -1) || (*nuid == (uid_t)-1)) {
     -                  fprintf (stderr,
     -                           _("%s: invalid user ID '%s'\n"),
    @@ src/passwd.c: main(int argc, char **argv)
     @@ src/passwd.c: main(int argc, char **argv)
        myname = xstrdup (pw->pw_name);
        if (optind < argc) {
    -           if (!is_valid_user_name (argv[optind])) {
    +           if (!is_valid_user_name (argv[optind]) && !is_valid_upn (argv[optind])) {
     -                  fprintf (stderr, _("%s: Provided user name is not a valid name\n"), Prog);
     +                  eprintf(_("%s: Provided user name is not a valid name\n"), Prog);
                        fail_exit (E_NOPERM, process_selinux);
3:  7bd642eb5aee = 3:  cd9841362c0c lib/io/fprintf/: eprinte(): Add macro
4:  310b9e2cf7aa = 4:  df50a6f8d4c9 lib/, src/: Use eprinte() instead of its pattern
```
</details>

v23: <https://github.com/shadow-maint/shadow/pull/1289#issuecomment-4948925779>

v24: <https://github.com/shadow-maint/shadow/pull/1289#issuecomment-4948969862>

<details>
<summary>v24b</summary>

-  Rebase

```
$ git range-diff gh/e..gh/eprintf e..eprintf 
1:  6524f83f5c68 = 1:  12c4de4e46a1 lib/io/fprintf/: eprintf(): Add macro to print to stderr
2:  2a06deb09927 = 2:  39a243276973 lib/, src/: Use eprintf() instead of its pattern
3:  9d7788b4705e = 3:  e09d71cdf62d lib/io/fprintf/: eprinte(): Add macro
4:  b133201f7fe0 = 4:  8baf67f64ba2 lib/, src/: Use eprinte() instead of its pattern
```
</details>

<details>
<summary>v25</summary>

-  Rebase

```
$ git rd 
 1:  33171d8842cc <  -:  ------------ lib/io/: SYSLOG(): Preserve errno
 2:  db70e71798f0 <  -:  ------------ lib/copydir.c: error_acl(): Preserve errno
 3:  2d148f9cd2cd <  -:  ------------ lib/io/fprintf.h: [v]fprintec(): Add functions
 4:  69fa1a43ffe9 <  -:  ------------ lib/copydir.c: error_acl(): Use vfprintec() instead of its pattern
 5:  666a1907b8f5 <  -:  ------------ lib/io/fprintf.h: fprinte(): Add macro
 6:  09bce139b94a <  -:  ------------ lib/, tests/: Use fprinte() instead of its pattern
 7:  edae9444733f <  -:  ------------ lib/io/syslog.h: SYSLOGE[C](): Add macros
 8:  4905ebac5476 <  -:  ------------ lib/, src/: Use SYSLOGE() instead of its pattern
 9:  5bb884194af2 <  -:  ------------ lib/string/: strerrno(): Remove unused macro
10:  3ca0c02b54f1 <  -:  ------------ lib/, src/: Use fprinte() instead of fprintf(3) with %m
11:  ce6b41c293c5 <  -:  ------------ lib/: Use SYSLOGE() instead of SYSLOG() with %m
12:  12c4de4e46a1 =  1:  3db3feb578a1 lib/io/fprintf/: eprintf(): Add macro to print to stderr
13:  39a243276973 !  2:  1dad92306a0d lib/, src/: Use eprintf() instead of its pattern
    @@ src/chfn.c: static void check_fields (bool process_selinux)
     @@ src/chfn.c: int main (int argc, char **argv)
         */
        if (optind < argc) {
    -           if (!is_valid_user_name (argv[optind])) {
    +           if (!is_valid_user_name(argv[optind], true)) {
     -                  fprintf (stderr, _("%s: Provided user name is not a valid name\n"), Prog);
     +                  eprintf(_("%s: Provided user name is not a valid name\n"), Prog);
                        fail_exit (E_NOPERM, process_selinux);
    @@ src/chsh.c: static void update_shell (const char *user, char *newshell, const st
     @@ src/chsh.c: int main (int argc, char **argv)
         */
        if (optind < argc) {
    -           if (!is_valid_user_name (argv[optind])) {
    +           if (!is_valid_user_name(argv[optind], true)) {
     -                  fprintf (stderr, _("%s: Provided user name is not a valid name\n"), Prog);
     +                  eprintf(_("%s: Provided user name is not a valid name\n"), Prog);
                        fail_exit (1, process_selinux);
    @@ src/newgrp.c: int main (int argc, char **argv)
     @@ src/newgrp.c: int main (int argc, char **argv)
                 */
                if ((argc > 0) && (argv[0][0] != '-')) {
    -                   if (!is_valid_group_name (argv[0])) {
    +                   if (!is_valid_group_name(argv[0])) {
     -                          fprintf (
     -                                  stderr, _("%s: provided group is not a valid group name\n"),
     +                          eprintf(_("%s: provided group is not a valid group name\n"),
    @@ src/newgrp.c: int main (int argc, char **argv)
     @@ src/newgrp.c: int main (int argc, char **argv)
                        goto failure;
                } else if (argv[0] != NULL) {
    -                   if (!is_valid_group_name (argv[0])) {
    +                   if (!is_valid_group_name(argv[0])) {
     -                          fprintf (
     -                                  stderr, _("%s: provided group is not a valid group name\n"),
     +                          eprintf(_("%s: provided group is not a valid group name\n"),
    @@ src/newusers.c: static int add_group (const char *name, const char *gid, gid_t *
     @@ src/newusers.c: static int add_group (const char *name, const char *gid, gid_t *ngid, uid_t uid)
      
        /* Check if this is a valid group name */
    -   if (!is_valid_group_name (grent.gr_name)) {
    +   if (!is_valid_group_name(grent.gr_name)) {
     -          fprintf (stderr,
     -                   _("%s: invalid group name '%s'\n"),
     -                   Prog, grent.gr_name);
    @@ src/newusers.c: static int get_user_id (const char *uid, uid_t *nuid) {
                        }
     @@ src/newusers.c: static int add_user (const char *name, uid_t uid, gid_t gid)
        /* Check if this is a valid user name */
    -   if (!is_valid_user_name(name)) {
    +   if (!is_valid_user_name(name, bflg)) {
                if (errno == EILSEQ) {
     -                  fprintf(stderr,
     -                          _("%s: invalid user name '%s': use --badname to ignore\n"),
    @@ src/passwd.c: main(int argc, char **argv)
     @@ src/passwd.c: main(int argc, char **argv)
        myname = xstrdup (pw->pw_name);
        if (optind < argc) {
    -           if (!is_valid_user_name (argv[optind]) && !is_valid_upn (argv[optind])) {
    +           if (!is_valid_user_name(argv[optind], true) && !is_valid_upn(argv[optind], true)) {
     -                  fprintf (stderr, _("%s: Provided user name is not a valid name\n"), Prog);
     +                  eprintf(_("%s: Provided user name is not a valid name\n"), Prog);
                        fail_exit (E_NOPERM, process_selinux);
    @@ src/useradd.c: static void process_flags (int argc, char **argv, struct option_f
        }
     @@ src/useradd.c: static void process_flags (int argc, char **argv, struct option_flags *flags)
                user_name = argv[optind];
    -           if (!is_valid_user_name(user_name)) {
    +           if (!is_valid_user_name(user_name, badnameflg)) {
                        if (errno == EILSEQ) {
     -                          fprintf(stderr,
     -                                  _("%s: invalid user name '%s': use --badname to ignore\n"),
    @@ src/usermod.c: process_flags(int argc, char **argv, struct option_flags *flags)
                                }
     @@ src/usermod.c: process_flags(int argc, char **argv, struct option_flags *flags)
                        case 'l':
    -                           if (!is_valid_user_name(optarg)) {
    +                           if (!is_valid_user_name(optarg, bflg)) {
                                        if (errno == EILSEQ) {
     -                                          fprintf(stderr,
     -                                                  _("%s: invalid user name '%s': use --badname to ignore\n"),
14:  e09d71cdf62d =  3:  2d7b8d2e98e5 lib/io/fprintf/: eprinte(): Add macro
15:  8baf67f64ba2 =  4:  1b77db29b5c4 lib/, src/: Use eprinte() instead of its pattern
```
</details>

<details>
<summary>v25b</summary>

-  Rebase

```
$ git rd 
1:  3db3feb578a1 = 1:  cf4b6248977e lib/io/fprintf/: eprintf(): Add macro to print to stderr
2:  1dad92306a0d ! 2:  320420613b9c lib/, src/: Use eprintf() instead of its pattern
    @@ src/useradd.c: static void unlock_group_files (bool process_selinux)
                fail_exit (E_PW_UPDATE, process_selinux);
        }
      
    -@@ src/useradd.c: static void open_files (bool process_selinux)
    - #ifdef ENABLE_SUBIDS
    +@@ src/useradd.c: static void open_subid_files (bool process_selinux)
    + {
        if (is_sub_uid) {
                if (sub_uid_lock () == 0) {
     -                  fprintf (stderr,
    @@ src/useradd.c: static void open_files (bool process_selinux)
                                 Prog, sub_gid_dbname ());
                        fail_exit (E_SUB_GID_UPDATE, process_selinux);
                }
    -@@ src/useradd.c: static void open_files (bool process_selinux)
    +@@ src/useradd.c: static void open_subid_files (bool process_selinux)
      static void open_group_files (bool process_selinux)
      {
        if (gr_lock () == 0) {
3:  2d7b8d2e98e5 = 3:  538a023ca4b3 lib/io/fprintf/: eprinte(): Add macro
4:  1b77db29b5c4 = 4:  7530d5d9ac4e lib/, src/: Use eprinte() instead of its pattern
```
</details>

<details>
<summary>v25c</summary>

-  Fix includes.

```
$ git rd -U0
1:  cf4b6248977e = 1:  cf4b6248977e lib/io/fprintf/: eprintf(): Add macro to print to stderr
2:  320420613b9c ! 2:  678712b0098f lib/, src/: Use eprintf() instead of its pattern
    @@ src/chfn.c
    -+#include "io/fprintf/eprintf.h"
    ++#include "io/fprintf.h"
    @@ src/chsh.c
    -+#include "io/fprintf/eprintf.h"
    ++#include "io/fprintf.h"
    @@ src/groupdel.c
    -+#include "io/fprintf/eprintf.h"
    ++#include "io/fprintf.h"
    @@ src/groupmod.c
    -+#include "io/fprintf/eprintf.h"
    ++#include "io/fprintf.h"
    @@ src/grpck.c
    -+#include "io/fprintf/eprintf.h"
    ++#include "io/fprintf.h"
    @@ src/grpconv.c
    -+#include "io/fprintf/eprintf.h"
    ++#include "io/fprintf.h"
    @@ src/grpunconv.c
    -+#include "io/fprintf/eprintf.h"
    ++#include "io/fprintf.h"
    @@ src/pwck.c
    -+#include "io/fprintf/eprintf.h"
    ++#include "io/fprintf.h"
    @@ src/pwunconv.c
    -+#include "io/fprintf/eprintf.h"
    ++#include "io/fprintf.h"
    @@ src/su.c
    -+#include "io/fprintf/eprintf.h"
    ++#include "io/fprintf.h"
3:  538a023ca4b3 = 3:  d6f748a86fb0 lib/io/fprintf/: eprinte(): Add macro
4:  7530d5d9ac4e = 4:  0b4effe886aa lib/, src/: Use eprinte() instead of its pattern
```
</details>

<details>
<summary>v25d</summary>

-  Rebase

```
$ git rd -U0
1:  cf4b6248977e = 1:  cf4b6248977e lib/io/fprintf/: eprintf(): Add macro to print to stderr
2:  678712b0098f ! 2:  0e1f4467f49a lib/, src/: Use eprintf() instead of its pattern
    @@ src/pwconv.c
    -+#include "io/fprintf/eprintf.h"
    ++#include "io/fprintf.h"
3:  d6f748a86fb0 = 3:  9db6e305121c lib/io/fprintf/: eprinte(): Add macro
4:  0b4effe886aa = 4:  fbece368d91f lib/, src/: Use eprinte() instead of its pattern
```
</details>

<details>
<summary>v25e</summary>

-  Rebase
-  Reviewed-by: @hallyn 

```
$ git rd -U0
1:  cf4b6248977e ! 1:  7728ac4747c4 lib/io/fprintf/: eprintf(): Add macro to print to stderr
    @@ Commit message
    +    Reviewed-by: Serge Hallyn <serge@hallyn.com>
2:  0e1f4467f49a ! 2:  bef1832fa6ce lib/, src/: Use eprintf() instead of its pattern
    @@ Commit message
    +    Reviewed-by: Serge Hallyn <serge@hallyn.com>
3:  9db6e305121c ! 3:  54b361f1ebcb lib/io/fprintf/: eprinte(): Add macro
    @@ Commit message
    +    Reviewed-by: Serge Hallyn <serge@hallyn.com>
4:  fbece368d91f ! 4:  966b75531a5f lib/, src/: Use eprinte() instead of its pattern
    @@ Commit message
    +    Reviewed-by: Serge Hallyn <serge@hallyn.com>
```
</details>

<details>
<summary>v25f</summary>

-  Rebase

```
$ git rd 
1:  7728ac4747c4 = 1:  60d81dd3f363 lib/io/fprintf/: eprintf(): Add macro to print to stderr
2:  bef1832fa6ce = 2:  59d755d7fe71 lib/, src/: Use eprintf() instead of its pattern
3:  54b361f1ebcb = 3:  3c6ee8d816f1 lib/io/fprintf/: eprinte(): Add macro
4:  966b75531a5f = 4:  4d8b991146b1 lib/, src/: Use eprinte() instead of its pattern
```
</details>