### PR TITLE
lib/utmp.c: Fixed generated strings for "ut_id"

### DIFF
--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -274,8 +274,7 @@ prepare_utmp(const char *name, const char *line, const char *host,
 	if (NULL != ut) {
 		STRNCPY(utent->ut_id, ut->ut_id);
 	} else {
-		/* XXX - assumes /dev/tty?? */
-		STRNCPY(utent->ut_id, line + 3);
+		STRNCPY(utent->ut_id, strprefix(line, "tty") ?: line);
 	}
 #if defined(HAVE_STRUCT_UTMPX_UT_NAME)
 	STRNCPY(utent->ut_name, name);


### PR DESCRIPTION
When no "ut_id" is provided by previous utmp file entry, "login" must generate its own "ut_id". Historically tty number  was used for it. However, if current device name is three characters or shorter, then empty "ut_id" is produced or even garbage is copied from uninitialised part of the "line".
This commit fixes it.
This patch uses unportable C extension Elvis operator as it is already used everywhere in the code.

Extracted from #1293