### PR TITLE
While-loop readability improvements.

### DIFF
--- a/lib/copydir.c
+++ b/lib/copydir.c
@@ -310,7 +310,7 @@ static int copy_tree_impl (const struct path_info *src, const struct path_info *
 		dst_orig = dst->full_path;
 		set_orig = true;
 	}
-	while ((0 == err) && (ent = readdir (dir)) != NULL) {
+	while (0 == err && NULL != (ent = readdir(dir))) {
 		char              *src_name = NULL;
 		char              *dst_name;
 		struct path_info  src_entry, dst_entry;

--- a/lib/find_new_gid.c
+++ b/lib/find_new_gid.c
@@ -245,7 +245,7 @@ int find_new_gid (bool sys_group,
 	(void) gr_rewind ();
 	highest_found = gid_min;
 	lowest_found = gid_max;
-	while ((grp = gr_next ()) != NULL) {
+	while (NULL != (grp = gr_next())) {
 		/*
 		 * Does this entry have a lower GID than the lowest we've found
 		 * so far?

--- a/lib/find_new_uid.c
+++ b/lib/find_new_uid.c
@@ -245,7 +245,7 @@ int find_new_uid(bool sys_user,
 	(void) pw_rewind ();
 	highest_found = uid_min;
 	lowest_found = uid_max;
-	while ((pwd = pw_next ()) != NULL) {
+	while (NULL != (pwd = pw_next())) {
 		/*
 		 * Does this entry have a lower UID than the lowest we've found
 		 * so far?

--- a/lib/gshadow.c
+++ b/lib/gshadow.c
@@ -166,7 +166,7 @@ sgetsgent(const char *s)
 
 	setsgent ();
 
-	while ((sgrp = getsgent ()) != NULL) {
+	while (NULL != (sgrp = getsgent())) {
 		if (streq(name, sgrp->sg_namp)) {
 			break;
 		}

--- a/lib/port.c
+++ b/lib/port.c
@@ -310,7 +310,7 @@ getttyuser(const char *tty, const char *user)
 
 	setportent();
 
-	while ((port = getportent()) != NULL) {
+	while (NULL != (port = getportent())) {
 		char  **ptn;
 		char  **ptu;
 

--- a/lib/prefix_flag.c
+++ b/lib/prefix_flag.c
@@ -153,7 +153,7 @@ extern struct group *prefix_getgrnam(const char *name)
 		fg = fopen(group_db_file, "rt");
 		if (!fg)
 			return NULL;
-		while ((grp = fgetgrent(fg)) != NULL) {
+		while (NULL != (grp = fgetgrent(fg))) {
 			if (streq(name, grp->gr_name))
 				break;
 		}
@@ -173,7 +173,7 @@ extern struct group *prefix_getgrgid(gid_t gid)
 		fg = fopen(group_db_file, "rt");
 		if (!fg)
 			return NULL;
-		while ((grp = fgetgrent(fg)) != NULL) {
+		while (NULL != (grp = fgetgrent(fg))) {
 			if (gid == grp->gr_gid)
 				break;
 		}
@@ -193,7 +193,7 @@ extern struct passwd *prefix_getpwuid(uid_t uid)
 		fg = fopen(passwd_db_file, "rt");
 		if (!fg)
 			return NULL;
-		while ((pwd = fgetpwent(fg)) != NULL) {
+		while (NULL != (pwd = fgetpwent(fg))) {
 			if (uid == pwd->pw_uid)
 				break;
 		}
@@ -213,7 +213,7 @@ extern struct passwd *prefix_getpwnam(const char* name)
 		fg = fopen(passwd_db_file, "rt");
 		if (!fg)
 			return NULL;
-		while ((pwd = fgetpwent(fg)) != NULL) {
+		while (NULL != (pwd = fgetpwent(fg))) {
 			if (streq(name, pwd->pw_name))
 				break;
 		}
@@ -256,7 +256,7 @@ extern struct spwd *prefix_getspnam(const char* name)
 		fg = fopen(spw_db_file, "rt");
 		if (!fg)
 			return NULL;
-		while ((sp = fgetspent(fg)) != NULL) {
+		while (NULL != (sp = fgetspent(fg))) {
 			if (streq(name, sp->sp_namp))
 				break;
 		}

--- a/lib/subordinateio.c
+++ b/lib/subordinateio.c
@@ -156,7 +156,7 @@ static bool range_exists(struct commonio_db *db, const char *owner)
 {
 	const struct subordinate_range *range;
 	commonio_rewind(db);
-	while ((range = commonio_next(db)) != NULL) {
+	while (NULL != (range = commonio_next(db))) {
 		if (streq(range->owner, owner))
 			return true;
 	}
@@ -188,7 +188,7 @@ static const struct subordinate_range *find_range(struct commonio_db *db,
 	 * before.
 	 */
 	commonio_rewind(db);
-	while ((range = commonio_next(db)) != NULL) {
+	while (NULL != (range = commonio_next(db))) {
 		unsigned long first = range->start;
 		unsigned long last = first + range->count - 1;
 
@@ -229,7 +229,7 @@ static const struct subordinate_range *find_range(struct commonio_db *db,
                 return NULL;
 
         commonio_rewind(db);
-        while ((range = commonio_next(db)) != NULL) {
+        while (NULL != (range = commonio_next(db))) {
                 unsigned long first = range->start;
                 unsigned long last = first + range->count - 1;
 
@@ -366,7 +366,7 @@ static unsigned long find_free_range(struct commonio_db *db,
 	commonio_rewind(db);
 
 	low = min;
-	while ((range = commonio_next(db)) != NULL) {
+	while (NULL != (range = commonio_next(db))) {
 		unsigned long first = range->start;
 		unsigned long last = first + range->count - 1;
 
@@ -884,7 +884,7 @@ int list_owner_ranges(const char *owner, enum subid_type id_type, struct subid_r
 	have_owner_id = get_owner_id(owner, id_type, id);
 
 	commonio_rewind(db);
-	while ((range = commonio_next(db)) != NULL) {
+	while (NULL != (range = commonio_next(db))) {
 		if (streq(range->owner, owner)) {
 			if (!append_range(&ranges, range, count++)) {
 				free(ranges);
@@ -989,7 +989,7 @@ int find_subid_owners(unsigned long id, enum subid_type id_type, uid_t **uids)
 	*uids = NULL;
 
 	commonio_rewind(db);
-	while ((range = commonio_next(db)) != NULL) {
+	while (NULL != (range = commonio_next(db))) {
 		if (id >= range->start && id < range->start + range-> count) {
 			n = append_uids(uids, range->owner, n);
 			if (n < 0)
@@ -1045,7 +1045,7 @@ bool new_subid_range(struct subordinate_range *range, enum subid_type id_type, b
 
 	commonio_rewind(db);
 	if (reuse) {
-		while ((r = commonio_next(db)) != NULL) {
+		while (NULL != (r = commonio_next(db))) {
 			// TODO account for username vs uid_t
 			if (!streq(r->owner, range->owner))
 				continue;

--- a/lib/user_busy.c
+++ b/lib/user_busy.c
@@ -65,7 +65,7 @@ user_busy_utmp(const char *name)
 	struct utmpx  *utent;
 
 	setutxent();
-	while ((utent = getutxent()) != NULL)
+	while (NULL != (utent = getutxent()))
 	{
 		if (utent->ut_type != USER_PROCESS) {
 			continue;
@@ -193,7 +193,7 @@ static int user_busy_processes (const char *name, uid_t uid)
 		return 0;
 	}
 
-	while ((ent = readdir (proc)) != NULL) {
+	while (NULL != (ent = readdir(proc))) {
 		tmp_d_name = ent->d_name;
 		/*
 		 * Ingo Molnar's patch introducing NPTL for 2.4 hides
@@ -236,7 +236,7 @@ static int user_busy_processes (const char *name, uid_t uid)
 		SNPRINTF(task_path, "/proc/%lu/task", (unsigned long) pid);
 		task_dir = opendir (task_path);
 		if (task_dir != NULL) {
-			while ((ent = readdir (task_dir)) != NULL) {
+			while (NULL != (ent = readdir(task_dir))) {
 				pid_t tid;
 				if (get_pid(ent->d_name, &tid) == -1) {
 					continue;

--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -156,7 +156,7 @@ get_current_utmp(pid_t main_pid)
 	setutxent();
 
 	/* First, try to find a valid utmp entry for this process.  */
-	while ((ut = getutxent()) != NULL) {
+	while (NULL != (ut = getutxent())) {
 		if (   (LOGIN_PROCESS != ut->ut_type)
 		    && (USER_PROCESS  != ut->ut_type))
 			continue;

--- a/src/groupmod.c
+++ b/src/groupmod.c
@@ -734,7 +734,7 @@ void update_primary_groups (gid_t ogid, gid_t ngid)
 	struct passwd *pwd;
 
 	prefix_setpwent ();
-	while ((pwd = prefix_getpwent ()) != NULL) {
+	while (NULL != (pwd = prefix_getpwent())) {
 		if (pwd->pw_gid == ogid) {
 			const struct passwd *lpwd;
 			struct passwd npwd;

--- a/src/grpconv.c
+++ b/src/grpconv.c
@@ -171,7 +171,7 @@ int main (int argc, char **argv)
 	 * Remove /etc/gshadow entries for groups not in /etc/group.
 	 */
 	(void) sgr_rewind ();
-	while ((sg = sgr_next ()) != NULL) {
+	while (NULL != (sg = sgr_next())) {
 		if (gr_locate (sg->sg_namp) != NULL) {
 			continue;
 		}

--- a/src/grpunconv.c
+++ b/src/grpunconv.c
@@ -175,7 +175,7 @@ int main (int argc, char **argv)
 	 * Update group passwords if non-shadow password is "x".
 	 */
 	(void) gr_rewind ();
-	while ((gr = gr_next ()) != NULL) {
+	while (NULL != (gr = gr_next())) {
 		sg = sgr_locate (gr->gr_name);
 		if (   (NULL != sg)
 		    && streq(gr->gr_passwd, SHADOW_PASSWD_STRING)) {

--- a/src/logoutd.c
+++ b/src/logoutd.c
@@ -171,7 +171,7 @@ main(int argc, char **argv)
 		 * for login sessions will be checked to see if the user
 		 * is permitted to be signed on at this time.
 		 */
-		while ((ut = getutxent()) != NULL) {
+		while (NULL != (ut = getutxent())) {
 			int   tty_fd;
 			char  tty_name[sizeof(ut->ut_line) + 6];  // /dev/ + NUL
 

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -96,7 +96,7 @@ static /*@null@*/struct group *find_matching_group (const char *name, struct gro
 		return gr;
 
 	setgrent ();
-	while ((gr = getgrent ()) != NULL) {
+	while (NULL != (gr = getgrent())) {
 		if (gr->gr_gid != gid) {
 			continue;
 		}

--- a/src/pwconv.c
+++ b/src/pwconv.c
@@ -207,7 +207,7 @@ int main (int argc, char **argv)
 	 * Remove /etc/shadow entries for users not in /etc/passwd.
 	 */
 	(void) spw_rewind ();
-	while ((sp = spw_next ()) != NULL) {
+	while (NULL != (sp = spw_next())) {
 		if (pw_locate (sp->sp_namp) != NULL) {
 			continue;
 		}
@@ -229,7 +229,7 @@ int main (int argc, char **argv)
 	 * missing shadow entries.
 	 */
 	(void) pw_rewind ();
-	while ((pw = pw_next ()) != NULL) {
+	while (NULL != (pw = pw_next())) {
 		sp = spw_locate (pw->pw_name);
 		if (NULL != sp) {
 			/* do we need to update this entry? */

--- a/src/pwunconv.c
+++ b/src/pwunconv.c
@@ -172,7 +172,7 @@ int main (int argc, char **argv)
 	}
 
 	(void) pw_rewind ();
-	while ((pw = pw_next ()) != NULL) {
+	while (NULL != (pw = pw_next())) {
 		spwd = spw_locate (pw->pw_name);
 		if (NULL == spwd) {
 			continue;

--- a/src/su.c
+++ b/src/su.c
@@ -187,7 +187,7 @@ static bool restricted_shell (const char *shellname)
 	/*@observer@*/const char *line;
 
 	setusershell ();
-	while ((line = getusershell ()) != NULL) {
+	while (NULL != (line = getusershell())) {
 		if (('#' != *line) && streq(line, shellname)) {
 			endusershell ();
 			return false;

--- a/src/userdel.c
+++ b/src/userdel.c
@@ -323,7 +323,7 @@ static void remove_usergroup (void)
 		 * used as a primary group.
 		 */
 		prefix_setpwent ();
-		while ((pwd = prefix_getpwent ()) != NULL) {
+		while (NULL != (pwd = prefix_getpwent())) {
 			if (streq(pwd->pw_name, user_name)) {
 				continue;
 			}

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -696,7 +696,7 @@ update_group_file(void)
 	 * Scan through the entire group file looking for the groups that
 	 * the user is a member of.
 	 */
-	while ((grp = gr_next()) != NULL)
+	while (NULL != (grp = gr_next()))
 		update_group(grp);
 }
 
@@ -822,7 +822,7 @@ update_gshadow_file(void)
 	 * Scan through the entire shadow group file looking for the groups
 	 * that the user is a member of.
 	 */
-	while ((sgrp = sgr_next()) != NULL)
+	while (NULL != (sgrp = sgr_next()))
 		update_gshadow(sgrp);
 }
 #endif				/* SHADOWGRP */


### PR DESCRIPTION
---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git rd
1:  49e5b01a ! 1:  682e6ae8 lib/, src/: Reorder while() conditions for safety
    @@ Metadata
      ## Commit message ##
         lib/, src/: Reorder while() conditions for safety
     
    -    In conditions that check for NULL after assignment, it's safer to put
    -    the NULL check first, as a mistake would result in a compiler error,
    -    as opposed to unwanted implicit conversions.  It's also more readable.
    +    In conditions that perform simple assignment (=) before comparison,
    +    it's safer to put the comparison first, as a mistake would result in a
    +    compiler error, as opposed to assigning something incorrect.
    +    It's also more readable, IMO.
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
```
</details>