### PR TITLE
lib/shadow/grp/: agetgroups(): Fix possible buffer overrun on non-Linux systems

### DIFF
--- a/lib/shadow/grp/agetgroups.h
+++ b/lib/shadow/grp/agetgroups.h
@@ -34,6 +34,8 @@ agetgroups(size_t *ngids)
 	if (n == -1)
 		return NULL;
 
+	n = n ?: 1;
+
 	gids = MALLOC(n, gid_t);
 	if (gids == NULL)
 		return NULL;


### PR DESCRIPTION
Linux seems to at least write one group always from getgroups(2). However, POSIX doesn't guarantee this, and a system might have 0 groups.

	It is implementation‐defined whether getgroups() also returns
	the effective group ID in the grouplist array.

Considering such a system, the call getgroups(0,NULL) could indeed return 0, and the second call to getgroups might return a higher value, if the group list has grown in between (race condition).  If this is the case, we'd return an array of 0 elements (or 1, due to the MALLOC() trick to avoid calling it with 0), with no elements filled, but where ngids has been updated to have a positive value.  When the caller of agetgroups() reads the array, they'd overrun the buffer.


Fixes: 05322ed89a1c (2025-01-24; "lib/shadow/grp/: agetgroups(): Add function")
Fixes: de941a7601f8 (2025-01-24; "lib/, src/: Simplify allocation of buffer")