### PR TITLE
Clean up lib/utmp.c and lib/logind.c

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -53,7 +53,6 @@ AC_SYS_LARGEFILE
 dnl Checks for typedefs, structures, and compiler characteristics.
 
 AC_CHECK_MEMBERS([struct utmpx.ut_name,
-                  struct utmpx.ut_host,
                   struct utmpx.ut_syslen,
                   struct utmpx.ut_addr,
                   struct utmpx.ut_addr_v6,

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -151,6 +151,7 @@ libshadow_la_SOURCES = \
 	search/sort/qsort.h \
 	selinux.c \
 	semanage.c \
+	session_management.h \
 	setugid.c \
 	setupenv.c \
 	sgroupio.c \

--- a/lib/limits.c
+++ b/lib/limits.c
@@ -32,6 +32,7 @@
 
 #include "atoi/a2i.h"
 #include "io/fgets/fgets.h"
+#include "session_management.h"
 #include "string/memset/memzero.h"
 #include "string/strcmp/streq.h"
 #include "string/strcmp/strprefix.h"

--- a/lib/logind.c
+++ b/lib/logind.c
@@ -1,8 +1,11 @@
 // SPDX-FileCopyrightText: 2023, Iker Pedrosa <ipedrosa@redhat.com>
+// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
 // SPDX-License-Identifier: BSD-3-Clause
 
 
 #include "config.h"
+
+#include "session_management.h"
 
 #include <systemd/sd-login.h>
 

--- a/lib/logind.c
+++ b/lib/logind.c
@@ -14,9 +14,9 @@
 int
 get_session_host(char **out, pid_t main_pid)
 {
-	char *host = NULL;
-	char *session = NULL;
-	int ret;
+	int   ret;
+	char  *host;
+	char  *session;
 
 	ret = sd_pid_get_session(main_pid, &session);
 	if (ret < 0)
@@ -36,13 +36,10 @@ unsigned long
 active_sessions_count(const char *name, unsigned long)
 {
 	struct passwd  *pw;
-	unsigned long  count = 0;
 
 	pw = prefix_getpwnam(name);
 	if (pw == NULL)
 		return 0;
 
-	count = sd_uid_get_sessions(pw->pw_uid, 0, NULL);
-
-	return count;
+	return sd_uid_get_sessions(pw->pw_uid, 0, NULL);
 }

--- a/lib/logind.c
+++ b/lib/logind.c
@@ -1,50 +1,46 @@
-/*
- * SPDX-FileCopyrightText:  2023, Iker Pedrosa <ipedrosa@redhat.com>
- *
- * SPDX-License-Identifier:  BSD-3-Clause
- */
+// SPDX-FileCopyrightText: 2023, Iker Pedrosa <ipedrosa@redhat.com>
+// SPDX-License-Identifier: BSD-3-Clause
+
 
 #include "config.h"
 
-#ident "$Id$"
+#include <systemd/sd-login.h>
 
 #include "attr.h"
 #include "defines.h"
 #include "prototypes.h"
 
-#include <systemd/sd-login.h>
 
-int get_session_host (char **out, pid_t main_pid)
+int
+get_session_host(char **out, pid_t main_pid)
 {
 	char *host = NULL;
 	char *session = NULL;
 	int ret;
 
 	ret = sd_pid_get_session(main_pid, &session);
-	if (ret < 0) {
+	if (ret < 0)
 		return ret;
-	}
-	ret = sd_session_get_remote_host (session, &host);
-	if (ret < 0) {
+	ret = sd_session_get_remote_host(session, &host);
+	if (ret < 0)
 		goto done;
-	}
 
 	*out = host;
 
 done:
-	free (session);
+	free(session);
 	return ret;
 }
 
-unsigned long active_sessions_count(const char *name, unsigned long)
+unsigned long
+active_sessions_count(const char *name, unsigned long)
 {
-	struct passwd *pw;
-	unsigned long count = 0;
+	struct passwd  *pw;
+	unsigned long  count = 0;
 
 	pw = prefix_getpwnam(name);
-	if (pw == NULL) {
+	if (pw == NULL)
 		return 0;
-	}
 
 	count = sd_uid_get_sessions(pw->pw_uid, 0, NULL);
 

--- a/lib/logind.c
+++ b/lib/logind.c
@@ -25,14 +25,12 @@ get_session_host(char **out, pid_t main_pid)
 	if (ret < 0)
 		return ret;
 	ret = sd_session_get_remote_host(session, &host);
+	free(session);
 	if (ret < 0)
-		goto done;
+		return ret;
 
 	*out = host;
-
-done:
-	free(session);
-	return ret;
+	return 0;
 }
 
 unsigned long

--- a/lib/logind.c
+++ b/lib/logind.c
@@ -25,23 +25,22 @@ ATTR_MALLOC(free) static char *pid_get_session(pid_t pid);
 ATTR_MALLOC(free) static char *session_get_remote_host(char *session);
 
 
-int
-get_session_host(char **out, pid_t main_pid)
+char *
+get_session_host(pid_t main_pid)
 {
 	char  *host;
 	char  *session;
 
 	session = pid_get_session(main_pid);
 	if (session == NULL)
-		return errno;
+		return NULL;
 
 	host = session_get_remote_host(session);
 	free(session);
 	if (host == NULL)
-		return errno;
+		return NULL;
 
-	*out = host;
-	return 0;
+	return host;
 }
 
 

--- a/lib/logind.c
+++ b/lib/logind.c
@@ -22,12 +22,12 @@
 
 
 ATTR_MALLOC(free) static char *pid_get_session(pid_t pid);
+ATTR_MALLOC(free) static char *session_get_remote_host(char *session);
 
 
 int
 get_session_host(char **out, pid_t main_pid)
 {
-	int   ret;
 	char  *host;
 	char  *session;
 
@@ -35,10 +35,10 @@ get_session_host(char **out, pid_t main_pid)
 	if (session == NULL)
 		return errno;
 
-	ret = sd_session_get_remote_host(session, &host);
+	host = session_get_remote_host(session);
 	free(session);
-	if (ret < 0)
-		return ret;
+	if (host == NULL)
+		return errno;
 
 	*out = host;
 	return 0;
@@ -71,4 +71,20 @@ pid_get_session(pid_t pid)
 	}
 
 	return session;
+}
+
+
+static char *
+session_get_remote_host(char *session)
+{
+	int   e;
+	char  *host;
+
+	e = sd_session_get_remote_host(session, &host);
+	if (e < 0) {
+		errno = -e;
+		return NULL;
+	}
+
+	return host;
 }

--- a/lib/prototypes.h
+++ b/lib/prototypes.h
@@ -439,66 +439,6 @@ extern int set_filesize_limit (int blocks);
 /* user_busy.c */
 extern int user_busy (const char *name, uid_t uid);
 
-/*
- * Session management: utmp.c or logind.c
- */
-
-/**
- * @brief Get host for the current session
- *
- * @param[out] out Host name
- * @param[in] main_pid the PID of the main process (the parent PID if
- *                     the process forked itself)
- *
- * @return 0 or a positive integer if the host was obtained properly,
- *         another value on error.
- */
-extern int get_session_host (char **out, pid_t main_pid);
-#ifndef ENABLE_LOGIND
-/**
- * @brief Update or create an utmp entry in utmp, wtmp, utmpw, or wtmpx
- *
- * @param[in] user username
- * @param[in] tty tty
- * @param[in] host hostname
- * @param[in] main_pid the PID of the main process (the parent PID if
- *                     the process forked itself)
- *
- * @return 0 if utmp was updated properly,
- *         1 on error.
- */
-extern int update_utmp (const char *user,
-                        const char *tty,
-                        const char *host,
-                        pid_t main_pid);
-/**
- * @brief Update the cumulative failure log
- *
- * @param[in] failent_user username
- * @param[in] tty tty
- * @param[in] host hostname
- * @param[in] main_pid the PID of the main process (the parent PID if
- *                     the process forked itself)
- *
- */
-extern void record_failure(const char *failent_user,
-                           const char *tty,
-                           const char *hostname,
-                           pid_t main_pid);
-#endif /* ENABLE_LOGIND */
-
-/**
- * @brief Number of active user sessions
- *
- * @param[in] name username
- * @param[in] limit maximum number of active sessions
- *
- * @return number of active sessions.
- *
- */
-extern unsigned long active_sessions_count(const char *name,
-                                           unsigned long limit);
-
 /* valid.c */
 extern bool valid (const char *, const struct passwd *);
 

--- a/lib/session_management.h
+++ b/lib/session_management.h
@@ -13,20 +13,14 @@
 
 #include "config.h"
 
+#include <stdlib.h>
 #include <sys/types.h>
 
+#include "attr.h"
 
-/**
- * @brief Get host for the current session
- *
- * @param[out] out Host name
- * @param[in] main_pid the PID of the main process (the parent PID if
- *                     the process forked itself)
- *
- * @return 0 or a positive integer if the host was obtained properly,
- *         another value on error.
- */
-int get_session_host(char **out, pid_t main_pid);
+
+ATTR_MALLOC(free)
+char *get_session_host(pid_t main_pid);
 
 
 #if !defined(ENABLE_LOGIND)

--- a/lib/session_management.h
+++ b/lib/session_management.h
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+/*
+ * Session management: utmp.c or logind.c
+ */
+
+
+#ifndef SHADOW_INCLUDE_LIB_SESSION_MANAGEMENT_H_
+#define SHADOW_INCLUDE_LIB_SESSION_MANAGEMENT_H_
+
+
+#include "config.h"
+
+#include <sys/types.h>
+
+
+/**
+ * @brief Get host for the current session
+ *
+ * @param[out] out Host name
+ * @param[in] main_pid the PID of the main process (the parent PID if
+ *                     the process forked itself)
+ *
+ * @return 0 or a positive integer if the host was obtained properly,
+ *         another value on error.
+ */
+int get_session_host(char **out, pid_t main_pid);
+
+
+#if !defined(ENABLE_LOGIND)
+/**
+ * @brief Update or create an utmp entry in utmp, wtmp, utmpw, or wtmpx
+ *
+ * @param[in] user username
+ * @param[in] tty tty
+ * @param[in] host hostname
+ * @param[in] main_pid the PID of the main process (the parent PID if
+ *                     the process forked itself)
+ *
+ * @return 0 if utmp was updated properly,
+ *         1 on error.
+ */
+int update_utmp(const char *user, const char *tty, const char *host,
+    pid_t main_pid);
+/**
+ * @brief Update the cumulative failure log
+ *
+ * @param[in] failent_user username
+ * @param[in] tty tty
+ * @param[in] host hostname
+ * @param[in] main_pid the PID of the main process (the parent PID if
+ *                     the process forked itself)
+ *
+ */
+void record_failure(const char *failent_user, const char *tty,
+    const char *hostname, pid_t main_pid);
+#endif /* !ENABLE_LOGIND */
+
+
+/**
+ * @brief Number of active user sessions
+ *
+ * @param[in] name username
+ * @param[in] limit maximum number of active sessions
+ *
+ * @return number of active sessions.
+ *
+ */
+unsigned long active_sessions_count(const char *name, unsigned long limit);
+
+
+#endif  // include guard

--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -10,6 +10,8 @@
 
 #include "config.h"
 
+#include "session_management.h"
+
 #include "defines.h"
 #include "prototypes.h"
 #include "getdef.h"

--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -203,17 +203,12 @@ get_session_host(char **out, pid_t main_pid)
 
 	ut = get_current_utmp(main_pid);
 
-#if defined(HAVE_STRUCT_UTMPX_UT_HOST)
 	if ((ut != NULL) && !strneq_a(ut->ut_host, "")) {
 		*out = xstrndup_a(ut->ut_host);
 	} else {
 		*out = NULL;
 		ret = -2;
 	}
-#else
-	*out = NULL;
-	ret = -2;
-#endif
 
 	free(ut);
 
@@ -274,10 +269,8 @@ prepare_utmp(const char *name, const char *line, const char *host,
 
 	if (NULL != host && !streq(host, ""))
 		hostname = xstrdup(host);
-#if defined(HAVE_STRUCT_UTMPX_UT_HOST)
 	else if (NULL != ut && !strneq_a(ut->ut_host, ""))
 		hostname = xstrndup_a(ut->ut_host);
-#endif
 
 	line = strprefix(line, "/dev/") ?: line;
 
@@ -299,9 +292,7 @@ prepare_utmp(const char *name, const char *line, const char *host,
 	strncpy_a(utent->ut_user, name);
 	if (NULL != hostname) {
 		struct addrinfo *info = NULL;
-#if defined(HAVE_STRUCT_UTMPX_UT_HOST)
 		strncpy_a(utent->ut_host, hostname);
-#endif
 #if defined(HAVE_STRUCT_UTMPX_UT_SYSLEN)
 		utent->ut_syslen = MIN(strlen(hostname),
 		                       sizeof(utent->ut_host));

--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -204,7 +204,7 @@ get_session_host(pid_t main_pid)
 	ut = get_current_utmp(main_pid);
 
 	if ((ut != NULL) && !strneq_a(ut->ut_host, ""))
-		host = xstrndup_a(ut->ut_host);
+		host = strndup_a(ut->ut_host);
 	else
 		host = NULL;
 

--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -195,24 +195,22 @@ get_current_utmp(pid_t main_pid)
 }
 
 
-int
-get_session_host(char **out, pid_t main_pid)
+char *
+get_session_host(pid_t main_pid)
 {
-	int           ret = 0;
+	char          *host;
 	struct utmpx  *ut;
 
 	ut = get_current_utmp(main_pid);
 
-	if ((ut != NULL) && !strneq_a(ut->ut_host, "")) {
-		*out = xstrndup_a(ut->ut_host);
-	} else {
-		*out = NULL;
-		ret = -2;
-	}
+	if ((ut != NULL) && !strneq_a(ut->ut_host, ""))
+		host = xstrndup_a(ut->ut_host);
+	else
+		host = NULL;
 
 	free(ut);
 
-	return ret;
+	return host;
 }
 
 

--- a/src/login.c
+++ b/src/login.c
@@ -38,6 +38,7 @@
 #include "io/fprintf.h"
 #include "prototypes.h"
 #include "pwauth.h"
+#include "session_management.h"
 #include "shadow/gshadow/endsgent.h"
 #include "shadowlog.h"
 #include "string/memset/memzero.h"

--- a/src/login.c
+++ b/src/login.c
@@ -506,12 +506,12 @@ int main (int argc, char **argv)
 	}
 
 	initial_pid = getpid();
-	err = get_session_host(&host, initial_pid);
+	host = get_session_host(initial_pid);
 	/*
 	 * Be picky if run by normal users (possible if installed setuid
 	 * root), but not if run by root.
 	 */
-	if (!amroot && (err != 0)) {
+	if (!amroot && host == NULL) {
 		SYSLOG(LOG_ERR,
 		       "No session entry, error %d.  You must exec \"login\" from the lowest level \"sh\"",
 		       err);

--- a/tests/unit/test_logind.c
+++ b/tests/unit/test_logind.c
@@ -13,8 +13,9 @@
 #include <stdlib.h>
 #include <sys/types.h>
 
-#include "prototypes.h"
 #include "attr.h"
+#include "session_management.h"
+
 
 /***********************
  * WRAPPERS


### PR DESCRIPTION
Cc: @Karlson2k , @ikerexxe 

---

Revisions:

<details>
<summary>v2</summary>

-  Use ENOSYS instead of ENOTSUP  [@ikerexxe ]

```
$ git range-diff shadow/master gh/logind_utmp logind_utmp 
 1:  bfb57d2b =  1:  bfb57d2b lib/logind.c: Fix style
 2:  738ee5d9 =  2:  738ee5d9 lib/logind.c: Remove dead initializations
 3:  00a50759 =  3:  00a50759 lib/: Move utmp.c and logind.c prototypes to new "session_management.h" header
 4:  d3ae3cf1 =  4:  d3ae3cf1 lib/logind.c: get_session_host(): free() earlier, to avoid a goto
 5:  98425add =  5:  98425add lib/logind.c: Wrap libsystemd function in our wrapper get_session()
 6:  7c58ee42 =  6:  7c58ee42 lib/logind.c: Wrap libsystemd function in our wrapper session_get_remote_host()
 7:  7f0fee3e =  7:  7f0fee3e lib/utmp.c: get_session_host(): Fix memory leak
 8:  99d5669b !  8:  c47b572f lib/, src/: get_session_host(): Return the host
    @@ lib/utmp.c: get_current_utmp(void)
      #else
     -  *out = NULL;
     -  ret = -2;
    -+  errno = ENOTSUP;
    ++  errno = ENOSYS;
      #endif
     +  host = NULL;
     +out:
 9:  528997fb =  9:  4fcf0a3d lib/string/strdup/: STRNDUP(): Add macro
10:  2361b195 = 10:  f6b6ec9d lib/utmp.c: get_session_host(): Don't exit from library code
```
</details>

<details>
<summary>v3</summary>

-  Avoid a goto [@hallyn ]

```
$ git range-diff shadow/master gh/logind_utmp logind_utmp 
 1:  bfb57d2b =  1:  bfb57d2b lib/logind.c: Fix style
 2:  738ee5d9 =  2:  738ee5d9 lib/logind.c: Remove dead initializations
 3:  00a50759 =  3:  00a50759 lib/: Move utmp.c and logind.c prototypes to new "session_management.h" header
 4:  d3ae3cf1 =  4:  d3ae3cf1 lib/logind.c: get_session_host(): free() earlier, to avoid a goto
 5:  98425add =  5:  98425add lib/logind.c: Wrap libsystemd function in our wrapper get_session()
 6:  7c58ee42 =  6:  7c58ee42 lib/logind.c: Wrap libsystemd function in our wrapper session_get_remote_host()
 7:  7f0fee3e =  7:  7f0fee3e lib/utmp.c: get_session_host(): Fix memory leak
 -:  -------- >  8:  25bbd1ca lib/utmp.c: get_session_host(): De-duplicate code
 8:  c47b572f !  9:  b40036ec lib/, src/: get_session_host(): Return the host
    @@ lib/utmp.c: get_current_utmp(void)
     +get_session_host(void)
      {
     -  int           ret = 0;
    -+  char          *host;
    ++  char          *host = NULL;
        struct utmpx  *ut;
      
    +-  *out = NULL;
    +-
        ut = get_current_utmp();
      
      #if defined(HAVE_STRUCT_UTMPX_UT_HOST)
    -   if ((ut != NULL) && (ut->ut_host[0] != '\0')) {
    +-  if ((ut != NULL) && (ut->ut_host[0] != '\0')) {
     -          *out = XSTRNDUP(ut->ut_host);
     -  } else {
    --          *out = NULL;
     -          ret = -2;
    +-  }
    ++  if ((ut != NULL) && (ut->ut_host[0] != '\0'))
     +          host = XSTRNDUP(ut->ut_host);
    -+          goto out;
    -   }
      #else
    --  *out = NULL;
     -  ret = -2;
     +  errno = ENOSYS;
      #endif
    -+  host = NULL;
    -+out:
    ++
        free(ut);
      
     -  return ret;
 9:  4fcf0a3d = 10:  181c56d7 lib/string/strdup/: STRNDUP(): Add macro
10:  f6b6ec9d ! 11:  660b4a26 lib/utmp.c: get_session_host(): Don't exit from library code
    @@ lib/utmp.c
     @@ lib/utmp.c: get_session_host(void)
      
      #if defined(HAVE_STRUCT_UTMPX_UT_HOST)
    -   if ((ut != NULL) && (ut->ut_host[0] != '\0')) {
    +   if ((ut != NULL) && (ut->ut_host[0] != '\0'))
     -          host = XSTRNDUP(ut->ut_host);
     +          host = STRNDUP(ut->ut_host);
    -           goto out;
    -   }
      #else
    +   errno = ENOSYS;
    + #endif
```
</details>

<details>
<summary>v4</summary>

-  `#include "config.h"` with quotes.  [@Karlson2k ]

```
$ git range-diff shadow/master gh/logind_utmp logind_utmp 
 1:  bfb57d2b =  1:  bfb57d2b lib/logind.c: Fix style
 2:  738ee5d9 =  2:  738ee5d9 lib/logind.c: Remove dead initializations
 3:  00a50759 !  3:  2def5951 lib/: Move utmp.c and logind.c prototypes to new "session_management.h" header
    @@ lib/session_management.h (new)
     +#define SHADOW_INCLUDE_LIB_SESSION_MANAGEMENT_H_
     +
     +
    -+#include <config.h>
    ++#include "config.h"
     +
     +
     +/**
 4:  d3ae3cf1 =  4:  3687176c lib/logind.c: get_session_host(): free() earlier, to avoid a goto
 5:  98425add =  5:  2060d338 lib/logind.c: Wrap libsystemd function in our wrapper get_session()
 6:  7c58ee42 =  6:  0df3cd6e lib/logind.c: Wrap libsystemd function in our wrapper session_get_remote_host()
 7:  7f0fee3e =  7:  85e3c05e lib/utmp.c: get_session_host(): Fix memory leak
 8:  25bbd1ca =  8:  0bfad9c0 lib/utmp.c: get_session_host(): De-duplicate code
 9:  b40036ec !  9:  e3513b02 lib/, src/: get_session_host(): Return the host
    @@ lib/logind.c: ATTR_MALLOC(free) static char *get_session(void);
      ## lib/session_management.h ##
     @@
      
    - #include <config.h>
    + #include "config.h"
      
     +#include <stdlib.h>
      
10:  181c56d7 ! 10:  3ad35e90 lib/string/strdup/: STRNDUP(): Add macro
    @@ lib/string/strdup/strndup.c (new)
     +// SPDX-License-Identifier: BSD-3-Clause
     +
     +
    -+#include <config.h>
    ++#include "config.h"
     +
     +#include "string/strdup/strndup.h"
     
    @@ lib/string/strdup/strndup.h (new)
     +#define SHADOW_INCLUDE_LIB_STRING_STRDUP_STRNDUP_H_
     +
     +
    -+#include <config.h>
    ++#include "config.h"
     +
     +#include <string.h>
     +
11:  660b4a26 = 11:  92829912 lib/utmp.c: get_session_host(): Don't exit from library code
```
</details>

<details>
<summary>v5</summary>

-  Rebase

```
$ git rd 
 1:  bfb57d2b !  1:  38b8516c lib/logind.c: Fix style
    @@ lib/logind.c
     - *
     - * SPDX-License-Identifier:  BSD-3-Clause
     - */
    -+// SPDX-FileCopyrightText:  2023, Iker Pedrosa <ipedrosa@redhat.com>
    -+// SPDX-License-Identifier:  BSD-3-Clause
    ++// SPDX-FileCopyrightText: 2023, Iker Pedrosa <ipedrosa@redhat.com>
    ++// SPDX-License-Identifier: BSD-3-Clause
     +
      
    - #include <config.h>
    + #include "config.h"
      
     -#ident "$Id$"
     +#include <systemd/sd-login.h>
    @@ lib/logind.c
      
     -#include <systemd/sd-login.h>
      
    --int get_session_host (char **out)
    +-int get_session_host (char **out, pid_t main_pid)
     +int
    -+get_session_host(char **out)
    ++get_session_host(char **out, pid_t main_pid)
      {
     -    char *host = NULL;
     -    char *session = NULL;
    @@ lib/logind.c
     +  char *session = NULL;
     +  int ret;
      
    --    ret = sd_pid_get_session (getpid(), &session);
    +-    ret = sd_pid_get_session(main_pid, &session);
     -    if (ret < 0) {
     -        return ret;
     -    }
    @@ lib/logind.c
     -    if (ret < 0) {
     -        goto done;
     -    }
    -+  ret = sd_pid_get_session(getpid(), &session);
    ++  ret = sd_pid_get_session(main_pid, &session);
     +  if (ret < 0)
     +          return ret;
     +  ret = sd_session_get_remote_host(session, &host);
 2:  738ee5d9 !  2:  c8e0f20f lib/logind.c: Remove dead initializations
    @@ Commit message
      ## lib/logind.c ##
     @@
      int
    - get_session_host(char **out)
    + get_session_host(char **out, pid_t main_pid)
      {
     -  char *host = NULL;
     -  char *session = NULL;
    @@ lib/logind.c
     +  char  *host;
     +  char  *session;
      
    -   ret = sd_pid_get_session(getpid(), &session);
    +   ret = sd_pid_get_session(main_pid, &session);
        if (ret < 0)
     @@ lib/logind.c: unsigned long
      active_sessions_count(const char *name, MAYBE_UNUSED unsigned long limit)
 3:  2def5951 !  3:  95211a21 lib/: Move utmp.c and logind.c prototypes to new "session_management.h" header
    @@ lib/limits.c
     
      ## lib/logind.c ##
     @@
    - // SPDX-FileCopyrightText:  2023, Iker Pedrosa <ipedrosa@redhat.com>
    -+// SPDX-FileCopyrightText:  2025, Alejandro Colomar <alx@kernel.org>
    - // SPDX-License-Identifier:  BSD-3-Clause
    + // SPDX-FileCopyrightText: 2023, Iker Pedrosa <ipedrosa@redhat.com>
    ++// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
    + // SPDX-License-Identifier: BSD-3-Clause
      
      
    - #include <config.h>
    + #include "config.h"
      
     +#include "session_management.h"
     +
    @@ lib/prototypes.h: extern int set_filesize_limit (int blocks);
     - * @brief Get host for the current session
     - *
     - * @param[out] out Host name
    +- * @param[in] main_pid the PID of the main process (the parent PID if
    +- *                     the process forked itself)
     - *
     - * @return 0 or a positive integer if the host was obtained properly,
     - *         another value on error.
     - */
    --extern int get_session_host (char **out);
    +-extern int get_session_host (char **out, pid_t main_pid);
     -#ifndef ENABLE_LOGIND
     -/**
     - * @brief Update or create an utmp entry in utmp, wtmp, utmpw, or wtmpx
    @@ lib/prototypes.h: extern int set_filesize_limit (int blocks);
     - * @param[in] user username
     - * @param[in] tty tty
     - * @param[in] host hostname
    +- * @param[in] main_pid the PID of the main process (the parent PID if
    +- *                     the process forked itself)
     - *
     - * @return 0 if utmp was updated properly,
     - *         1 on error.
     - */
     -extern int update_utmp (const char *user,
     -                        const char *tty,
    --                        const char *host);
    +-                        const char *host,
    +-                        pid_t main_pid);
     -/**
     - * @brief Update the cumulative failure log
     - *
     - * @param[in] failent_user username
     - * @param[in] tty tty
     - * @param[in] host hostname
    +- * @param[in] main_pid the PID of the main process (the parent PID if
    +- *                     the process forked itself)
     - *
     - */
     -extern void record_failure(const char *failent_user,
     -                           const char *tty,
    --                           const char *hostname);
    +-                           const char *hostname,
    +-                           pid_t main_pid);
     -#endif /* ENABLE_LOGIND */
     -
     -/**
    @@ lib/session_management.h (new)
     +
     +#include "config.h"
     +
    ++#include <sys/types.h>
    ++
     +
     +/**
     + * @brief Get host for the current session
     + *
     + * @param[out] out Host name
    ++ * @param[in] main_pid the PID of the main process (the parent PID if
    ++ *                     the process forked itself)
     + *
     + * @return 0 or a positive integer if the host was obtained properly,
     + *         another value on error.
     + */
    -+int get_session_host(char **out);
    ++int get_session_host(char **out, pid_t main_pid);
     +
     +
     +#if !defined(ENABLE_LOGIND)
    @@ lib/session_management.h (new)
     + * @param[in] user username
     + * @param[in] tty tty
     + * @param[in] host hostname
    ++ * @param[in] main_pid the PID of the main process (the parent PID if
    ++ *                     the process forked itself)
     + *
     + * @return 0 if utmp was updated properly,
     + *         1 on error.
     + */
    -+int update_utmp(const char *user, const char *tty, const char *host);
    ++int update_utmp(const char *user, const char *tty, const char *host,
    ++    pid_t main_pid);
     +/**
     + * @brief Update the cumulative failure log
     + *
     + * @param[in] failent_user username
     + * @param[in] tty tty
     + * @param[in] host hostname
    ++ * @param[in] main_pid the PID of the main process (the parent PID if
    ++ *                     the process forked itself)
     + *
     + */
     +void record_failure(const char *failent_user, const char *tty,
    -+    const char *hostname);
    ++    const char *hostname, pid_t main_pid);
     +#endif /* !ENABLE_LOGIND */
     +
     +
    @@ lib/session_management.h (new)
      ## lib/utmp.c ##
     @@
      
    - #include <config.h>
    + #include "config.h"
      
     +#include "session_management.h"
     +
 4:  3687176c !  4:  bb38cff0 lib/logind.c: get_session_host(): free() earlier, to avoid a goto
    @@ Commit message
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/logind.c ##
    -@@ lib/logind.c: get_session_host(char **out)
    +@@ lib/logind.c: get_session_host(char **out, pid_t main_pid)
        if (ret < 0)
                return ret;
        ret = sd_session_get_remote_host(session, &host);
 5:  2060d338 !  5:  5d73f429 lib/logind.c: Wrap libsystemd function in our wrapper get_session()
    @@ lib/logind.c
     +#include <pwd.h>
     +#include <stddef.h>
     +#include <stdlib.h>
    ++#include <sys/types.h>
     +#include <unistd.h>
     +
      #include <systemd/sd-login.h>
    @@ lib/logind.c
      #include "prototypes.h"
      
      
    -+ATTR_MALLOC(free) static char *get_session(void);
    ++ATTR_MALLOC(free) static char *pid_get_session(pid_t pid);
     +
     +
      int
    - get_session_host(char **out)
    + get_session_host(char **out, pid_t main_pid)
      {
    -@@ lib/logind.c: get_session_host(char **out)
    +@@ lib/logind.c: get_session_host(char **out, pid_t main_pid)
        char  *host;
        char  *session;
      
    --  ret = sd_pid_get_session(getpid(), &session);
    +-  ret = sd_pid_get_session(main_pid, &session);
     -  if (ret < 0)
     -          return ret;
    -+  session = get_session();
    ++  session = pid_get_session(main_pid);
     +  if (session == NULL)
     +          return errno;
     +
        ret = sd_session_get_remote_host(session, &host);
        free(session);
        if (ret < 0)
    -@@ lib/logind.c: get_session_host(char **out)
    +@@ lib/logind.c: get_session_host(char **out, pid_t main_pid)
        return 0;
      }
      
    @@ lib/logind.c: active_sessions_count(const char *name, MAYBE_UNUSED unsigned long
     +
     +
     +static char *
    -+get_session(void)
    ++pid_get_session(pid_t pid)
     +{
     +  int   e;
     +  char  *session;
     +
    -+  e = sd_pid_get_session(getpid(), &session);
    ++  e = sd_pid_get_session(pid, &session);
     +  if (e < 0) {
     +          errno = -e;
     +          return NULL;
 6:  0df3cd6e !  6:  f4e39432 lib/logind.c: Wrap libsystemd function in our wrapper session_get_remote_host()
    @@ lib/logind.c
     @@
      
      
    - ATTR_MALLOC(free) static char *get_session(void);
    + ATTR_MALLOC(free) static char *pid_get_session(pid_t pid);
     +ATTR_MALLOC(free) static char *session_get_remote_host(char *session);
      
      
      int
    - get_session_host(char **out)
    + get_session_host(char **out, pid_t main_pid)
      {
     -  int   ret;
        char  *host;
        char  *session;
      
    -@@ lib/logind.c: get_session_host(char **out)
    +@@ lib/logind.c: get_session_host(char **out, pid_t main_pid)
        if (session == NULL)
                return errno;
      
    @@ lib/logind.c: get_session_host(char **out)
      
        *out = host;
        return 0;
    -@@ lib/logind.c: get_session(void)
    +@@ lib/logind.c: pid_get_session(pid_t pid)
      
        return session;
      }
 7:  85e3c05e !  7:  5708040f lib/utmp.c: get_session_host(): Fix memory leak
    @@ Commit message
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/utmp.c ##
    -@@ lib/utmp.c: get_session_host(char **out)
    +@@ lib/utmp.c: get_session_host(char **out, pid_t main_pid)
      #if defined(HAVE_STRUCT_UTMPX_UT_HOST)
        if ((ut != NULL) && (ut->ut_host[0] != '\0')) {
                *out = XSTRNDUP(ut->ut_host);
    @@ lib/utmp.c: get_session_host(char **out)
        } else {
                *out = NULL;
                ret = -2;
    -@@ lib/utmp.c: get_session_host(char **out)
    +@@ lib/utmp.c: get_session_host(char **out, pid_t main_pid)
        *out = NULL;
        ret = -2;
      #endif
 8:  0bfad9c0 !  8:  4525e661 lib/utmp.c: get_session_host(): De-duplicate code
    @@ Commit message
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/utmp.c ##
    -@@ lib/utmp.c: get_session_host(char **out)
    +@@ lib/utmp.c: get_session_host(char **out, pid_t main_pid)
        int           ret = 0;
        struct utmpx  *ut;
      
     +  *out = NULL;
     +
    -   ut = get_current_utmp();
    +   ut = get_current_utmp(main_pid);
      
      #if defined(HAVE_STRUCT_UTMPX_UT_HOST)
        if ((ut != NULL) && (ut->ut_host[0] != '\0')) {
 9:  e3513b02 !  9:  b581254e lib/, src/: get_session_host(): Return the host
    @@ Commit message
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/logind.c ##
    -@@ lib/logind.c: ATTR_MALLOC(free) static char *get_session(void);
    +@@ lib/logind.c: ATTR_MALLOC(free) static char *pid_get_session(pid_t pid);
      ATTR_MALLOC(free) static char *session_get_remote_host(char *session);
      
      
     -int
    --get_session_host(char **out)
    +-get_session_host(char **out, pid_t main_pid)
     +char *
    -+get_session_host(void)
    ++get_session_host(pid_t main_pid)
      {
        char  *host;
        char  *session;
      
    -   session = get_session();
    +   session = pid_get_session(main_pid);
        if (session == NULL)
     -          return errno;
     +          return NULL;
    @@ lib/session_management.h
      #include "config.h"
      
     +#include <stdlib.h>
    + #include <sys/types.h>
    + 
    ++#include "attr.h"
      
     -/**
     - * @brief Get host for the current session
     - *
     - * @param[out] out Host name
    +- * @param[in] main_pid the PID of the main process (the parent PID if
    +- *                     the process forked itself)
     - *
     - * @return 0 or a positive integer if the host was obtained properly,
     - *         another value on error.
     - */
    --int get_session_host(char **out);
    -+#include "attr.h"
    -+
    +-int get_session_host(char **out, pid_t main_pid);
     +
     +ATTR_MALLOC(free)
    -+char *get_session_host(void);
    ++char *get_session_host(pid_t main_pid);
      
      
      #if !defined(ENABLE_LOGIND)
     
      ## lib/utmp.c ##
    -@@ lib/utmp.c: get_current_utmp(void)
    +@@ lib/utmp.c: get_current_utmp(pid_t main_pid)
      }
      
      
     -int
    --get_session_host(char **out)
    +-get_session_host(char **out, pid_t main_pid)
     +char *
    -+get_session_host(void)
    ++get_session_host(pid_t main_pid)
      {
     -  int           ret = 0;
     +  char          *host = NULL;
    @@ lib/utmp.c: get_current_utmp(void)
      
     -  *out = NULL;
     -
    -   ut = get_current_utmp();
    +   ut = get_current_utmp(main_pid);
      
      #if defined(HAVE_STRUCT_UTMPX_UT_HOST)
     -  if ((ut != NULL) && (ut->ut_host[0] != '\0')) {
    @@ lib/utmp.c: get_current_utmp(void)
     
      ## src/login.c ##
     @@ src/login.c: int main (int argc, char **argv)
    -           exit (1);       /* must be a terminal */
        }
      
    --  err = get_session_host(&host);
    -+  host = get_session_host();
    +   initial_pid = getpid();
    +-  err = get_session_host(&host, initial_pid);
    ++  host = get_session_host(initial_pid);
        /*
         * Be picky if run by normal users (possible if installed setuid
         * root), but not if run by root.
10:  3ad35e90 = 10:  6b2491e3 lib/string/strdup/: STRNDUP(): Add macro
11:  92829912 ! 11:  efff3048 lib/utmp.c: get_session_host(): Don't exit from library code
    @@ lib/utmp.c
      
      #define UTX_LINESIZE  countof(memberof(struct utmpx, ut_line))
      
    -@@ lib/utmp.c: get_session_host(void)
    +@@ lib/utmp.c: get_session_host(pid_t main_pid)
      
      #if defined(HAVE_STRUCT_UTMPX_UT_HOST)
        if ((ut != NULL) && (ut->ut_host[0] != '\0'))
```
</details>

<details>
<summary>v6</summary>

-  Assume `ut_host` exists.

```
$ git range-diff shadow/master gh/logind_utmp logind_utmp 
 1:  38b8516c =  1:  38b8516c lib/logind.c: Fix style
 2:  c8e0f20f =  2:  c8e0f20f lib/logind.c: Remove dead initializations
 3:  95211a21 =  3:  95211a21 lib/: Move utmp.c and logind.c prototypes to new "session_management.h" header
 4:  bb38cff0 =  4:  bb38cff0 lib/logind.c: get_session_host(): free() earlier, to avoid a goto
 5:  5d73f429 =  5:  5d73f429 lib/logind.c: Wrap libsystemd function in our wrapper get_session()
 6:  f4e39432 =  6:  f4e39432 lib/logind.c: Wrap libsystemd function in our wrapper session_get_remote_host()
 7:  5708040f =  7:  5708040f lib/utmp.c: get_session_host(): Fix memory leak
 8:  4525e661 =  8:  4525e661 lib/utmp.c: get_session_host(): De-duplicate code
 9:  b581254e =  9:  b581254e lib/, src/: get_session_host(): Return the host
10:  6b2491e3 = 10:  6b2491e3 lib/string/strdup/: STRNDUP(): Add macro
11:  efff3048 = 11:  efff3048 lib/utmp.c: get_session_host(): Don't exit from library code
 -:  -------- > 12:  f22dfbd7 configure.ac, lib/utmp.c: Assume utmpx(5) has ut_host
```
</details>

<details>
<summary>v7</summary>

-  Reorder commits, so that one can be dropped, and an initialization can be replaced by an assignment.

```
$ git range-diff shadow/master gh/logind_utmp logind_utmp 
 1:  38b8516c =  1:  38b8516c lib/logind.c: Fix style
 2:  c8e0f20f =  2:  c8e0f20f lib/logind.c: Remove dead initializations
 3:  95211a21 =  3:  95211a21 lib/: Move utmp.c and logind.c prototypes to new "session_management.h" header
 4:  bb38cff0 =  4:  bb38cff0 lib/logind.c: get_session_host(): free() earlier, to avoid a goto
 5:  5d73f429 =  5:  5d73f429 lib/logind.c: Wrap libsystemd function in our wrapper get_session()
 6:  f4e39432 =  6:  f4e39432 lib/logind.c: Wrap libsystemd function in our wrapper session_get_remote_host()
 7:  5708040f <  -:  -------- lib/utmp.c: get_session_host(): Fix memory leak
 8:  4525e661 <  -:  -------- lib/utmp.c: get_session_host(): De-duplicate code
12:  f22dfbd7 !  7:  ffa5ad10 configure.ac, lib/utmp.c: Assume utmpx(5) has ut_host
    @@ configure.ac: AC_SYS_LARGEFILE
                        struct utmpx.ut_addr_v6,
     
      ## lib/utmp.c ##
    -@@ lib/utmp.c: get_session_host(pid_t main_pid)
    +@@ lib/utmp.c: get_session_host(char **out, pid_t main_pid)
      
        ut = get_current_utmp(main_pid);
      
     -#if defined(HAVE_STRUCT_UTMPX_UT_HOST)
    -   if ((ut != NULL) && (ut->ut_host[0] != '\0'))
    -           host = STRNDUP(ut->ut_host);
    +   if ((ut != NULL) && (ut->ut_host[0] != '\0')) {
    +           *out = XSTRNDUP(ut->ut_host);
    +           free (ut);
    +@@ lib/utmp.c: get_session_host(char **out, pid_t main_pid)
    +           *out = NULL;
    +           ret = -2;
    +   }
     -#else
    --  errno = ENOSYS;
    +-  *out = NULL;
    +-  ret = -2;
     -#endif
      
    -   free(ut);
    - 
    +   return ret;
    + }
     @@ lib/utmp.c: prepare_utmp(const char *name, const char *line, const char *host,
      
        if (NULL != host && !streq(host, ""))
 -:  -------- >  8:  f78826d0 lib/utmp.c: get_session_host(): Fix memory leak
 9:  b581254e !  9:  806dff1b lib/, src/: get_session_host(): Return the host
    @@ lib/utmp.c: get_current_utmp(pid_t main_pid)
     +get_session_host(pid_t main_pid)
      {
     -  int           ret = 0;
    -+  char          *host = NULL;
    ++  char          *host;
        struct utmpx  *ut;
      
    --  *out = NULL;
    --
        ut = get_current_utmp(main_pid);
      
    - #if defined(HAVE_STRUCT_UTMPX_UT_HOST)
     -  if ((ut != NULL) && (ut->ut_host[0] != '\0')) {
     -          *out = XSTRNDUP(ut->ut_host);
     -  } else {
    +-          *out = NULL;
     -          ret = -2;
     -  }
     +  if ((ut != NULL) && (ut->ut_host[0] != '\0'))
     +          host = XSTRNDUP(ut->ut_host);
    - #else
    --  ret = -2;
    -+  errno = ENOSYS;
    - #endif
    -+
    ++  else
    ++          host = NULL;
    + 
        free(ut);
      
     -  return ret;
10:  6b2491e3 = 10:  ab38ff9d lib/string/strdup/: STRNDUP(): Add macro
11:  efff3048 ! 11:  5a2eb4e8 lib/utmp.c: get_session_host(): Don't exit from library code
    @@ lib/utmp.c
      #define UTX_LINESIZE  countof(memberof(struct utmpx, ut_line))
      
     @@ lib/utmp.c: get_session_host(pid_t main_pid)
    +   ut = get_current_utmp(main_pid);
      
    - #if defined(HAVE_STRUCT_UTMPX_UT_HOST)
        if ((ut != NULL) && (ut->ut_host[0] != '\0'))
     -          host = XSTRNDUP(ut->ut_host);
     +          host = STRNDUP(ut->ut_host);
    - #else
    -   errno = ENOSYS;
    - #endif
    +   else
    +           host = NULL;
    + 
```
```diff
$ git diff gh/logind_utmp 
diff --git c/lib/utmp.c w/lib/utmp.c
index 4cc7a394..52f9303c 100644
--- c/lib/utmp.c
+++ w/lib/utmp.c
@@ -189,13 +189,15 @@ get_current_utmp(pid_t main_pid)
 char *
 get_session_host(pid_t main_pid)
 {
-       char          *host = NULL;
+       char          *host;
        struct utmpx  *ut;
 
        ut = get_current_utmp(main_pid);
 
        if ((ut != NULL) && (ut->ut_host[0] != '\0'))
                host = STRNDUP(ut->ut_host);
+       else
+               host = NULL;
 
        free(ut);
 
```
</details>

<details>
<summary>v7b</summary>

-  Rebase

```
$ git rd 
 1:  38b8516c =  1:  0b8acee3 lib/logind.c: Fix style
 2:  c8e0f20f =  2:  7a7842e5 lib/logind.c: Remove dead initializations
 3:  95211a21 =  3:  c9b6f10d lib/: Move utmp.c and logind.c prototypes to new "session_management.h" header
 4:  bb38cff0 =  4:  d0074ac2 lib/logind.c: get_session_host(): free() earlier, to avoid a goto
 5:  5d73f429 =  5:  2e182f2d lib/logind.c: Wrap libsystemd function in our wrapper get_session()
 6:  f4e39432 =  6:  4d6d25d2 lib/logind.c: Wrap libsystemd function in our wrapper session_get_remote_host()
 7:  ffa5ad10 =  7:  198abd73 configure.ac, lib/utmp.c: Assume utmpx(5) has ut_host
 8:  f78826d0 =  8:  a3667fdf lib/utmp.c: get_session_host(): Fix memory leak
 9:  806dff1b =  9:  2a51a80e lib/, src/: get_session_host(): Return the host
10:  ab38ff9d = 10:  586f4554 lib/string/strdup/: STRNDUP(): Add macro
11:  5a2eb4e8 = 11:  540e2dbe lib/utmp.c: get_session_host(): Don't exit from library code
```
</details>

<details>
<summary>v8</summary>

-  Rebase.  The fix for the memory leak has already been merged separately.

```
$ git rd 
 1:  0b8acee3 =  1:  3620b38e lib/logind.c: Fix style
 2:  7a7842e5 =  2:  ed3ae816 lib/logind.c: Remove dead initializations
 3:  c9b6f10d =  3:  b811b97c lib/: Move utmp.c and logind.c prototypes to new "session_management.h" header
 4:  d0074ac2 =  4:  7004410c lib/logind.c: get_session_host(): free() earlier, to avoid a goto
 5:  2e182f2d =  5:  2f59752b lib/logind.c: Wrap libsystemd function in our wrapper get_session()
 6:  4d6d25d2 =  6:  eda9907a lib/logind.c: Wrap libsystemd function in our wrapper session_get_remote_host()
 7:  198abd73 !  7:  29bc7157 configure.ac, lib/utmp.c: Assume utmpx(5) has ut_host
    @@ lib/utmp.c: get_session_host(char **out, pid_t main_pid)
     -#if defined(HAVE_STRUCT_UTMPX_UT_HOST)
        if ((ut != NULL) && (ut->ut_host[0] != '\0')) {
                *out = XSTRNDUP(ut->ut_host);
    -           free (ut);
    -@@ lib/utmp.c: get_session_host(char **out, pid_t main_pid)
    +   } else {
                *out = NULL;
                ret = -2;
        }
    @@ lib/utmp.c: get_session_host(char **out, pid_t main_pid)
     -  ret = -2;
     -#endif
      
    -   return ret;
    - }
    +   free(ut);
    + 
     @@ lib/utmp.c: prepare_utmp(const char *name, const char *line, const char *host,
      
        if (NULL != host && !streq(host, ""))
 8:  a3667fdf <  -:  -------- lib/utmp.c: get_session_host(): Fix memory leak
 9:  2a51a80e =  8:  7e7fcc3b lib/, src/: get_session_host(): Return the host
10:  586f4554 =  9:  89a53850 lib/string/strdup/: STRNDUP(): Add macro
11:  540e2dbe = 10:  e0bdc496 lib/utmp.c: get_session_host(): Don't exit from library code
```
</details>

<details>
<summary>v8b</summary>

-  Rebase

```
$ git rd 
 1:  3620b38e =  1:  24a29ca2 lib/logind.c: Fix style
 2:  ed3ae816 =  2:  18cf9dd8 lib/logind.c: Remove dead initializations
 3:  b811b97c =  3:  2b41b114 lib/: Move utmp.c and logind.c prototypes to new "session_management.h" header
 4:  7004410c =  4:  795d0c23 lib/logind.c: get_session_host(): free() earlier, to avoid a goto
 5:  2f59752b =  5:  6dd5e258 lib/logind.c: Wrap libsystemd function in our wrapper get_session()
 6:  eda9907a =  6:  564522f7 lib/logind.c: Wrap libsystemd function in our wrapper session_get_remote_host()
 7:  29bc7157 =  7:  7662e3b6 configure.ac, lib/utmp.c: Assume utmpx(5) has ut_host
 8:  7e7fcc3b =  8:  b810ce7a lib/, src/: get_session_host(): Return the host
 9:  89a53850 =  9:  4d7b55c1 lib/string/strdup/: STRNDUP(): Add macro
10:  e0bdc496 = 10:  95781090 lib/utmp.c: get_session_host(): Don't exit from library code
```
</details>

<details>
<summary>v8c</summary>

-  Rebase

```
$ git rd 
 1:  24a29ca2 =  1:  0d758316 lib/logind.c: Fix style
 2:  18cf9dd8 =  2:  0d68bd32 lib/logind.c: Remove dead initializations
 3:  2b41b114 !  3:  0c41d4bc lib/: Move utmp.c and logind.c prototypes to new "session_management.h" header
    @@ lib/Makefile.am: libshadow_la_SOURCES = \
     +  session_management.h \
        setugid.c \
        setupenv.c \
    -   sgetgrent.c \
    +   sgroupio.c \
     
      ## lib/limits.c ##
     @@
    @@ src/login.c
      #include "prototypes.h"
      #include "pwauth.h"
     +#include "session_management.h"
    + #include "shadow/gshadow/endsgent.h"
      #include "shadowlog.h"
      #include "string/memset/memzero.h"
    - #include "string/sprintf/snprintf.h"
     
      ## tests/unit/test_logind.c ##
     @@
 4:  795d0c23 =  4:  0d30f58e lib/logind.c: get_session_host(): free() earlier, to avoid a goto
 5:  6dd5e258 =  5:  cd722c36 lib/logind.c: Wrap libsystemd function in our wrapper get_session()
 6:  564522f7 =  6:  1373b72e lib/logind.c: Wrap libsystemd function in our wrapper session_get_remote_host()
 7:  7662e3b6 =  7:  9e384d21 configure.ac, lib/utmp.c: Assume utmpx(5) has ut_host
 8:  b810ce7a =  8:  ff162ed1 lib/, src/: get_session_host(): Return the host
 9:  4d7b55c1 =  9:  0a6f87fe lib/string/strdup/: STRNDUP(): Add macro
10:  95781090 = 10:  b0a25760 lib/utmp.c: get_session_host(): Don't exit from library code
```
</details>

<details>
<summary>v8d</summary>

-  Rebase

```
$ git rd 
 1:  0d758316 =  1:  349d8b91 lib/logind.c: Fix style
 2:  0d68bd32 =  2:  0d263a98 lib/logind.c: Remove dead initializations
 3:  0c41d4bc =  3:  a73bcad3 lib/: Move utmp.c and logind.c prototypes to new "session_management.h" header
 4:  0d30f58e =  4:  57b99743 lib/logind.c: get_session_host(): free() earlier, to avoid a goto
 5:  cd722c36 =  5:  5dbb748d lib/logind.c: Wrap libsystemd function in our wrapper get_session()
 6:  1373b72e =  6:  13e84d28 lib/logind.c: Wrap libsystemd function in our wrapper session_get_remote_host()
 7:  9e384d21 !  7:  0060878e configure.ac, lib/utmp.c: Assume utmpx(5) has ut_host
    @@ lib/utmp.c: get_session_host(char **out, pid_t main_pid)
        ut = get_current_utmp(main_pid);
      
     -#if defined(HAVE_STRUCT_UTMPX_UT_HOST)
    -   if ((ut != NULL) && (ut->ut_host[0] != '\0')) {
    +   if ((ut != NULL) && !STRNEQ(ut->ut_host, "")) {
                *out = XSTRNDUP(ut->ut_host);
        } else {
                *out = NULL;
    @@ lib/utmp.c: prepare_utmp(const char *name, const char *line, const char *host,
        if (NULL != host && !streq(host, ""))
                hostname = xstrdup(host);
     -#if defined(HAVE_STRUCT_UTMPX_UT_HOST)
    -   else if (NULL != ut && '\0' != ut->ut_host[0])
    +   else if (NULL != ut && !STRNEQ(ut->ut_host, ""))
                hostname = XSTRNDUP(ut->ut_host);
     -#endif
      
 8:  ff162ed1 !  8:  96656408 lib/, src/: get_session_host(): Return the host
    @@ lib/utmp.c: get_current_utmp(pid_t main_pid)
      
        ut = get_current_utmp(main_pid);
      
    --  if ((ut != NULL) && (ut->ut_host[0] != '\0')) {
    +-  if ((ut != NULL) && !STRNEQ(ut->ut_host, "")) {
     -          *out = XSTRNDUP(ut->ut_host);
     -  } else {
     -          *out = NULL;
     -          ret = -2;
     -  }
    -+  if ((ut != NULL) && (ut->ut_host[0] != '\0'))
    ++  if ((ut != NULL) && !STRNEQ(ut->ut_host, ""))
     +          host = XSTRNDUP(ut->ut_host);
     +  else
     +          host = NULL;
 9:  0a6f87fe =  9:  d4e014fd lib/string/strdup/: STRNDUP(): Add macro
10:  b0a25760 ! 10:  068b363a lib/utmp.c: get_session_host(): Don't exit from library code
    @@ lib/utmp.c
     @@ lib/utmp.c: get_session_host(pid_t main_pid)
        ut = get_current_utmp(main_pid);
      
    -   if ((ut != NULL) && (ut->ut_host[0] != '\0'))
    +   if ((ut != NULL) && !STRNEQ(ut->ut_host, ""))
     -          host = XSTRNDUP(ut->ut_host);
     +          host = STRNDUP(ut->ut_host);
        else
```
</details>

<details>
<summary>v8e</summary>

-  Rebase

```
$ git rd 
 1:  349d8b91 =  1:  6c09587d lib/logind.c: Fix style
 2:  0d263a98 =  2:  74ebeb4e lib/logind.c: Remove dead initializations
 3:  a73bcad3 =  3:  d50ae442 lib/: Move utmp.c and logind.c prototypes to new "session_management.h" header
 4:  57b99743 =  4:  281ffa0c lib/logind.c: get_session_host(): free() earlier, to avoid a goto
 5:  5dbb748d =  5:  4b92d013 lib/logind.c: Wrap libsystemd function in our wrapper get_session()
 6:  13e84d28 =  6:  254a7685 lib/logind.c: Wrap libsystemd function in our wrapper session_get_remote_host()
 7:  0060878e =  7:  06979f29 configure.ac, lib/utmp.c: Assume utmpx(5) has ut_host
 8:  96656408 =  8:  5d171b63 lib/, src/: get_session_host(): Return the host
 9:  d4e014fd <  -:  -------- lib/string/strdup/: STRNDUP(): Add macro
10:  068b363a !  9:  df67d51c lib/utmp.c: get_session_host(): Don't exit from library code
    @@ Commit message
     
      ## lib/utmp.c ##
     @@
    - #include "string/strcmp/strprefix.h"
    - #include "string/strcpy/strncpy.h"
    - #include "string/strcpy/strtcpy.h"
    -+#include "string/strdup/strndup.h"
    - #include "string/strdup/xstrdup.h"
    - #include "string/strdup/xstrndup.h"
    + #include "string/strdup/strdup.h"
    + #include "string/strdup/strndup.h"
      
     -#ident "$Id$"
     -
```
</details>

<details>
<summary>v8f</summary>

-  Rebase

```
$ git rd 
 1:  6c09587d7 =  1:  c18caaa37 lib/logind.c: Fix style
 2:  74ebeb4e3 =  2:  c798fcd63 lib/logind.c: Remove dead initializations
 3:  d50ae4428 =  3:  483d42d2e lib/: Move utmp.c and logind.c prototypes to new "session_management.h" header
 4:  281ffa0ce =  4:  9881c93bf lib/logind.c: get_session_host(): free() earlier, to avoid a goto
 5:  4b92d0134 =  5:  518c85f84 lib/logind.c: Wrap libsystemd function in our wrapper get_session()
 6:  254a76857 =  6:  b11e0591d lib/logind.c: Wrap libsystemd function in our wrapper session_get_remote_host()
 7:  06979f29d =  7:  c57159485 configure.ac, lib/utmp.c: Assume utmpx(5) has ut_host
 8:  5d171b63a =  8:  956d7b1b8 lib/, src/: get_session_host(): Return the host
 9:  df67d51ce =  9:  92b948da6 lib/utmp.c: get_session_host(): Don't exit from library code
```
</details>

<details>
<summary>v9</summary>

-  Rebase

```
$ git rd 
 1:  c18caaa37 =  1:  cf6e0a530 lib/logind.c: Fix style
 2:  c798fcd63 =  2:  387e3dc77 lib/logind.c: Remove dead initializations
 3:  483d42d2e !  3:  c053d9788 lib/: Move utmp.c and logind.c prototypes to new "session_management.h" header
    @@ lib/Makefile.am: libshadow_la_SOURCES = \
     
      ## lib/limits.c ##
     @@
    - #include "atoi/a2i/a2i.h"
    - #include "atoi/a2i/a2s.h"
    - #include "atoi/str2i.h"
    + #include <sys/resource.h>
    + 
    + #include "atoi/a2i.h"
     +#include "session_management.h"
      #include "string/memset/memzero.h"
      #include "string/strcmp/streq.h"
 4:  9881c93bf =  4:  860932760 lib/logind.c: get_session_host(): free() earlier, to avoid a goto
 5:  518c85f84 =  5:  9b656d919 lib/logind.c: Wrap libsystemd function in our wrapper get_session()
 6:  b11e0591d =  6:  b68223ef0 lib/logind.c: Wrap libsystemd function in our wrapper session_get_remote_host()
 7:  c57159485 !  7:  9860f2d7b configure.ac, lib/utmp.c: Assume utmpx(5) has ut_host
    @@ lib/utmp.c: get_session_host(char **out, pid_t main_pid)
        ut = get_current_utmp(main_pid);
      
     -#if defined(HAVE_STRUCT_UTMPX_UT_HOST)
    -   if ((ut != NULL) && !STRNEQ(ut->ut_host, "")) {
    -           *out = XSTRNDUP(ut->ut_host);
    +   if ((ut != NULL) && !strneq_a(ut->ut_host, "")) {
    +           *out = xstrndup_a(ut->ut_host);
        } else {
                *out = NULL;
                ret = -2;
    @@ lib/utmp.c: prepare_utmp(const char *name, const char *line, const char *host,
        if (NULL != host && !streq(host, ""))
                hostname = xstrdup(host);
     -#if defined(HAVE_STRUCT_UTMPX_UT_HOST)
    -   else if (NULL != ut && !STRNEQ(ut->ut_host, ""))
    -           hostname = XSTRNDUP(ut->ut_host);
    +   else if (NULL != ut && !strneq_a(ut->ut_host, ""))
    +           hostname = xstrndup_a(ut->ut_host);
     -#endif
      
        line = strprefix(line, "/dev/") ?: line;
      
     @@ lib/utmp.c: prepare_utmp(const char *name, const char *line, const char *host,
    -   STRNCPY(utent->ut_user, name);
    +   strncpy_a(utent->ut_user, name);
        if (NULL != hostname) {
                struct addrinfo *info = NULL;
     -#if defined(HAVE_STRUCT_UTMPX_UT_HOST)
    -           STRNCPY(utent->ut_host, hostname);
    +           strncpy_a(utent->ut_host, hostname);
     -#endif
      #if defined(HAVE_STRUCT_UTMPX_UT_SYSLEN)
    -           utent->ut_syslen = MIN (strlen (hostname),
    -                                   sizeof (utent->ut_host));
    +           utent->ut_syslen = MIN(strlen(hostname),
    +                                  sizeof(utent->ut_host));
 8:  956d7b1b8 !  8:  e53233ea0 lib/, src/: get_session_host(): Return the host
    @@ lib/utmp.c: get_current_utmp(pid_t main_pid)
      
        ut = get_current_utmp(main_pid);
      
    --  if ((ut != NULL) && !STRNEQ(ut->ut_host, "")) {
    --          *out = XSTRNDUP(ut->ut_host);
    +-  if ((ut != NULL) && !strneq_a(ut->ut_host, "")) {
    +-          *out = xstrndup_a(ut->ut_host);
     -  } else {
     -          *out = NULL;
     -          ret = -2;
     -  }
    -+  if ((ut != NULL) && !STRNEQ(ut->ut_host, ""))
    -+          host = XSTRNDUP(ut->ut_host);
    ++  if ((ut != NULL) && !strneq_a(ut->ut_host, ""))
    ++          host = xstrndup_a(ut->ut_host);
     +  else
     +          host = NULL;
      
 9:  92b948da6 !  9:  915a86c49 lib/utmp.c: get_session_host(): Don't exit from library code
    @@ lib/utmp.c
     @@ lib/utmp.c: get_session_host(pid_t main_pid)
        ut = get_current_utmp(main_pid);
      
    -   if ((ut != NULL) && !STRNEQ(ut->ut_host, ""))
    --          host = XSTRNDUP(ut->ut_host);
    -+          host = STRNDUP(ut->ut_host);
    +   if ((ut != NULL) && !strneq_a(ut->ut_host, ""))
    +-          host = xstrndup_a(ut->ut_host);
    ++          host = strndup_a(ut->ut_host);
        else
                host = NULL;
      
```
</details>

<details>
<summary>v9b</summary>

-  Rebase

```
$ git rd 
 1:  cf6e0a530 !  1:  f69fdadcd lib/logind.c: Fix style
    @@ lib/logind.c
     +  return ret;
      }
      
    --unsigned long active_sessions_count(const char *name, MAYBE_UNUSED unsigned long limit)
    +-unsigned long active_sessions_count(const char *name, unsigned long)
     +unsigned long
    -+active_sessions_count(const char *name, MAYBE_UNUSED unsigned long limit)
    ++active_sessions_count(const char *name, unsigned long)
      {
     -    struct passwd *pw;
     -    unsigned long count = 0;
 2:  387e3dc77 !  2:  b55bff9e2 lib/logind.c: Remove dead initializations
    @@ lib/logind.c
        ret = sd_pid_get_session(main_pid, &session);
        if (ret < 0)
     @@ lib/logind.c: unsigned long
    - active_sessions_count(const char *name, MAYBE_UNUSED unsigned long limit)
    + active_sessions_count(const char *name, unsigned long)
      {
        struct passwd  *pw;
     -  unsigned long  count = 0;
 3:  c053d9788 =  3:  30e4c5cc5 lib/: Move utmp.c and logind.c prototypes to new "session_management.h" header
 4:  860932760 =  4:  05e995aba lib/logind.c: get_session_host(): free() earlier, to avoid a goto
 5:  9b656d919 !  5:  f23660579 lib/logind.c: Wrap libsystemd function in our wrapper get_session()
    @@ lib/logind.c: get_session_host(char **out, pid_t main_pid)
      
     +
      unsigned long
    - active_sessions_count(const char *name, MAYBE_UNUSED unsigned long limit)
    + active_sessions_count(const char *name, unsigned long)
      {
    -@@ lib/logind.c: active_sessions_count(const char *name, MAYBE_UNUSED unsigned long limit)
    +@@ lib/logind.c: active_sessions_count(const char *name, unsigned long)
      
        return sd_uid_get_sessions(pw->pw_uid, 0, NULL);
      }
 6:  b68223ef0 =  6:  674758db6 lib/logind.c: Wrap libsystemd function in our wrapper session_get_remote_host()
 7:  9860f2d7b =  7:  2a930aec9 configure.ac, lib/utmp.c: Assume utmpx(5) has ut_host
 8:  e53233ea0 =  8:  80ad1e17c lib/, src/: get_session_host(): Return the host
 9:  915a86c49 =  9:  d74433aff lib/utmp.c: get_session_host(): Don't exit from library code
```
</details>

<details>
<summary>v9c</summary>

-  Rebase

```
$ git rd 
 1:  f69fdadcd =  1:  e74f7e82f lib/logind.c: Fix style
 2:  b55bff9e2 =  2:  a8dde7fd2 lib/logind.c: Remove dead initializations
 3:  30e4c5cc5 =  3:  61ab7f271 lib/: Move utmp.c and logind.c prototypes to new "session_management.h" header
 4:  05e995aba =  4:  118ea850c lib/logind.c: get_session_host(): free() earlier, to avoid a goto
 5:  f23660579 =  5:  f6eb8d3ce lib/logind.c: Wrap libsystemd function in our wrapper get_session()
 6:  674758db6 =  6:  d4722075f lib/logind.c: Wrap libsystemd function in our wrapper session_get_remote_host()
 7:  2a930aec9 =  7:  f768e928a configure.ac, lib/utmp.c: Assume utmpx(5) has ut_host
 8:  80ad1e17c =  8:  e3d6429ef lib/, src/: get_session_host(): Return the host
 9:  d74433aff =  9:  0b1916810 lib/utmp.c: get_session_host(): Don't exit from library code
```
</details>

<details>
<summary>v9d</summary>

-  Rebase

```
$ git rd 
 1:  e74f7e82f !  1:  f96e4d3e3 lib/logind.c: Fix style
    @@ lib/logind.c
     +int
     +get_session_host(char **out, pid_t main_pid)
      {
    --    char *host = NULL;
    --    char *session = NULL;
    --    int ret;
    -+  char *host = NULL;
    -+  char *session = NULL;
    -+  int ret;
    +   char *host = NULL;
    +   char *session = NULL;
    +   int ret;
      
    --    ret = sd_pid_get_session(main_pid, &session);
    --    if (ret < 0) {
    --        return ret;
    --    }
    --    ret = sd_session_get_remote_host (session, &host);
    --    if (ret < 0) {
    --        goto done;
    --    }
    -+  ret = sd_pid_get_session(main_pid, &session);
    +   ret = sd_pid_get_session(main_pid, &session);
    +-  if (ret < 0) {
     +  if (ret < 0)
    -+          return ret;
    +           return ret;
    +-  }
    +-  ret = sd_session_get_remote_host (session, &host);
    +-  if (ret < 0) {
     +  ret = sd_session_get_remote_host(session, &host);
     +  if (ret < 0)
    -+          goto done;
    +           goto done;
    +-  }
      
    --    *out = host;
    -+  *out = host;
    +   *out = host;
      
      done:
    --    free (session);
    --    return ret;
    +-  free (session);
     +  free(session);
    -+  return ret;
    +   return ret;
      }
      
     -unsigned long active_sessions_count(const char *name, unsigned long)
     +unsigned long
     +active_sessions_count(const char *name, unsigned long)
      {
    --    struct passwd *pw;
    --    unsigned long count = 0;
    +-  struct passwd *pw;
    +-  unsigned long count = 0;
     +  struct passwd  *pw;
     +  unsigned long  count = 0;
      
    --    pw = prefix_getpwnam(name);
    --    if (pw == NULL) {
    --        return 0;
    --    }
    -+  pw = prefix_getpwnam(name);
    +   pw = prefix_getpwnam(name);
    +-  if (pw == NULL) {
     +  if (pw == NULL)
    -+          return 0;
    +           return 0;
    +-  }
      
    --    count = sd_uid_get_sessions(pw->pw_uid, 0, NULL);
    -+  count = sd_uid_get_sessions(pw->pw_uid, 0, NULL);
    +   count = sd_uid_get_sessions(pw->pw_uid, 0, NULL);
      
    --    return count;
    -+  return count;
    - }
 2:  a8dde7fd2 =  2:  b856606ff lib/logind.c: Remove dead initializations
 3:  61ab7f271 =  3:  19ab9808d lib/: Move utmp.c and logind.c prototypes to new "session_management.h" header
 4:  118ea850c =  4:  e7b6815c9 lib/logind.c: get_session_host(): free() earlier, to avoid a goto
 5:  f6eb8d3ce =  5:  a9dc7f2c2 lib/logind.c: Wrap libsystemd function in our wrapper get_session()
 6:  d4722075f =  6:  b5e03d2cf lib/logind.c: Wrap libsystemd function in our wrapper session_get_remote_host()
 7:  f768e928a =  7:  6bd288bdc configure.ac, lib/utmp.c: Assume utmpx(5) has ut_host
 8:  e3d6429ef =  8:  cd222c9a4 lib/, src/: get_session_host(): Return the host
 9:  0b1916810 =  9:  90d143294 lib/utmp.c: get_session_host(): Don't exit from library code
```
</details>

<details>
<summary>v9e</summary>

-  Rebase

```
$ git rd 
 1:  f96e4d3e3 =  1:  c23ea493b lib/logind.c: Fix style
 2:  b856606ff =  2:  ba2dcc101 lib/logind.c: Remove dead initializations
 3:  19ab9808d =  3:  b1eb7cf46 lib/: Move utmp.c and logind.c prototypes to new "session_management.h" header
 4:  e7b6815c9 =  4:  c6a237046 lib/logind.c: get_session_host(): free() earlier, to avoid a goto
 5:  a9dc7f2c2 =  5:  939af47a2 lib/logind.c: Wrap libsystemd function in our wrapper get_session()
 6:  b5e03d2cf =  6:  bf8f26a92 lib/logind.c: Wrap libsystemd function in our wrapper session_get_remote_host()
 7:  6bd288bdc =  7:  ed3e417f2 configure.ac, lib/utmp.c: Assume utmpx(5) has ut_host
 8:  cd222c9a4 =  8:  2cc25621f lib/, src/: get_session_host(): Return the host
 9:  90d143294 =  9:  1a6a0ee41 lib/utmp.c: get_session_host(): Don't exit from library code
```
</details>

<details>
<summary>v9f</summary>

-  Rebase

```
$ git rd 
 1:  c23ea493be60 =  1:  a0c894e4c028 lib/logind.c: Fix style
 2:  ba2dcc101632 =  2:  a7a948b8a8a3 lib/logind.c: Remove dead initializations
 3:  b1eb7cf46699 =  3:  e5fa345c8042 lib/: Move utmp.c and logind.c prototypes to new "session_management.h" header
 4:  c6a23704637f =  4:  835eb698f4a8 lib/logind.c: get_session_host(): free() earlier, to avoid a goto
 5:  939af47a2ff6 =  5:  ffa21257cbd9 lib/logind.c: Wrap libsystemd function in our wrapper get_session()
 6:  bf8f26a929d3 =  6:  c9c5ea0fc23b lib/logind.c: Wrap libsystemd function in our wrapper session_get_remote_host()
 7:  ed3e417f2269 =  7:  acf462ead5f3 configure.ac, lib/utmp.c: Assume utmpx(5) has ut_host
 8:  2cc25621f436 =  8:  3550af928d19 lib/, src/: get_session_host(): Return the host
 9:  1a6a0ee41609 =  9:  c02ac2d2ec02 lib/utmp.c: get_session_host(): Don't exit from library code
```
</details>

<details>
<summary>v9g</summary>

-  Rebase

```
$ git rd -U0
 1:  a0c894e4 =  1:  78031831 lib/logind.c: Fix style
 2:  a7a948b8 =  2:  72afe477 lib/logind.c: Remove dead initializations
 3:  e5fa345c !  3:  7197a7ae lib/: Move utmp.c and logind.c prototypes to new "session_management.h" header
    @@ tests/unit/test_logind.c
    + #include "attr.h"
    @@ tests/unit/test_logind.c
    ++
 4:  835eb698 =  4:  d6947652 lib/logind.c: get_session_host(): free() earlier, to avoid a goto
 5:  ffa21257 =  5:  426017da lib/logind.c: Wrap libsystemd function in our wrapper get_session()
 6:  c9c5ea0f =  6:  63b8c7d8 lib/logind.c: Wrap libsystemd function in our wrapper session_get_remote_host()
 7:  acf462ea =  7:  7eae1ded configure.ac, lib/utmp.c: Assume utmpx(5) has ut_host
 8:  3550af92 !  8:  3902ef46 lib/, src/: get_session_host(): Return the host
    @@ src/login.c: int main (int argc, char **argv)
    --          SYSLOG ((LOG_ERR,
    --                           "No session entry, error %d.  You must exec \"login\" from the lowest level \"sh\"",
    --                           err));
    @@ src/login.c: int main (int argc, char **argv)
    -+          SYSLOG((LOG_ERR,
    -+                  "No session entry, error %d.  You must exec \"login\" from the lowest level \"sh\"",
    -+                  errno));
    -           exit (1);
    -   }
    - 
    +           SYSLOG(LOG_ERR,
    +                  "No session entry, error %d.  You must exec \"login\" from the lowest level \"sh\"",
    +                  err);
 9:  c02ac2d2 =  9:  1e523d81 lib/utmp.c: get_session_host(): Don't exit from library code
```
</details>

<details>
<summary>v9h</summary>

-  Rebase

```
$ git rd -U0
 1:  78031831 =  1:  3af81f59 lib/logind.c: Fix style
 2:  72afe477 =  2:  8d5bb01d lib/logind.c: Remove dead initializations
 3:  7197a7ae !  3:  1aaa11a7 lib/: Move utmp.c and logind.c prototypes to new "session_management.h" header
    @@ lib/limits.c
    - #include <sys/resource.h>
    @@ lib/limits.c
    + #include "io/fgets/fgets.h"
 4:  d6947652 =  4:  8507b3d8 lib/logind.c: get_session_host(): free() earlier, to avoid a goto
 5:  426017da =  5:  cdfb40d1 lib/logind.c: Wrap libsystemd function in our wrapper get_session()
 6:  63b8c7d8 =  6:  b6e7134e lib/logind.c: Wrap libsystemd function in our wrapper session_get_remote_host()
 7:  7eae1ded =  7:  4a0633c9 configure.ac, lib/utmp.c: Assume utmpx(5) has ut_host
 8:  3902ef46 =  8:  481b6ace lib/, src/: get_session_host(): Return the host
 9:  1e523d81 !  9:  7868607e lib/utmp.c: get_session_host(): Don't exit from library code
    @@ lib/utmp.c
    -@@
    - #include "string/strdup/strdup.h"
    - #include "string/strdup/strndup.h"
    - 
    --#ident "$Id$"
    --
    - 
    - #define UTX_LINESIZE  countof(memberof(struct utmpx, ut_line))
    - 
```
</details>