### PR TITLE
*/: Fix including <config.h> as system header

### DIFF
--- a/lib/addgrps.c
+++ b/lib/addgrps.c
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #if !defined(USE_PAM)
 

--- a/lib/adds.c
+++ b/lib/adds.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "adds.h"
 

--- a/lib/adds.h
+++ b/lib/adds.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_ADDS_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <errno.h>
 #include <limits.h>

--- a/lib/age.c
+++ b/lib/age.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <sys/types.h>
 #include <stdio.h>

--- a/lib/agetpass.c
+++ b/lib/agetpass.c
@@ -5,7 +5,7 @@
  */
 
 
-#include <config.h>
+#include "config.h"
 
 #include "agetpass.h"
 

--- a/lib/agetpass.h
+++ b/lib/agetpass.h
@@ -8,7 +8,7 @@
 #define SHADOW_INCLUDE_LIB_AGETPASS_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include "attr.h"
 #include "defines.h"

--- a/lib/alloc/calloc.c
+++ b/lib/alloc/calloc.c
@@ -6,6 +6,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "alloc/calloc.h"

--- a/lib/alloc/calloc.h
+++ b/lib/alloc/calloc.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_ALLOC_CALLOC_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <stdlib.h>
 

--- a/lib/alloc/malloc.c
+++ b/lib/alloc/malloc.c
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "alloc/malloc.h"
 

--- a/lib/alloc/malloc.h
+++ b/lib/alloc/malloc.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_ALLOC_MALLOC_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <stdlib.h>
 

--- a/lib/alloc/realloc.c
+++ b/lib/alloc/realloc.c
@@ -6,6 +6,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "alloc/realloc.h"

--- a/lib/alloc/realloc.h
+++ b/lib/alloc/realloc.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_ALLOC_REALLOC_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <stdlib.h>
 

--- a/lib/alloc/reallocf.c
+++ b/lib/alloc/reallocf.c
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "alloc/reallocf.h"
 

--- a/lib/alloc/reallocf.h
+++ b/lib/alloc/reallocf.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_ALLOC_REALLOCF_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <stddef.h>
 #include <stdlib.h>

--- a/lib/alloc/x/xcalloc.c
+++ b/lib/alloc/x/xcalloc.c
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "alloc/x/xcalloc.h"
 

--- a/lib/alloc/x/xcalloc.h
+++ b/lib/alloc/x/xcalloc.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_ALLOC_X_XCALLOC_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <stddef.h>
 #include <stdlib.h>

--- a/lib/alloc/x/xmalloc.c
+++ b/lib/alloc/x/xmalloc.c
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "alloc/x/xmalloc.h"
 

--- a/lib/alloc/x/xmalloc.h
+++ b/lib/alloc/x/xmalloc.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_ALLOC_X_XMALLOC_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <stddef.h>
 

--- a/lib/alloc/x/xrealloc.c
+++ b/lib/alloc/x/xrealloc.c
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "alloc/x/xrealloc.h"
 

--- a/lib/alloc/x/xrealloc.h
+++ b/lib/alloc/x/xrealloc.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_MALLOC_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <assert.h>
 #include <errno.h>

--- a/lib/atoi/a2i/a2i.c
+++ b/lib/atoi/a2i/a2i.c
@@ -2,6 +2,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "atoi/a2i/a2i.h"

--- a/lib/atoi/a2i/a2i.h
+++ b/lib/atoi/a2i/a2i.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_ATOI_A2I_A2I_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include "atoi/a2i/a2s_c.h"
 #include "atoi/a2i/a2s_nc.h"

--- a/lib/atoi/a2i/a2s.c
+++ b/lib/atoi/a2i/a2s.c
@@ -2,6 +2,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "atoi/a2i/a2s.h"

--- a/lib/atoi/a2i/a2s.h
+++ b/lib/atoi/a2i/a2s.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_ATOI_A2I_A2S_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include "atoi/a2i/a2i.h"
 

--- a/lib/atoi/a2i/a2s_c.c
+++ b/lib/atoi/a2i/a2s_c.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "atoi/a2i/a2s_c.h"
 

--- a/lib/atoi/a2i/a2s_c.h
+++ b/lib/atoi/a2i/a2s_c.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_ATOI_A2I_A2S_C_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <errno.h>
 #include <inttypes.h>

--- a/lib/atoi/a2i/a2s_nc.c
+++ b/lib/atoi/a2i/a2s_nc.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "atoi/a2i/a2s_nc.h"
 

--- a/lib/atoi/a2i/a2s_nc.h
+++ b/lib/atoi/a2i/a2s_nc.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_ATOI_A2I_A2S_NC_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <errno.h>
 

--- a/lib/atoi/a2i/a2u.c
+++ b/lib/atoi/a2i/a2u.c
@@ -2,6 +2,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "atoi/a2i/a2u.h"

--- a/lib/atoi/a2i/a2u.h
+++ b/lib/atoi/a2i/a2u.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_ATOI_A2I_A2U_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include "atoi/a2i/a2i.h"
 

--- a/lib/atoi/a2i/a2u_c.c
+++ b/lib/atoi/a2i/a2u_c.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "atoi/a2i/a2u_c.h"
 

--- a/lib/atoi/a2i/a2u_c.h
+++ b/lib/atoi/a2i/a2u_c.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_ATOI_A2I_A2U_C_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include "atoi/a2i/a2u_nc.h"
 #include "attr.h"

--- a/lib/atoi/a2i/a2u_nc.c
+++ b/lib/atoi/a2i/a2u_nc.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "atoi/a2i/a2u_nc.h"
 

--- a/lib/atoi/a2i/a2u_nc.h
+++ b/lib/atoi/a2i/a2u_nc.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_ATOI_A2I_A2U_NC_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <errno.h>
 

--- a/lib/atoi/getnum.c
+++ b/lib/atoi/getnum.c
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include <sys/types.h>
 

--- a/lib/atoi/getnum.h
+++ b/lib/atoi/getnum.h
@@ -7,7 +7,7 @@
 #define SHADOW_INCLUDE_LIB_ATOI_GETNUM_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <limits.h>
 #include <stddef.h>

--- a/lib/atoi/str2i.c
+++ b/lib/atoi/str2i.c
@@ -3,6 +3,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "atoi/str2i.h"

--- a/lib/atoi/str2i.h
+++ b/lib/atoi/str2i.h
@@ -7,7 +7,7 @@
 #define SHADOW_INCLUDE_LIB_ATOI_STR2I_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <stddef.h>
 

--- a/lib/atoi/strtoi/strtoi.c
+++ b/lib/atoi/strtoi/strtoi.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "atoi/strtoi/strtoi.h"
 

--- a/lib/atoi/strtoi/strtoi.h
+++ b/lib/atoi/strtoi/strtoi.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_ATOI_STRTOI_STRTOI_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <errno.h>
 #include <inttypes.h>

--- a/lib/atoi/strtoi/strtou.c
+++ b/lib/atoi/strtoi/strtou.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "atoi/strtoi/strtou.h"
 

--- a/lib/atoi/strtoi/strtou.h
+++ b/lib/atoi/strtoi/strtou.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_ATOI_STRTOI_STRTOU_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <errno.h>
 #include <inttypes.h>

--- a/lib/atoi/strtoi/strtou_noneg.c
+++ b/lib/atoi/strtoi/strtou_noneg.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "atoi/strtoi/strtou_noneg.h"
 

--- a/lib/atoi/strtoi/strtou_noneg.h
+++ b/lib/atoi/strtoi/strtou_noneg.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_ATOI_STRTOI_STRTOU_NONEG_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <errno.h>
 #include <stddef.h>

--- a/lib/audit_help.c
+++ b/lib/audit_help.c
@@ -11,7 +11,7 @@
  *
  */
 
-#include <config.h>
+#include "config.h"
 
 #ifdef WITH_AUDIT
 

--- a/lib/basename.c
+++ b/lib/basename.c
@@ -11,7 +11,7 @@
  * --marekm
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <stddef.h>
 #include <stdlib.h>

--- a/lib/bit.c
+++ b/lib/bit.c
@@ -5,7 +5,7 @@
  */
 
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/bit.h
+++ b/lib/bit.h
@@ -9,7 +9,7 @@
 #define SHADOW_INCLUDE_LIB_BIT_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <limits.h>
 

--- a/lib/cast.h
+++ b/lib/cast.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_CAST_H_
 
 
-#include <config.h>
+#include "config.h"
 
 
 #define const_cast(T, p)  _Generic(p, const T:  (T) (p))

--- a/lib/chkname.c
+++ b/lib/chkname.c
@@ -18,7 +18,7 @@
  */
 
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/chkname.h
+++ b/lib/chkname.h
@@ -21,7 +21,7 @@
  */
 
 
-#include <config.h>
+#include "config.h"
 
 #include <stdbool.h>
 #include <stddef.h>

--- a/lib/chowndir.c
+++ b/lib/chowndir.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/chowntty.c
+++ b/lib/chowntty.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/cleanup.c
+++ b/lib/cleanup.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <assert.h>
 #include <stdio.h>

--- a/lib/cleanup_group.c
+++ b/lib/cleanup_group.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <assert.h>
 #include <stdio.h>

--- a/lib/cleanup_user.c
+++ b/lib/cleanup_user.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <assert.h>
 #include <stdio.h>

--- a/lib/commonio.c
+++ b/lib/commonio.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/console.c
+++ b/lib/console.c
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/lib/copydir.c
+++ b/lib/copydir.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/csrand.c
+++ b/lib/csrand.c
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022-2024, Alejandro Colomar <alx@kernel.org>
 // SPDX-License-Identifier: BSD-3-Clause
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/encrypt.c
+++ b/lib/encrypt.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/env.c
+++ b/lib/env.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/failure.c
+++ b/lib/failure.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/fields.c
+++ b/lib/fields.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #include "fields.h"
 

--- a/lib/fields.h
+++ b/lib/fields.h
@@ -5,7 +5,7 @@
 #define _SHADOW_INCLUDE_LIB_FIELDS_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <stddef.h>
 

--- a/lib/find_new_gid.c
+++ b/lib/find_new_gid.c
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <assert.h>
 #include <stdint.h>

--- a/lib/find_new_sub_gids.c
+++ b/lib/find_new_sub_gids.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ifdef ENABLE_SUBIDS
 

--- a/lib/find_new_sub_uids.c
+++ b/lib/find_new_sub_uids.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ifdef ENABLE_SUBIDS
 

--- a/lib/find_new_uid.c
+++ b/lib/find_new_uid.c
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <assert.h>
 #include <stdint.h>

--- a/lib/fputsx.c
+++ b/lib/fputsx.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/lib/fs/mkstemp/fmkomstemp.c
+++ b/lib/fs/mkstemp/fmkomstemp.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "fs/mkstemp/fmkomstemp.h"
 

--- a/lib/fs/mkstemp/fmkomstemp.h
+++ b/lib/fs/mkstemp/fmkomstemp.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_FS_MKSTEMP_FMKOMSTEMP_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <stdio.h>
 #include <sys/types.h>

--- a/lib/fs/mkstemp/mkomstemp.c
+++ b/lib/fs/mkstemp/mkomstemp.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "fs/mkstemp/mkomstemp.h"
 

--- a/lib/fs/mkstemp/mkomstemp.h
+++ b/lib/fs/mkstemp/mkomstemp.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_FS_MKSTEMP_MKOMSTEMP_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <stdlib.h>
 #include <sys/stat.h>

--- a/lib/fs/readlink/areadlink.c
+++ b/lib/fs/readlink/areadlink.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "fs/readlink/areadlink.h"
 

--- a/lib/fs/readlink/areadlink.h
+++ b/lib/fs/readlink/areadlink.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_FS_READLINK_AREADLINK_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <errno.h>
 #include <stdbool.h>

--- a/lib/fs/readlink/readlinknul.c
+++ b/lib/fs/readlink/readlinknul.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "fs/readlink/readlinknul.h"
 

--- a/lib/fs/readlink/readlinknul.h
+++ b/lib/fs/readlink/readlinknul.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_FS_READLINK_READLINKNUL_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <errno.h>
 #include <string.h>

--- a/lib/get_pid.c
+++ b/lib/get_pid.c
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include <limits.h>
 #include <fcntl.h>

--- a/lib/getdef.c
+++ b/lib/getdef.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/getgr_nam_gid.c
+++ b/lib/getgr_nam_gid.c
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/getrange.c
+++ b/lib/getrange.c
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id: $"
 

--- a/lib/gettime.c
+++ b/lib/gettime.c
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/groupio.c
+++ b/lib/groupio.c
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/groupmem.c
+++ b/lib/groupmem.c
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/gshadow.c
+++ b/lib/gshadow.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #if defined(SHADOWGRP) && !__has_include(<gshadow.h>)
 

--- a/lib/hushed.c
+++ b/lib/hushed.c
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/idmapping.c
+++ b/lib/idmapping.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>

--- a/lib/isexpired.c
+++ b/lib/isexpired.c
@@ -12,7 +12,7 @@
  * in other shadow-aware programs.  --marekm
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <sys/types.h>
 #include <pwd.h>

--- a/lib/limits.c
+++ b/lib/limits.c
@@ -13,7 +13,7 @@
  * Enhancements of resource limit code by Thomas Orgis <thomas@orgis.org>
  */
 
-#include <config.h>
+#include "config.h"
 
 #ifndef USE_PAM
 

--- a/lib/list.c
+++ b/lib/list.c
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/lockpw.c
+++ b/lib/lockpw.c
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ifndef HAVE_LCKPWDF
 

--- a/lib/log.c
+++ b/lib/log.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/logind.c
+++ b/lib/logind.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier:  BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/loginprompt.c
+++ b/lib/loginprompt.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/mail.c
+++ b/lib/mail.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 #include "prototypes.h"
 #include "defines.h"
 #include <assert.h>

--- a/lib/motd.c
+++ b/lib/motd.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/myname.c
+++ b/lib/myname.c
@@ -11,7 +11,7 @@
  *
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/nscd.c
+++ b/lib/nscd.c
@@ -1,6 +1,6 @@
 /* Author: Peter Vrabec <pvrabec@redhat.com> */
 
-#include <config.h>
+#include "config.h"
 #ifdef USE_NSCD
 
 #include <stdio.h>

--- a/lib/nss.c
+++ b/lib/nss.c
@@ -1,4 +1,4 @@
-#include <config.h>
+#include "config.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/lib/obscure.c
+++ b/lib/obscure.c
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/pam_defs.h
+++ b/lib/pam_defs.h
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <security/pam_appl.h>
 #if __has_include(<security/pam_misc.h>)

--- a/lib/pam_pass.c
+++ b/lib/pam_pass.c
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ifdef USE_PAM
 

--- a/lib/pam_pass_non_interactive.c
+++ b/lib/pam_pass_non_interactive.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id:$"
 

--- a/lib/port.c
+++ b/lib/port.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/prefix_flag.c
+++ b/lib/prefix_flag.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/prototypes.h
+++ b/lib/prototypes.h
@@ -19,7 +19,7 @@
 #ifndef _PROTOTYPES_H
 #define _PROTOTYPES_H
 
-#include <config.h>
+#include "config.h"
 
 #include <sys/socket.h>
 #include <sys/stat.h>

--- a/lib/pwauth.c
+++ b/lib/pwauth.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ifndef USE_PAM
 #ident "$Id$"

--- a/lib/pwd2spwd.c
+++ b/lib/pwd2spwd.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/pwd_init.c
+++ b/lib/pwd_init.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/pwdcheck.c
+++ b/lib/pwdcheck.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/pwio.c
+++ b/lib/pwio.c
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <pwd.h>
 #include <stdio.h>

--- a/lib/pwmem.c
+++ b/lib/pwmem.c
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/remove_tree.c
+++ b/lib/remove_tree.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/root_flag.c
+++ b/lib/root_flag.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/run_part.c
+++ b/lib/run_part.c
@@ -1,4 +1,4 @@
-#include <config.h>
+#include "config.h"
 
 #include <dirent.h>
 #include <errno.h>

--- a/lib/salt.c
+++ b/lib/salt.c
@@ -12,7 +12,7 @@
  * it is in the public domain.
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/search/cmp/cmp.c
+++ b/lib/search/cmp/cmp.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "search/cmp/cmp.h"
 

--- a/lib/search/cmp/cmp.h
+++ b/lib/search/cmp/cmp.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_SEARCH_CMP_CMP_H_
 
 
-#include <config.h>
+#include "config.h"
 
 
 #define CMP(TYPE)                                                     \

--- a/lib/search/l/lfind.c
+++ b/lib/search/l/lfind.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "search/l/lfind.h"
 

--- a/lib/search/l/lfind.h
+++ b/lib/search/l/lfind.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_SEARCH_L_LFIND_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <search.h>
 #include <stddef.h>

--- a/lib/search/l/lsearch.c
+++ b/lib/search/l/lsearch.c
@@ -2,6 +2,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "search/l/lsearch.h"

--- a/lib/search/l/lsearch.h
+++ b/lib/search/l/lsearch.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_SEARCH_L_LSEARCH_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <search.h>
 

--- a/lib/search/sort/qsort.c
+++ b/lib/search/sort/qsort.c
@@ -2,6 +2,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "search/sort/qsort.h"

--- a/lib/search/sort/qsort.h
+++ b/lib/search/sort/qsort.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_SEARCH_SORT_QSORT_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <stdlib.h>
 

--- a/lib/selinux.c
+++ b/lib/selinux.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ifdef WITH_SELINUX
 

--- a/lib/semanage.c
+++ b/lib/semanage.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ifdef WITH_SELINUX
 

--- a/lib/setugid.c
+++ b/lib/setugid.c
@@ -11,7 +11,7 @@
  * Separated from setup.c.  --marekm
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/setupenv.c
+++ b/lib/setupenv.c
@@ -11,7 +11,7 @@
  * Separated from setup.c.  --marekm
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/sgetgrent.c
+++ b/lib/sgetgrent.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/sgetpwent.c
+++ b/lib/sgetpwent.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/sgetspent.c
+++ b/lib/sgetspent.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 /* Newer versions of Linux libc already have shadow support.  */
 #ifndef HAVE_SGETSPENT

--- a/lib/sgroupio.c
+++ b/lib/sgroupio.c
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ifdef SHADOWGRP
 

--- a/lib/shadow/grp/agetgroups.c
+++ b/lib/shadow/grp/agetgroups.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "shadow/grp/agetgroups.h"
 

--- a/lib/shadow/grp/agetgroups.h
+++ b/lib/shadow/grp/agetgroups.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_SHADOW_GRP_AGETGROUPS_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <stddef.h>
 #include <stdlib.h>

--- a/lib/shadowio.c
+++ b/lib/shadowio.c
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <shadow.h>
 #include <stdio.h>

--- a/lib/shadowmem.c
+++ b/lib/shadowmem.c
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/shell.c
+++ b/lib/shell.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/sizeof.h
+++ b/lib/sizeof.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIBMISC_SIZEOF_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <limits.h>
 #if __has_include(<stdcountof.h>)

--- a/lib/spawn.c
+++ b/lib/spawn.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <stdio.h>
 #include <sys/types.h>

--- a/lib/sssd.c
+++ b/lib/sssd.c
@@ -1,6 +1,6 @@
 /* Author: Peter Vrabec <pvrabec@redhat.com> */
 
-#include <config.h>
+#include "config.h"
 
 #ifdef USE_SSSD
 #include "sssd.h"

--- a/lib/string/ctype/strchrisascii/strchriscntrl.c
+++ b/lib/string/ctype/strchrisascii/strchriscntrl.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "string/ctype/strchrisascii/strchriscntrl.h"
 

--- a/lib/string/ctype/strchrisascii/strchriscntrl.h
+++ b/lib/string/ctype/strchrisascii/strchriscntrl.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_STRING_CTYPE_STRCHRISASCII_STRCHRISCNTRL_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <ctype.h>
 #include <stdbool.h>

--- a/lib/string/ctype/strisascii/strisdigit.c
+++ b/lib/string/ctype/strisascii/strisdigit.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "string/ctype/strisascii/strisdigit.h"
 

--- a/lib/string/ctype/strisascii/strisdigit.h
+++ b/lib/string/ctype/strisascii/strisdigit.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_STRING_CTYPE_STRISASCII_STRISDIGIT_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <stdbool.h>
 

--- a/lib/string/ctype/strisascii/strisprint.c
+++ b/lib/string/ctype/strisascii/strisprint.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "string/ctype/strisascii/strisprint.h"
 

--- a/lib/string/ctype/strisascii/strisprint.h
+++ b/lib/string/ctype/strisascii/strisprint.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_STRING_CTYPE_STRISASCII_STRISPRINT_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <ctype.h>
 #include <stdbool.h>

--- a/lib/string/ctype/strtoascii/strtolower.c
+++ b/lib/string/ctype/strtoascii/strtolower.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "string/ctype/strtoascii/strtolower.h"
 

--- a/lib/string/ctype/strtoascii/strtolower.h
+++ b/lib/string/ctype/strtoascii/strtolower.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_STRING_CTYPE_STRTOASCII_STRTOLOWER_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <ctype.h>
 

--- a/lib/string/memset/memzero.c
+++ b/lib/string/memset/memzero.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include <stddef.h>
 

--- a/lib/string/memset/memzero.h
+++ b/lib/string/memset/memzero.h
@@ -7,7 +7,7 @@
 #define SHADOW_INCLUDE_LIB_STRING_MEMSET_MEMZERO_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <stddef.h>
 #include <string.h>

--- a/lib/string/sprintf/aprintf.c
+++ b/lib/string/sprintf/aprintf.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "string/sprintf/aprintf.h"
 

--- a/lib/string/sprintf/aprintf.h
+++ b/lib/string/sprintf/aprintf.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_STRING_SPRINTF_APRINTF_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <stdarg.h>
 #include <stddef.h>

--- a/lib/string/sprintf/snprintf.c
+++ b/lib/string/sprintf/snprintf.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "string/sprintf/snprintf.h"
 

--- a/lib/string/sprintf/snprintf.h
+++ b/lib/string/sprintf/snprintf.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_STRING_SPRINTF_SNPRINTF_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <stdarg.h>
 #include <stddef.h>

--- a/lib/string/sprintf/stpeprintf.c
+++ b/lib/string/sprintf/stpeprintf.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "string/sprintf/stpeprintf.h"
 

--- a/lib/string/sprintf/stpeprintf.h
+++ b/lib/string/sprintf/stpeprintf.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_STRING_SPRINTF_STPEPRINTF_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <stdarg.h>
 #include <stddef.h>

--- a/lib/string/sprintf/xaprintf.c
+++ b/lib/string/sprintf/xaprintf.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "string/sprintf/xaprintf.h"
 

--- a/lib/string/sprintf/xaprintf.h
+++ b/lib/string/sprintf/xaprintf.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_STRING_SPRINTF_XASPRINTF_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <stdarg.h>
 #include <stddef.h>

--- a/lib/string/strchr/strchrcnt.c
+++ b/lib/string/strchr/strchrcnt.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "string/strchr/strchrcnt.h"
 

--- a/lib/string/strchr/strchrcnt.h
+++ b/lib/string/strchr/strchrcnt.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_STRING_STRCHR_STRCHRCNT_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <stddef.h>
 

--- a/lib/string/strchr/strchrscnt.c
+++ b/lib/string/strchr/strchrscnt.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "string/strchr/strchrscnt.h"
 

--- a/lib/string/strchr/strchrscnt.h
+++ b/lib/string/strchr/strchrscnt.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_STRING_STRCHR_STRCHRSCNT_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <stddef.h>
 

--- a/lib/string/strchr/strnul.c
+++ b/lib/string/strchr/strnul.c
@@ -2,6 +2,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "string/strchr/strnul.h"

--- a/lib/string/strchr/strnul.h
+++ b/lib/string/strchr/strnul.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_STRING_STRCHR_STRNUL_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <string.h>
 

--- a/lib/string/strcmp/strcaseeq.c
+++ b/lib/string/strcmp/strcaseeq.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include <stdbool.h>
 

--- a/lib/string/strcmp/strcaseeq.h
+++ b/lib/string/strcmp/strcaseeq.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_STRING_STRCMP_STRCASEEQ_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <stdbool.h>
 #include <strings.h>

--- a/lib/string/strcmp/strcaseprefix.c
+++ b/lib/string/strcmp/strcaseprefix.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "string/strcmp/strcaseprefix.h"
 

--- a/lib/string/strcmp/strcaseprefix.h
+++ b/lib/string/strcmp/strcaseprefix.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_STRING_STRCMP_STRCASEPREFIX_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <stddef.h>
 #include <string.h>

--- a/lib/string/strcmp/streq.c
+++ b/lib/string/strcmp/streq.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include <stdbool.h>
 

--- a/lib/string/strcmp/streq.h
+++ b/lib/string/strcmp/streq.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_STRING_STRCMP_STREQ_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <stdbool.h>
 #include <string.h>

--- a/lib/string/strcmp/strprefix.c
+++ b/lib/string/strcmp/strprefix.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "string/strcmp/strprefix.h"
 

--- a/lib/string/strcmp/strprefix.h
+++ b/lib/string/strcmp/strprefix.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_STRING_STRCMP_STRPREFIX_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <stddef.h>
 #include <string.h>

--- a/lib/string/strcpy/stpecpy.c
+++ b/lib/string/strcpy/stpecpy.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "string/strcpy/stpecpy.h"
 

--- a/lib/string/strcpy/stpecpy.h
+++ b/lib/string/strcpy/stpecpy.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_STRING_STRCPY_STPECPY_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <stdbool.h>
 #include <stddef.h>

--- a/lib/string/strcpy/strncat.c
+++ b/lib/string/strcpy/strncat.c
@@ -2,6 +2,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "string/strcpy/strncat.h"

--- a/lib/string/strcpy/strncat.h
+++ b/lib/string/strcpy/strncat.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_STRING_STRCPY_STRNCAT_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <string.h>
 

--- a/lib/string/strcpy/strncpy.c
+++ b/lib/string/strcpy/strncpy.c
@@ -2,6 +2,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "string/strcpy/strncpy.h"

--- a/lib/string/strcpy/strncpy.h
+++ b/lib/string/strcpy/strncpy.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_STRING_STRCPY_STRNCPY_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <string.h>
 

--- a/lib/string/strcpy/strtcpy.c
+++ b/lib/string/strcpy/strtcpy.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include <stddef.h>
 #include <sys/types.h>

--- a/lib/string/strcpy/strtcpy.h
+++ b/lib/string/strcpy/strtcpy.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_STRING_STRCPY_STRTCPY_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <stdbool.h>
 #include <stddef.h>

--- a/lib/string/strdup/strndupa.c
+++ b/lib/string/strdup/strndupa.c
@@ -2,6 +2,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "string/strdup/strndupa.h"

--- a/lib/string/strdup/strndupa.h
+++ b/lib/string/strdup/strndupa.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_STRING_STRDUP_STRNDUPA_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <alloca.h>
 #include <string.h>

--- a/lib/string/strdup/xstrdup.c
+++ b/lib/string/strdup/xstrdup.c
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "string/strdup/xstrdup.h"
 

--- a/lib/string/strdup/xstrdup.h
+++ b/lib/string/strdup/xstrdup.h
@@ -10,7 +10,7 @@
 #define SHADOW_INCLUDE_LIB_STRING_STRDUP_XSTRDUP_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <string.h>
 

--- a/lib/string/strdup/xstrndup.c
+++ b/lib/string/strdup/xstrndup.c
@@ -2,6 +2,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "string/strdup/xstrndup.h"

--- a/lib/string/strdup/xstrndup.h
+++ b/lib/string/strdup/xstrndup.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_STRING_STRDUP_XSTRNDUP_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <string.h>
 

--- a/lib/string/strftime.c
+++ b/lib/string/strftime.c
@@ -2,6 +2,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "strftime.h"

--- a/lib/string/strftime.h
+++ b/lib/string/strftime.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_STRFTIME_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <time.h>
 

--- a/lib/string/strspn/stprcspn.c
+++ b/lib/string/strspn/stprcspn.c
@@ -2,6 +2,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "string/strspn/stprcspn.h"

--- a/lib/string/strspn/stprcspn.h
+++ b/lib/string/strspn/stprcspn.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_STRING_STRSPN_STPRCSPN_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <string.h>
 

--- a/lib/string/strspn/stprspn.c
+++ b/lib/string/strspn/stprspn.c
@@ -2,6 +2,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "string/strspn/stprspn.h"

--- a/lib/string/strspn/stprspn.h
+++ b/lib/string/strspn/stprspn.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_STRING_STRSPN_STPRSPN_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <string.h>
 

--- a/lib/string/strspn/stpspn.c
+++ b/lib/string/strspn/stpspn.c
@@ -2,6 +2,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "string/strspn/stpspn.h"

--- a/lib/string/strspn/stpspn.h
+++ b/lib/string/strspn/stpspn.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_STRING_STRSPN_STPSPN_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <string.h>
 

--- a/lib/string/strspn/strrcspn.c
+++ b/lib/string/strspn/strrcspn.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "string/strspn/strrcspn.h"
 

--- a/lib/string/strspn/strrcspn.h
+++ b/lib/string/strspn/strrcspn.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_STRING_STRSPN_STRRCSPN_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <stddef.h>
 #include <string.h>

--- a/lib/string/strspn/strrspn.c
+++ b/lib/string/strspn/strrspn.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "string/strspn/strrspn.h"
 

--- a/lib/string/strspn/strrspn.h
+++ b/lib/string/strspn/strrspn.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_STRING_STRSPN_STRRSPN_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <stddef.h>
 #include <string.h>

--- a/lib/string/strtok/astrsep2ls.c
+++ b/lib/string/strtok/astrsep2ls.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "string/strtok/astrsep2ls.h"
 

--- a/lib/string/strtok/astrsep2ls.h
+++ b/lib/string/strtok/astrsep2ls.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_STRING_STRTOK_ASTRSEP2LS_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <stddef.h>
 

--- a/lib/string/strtok/stpsep.c
+++ b/lib/string/strtok/stpsep.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "string/strtok/stpsep.h"
 

--- a/lib/string/strtok/stpsep.h
+++ b/lib/string/strtok/stpsep.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_STRING_STRTOK_STPSEP_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <string.h>
 

--- a/lib/string/strtok/strsep2arr.c
+++ b/lib/string/strtok/strsep2arr.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "string/strtok/strsep2arr.h"
 

--- a/lib/string/strtok/strsep2arr.h
+++ b/lib/string/strtok/strsep2arr.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_STRING_STRTOK_STRSEP2ARR_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <errno.h>
 #include <stddef.h>

--- a/lib/string/strtok/strsep2ls.c
+++ b/lib/string/strtok/strsep2ls.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "string/strtok/strsep2ls.h"
 

--- a/lib/string/strtok/strsep2ls.h
+++ b/lib/string/strtok/strsep2ls.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_STRING_STRTOK_STRSEP2LS_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <errno.h>
 #include <stddef.h>

--- a/lib/string/strtok/xastrsep2ls.c
+++ b/lib/string/strtok/xastrsep2ls.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "string/strtok/xastrsep2ls.h"
 

--- a/lib/string/strtok/xastrsep2ls.h
+++ b/lib/string/strtok/xastrsep2ls.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_STRING_STRTOK_XASTRSEP2LS_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <errno.h>
 #include <stddef.h>

--- a/lib/strtoday.c
+++ b/lib/strtoday.c
@@ -7,7 +7,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include <stddef.h>
 #include <time.h>

--- a/lib/sub.c
+++ b/lib/sub.c
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/subordinateio.c
+++ b/lib/subordinateio.c
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: 2012 - Eric Biederman
  */
 
-#include <config.h>
+#include "config.h"
 
 #ifdef ENABLE_SUBIDS
 

--- a/lib/subordinateio.h
+++ b/lib/subordinateio.h
@@ -5,7 +5,7 @@
 #ifndef _SUBORDINATEIO_H
 #define _SUBORDINATEIO_H
 
-#include <config.h>
+#include "config.h"
 
 #ifdef ENABLE_SUBIDS
 

--- a/lib/sulog.c
+++ b/lib/sulog.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/tcbfuncs.c
+++ b/lib/tcbfuncs.c
@@ -5,7 +5,7 @@
 
 #define _GNU_SOURCE
 
-#include <config.h>
+#include "config.h"
 
 #include <errno.h>
 #include <fcntl.h>

--- a/lib/time/day_to_str.c
+++ b/lib/time/day_to_str.c
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include "time/day_to_str.h"
 

--- a/lib/time/day_to_str.h
+++ b/lib/time/day_to_str.h
@@ -7,7 +7,7 @@
 #define SHADOW_INCLUDE_LIB_TIME_DAY_TO_STR_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include <time.h>
 

--- a/lib/ttytype.c
+++ b/lib/ttytype.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/typetraits.h
+++ b/lib/typetraits.h
@@ -6,7 +6,7 @@
 #define SHADOW_INCLUDE_LIB_TYPETRAITS_H_
 
 
-#include <config.h>
+#include "config.h"
 
 #include "sizeof.h"
 

--- a/lib/tz.c
+++ b/lib/tz.c
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ifndef USE_PAM
 

--- a/lib/ulimit.c
+++ b/lib/ulimit.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/user_busy.c
+++ b/lib/user_busy.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id: $"
 

--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #include "defines.h"
 #include "prototypes.h"

--- a/lib/valid.c
+++ b/lib/valid.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/write_full.c
+++ b/lib/write_full.c
@@ -6,7 +6,7 @@
  */
 
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/lib/xgetgrgid.c
+++ b/lib/xgetgrgid.c
@@ -26,7 +26,7 @@
  * This file provides wrapper to the getgrgid or getgrgid_r functions.
  */
 
-#include <config.h>
+#include "config.h"
 
 #include "groupio.h"
 

--- a/lib/xgetgrnam.c
+++ b/lib/xgetgrnam.c
@@ -26,7 +26,7 @@
  * This file provides wrapper to the getgrnam or getgrnam_r functions.
  */
 
-#include <config.h>
+#include "config.h"
 
 #include "groupio.h"
 

--- a/lib/xgetpwnam.c
+++ b/lib/xgetpwnam.c
@@ -26,7 +26,7 @@
  * This file provides wrapper to the getpwnam or getpwnam_r functions.
  */
 
-#include <config.h>
+#include "config.h"
 
 #include "pwio.h"
 

--- a/lib/xgetpwuid.c
+++ b/lib/xgetpwuid.c
@@ -26,7 +26,7 @@
  * This file provides wrapper to the getpwuid or getpwuid_r functions.
  */
 
-#include <config.h>
+#include "config.h"
 
 #include "pwio.h"
 

--- a/lib/xgetspnam.c
+++ b/lib/xgetspnam.c
@@ -26,7 +26,7 @@
  * This file provides wrapper to the getspnam or getspnam_r functions.
  */
 
-#include <config.h>
+#include "config.h"
 
 #include "shadowio.h"
 

--- a/lib/xprefix_getpwnam.c
+++ b/lib/xprefix_getpwnam.c
@@ -26,7 +26,7 @@
  * This file provides wrapper to the prefix_getpwnam or prefix_getpwnam_r functions.
  */
 
-#include <config.h>
+#include "config.h"
 
 #include "pwio.h"
 

--- a/lib/yesno.c
+++ b/lib/yesno.c
@@ -7,7 +7,7 @@
  */
 
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/libsubid/api.c
+++ b/libsubid/api.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 #include <fcntl.h>
 #include <stdio.h>
 #include <errno.h>

--- a/src/chage.c
+++ b/src/chage.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/src/check_subid_range.c
+++ b/src/check_subid_range.c
@@ -3,7 +3,7 @@
 // Exits 0 if owner has subid range starting start, of size count
 // Exits 1 otherwise.
 
-#include <config.h>
+#include "config.h"
 #include <stdio.h>
 #include <string.h>
 #include <stdbool.h>

--- a/src/chfn.c
+++ b/src/chfn.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/src/chgpasswd.c
+++ b/src/chgpasswd.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/src/chpasswd.c
+++ b/src/chpasswd.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/src/chsh.c
+++ b/src/chsh.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/src/expiry.c
+++ b/src/expiry.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/src/faillog.c
+++ b/src/faillog.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/src/gpasswd.c
+++ b/src/gpasswd.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/src/groupadd.c
+++ b/src/groupadd.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/src/groupdel.c
+++ b/src/groupdel.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/src/groupmems.c
+++ b/src/groupmems.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <fcntl.h>
 #include <getopt.h>

--- a/src/groupmod.c
+++ b/src/groupmod.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/src/grpck.c
+++ b/src/grpck.c
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <fcntl.h>
 #include <grp.h>

--- a/src/grpconv.c
+++ b/src/grpconv.c
@@ -12,7 +12,7 @@
  *
  */
 
-#include <config.h>
+#include "config.h"
 #ident "$Id$"
 
 #include <errno.h>

--- a/src/grpunconv.c
+++ b/src/grpunconv.c
@@ -12,7 +12,7 @@
  *
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/src/lastlog.c
+++ b/src/lastlog.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/src/login.c
+++ b/src/login.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -23,7 +23,7 @@
 ************************************************************************/
 
 #ifdef HAVE_CONFIG_H
-#include <config.h>
+#include "config.h"
 #endif
 
 #ifndef USE_PAM

--- a/src/logoutd.c
+++ b/src/logoutd.c
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/src/newgidmap.c
+++ b/src/newgidmap.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/src/newuidmap.c
+++ b/src/newuidmap.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>

--- a/src/newusers.c
+++ b/src/newusers.c
@@ -15,7 +15,7 @@
  *	adding entries in the related directories.
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/src/passwd.c
+++ b/src/passwd.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/src/pwck.c
+++ b/src/pwck.c
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/src/pwconv.c
+++ b/src/pwconv.c
@@ -30,7 +30,7 @@
  *
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/src/pwunconv.c
+++ b/src/pwunconv.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/src/su.c
+++ b/src/su.c
@@ -28,7 +28,7 @@
    Boston, MA 02110-1301, USA.  */
 
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/src/suauth.c
+++ b/src/suauth.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #include <errno.h>
 #include <grp.h>

--- a/src/sulogin.c
+++ b/src/sulogin.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/src/userdel.c
+++ b/src/userdel.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 #include <assert.h>
 #include <dirent.h>
 #include <errno.h>

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/src/vipw.c
+++ b/src/vipw.c
@@ -10,7 +10,7 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-#include <config.h>
+#include "config.h"
 
 #ident "$Id$"
 

--- a/tests/unit/test_snprintf.c
+++ b/tests/unit/test_snprintf.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/tests/unit/test_strncpy.c
+++ b/tests/unit/test_strncpy.c
@@ -4,7 +4,7 @@
  */
 
 
-#include <config.h>
+#include "config.h"
 
 #include <string.h>
 

--- a/tests/unit/test_strtcpy.c
+++ b/tests/unit/test_strtcpy.c
@@ -4,7 +4,7 @@
  */
 
 
-#include <config.h>
+#include "config.h"
 
 #include <string.h>
 

--- a/tests/unit/test_typetraits.c
+++ b/tests/unit/test_typetraits.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 
-#include <config.h>
+#include "config.h"
 
 #include <stdarg.h>  // Required by <cmocka.h>
 #include <stddef.h>  // Required by <cmocka.h>


### PR DESCRIPTION
"config.h" is a locally generated header. It must be included as '#include "config.h"'.
It is already included correctly in some sources files. This commit unifies the way how "config.h" is included.
Examples of current correct includes:
* https://github.com/shadow-maint/shadow/blob/9195f3807dfaa2062bcb8f79c61efc1e1f6dba46/lib/defines.h#L7
* https://github.com/shadow-maint/shadow/blob/9195f3807dfaa2062bcb8f79c61efc1e1f6dba46/lib/attr.h#L5