### PR TITLE
Add memcpy_a(), and use it instead of its pattern

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -219,6 +219,8 @@ libshadow_la_SOURCES = \
 	string/strcmp/strneq.h \
 	string/strcmp/strprefix.c \
 	string/strcmp/strprefix.h \
+	string/strcpy/memcpy.c \
+	string/strcpy/memcpy.h \
 	string/strcpy/stpecpy.c \
 	string/strcpy/stpecpy.h \
 	string/strcpy/strncat.c \

--- a/lib/string/README
+++ b/lib/string/README
@@ -210,7 +210,7 @@ strcpy/ - String copying
 	a size.  This makes it safer for chaining several calls.
 
   m/
-    MEMCPY()
+    memcpy_a()
 	Like memcpy(3), but takes two arrays.
 
 sprintf/ - Formatted string creation

--- a/lib/string/strcpy/memcpy.c
+++ b/lib/string/strcpy/memcpy.c
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#include "config.h"
+
+#include "string/strcpy/memcpy.h"

--- a/lib/string/strcpy/memcpy.h
+++ b/lib/string/strcpy/memcpy.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#ifndef SHADOW_INCLUDE_LIB_STRING_STRCPY_MEMCPY_H_
+#define SHADOW_INCLUDE_LIB_STRING_STRCPY_MEMCPY_H_
+
+
+#include "config.h"
+
+#include <string.h>
+
+#include "sizeof.h"
+
+#include <assert.h>
+
+
+// memcpy_a - memory copy array
+#define memcpy_a(dst, src)                                            \
+({                                                                    \
+	static_assert(sizeof_a(dst) == sizeof_a(src), "");            \
+                                                                      \
+	memcpy(dst, src, sizeof_a(dst));                              \
+})
+
+
+#endif  // include guard

--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -34,6 +34,7 @@
 #include "string/strcmp/streq.h"
 #include "string/strcmp/strneq.h"
 #include "string/strcmp/strprefix.h"
+#include "string/strcpy/memcpy.h"
 #include "string/strcpy/strncpy.h"
 #include "string/strdup/memdup.h"
 #include "string/strdup/strdup.h"
@@ -319,10 +320,7 @@ prepare_utmp(const char *name, const char *line, const char *host,
 			} else if (info->ai_family == AF_INET6) {
 				struct sockaddr_in6 *sa =
 					(struct sockaddr_in6 *) info->ai_addr;
-				memcpy (utent->ut_addr_v6,
-				        &(sa->sin6_addr),
-				        MIN(sizeof(utent->ut_addr_v6),
-				            sizeof(sa->sin6_addr)));
+				memcpy_a(utent->ut_addr_v6, sa->sin6_addr.s6_addr);
 # endif
 			}
 			freeaddrinfo (info);


### PR DESCRIPTION
Cc: @kees, @uecker 

---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git rd 
1:  dffde298 = 1:  6bc38c93 lib/string/strcpy/: MEMCPY(): Add macro
2:  bb82ea8f = 2:  fcbdb102 lib/utmp.c: prepare_utmp(): Use MEMCPY() instead of its pattern
```
</details>

<details>
<summary>v1c</summary>

-  Rebase

```
$ git rd 
1:  6bc38c93 = 1:  4e58e271 lib/string/strcpy/: MEMCPY(): Add macro
2:  fcbdb102 = 2:  593fd728 lib/utmp.c: prepare_utmp(): Use MEMCPY() instead of its pattern
```
</details>

<details>
<summary>v1d</summary>

-  Rebase

```
$ git rd 
1:  4e58e271 = 1:  547300ae lib/string/strcpy/: MEMCPY(): Add macro
2:  593fd728 = 2:  33c2c97f lib/utmp.c: prepare_utmp(): Use MEMCPY() instead of its pattern
```
</details>

<details>
<summary>v1d</summary>

-  Rebase

```
$ git rd 
1:  4fc3f696 = 1:  163d8535 lib/string/strcpy/: strncpytail(), STRNCPYTAIL(): Add APIs
2:  df8b604d ! 2:  95ab3cb6 lib/utmp.c: Use STRNCPYTAIL() instead of its pattern
    @@ Commit message
     
      ## lib/utmp.c ##
     @@
    - #include "string/strcmp/streq.h"
    + #include "string/strcmp/strneq.h"
      #include "string/strcmp/strprefix.h"
      #include "string/strcpy/strncpy.h"
     +#include "string/strcpy/strncpytail.h"
```
</details>

<details>
<summary>v1e</summary>

-  Rebase

```
$ git rd 
1:  c6e3fb88 = 1:  09766c81 lib/string/strcpy/: MEMCPY(): Add macro
2:  b490b803 ! 2:  136fb881 lib/utmp.c: prepare_utmp(): Use MEMCPY() instead of its pattern
    @@ lib/utmp.c
     +#include "string/strcpy/memcpy.h"
      #include "string/strcpy/strncpy.h"
      #include "string/strcpy/strtcpy.h"
    - #include "string/strdup/xstrdup.h"
    + #include "string/strdup/strdup.h"
     @@ lib/utmp.c: prepare_utmp(const char *name, const char *line, const char *host,
                        } else if (info->ai_family == AF_INET6) {
                                struct sockaddr_in6 *sa =
```
</details>

<details>
<summary>v2</summary>

-  Rebase on top of #1373.
-  Rename s/MEMCPY/memcpy_a/.

```
$ git range-diff shadow/master..gh/mc gh/_a..mc 
1:  09766c81b ! 1:  03bbc341e lib/string/strcpy/: MEMCPY(): Add macro
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/string/strcpy/: MEMCPY(): Add macro
    +    lib/string/strcpy/: memcpy_a(): Add macro
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    @@ lib/string/strcpy/memcpy.h (new)
     +#include <assert.h>
     +
     +
    -+#define MEMCPY(dst, src)                                              \
    ++// memcpy_a - memory copy array
    ++#define memcpy_a(dst, src)                                            \
     +({                                                                    \
    -+  static_assert(SIZEOF_ARRAY(dst) == SIZEOF_ARRAY(src), "");    \
    ++  static_assert(sizeof_a(dst) == sizeof_a(src), "");            \
     +                                                                      \
    -+  memcpy(dst, src, SIZEOF_ARRAY(dst));                          \
    ++  memcpy(dst, src, sizeof_a(dst));                              \
     +})
     +
     +
2:  136fb8812 ! 2:  e7edb3b27 lib/utmp.c: prepare_utmp(): Use MEMCPY() instead of its pattern
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/utmp.c: prepare_utmp(): Use MEMCPY() instead of its pattern
    +    lib/utmp.c: prepare_utmp(): Use memcpy_a() instead of its pattern
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    @@ lib/utmp.c: prepare_utmp(const char *name, const char *line, const char *host,
     -                                  &(sa->sin6_addr),
     -                                  MIN (sizeof (utent->ut_addr_v6),
     -                                       sizeof (sa->sin6_addr)));
    -+                          MEMCPY(utent->ut_addr_v6, sa->sin6_addr.s6_addr);
    ++                          memcpy_a(utent->ut_addr_v6, sa->sin6_addr.s6_addr);
      # endif
                        }
                        freeaddrinfo (info);
```
</details>

<details>
<summary>v2b</summary>

-  Update lib/string/README.

```
$ git range-diff gh/_a gh/mc mc 
1:  03bbc341e ! 1:  c4cc91187 lib/string/strcpy/: memcpy_a(): Add macro
    @@ lib/Makefile.am: libshadow_la_SOURCES = \
        string/strcpy/stpecpy.h \
        string/strcpy/strncat.c \
     
    + ## lib/string/README ##
    +@@ lib/string/README: strcpy/ - String copying
    +   a size.  This makes it safer for chaining several calls.
    + 
    +   m/
    +-    MEMCPY()
    ++    memcpy_a()
    +   Like memcpy(3), but takes two arrays.
    + 
    + sprintf/ - Formatted string creation
    +
      ## lib/string/strcpy/memcpy.c (new) ##
     @@
     +// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
2:  e7edb3b27 = 2:  2c9c74b0f lib/utmp.c: prepare_utmp(): Use memcpy_a() instead of its pattern
```
</details>

<details>
<summary>v2c</summary>

-  Rebase

```
$ git range-diff gh/_a..gh/mc _a..mc
1:  c4cc91187 = 1:  c82bca8d0 lib/string/strcpy/: memcpy_a(): Add macro
2:  2c9c74b0f ! 2:  1ac79da9e lib/utmp.c: prepare_utmp(): Use memcpy_a() instead of its pattern
    @@ lib/utmp.c
      #include "string/strcmp/strprefix.h"
     +#include "string/strcpy/memcpy.h"
      #include "string/strcpy/strncpy.h"
    - #include "string/strcpy/strtcpy.h"
      #include "string/strdup/strdup.h"
    + #include "string/strdup/strndup.h"
     @@ lib/utmp.c: prepare_utmp(const char *name, const char *line, const char *host,
                        } else if (info->ai_family == AF_INET6) {
                                struct sockaddr_in6 *sa =
```
</details>

<details>
<summary>v2d</summary>

-  Rebase

```
$ git range-diff gh/_a..gh/mc _a..mc
1:  c82bca8d0 = 1:  3e22dd033 lib/string/strcpy/: memcpy_a(): Add macro
2:  1ac79da9e = 2:  3dc937da5 lib/utmp.c: prepare_utmp(): Use memcpy_a() instead of its pattern
```
</details>

<details>
<summary>v2e</summary>

-  Rebase

```
$ git range-diff gh/_a..gh/mc shadow/master..mc 
1:  3e22dd033 = 1:  f3b1edd31 lib/string/strcpy/: memcpy_a(): Add macro
2:  3dc937da5 = 2:  ed7398219 lib/utmp.c: prepare_utmp(): Use memcpy_a() instead of its pattern
```
</details>

<details>
<summary>v2f</summary>

-  Rebase

```
$ git rd 
1:  f3b1edd31 = 1:  2e5f5f92c lib/string/strcpy/: memcpy_a(): Add macro
2:  ed7398219 ! 2:  8262a4dc3 lib/utmp.c: prepare_utmp(): Use memcpy_a() instead of its pattern
    @@ lib/utmp.c: prepare_utmp(const char *name, const char *line, const char *host,
                                        (struct sockaddr_in6 *) info->ai_addr;
     -                          memcpy (utent->ut_addr_v6,
     -                                  &(sa->sin6_addr),
    --                                  MIN (sizeof (utent->ut_addr_v6),
    --                                       sizeof (sa->sin6_addr)));
    +-                                  MIN(sizeof(utent->ut_addr_v6),
    +-                                      sizeof(sa->sin6_addr)));
     +                          memcpy_a(utent->ut_addr_v6, sa->sin6_addr.s6_addr);
      # endif
                        }
```
</details>

<details>
<summary>v2g</summary>

-  Rebase

```
$ git rd 
1:  2e5f5f92c = 1:  3fa525926 lib/string/strcpy/: memcpy_a(): Add macro
2:  8262a4dc3 = 2:  47529a5b8 lib/utmp.c: prepare_utmp(): Use memcpy_a() instead of its pattern
```
</details>

<details>
<summary>v2h</summary>

-  Rebase

```
$ git rd 
1:  3fa525926 = 1:  a717e5bb3 lib/string/strcpy/: memcpy_a(): Add macro
2:  47529a5b8 = 2:  21a9f6c38 lib/utmp.c: prepare_utmp(): Use memcpy_a() instead of its pattern
```
</details>

<details>
<summary>v2i</summary>

-  Rebase

```
$ git rd 
1:  a717e5bb3 = 1:  35f71d23a lib/string/strcpy/: memcpy_a(): Add macro
2:  21a9f6c38 = 2:  affe3d5a9 lib/utmp.c: prepare_utmp(): Use memcpy_a() instead of its pattern
```
</details>

<details>
<summary>v2j</summary>

-  Rebase

```
$ git rd 
1:  35f71d23aca9 = 1:  4b4ad74692d0 lib/string/strcpy/: memcpy_a(): Add macro
2:  affe3d5a9616 ! 2:  c606c9d28684 lib/utmp.c: prepare_utmp(): Use memcpy_a() instead of its pattern
    @@ lib/utmp.c
      #include "string/strcmp/strprefix.h"
     +#include "string/strcpy/memcpy.h"
      #include "string/strcpy/strncpy.h"
    + #include "string/strdup/memdup.h"
      #include "string/strdup/strdup.h"
    - #include "string/strdup/strndup.h"
     @@ lib/utmp.c: prepare_utmp(const char *name, const char *line, const char *host,
                        } else if (info->ai_family == AF_INET6) {
                                struct sockaddr_in6 *sa =
```
</details>

<details>
<summary>v2k</summary>

-  Rebase

```
$ git rd 
1:  4b4ad746 = 1:  ef2d1535 lib/string/strcpy/: memcpy_a(): Add macro
2:  c606c9d2 = 2:  1663d8a2 lib/utmp.c: prepare_utmp(): Use memcpy_a() instead of its pattern
```
</details>

<details>
<summary>v2l</summary>

-  Rebase

```
$ git rd 
1:  ef2d1535 = 1:  4cb63560 lib/string/strcpy/: memcpy_a(): Add macro
2:  1663d8a2 = 2:  4893be27 lib/utmp.c: prepare_utmp(): Use memcpy_a() instead of its pattern
```
</details>

<details>
<summary>v2m</summary>

-  Rebase

```
$ git rd 
1:  4cb635604bcb = 1:  25f1333d2ec8 lib/string/strcpy/: memcpy_a(): Add macro
2:  4893be270c99 = 2:  7613ad8dd644 lib/utmp.c: prepare_utmp(): Use memcpy_a() instead of its pattern
```
</details>

<details>
<summary>v2n</summary>

-  Rebase

```
$ git rd 
1:  25f1333d2ec8 = 1:  1528fe36e36b lib/string/strcpy/: memcpy_a(): Add macro
2:  7613ad8dd644 = 2:  6255ecf45cd6 lib/utmp.c: prepare_utmp(): Use memcpy_a() instead of its pattern
```
</details>

<details>
<summary>v2o</summary>

-  Rebase

```
$ git rd 
1:  1528fe36e36b = 1:  063a158fc7cc lib/string/strcpy/: memcpy_a(): Add macro
2:  6255ecf45cd6 = 2:  c55bfb47cecf lib/utmp.c: prepare_utmp(): Use memcpy_a() instead of its pattern
```
</details>

<details>
<summary>v3</summary>

-  Use <memory.h> instead of <string.h>. Historically, and morally, it's more appropriate. It's quite portable, so it should be fine, even though it's non-standard. See memory.h(3head).

```
$ git rd 
1:  063a158fc7cc ! 1:  ae476d2d4f00 lib/string/strcpy/: memcpy_a(): Add macro
    @@ lib/string/strcpy/memcpy.h (new)
     +
     +#include "config.h"
     +
    -+#include <string.h>
    ++#include <memory.h>
     +
     +#include "sizeof.h"
     +
2:  c55bfb47cecf = 2:  d3e94c2d9bfe lib/utmp.c: prepare_utmp(): Use memcpy_a() instead of its pattern
```
</details>

<details>
<summary>v3b</summary>

-  wsfix

```
$ git rd 
1:  ae476d2d4f00 ! 1:  81ee46501194 lib/string/strcpy/: memcpy_a(): Add macro
    @@ lib/string/strcpy/memcpy.h (new)
     +#define memcpy_a(dst, src)                                            \
     +({                                                                    \
     +  static_assert(sizeof_a(dst) == sizeof_a(src), "");            \
    -+                                                                      \
    ++                                                                \
     +  memcpy(dst, src, sizeof_a(dst));                              \
     +})
     +
2:  d3e94c2d9bfe = 2:  ba80e2885cf9 lib/utmp.c: prepare_utmp(): Use memcpy_a() instead of its pattern
```
</details>

<details>
<summary>v4</summary>

-  Move API to a new lib/memory/.  [@ikerexxe ]

```
$ git rd --creation-factor=99 
1:  81ee46501194 ! 1:  aa8bdefd8bab lib/string/strcpy/: memcpy_a(): Add macro
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/string/strcpy/: memcpy_a(): Add macro
    +    lib/memory/memcpy/: memcpy_a(): Add macro
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/Makefile.am ##
     @@ lib/Makefile.am: libshadow_la_SOURCES = \
    -   string/strcmp/strneq.h \
    -   string/strcmp/strprefix.c \
    -   string/strcmp/strprefix.h \
    -+  string/strcpy/memcpy.c \
    -+  string/strcpy/memcpy.h \
    -   string/strcpy/stpecpy.c \
    -   string/strcpy/stpecpy.h \
    -   string/strcpy/strncat.c \
    +   lockpw.c \
    +   loginprompt.c \
    +   mail.c \
    ++  memory/memcpy/memcpy.c \
    ++  memory/memcpy/memcpy.h \
    +   motd.c \
    +   myname.c \
    +   nss.c \
     
    - ## lib/string/README ##
    -@@ lib/string/README: strcpy/ - String copying
    -   a size.  This makes it safer for chaining several calls.
    - 
    -   m/
    --    MEMCPY()
    -+    memcpy_a()
    -   Like memcpy(3), but takes two arrays.
    - 
    - sprintf/ - Formatted string creation
    -
    - ## lib/string/strcpy/memcpy.c (new) ##
    + ## lib/memory/memcpy/memcpy.c (new) ##
     @@
    -+// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
    ++// SPDX-FileCopyrightText: 2025-2026, Alejandro Colomar <alx@kernel.org>
     +// SPDX-License-Identifier: BSD-3-Clause
     +
     +
     +#include "config.h"
     +
    -+#include "string/strcpy/memcpy.h"
    ++#include "memory/memcpy/memcpy.h"
     
    - ## lib/string/strcpy/memcpy.h (new) ##
    + ## lib/memory/memcpy/memcpy.h (new) ##
     @@
    -+// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
    ++// SPDX-FileCopyrightText: 2025-2026, Alejandro Colomar <alx@kernel.org>
     +// SPDX-License-Identifier: BSD-3-Clause
     +
     +
    -+#ifndef SHADOW_INCLUDE_LIB_STRING_STRCPY_MEMCPY_H_
    -+#define SHADOW_INCLUDE_LIB_STRING_STRCPY_MEMCPY_H_
    ++#ifndef SHADOW_INCLUDE_LIB_MEMORY_MEMCPY_MEMCPY_H_
    ++#define SHADOW_INCLUDE_LIB_MEMORY_MEMCPY_MEMCPY_H_
     +
     +
     +#include "config.h"
    @@ lib/string/strcpy/memcpy.h (new)
     +
     +
     +#endif  // include guard
    +
    + ## lib/string/README ##
    +@@ lib/string/README: strcpy/ - String copying
    +   a size.  This makes it safer for chaining several calls.
    + 
    +   m/
    +-    MEMCPY()
    ++    memcpy_a()
    +   Like memcpy(3), but takes two arrays.
    + 
    + sprintf/ - Formatted string creation
2:  ba80e2885cf9 ! 2:  fc89d8f3710b lib/utmp.c: prepare_utmp(): Use memcpy_a() instead of its pattern
    @@ Commit message
     
      ## lib/utmp.c ##
     @@
    + #include "alloc/malloc.h"
    + #include "attr.h"
    + #include "io/syslog.h"
    ++#include "memory/memcpy/memcpy.h"
    + #include "sizeof.h"
    + #include "string/strchr/strnul.h"
      #include "string/strcmp/streq.h"
    - #include "string/strcmp/strneq.h"
    - #include "string/strcmp/strprefix.h"
    -+#include "string/strcpy/memcpy.h"
    - #include "string/strcpy/strncpy.h"
    - #include "string/strdup/memdup.h"
    - #include "string/strdup/strdup.h"
     @@ lib/utmp.c: prepare_utmp(const char *name, const char *line, const char *host,
                        } else if (info->ai_family == AF_INET6) {
                                struct sockaddr_in6 *sa =
```
</details>

<details>
<summary>v4b</summary>

-  Rebase

```
$ git rd 
1:  aa8bdefd8bab ! 1:  7f7b46ef523b lib/memory/memcpy/: memcpy_a(): Add macro
    @@ lib/Makefile.am: libshadow_la_SOURCES = \
        mail.c \
     +  memory/memcpy/memcpy.c \
     +  memory/memcpy/memcpy.h \
    +   memory/memcpy/strncpytail.c \
    +   memory/memcpy/strncpytail.h \
        motd.c \
    -   myname.c \
    -   nss.c \
     
      ## lib/memory/memcpy/memcpy.c (new) ##
     @@
2:  fc89d8f3710b ! 2:  45fba36133fe lib/utmp.c: prepare_utmp(): Use memcpy_a() instead of its pattern
    @@ lib/utmp.c
      #include "attr.h"
      #include "io/syslog.h"
     +#include "memory/memcpy/memcpy.h"
    + #include "memory/memcpy/strncpytail.h"
      #include "sizeof.h"
      #include "string/strchr/strnul.h"
    - #include "string/strcmp/streq.h"
     @@ lib/utmp.c: prepare_utmp(const char *name, const char *line, const char *host,
                        } else if (info->ai_family == AF_INET6) {
                                struct sockaddr_in6 *sa =
```
</details>

<details>
<summary>v5</summary>

-  `#undef NDEBUG` before including `<assert.h>`.

```
$ git rd 
1:  7f7b46ef523b ! 1:  de060e37228d lib/memory/memcpy/: memcpy_a(): Add macro
    @@ lib/memory/memcpy/memcpy.h (new)
     +
     +#include "sizeof.h"
     +
    ++#undef NDEBUG
     +#include <assert.h>
     +
     +
2:  45fba36133fe = 2:  591720a5fbf2 lib/utmp.c: prepare_utmp(): Use memcpy_a() instead of its pattern
```
</details>

<details>
<summary>v6</summary>

-  Don't return anything from memcpy_a().  It takes real arrays as input, which means we already have them available, and returning them isn't very useful.  If we ever find them useful, we'll see if we want to return anything, but for now let's keep it simpler, and thus more robust.

```
$ git rd 
1:  de060e37228d ! 1:  ce4ddfb9b1ef lib/memory/memcpy/: memcpy_a(): Add macro
    @@ lib/memory/memcpy/memcpy.h (new)
     +
     +
     +// memcpy_a - memory copy array
    -+#define memcpy_a(dst, src)                                            \
    -+({                                                                    \
    ++#define memcpy_a(dst, src)  do                                        \
    ++{                                                                     \
     +  static_assert(sizeof_a(dst) == sizeof_a(src), "");            \
     +                                                                \
     +  memcpy(dst, src, sizeof_a(dst));                              \
    -+})
    ++} while (0)
     +
     +
     +#endif  // include guard
2:  591720a5fbf2 = 2:  b1f081a81cb0 lib/utmp.c: prepare_utmp(): Use memcpy_a() instead of its pattern
```
</details>

<details>
<summary>v6b</summary>

-  Rebase

```
$ git rd 
1:  ce4ddfb9b1ef = 1:  e14ed3f55bf6 lib/memory/memcpy/: memcpy_a(): Add macro
2:  b1f081a81cb0 = 2:  fa6a821864b2 lib/utmp.c: prepare_utmp(): Use memcpy_a() instead of its pattern
```
</details>

<details>
<summary>v6c</summary>

-  Rebase

```
$ git rd 
1:  e14ed3f55bf6 ! 1:  23bac78e5bbf lib/memory/memcpy/: memcpy_a(): Add macro
    @@ Commit message
     
      ## lib/Makefile.am ##
     @@ lib/Makefile.am: libshadow_la_SOURCES = \
    -   lockpw.c \
    -   loginprompt.c \
    -   mail.c \
    +   memory/memcmp/memeq.h \
    +   memory/memcmp/strneq.c \
    +   memory/memcmp/strneq.h \
     +  memory/memcpy/memcpy.c \
     +  memory/memcpy/memcpy.h \
    -   memory/memcpy/strncpytail.c \
    -   memory/memcpy/strncpytail.h \
    -   motd.c \
    +   memory/memcpy/strncat.c \
    +   memory/memcpy/strncat.h \
    +   memory/memcpy/strncpy.c \
     
      ## lib/memory/memcpy/memcpy.c (new) ##
     @@
    @@ lib/memory/memcpy/memcpy.h (new)
     +
     +
     +#endif  // include guard
    -
    - ## lib/string/README ##
    -@@ lib/string/README: strcpy/ - String copying
    -   a size.  This makes it safer for chaining several calls.
    - 
    -   m/
    --    MEMCPY()
    -+    memcpy_a()
    -   Like memcpy(3), but takes two arrays.
    - 
    - sprintf/ - Formatted string creation
2:  fa6a821864b2 ! 2:  81bbab95ac78 lib/utmp.c: prepare_utmp(): Use memcpy_a() instead of its pattern
    @@ Commit message
     
      ## lib/utmp.c ##
     @@
    - #include "alloc/malloc.h"
      #include "attr.h"
      #include "io/syslog.h"
    + #include "memory/memcmp/strneq.h"
     +#include "memory/memcpy/memcpy.h"
    + #include "memory/memcpy/strncpy.h"
      #include "memory/memcpy/strncpytail.h"
    - #include "sizeof.h"
    - #include "string/strchr/strnul.h"
    + #include "memory/memdup/memdup.h"
     @@ lib/utmp.c: prepare_utmp(const char *name, const char *line, const char *host,
                        } else if (info->ai_family == AF_INET6) {
                                struct sockaddr_in6 *sa =
```
</details>