### PR TITLE
lib/utmp.c: align generated "ut_id" with other software

### DIFF
--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -26,6 +26,7 @@
 #include "alloc/x/xcalloc.h"
 #include "alloc/x/xmalloc.h"
 #include "sizeof.h"
+#include "string/strchr/strnul.h"
 #include "string/strcmp/streq.h"
 #include "string/strcmp/strprefix.h"
 #include "string/strcpy/strncpy.h"
@@ -274,7 +275,7 @@ prepare_utmp(const char *name, const char *line, const char *host,
 	if (NULL != ut) {
 		STRNCPY(utent->ut_id, ut->ut_id);
 	} else {
-		STRNCPY(utent->ut_id, strprefix(line, "tty") ?: line);
+		STRNCPY(utent->ut_id, strnul(line) - MIN(strlen(line), countof(utent->ut_id)));
 	}
 #if defined(HAVE_STRUCT_UTMPX_UT_NAME)
 	STRNCPY(utent->ut_name, name);


### PR DESCRIPTION
This PR aligns generated "ut_id" with ids produced by other modern software, like systemd and libutemper.
For reference: 
* libutemper implementation: https://github.com/altlinux/libutempter/blob/4caa8ab94ff8b207228fa723a89214bf5e929321/libutempter/utempter.c#L99-L103
Note: libutemper is used by many graphical terminal emulator applications (konsole, xterm, others) to deal with utmp file.
* systemd implementation:
use full name of the device (see https://github.com/systemd/systemd/blob/8013beb4a2221680b2c741bac6b3a33fe66406e1/units/getty%40.service.in#L41-L44) or last four chars if name is longer then four chars (see https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#UtmpIdentifier=)

To summarise the idea of this PR.
This PR **does not** change functionality for normal workflow (when `utmp` entry is created before `login` is started).

This PR **does** correct behaviour in non-standard situations, for example, when `login` is started as `init` process, aligning choice of `ut_id` value with modern software (systemd, utemper).