### PR TITLE
Make parsing of gecos field more robust and strict

### DIFF
--- a/src/chfn.c
+++ b/src/chfn.c
@@ -480,23 +480,23 @@ static void get_old_fields (const char *gecos)
 
 	f = strsep(&p, ",");
 	if (!fflg)
-		strcpy(fullnm, f);
+		strcpy(fullnm, f ?: "");
 
 	f = strsep(&p, ",");
-	if (!rflg && f != NULL)
-		strcpy(roomno, f);
+	if (!rflg)
+		strcpy(roomno, f ?: "");
 
 	f = strsep(&p, ",");
-	if (!wflg && f != NULL)
-		strcpy(workph, f);
+	if (!wflg)
+		strcpy(workph, f ?: "");
 
 	f = strsep(&p, ",");
-	if (!hflg && f != NULL)
-		strcpy(homeph, f);
+	if (!hflg)
+		strcpy(homeph, f ?: "");
 
 	/* Anything left over is "slop".  */
-	if (!oflg && p != NULL)
-		strcpy(slop, p);
+	if (!oflg)
+		strcpy(slop, p ?: "");
 }
 
 /*

--- a/src/chfn.c
+++ b/src/chfn.c
@@ -47,7 +47,7 @@ static char fullnm[BUFSIZ];
 static char roomno[BUFSIZ];
 static char workph[BUFSIZ];
 static char homeph[BUFSIZ];
-static char slop[BUFSIZ + 1 + 80];
+static char slop[BUFSIZ];
 static bool amroot;
 /* Flags */
 static bool fflg = false;		/* -f - set full name                */

--- a/src/chfn.c
+++ b/src/chfn.c
@@ -561,7 +561,8 @@ static void check_fields (void)
  */
 int main (int argc, char **argv)
 {
-	char                 new_gecos[BUFSIZ];
+	int                  ret;
+	char                 new_gecos[80];
 	char                 *user;
 	const struct passwd  *pw;
 
@@ -643,14 +644,13 @@ int main (int argc, char **argv)
 	 * Build the new GECOS field by plastering all the pieces together,
 	 * if they will fit ...
 	 */
-	if ((strlen (fullnm) + strlen (roomno) + strlen (workph) +
-	     strlen (homeph) + strlen (slop)) > (unsigned int) 80) {
+	ret = SNPRINTF(new_gecos, "%s,%s,%s,%s%s%s",
+	               fullnm, roomno, workph, homeph,
+	               (!streq(slop, "")) ? "," : "", slop);
+	if (ret == -1) {
 		fprintf (stderr, _("%s: fields too long\n"), Prog);
 		fail_exit (E_NOPERM);
 	}
-	SNPRINTF(new_gecos, "%s,%s,%s,%s%s%s",
-	         fullnm, roomno, workph, homeph,
-	         (!streq(slop, "")) ? "," : "", slop);
 
 	/* Rewrite the user's gecos in the passwd file */
 	update_gecos (user, new_gecos);

--- a/src/chfn.c
+++ b/src/chfn.c
@@ -214,33 +214,15 @@ static void new_fields (void)
  *
  *	in - the current GECOS field
  *	out - where to copy the field to
- *	extra - fields with '=' get copied here
  */
-static char *copy_field (char *in, char *out, char *extra)
+static char *copy_field(char *in, char *out)
 {
-	char  *next = NULL;
+	char  *next;
 
-	while (NULL != in) {
-		const char  *f;
+	next = stpsep(in, ",");
 
-		f = in;
-		next = stpsep(in, ",");
-
-		if (strchr(f, '=') == NULL)
-			break;
-
-		if (NULL != extra) {
-			if (!streq(extra, "")) {
-				strcat (extra, ",");
-			}
-
-			strcat(extra, f);
-		}
-		in = next;
-	}
-	if ((NULL != in) && (NULL != out)) {
-		strcpy (out, in);
-	}
+	if (out != NULL)
+		strcpy(out, in);
 
 	return next;
 }
@@ -521,39 +503,35 @@ static void get_old_fields (const char *gecos)
 	 * Now get the full name. It is the first comma separated field in
 	 * the GECOS field.
 	 */
-	cp = copy_field (old_gecos, fflg ? NULL : fullnm, slop);
+	cp = copy_field(old_gecos, fflg ? NULL : fullnm);
 
 	/*
 	 * Now get the room number. It is the next comma separated field,
 	 * if there is indeed one.
 	 */
 	if (NULL != cp) {
-		cp = copy_field (cp, rflg ? NULL : roomno, slop);
+		cp = copy_field(cp, rflg ? NULL : roomno);
 	}
 
 	/*
 	 * Now get the work phone number. It is the third field.
 	 */
 	if (NULL != cp) {
-		cp = copy_field (cp, wflg ? NULL : workph, slop);
+		cp = copy_field(cp, wflg ? NULL : workph);
 	}
 
 	/*
 	 * Now get the home phone number. It is the fourth field.
 	 */
 	if (NULL != cp) {
-		cp = copy_field (cp, hflg ? NULL : homeph, slop);
+		cp = copy_field(cp, hflg ? NULL : homeph);
 	}
 
 	/*
 	 * Anything left over is "slop".
 	 */
 	if ((NULL != cp) && !oflg) {
-		if (!streq(slop, "")) {
-			strcat (slop, ",");
-		}
-
-		strcat (slop, cp);
+		strcpy(slop, cp);
 	}
 }
 


### PR DESCRIPTION
I finally understood what this function was doing.  It was over-engineered, for supporting gecos fields that nobody should be writing in the first place.  It was also bogus: if the gecos field was missing some subfield, it left the buffers with garbage.  Even more buggy: if any of the first 4 CSV fields contained any '=' in them, those would be appended to the slop, regardless of oflg, which is inconsistent with the last lines, which parse the remaining slop depending on oflg.  This code was very broken.

---

Revisions:

<details>
<summary>v2</summary>

-  wfix
-  Fix more bugs, and improve readability.

```
$ git range-diff shadow/master gh/gecos gecos 
1:  91431a96 ! 1:  8cfc1c19 src/chfn.c: Do not allow the 'slop' fields to appear before any non-slop gecos fields
    @@ Commit message
         2)  Building and room number or contact person
         3)  Office telephone number
         4)  Home telephone number
    -    5)  Any other contact information (pager number, fax, external e-mail address, etc.)
    +    5+) Any other contact information (pager number, fax, external e-mail address, etc.)
     
         But our code supported the "other contact information", which we call
         slop, and which is composed of an arbitrary number of key=value fields,
    @@ Commit message
     
         After this patch, the GECOS field is treated as a CSV, blindly copying
         the fields as they appear, where the first 4 fields are as specified
    -    above, and anything after them is the slop (5th field, any other contact
    +    above, and anything after them is the slop (5+ fields, any other contact
         information).
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
2:  d523246f = 2:  286739a2 src/chfn.c: Use strsep(3) and strcpy(3) instead of its pattern
3:  d624fbf0 = 3:  aa6755fe src/chfn.c: Write an empty string if there's nothing in the GECOS field
-:  -------- > 4:  f4b1950b src/chfn.c: slop: Reduce buffer size
-:  -------- > 5:  81e28291 src/chfn.c: Simplify checking for a long GECOS field
-:  -------- > 6:  4ac43002 src/chfn.c: Use stpeprintf() to improve readability
```
</details>

<details>
<summary>v2b</summary>

-  Shorten comment.

```
$ git range-diff shadow/master gh/gecos gecos 
1:  8cfc1c19 = 1:  8cfc1c19 src/chfn.c: Do not allow the 'slop' fields to appear before any non-slop gecos fields
2:  286739a2 = 2:  286739a2 src/chfn.c: Use strsep(3) and strcpy(3) instead of its pattern
3:  aa6755fe = 3:  aa6755fe src/chfn.c: Write an empty string if there's nothing in the GECOS field
4:  f4b1950b = 4:  f4b1950b src/chfn.c: slop: Reduce buffer size
5:  81e28291 = 5:  81e28291 src/chfn.c: Simplify checking for a long GECOS field
6:  4ac43002 ! 6:  f01f131b src/chfn.c: Use stpeprintf() to improve readability
    @@ Commit message
         This allows us to split the formation of the string into several
         s*printf() calls.
     
    +    Shorten comment, to make it fit in one line.
    +
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## src/chfn.c ##
    @@ src/chfn.c: static void check_fields (void)
      
        sanitize_env ();
     @@ src/chfn.c: int main (int argc, char **argv)
    -    * Build the new GECOS field by plastering all the pieces together,
    -    * if they will fit ...
         */
    +   check_fields ();
    + 
    +-  /*
    +-   * Build the new GECOS field by plastering all the pieces together,
    +-   * if they will fit ...
    +-   */
     -  ret = SNPRINTF(new_gecos, "%s,%s,%s,%s%s%s",
     -                 fullnm, roomno, workph, homeph,
     -                 (!streq(slop, "")) ? "," : "", slop);
     -  if (ret == -1) {
    ++  /* Build the new GECOS field by plastering all the pieces together.  */
     +  p = new_gecos;
     +  e = new_gecos + countof(new_gecos);
     +  p = stpeprintf(p, e, "%s", fullnm);
```
</details>

<details>
<summary>v2c</summary>

-  Add missing include.

```
$ git range-diff shadow/master gh/gecos gecos 
1:  8cfc1c19 = 1:  8cfc1c19 src/chfn.c: Do not allow the 'slop' fields to appear before any non-slop gecos fields
2:  286739a2 = 2:  286739a2 src/chfn.c: Use strsep(3) and strcpy(3) instead of its pattern
3:  aa6755fe = 3:  aa6755fe src/chfn.c: Write an empty string if there's nothing in the GECOS field
4:  f4b1950b = 4:  f4b1950b src/chfn.c: slop: Reduce buffer size
5:  81e28291 = 5:  81e28291 src/chfn.c: Simplify checking for a long GECOS field
6:  f01f131b ! 6:  bbdcc006 src/chfn.c: Use stpeprintf() to improve readability
    @@ Commit message
     
      ## src/chfn.c ##
     @@
    + #include "pwauth.h"
      #include "pwio.h"
      #include "shadowlog.h"
    ++#include "sizeof.h"
      #include "sssd.h"
     -#include "string/sprintf/snprintf.h"
     +#include "string/sprintf/stpeprintf.h"
```
</details>