### PR TITLE
lib/utmp.c: prepare_utmp(): Fix buffer overrun when 'line' isn't "tty*"

### DIFF
--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -271,12 +271,11 @@ prepare_utmp(const char *name, const char *line, const char *host,
 	utent->ut_type = USER_PROCESS;
 	utent->ut_pid = getpid ();
 	STRNCPY(utent->ut_line, line);
-	if (NULL != ut) {
+	if (NULL != ut)
 		STRNCPY(utent->ut_id, ut->ut_id);
-	} else {
-		/* XXX - assumes /dev/tty?? */
-		STRNCPY(utent->ut_id, line + 3);
-	}
+	else
+		STRNCPY(utent->ut_id, strprefix(line, "tty") ?: line);
+
 #if defined(HAVE_STRUCT_UTMPX_UT_NAME)
 	STRNCPY(utent->ut_name, name);
 #endif


### PR DESCRIPTION
    Sometimes, line may be a string of length less than 3, in which case the
    +3 was jumping somewhere after the terminating null byte.  This is
    probably not easy to exploit, as we only read at most 4 bytes, but this
    was theoretically quite bad.

Reported-by: @Karlson2k