### PR TITLE
Simplify error handling (mainly, error messages)

### DIFF
--- a/lib/commonio.c
+++ b/lib/commonio.c
@@ -72,9 +72,9 @@ static int check_link_count (const char *file, bool log)
 {
 	struct stat sb;
 
-	if (stat (file, &sb) != 0) {
+	if (stat(file, &sb) == -1) {
 		if (log) {
-			fprinte(log_get_logfd(), "%s: %s file stat error",
+			fprinte(log_get_logfd(), "%s: stat(\"%s\")",
 			        log_get_progname(), file);
 		}
 		return 0;
@@ -104,7 +104,7 @@ static int do_lock_file (const char *file, const char *lock, bool log)
 	fd = open (file, O_CREAT | O_TRUNC | O_WRONLY, 0600);
 	if (-1 == fd) {
 		if (log) {
-			fprinte(log_get_logfd(), "%s: %s", log_get_progname(), file);
+			fprinte(log_get_logfd(), "%s: open(\"%s\")", log_get_progname(), file);
 		}
 		return 0;
 	}
@@ -114,7 +114,7 @@ static int do_lock_file (const char *file, const char *lock, bool log)
 	len = (ssize_t) strlen (buf) + 1;
 	if (write_full(fd, buf, len) == -1) {
 		if (log) {
-			fprinte(log_get_logfd(), "%s: %s file write error",
+			fprinte(log_get_logfd(), "%s: write(\"%s\")",
 			        log_get_progname(), file);
 		}
 		(void) close (fd);
@@ -123,7 +123,7 @@ static int do_lock_file (const char *file, const char *lock, bool log)
 	}
 	if (fdatasync (fd) == -1) {
 		if (log) {
-			fprinte(log_get_logfd(), "%s: %s file sync error",
+			fprinte(log_get_logfd(), "%s: fdatasync(\"%s\")",
 			        log_get_progname(), file);
 		}
 		(void) close (fd);
@@ -141,7 +141,7 @@ static int do_lock_file (const char *file, const char *lock, bool log)
 	fd = open (lock, O_RDWR);
 	if (-1 == fd) {
 		if (log) {
-			fprinte(log_get_logfd(), "%s: %s", log_get_progname(), lock);
+			fprinte(log_get_logfd(), "%s: open(\"%s\")", log_get_progname(), lock);
 		}
 		unlink (file);
 		errno = EINVAL;

--- a/lib/copydir.c
+++ b/lib/copydir.c
@@ -106,7 +106,7 @@ error_acl(MAYBE_UNUSED struct error_context *_1, const char *fmt, ...)
 	e = errno;
 
 	va_start (ap, fmt);
-	(void) fprintf (log_get_logfd(), _("%s: "), log_get_progname());
+	fprintf(log_get_logfd(), "%s: ", log_get_progname());
 	vfprintec(log_get_logfd(), e, fmt, ap);
 	va_end (ap);
 

--- a/lib/find_new_gid.c
+++ b/lib/find_new_gid.c
@@ -240,8 +240,7 @@ int find_new_gid (bool sys_group,
 	/* Create an array to hold all of the discovered GIDs */
 	used_gids = calloc_T(gid_max + 1, bool);
 	if (NULL == used_gids) {
-		fprinte(log_get_logfd(), _("%s: failed to allocate memory"),
-			log_get_progname());
+		fprinte(log_get_logfd(), "%s: calloc", log_get_progname());
 		return -1;
 	}
 

--- a/lib/find_new_uid.c
+++ b/lib/find_new_uid.c
@@ -239,8 +239,7 @@ int find_new_uid(bool sys_user,
 	/* Create an array to hold all of the discovered UIDs */
 	used_uids = calloc_T(uid_max + 1, bool);
 	if (NULL == used_uids) {
-		fprinte(log_get_logfd(), _("%s: failed to allocate memory"),
-			log_get_progname());
+		fprinte(log_get_logfd(), "%s: calloc", log_get_progname());
 		return -1;
 	}
 

--- a/lib/get_pid.c
+++ b/lib/get_pid.c
@@ -60,13 +60,13 @@ int open_pidfd(const char *pidstr)
 		return -ENOENT;
 
 	if (stprintf_a(proc_dir_name, "/proc/%d/", target) == -1) {
-		eprinte("snprintf of proc path failed for %d", target);
+		eprinte("snprintf");
 		return -EINVAL;
 	}
 
 	proc_dir_fd = open(proc_dir_name, O_DIRECTORY);
-	if (proc_dir_fd < 0) {
-		eprinte(_("Could not open proc directory for target %d"), target);
+	if (proc_dir_fd == -1) {
+		eprinte("open(\"%s\")", proc_dir_name);
 		return -EINVAL;
 	}
 	return proc_dir_fd;

--- a/lib/gettime.c
+++ b/lib/gettime.c
@@ -38,8 +38,7 @@ gettime(void)
 		return fallback;
 
 	if (a2i(time_t, &epoch, source_date_epoch, NULL, 10, 0, fallback) == -1) {
-		fprinte(log_get_logfd(),
-		        _("Environment variable $SOURCE_DATE_EPOCH: a2i(\"%s\")"),
+		fprinte(log_get_logfd(), "a2i(SOURCE_DATE_EPOCH=\"%s\")",
 		        source_date_epoch);
 		return fallback;
 	}

--- a/lib/idmapping.c
+++ b/lib/idmapping.c
@@ -49,8 +49,7 @@ get_map_ranges(int ranges, int argc, char **argv)
 
 	mappings = calloc_T(ranges, struct map_range);
 	if (!mappings) {
-		fprintf(log_get_logfd(), _( "%s: Memory allocation failure\n"),
-			log_get_progname());
+		fprinte(log_get_logfd(), "%s: calloc:", log_get_progname());
 		return NULL;
 	}
 
@@ -150,12 +149,12 @@ void write_mapping(int proc_dir_fd, int ranges, const struct map_range *mappings
 	/* Align setuid- and fscaps-based new{g,u}idmap behavior. */
 	if (geteuid() == 0 && geteuid() != ruid) {
 		if (prctl(PR_SET_KEEPCAPS, 1L) == -1) {
-			fprintf(log_get_logfd(), _("%s: Could not prctl(PR_SET_KEEPCAPS)\n"), log_get_progname());
+			fprinte(log_get_logfd(), "%s: prctl(PR_SET_KEEPCAPS)", log_get_progname());
 			exit(EXIT_FAILURE);
 		}
 
-		if (seteuid(ruid) < 0) {
-			fprintf(log_get_logfd(), _("%s: Could not seteuid to %d\n"), log_get_progname(), ruid);
+		if (seteuid(ruid) == -1) {
+			fprinte(log_get_logfd(), "%s: seteuid(%d)", log_get_progname(), ruid);
 			exit(EXIT_FAILURE);
 		}
 	}
@@ -170,8 +169,8 @@ void write_mapping(int proc_dir_fd, int ranges, const struct map_range *mappings
 	if (maps_lower_root(cap, ranges, mappings))
 		data[0].effective |= CAP_TO_MASK(CAP_SETFCAP);
 	data[0].permitted = data[0].effective;
-	if (capset(&hdr, data) < 0) {
-		fprintf(log_get_logfd(), _("%s: Could not set caps\n"), log_get_progname());
+	if (capset(&hdr, data) == -1) {
+		fprinte(log_get_logfd(), "%s: capset", log_get_progname());
 		exit(EXIT_FAILURE);
 	}
 #endif
@@ -190,24 +189,24 @@ void write_mapping(int proc_dir_fd, int ranges, const struct map_range *mappings
 		                 mapping->count);
 	}
 	if (pos == end || pos == NULL) {
-		fprintf(log_get_logfd(), _("%s: seprintf failed!\n"), log_get_progname());
+		fprinte(log_get_logfd(), "%s: seprintf", log_get_progname());
 		exit(EXIT_FAILURE);
 	}
 
 	/* Write the mapping to the mapping file */
 	fd = openat(proc_dir_fd, map_file, O_WRONLY);
-	if (fd < 0) {
-		fprinte(log_get_logfd(), _("%s: open of %s failed"),
+	if (fd == -1) {
+		fprinte(log_get_logfd(), "%s: openat(%s)",
 			log_get_progname(), map_file);
 		exit(EXIT_FAILURE);
 	}
 	if (write_full(fd, buf, pos - buf) == -1) {
-		fprinte(log_get_logfd(), _("%s: write to %s failed"),
+		fprinte(log_get_logfd(), "%s: write(\"%s\")",
 			log_get_progname(), map_file);
 		exit(EXIT_FAILURE);
 	}
-	if (close(fd) != 0 && errno != EINTR) {
-		fprinte(log_get_logfd(), _("%s: closing %s failed"),
+	if (close(fd) == -1 && errno != EINTR) {
+		fprinte(log_get_logfd(), "%s: close(\"%s\")",
 			log_get_progname(), map_file);
 		exit(EXIT_FAILURE);
 	}

--- a/lib/nss.c
+++ b/lib/nss.c
@@ -12,7 +12,6 @@
 #include "alloc/malloc.h"
 #include "io/fprintf.h"
 #include "prototypes.h"
-#include "../libsubid/subid.h"
 #include "shadowlog.h"
 #include "string/sprintf/stprintf.h"
 #include "string/strcmp/strcaseprefix.h"
@@ -20,6 +19,8 @@
 #include "string/strcmp/strprefix.h"
 #include "string/strspn/stpspn.h"
 #include "string/strtok/stpsep.h"
+
+#include "../libsubid/subid.h"
 
 
 #define NSSWITCH "/etc/nsswitch.conf"
@@ -71,9 +72,9 @@ nss_init(const char *nsswitch_path) {
 	// read nsswitch.conf to check for a line like:
 	//   subid:	files
 	nssfp = fopen(nsswitch_path, "r");
-	if (!nssfp) {
+	if (nssfp == NULL) {
 		if (errno != ENOENT)
-			fprinte(log_get_logfd(), "Failed opening %s", nsswitch_path);
+			fprinte(log_get_logfd(), "fopen(\"%s\")", nsswitch_path);
 
 		atomic_store(&nss_init_completed, true);
 		return;

--- a/lib/prefix_flag.c
+++ b/lib/prefix_flag.c
@@ -89,10 +89,12 @@ extern const char* process_prefix_flag (const char* short_opt, int argc, char **
 
 	if (prefix != NULL) {
 		/* Drop privileges */
-		if (   (setregid (getgid (), getgid ()) != 0)
-		    || (setreuid (getuid (), getuid ()) != 0)) {
-			fprinte(log_get_logfd(), _("%s: failed to drop privileges"),
-			        log_get_progname());
+		if (setregid(getgid(), getgid()) == -1) {
+			fprinte(log_get_logfd(), "%s: setregid", log_get_progname());
+			exit (EXIT_FAILURE);
+		}
+		if (setreuid(getuid(), getuid()) == -1) {
+			fprinte(log_get_logfd(), "%s: setreuid", log_get_progname());
 			exit (EXIT_FAILURE);
 		}
 

--- a/lib/root_flag.c
+++ b/lib/root_flag.c
@@ -73,10 +73,12 @@ extern void process_root_flag (const char* short_opt, int argc, char **argv)
 static void change_root (const char* newroot)
 {
 	/* Drop privileges */
-	if (   (setregid (getgid (), getgid ()) != 0)
-	    || (setreuid (getuid (), getuid ()) != 0)) {
-		fprinte(log_get_logfd(), _("%s: failed to drop privileges"),
-		        log_get_progname());
+	if (setregid(getgid(), getgid()) == -1) {
+		fprinte(log_get_logfd(), "%s: setregid", log_get_progname());
+		exit (EXIT_FAILURE);
+	}
+	if (setreuid(getuid(), getuid()) == -1) {
+		fprinte(log_get_logfd(), "%s: setreuid", log_get_progname());
 		exit (EXIT_FAILURE);
 	}
 
@@ -87,20 +89,20 @@ static void change_root (const char* newroot)
 		exit (E_BAD_ARG);
 	}
 
-	if (access (newroot, F_OK) != 0) {
-		fprinte(log_get_logfd(), _("%s: cannot access chroot directory %s"),
+	if (access(newroot, F_OK) == -1) {
+		fprinte(log_get_logfd(), "%s: access(\"%s\", F_OK)",
 		        log_get_progname(), newroot);
 		exit (E_BAD_ARG);
 	}
 
-	if (chroot (newroot) != 0) {
-		fprinte(log_get_logfd(), _("%s: unable to chroot to directory %s"),
+	if (chroot(newroot) == -1) {
+		fprinte(log_get_logfd(), "%s: chroot(\"%s\")",
 		        log_get_progname(), newroot);
 		exit (E_BAD_ARG);
 	}
 
-	if (chdir ("/") != 0) {
-		fprinte(log_get_logfd(), _("%s: cannot chdir in chroot directory %s"),
+	if (chdir("/") == -1) {
+		fprinte(log_get_logfd(), "%s: chdir(\"%s\")",
 		        log_get_progname(), newroot);
 		exit (E_BAD_ARG);
 	}

--- a/lib/salt.c
+++ b/lib/salt.c
@@ -21,6 +21,7 @@
 
 #include "defines.h"
 #include "getdef.h"
+#include "io/fprintf.h"
 #include "prototypes.h"
 #include "shadowlog.h"
 #include "string/sprintf/stprintf.h"
@@ -393,13 +394,8 @@ sha512:
 
 	/* Should not happen, but... */
 	if (NULL == retval) {
-		fprintf (log_get_logfd(),
-			 _("Unable to generate a salt from setting "
-			   "\"%s\", check your settings in "
-			   "ENCRYPT_METHOD and the corresponding "
-			   "configuration for your selected hash "
-			   "method.\n"), result);
-
+		fprinte(log_get_logfd(), "crypt_gensalt(\"%s\", %lu)",
+		        result, rounds);
 		exit (1);
 	}
 

--- a/lib/semanage.c
+++ b/lib/semanage.c
@@ -44,7 +44,7 @@ static void semanage_error_callback(MAYBE_UNUSED void *_1,
 	switch (semanage_msg_get_level (handle)) {
 	case SEMANAGE_MSG_ERR:
 	case SEMANAGE_MSG_WARN:
-		fprintf (log_get_logfd(), _("[libsemanage]: %s\n"), message);
+		fprintf(log_get_logfd(), "[libsemanage]: %s\n", message);
 		break;
 	case SEMANAGE_MSG_INFO:
 		/* nop */

--- a/lib/setupenv.c
+++ b/lib/setupenv.c
@@ -24,6 +24,7 @@
 #include "defines.h"
 #include "getdef.h"
 #include "io/fgets/fgets.h"
+#include "io/fprintf.h"
 #include "shadowlog.h"
 #include "string/sprintf/aprintf.h"
 #include "string/strcmp/streq.h"
@@ -109,10 +110,9 @@ void setup_env (struct passwd *info)
 	 * this a configurable option.  --marekm
 	 */
 
-	if (chdir (info->pw_dir) == -1) {
+	if (chdir(info->pw_dir) == -1) {
 		if (!getdef_bool ("DEFAULT_HOME") || chdir ("/") == -1) {
-			fprintf (log_get_logfd(), _("Unable to cd to '%s'\n"),
-				 info->pw_dir);
+			fprinte(log_get_logfd(), "chdir(\"%s\")", info->pw_dir);
 			SYSLOG(LOG_WARN,
 				"unable to cd to `%s' for user `%s'\n",
 				info->pw_dir, info->pw_name);

--- a/lib/spawn.c
+++ b/lib/spawn.c
@@ -39,12 +39,10 @@ run_command(const char *cmd, const char *argv[],
 		if (ENOENT == errno) {
 			_exit (E_CMD_NOTFOUND);
 		}
-		fprinte(log_get_logfd(), "%s: cannot execute %s",
-		        log_get_progname(), cmd);
+		fprinte(log_get_logfd(), "%s: execve(\"%s\")", log_get_progname(), cmd);
 		_exit (E_CMD_NOEXEC);
 	} else if ((pid_t)-1 == pid) {
-		fprinte(log_get_logfd(), "%s: cannot execute %s",
-		        log_get_progname(), cmd);
+		fprinte(log_get_logfd(), "%s: fork(\"%s\")", log_get_progname(), cmd);
 		return -1;
 	}
 
@@ -56,7 +54,7 @@ run_command(const char *cmd, const char *argv[],
 	         || ((pid_t)-1 != wpid && wpid != pid));
 
 	if ((pid_t)-1 == wpid) {
-		fprinte(log_get_logfd(), "%s: waitpid (status: %d)",
+		fprinte(log_get_logfd(), "%s: waitpid(status: %d)",
 		        log_get_progname(), *status);
 		return -1;
 	}

--- a/lib/tcbfuncs.c
+++ b/lib/tcbfuncs.c
@@ -64,7 +64,7 @@ shadowtcb_status shadowtcb_gain_priv (void)
  * to exit soon.
  */
 #define OUT_OF_MEMORY do { \
-	fprintf (log_get_logfd(), _("%s: out of memory\n"), log_get_progname()); \
+	fprinte(log_get_logfd(), "%s: malloc", log_get_progname()); \
 	(void) fflush (log_get_logfd()); \
 } while (false)
 
@@ -101,8 +101,8 @@ static /*@null@*/ char *shadowtcb_path_rel_existing (const char *name)
 		OUT_OF_MEMORY;
 		return NULL;
 	}
-	if (lstat (path, &st) != 0) {
-		fprinte(log_get_logfd(), _("%s: Cannot stat %s"), log_get_progname(), path);
+	if (lstat(path, &st) == -1) {
+		fprinte(log_get_logfd(), "%s: lstat(\"%s\")", log_get_progname(), path);
 		free (path);
 		return NULL;
 	}
@@ -123,7 +123,7 @@ static /*@null@*/ char *shadowtcb_path_rel_existing (const char *name)
 		return NULL;
 	}
 	if (readlinknul_a(path, link) == -1) {
-		fprinte(log_get_logfd(), _("%s: Cannot read symbolic link %s"),
+		fprinte(log_get_logfd(), "%s: readlinknul(\"%s\")",
 		        log_get_progname(), path);
 		free (path);
 		return NULL;
@@ -182,9 +182,8 @@ static shadowtcb_status mkdir_leading (const char *name, uid_t uid)
 		return SHADOWTCB_FAILURE;
 	}
 	ptr = path;
-	if (stat (TCB_DIR, &st) != 0) {
-		fprinte(log_get_logfd(), _("%s: Cannot stat %s"),
-		        log_get_progname(), TCB_DIR);
+	if (stat(TCB_DIR, &st) == -1) {
+		fprinte(log_get_logfd(), "%s: stat(\"%s\")", log_get_progname(), TCB_DIR);
 		goto out_free_path;
 	}
 	while (NULL != (ind = strchr(ptr, '/'))) {
@@ -194,18 +193,18 @@ static shadowtcb_status mkdir_leading (const char *name, uid_t uid)
 			OUT_OF_MEMORY;
 			return SHADOWTCB_FAILURE;
 		}
-		if ((mkdir (dir, 0700) != 0) && (errno != EEXIST)) {
-			fprinte(log_get_logfd(), _("%s: Cannot create directory %s"),
+		if (mkdir(dir, 0700) == -1 && errno != EEXIST) {
+			fprinte(log_get_logfd(), "%s: mkdir(\"%s\")",
 			        log_get_progname(), dir);
 			goto out_free_dir;
 		}
-		if (chown (dir, 0, st.st_gid) != 0) {
-			fprinte(log_get_logfd(), _("%s: Cannot change owner of %s"),
+		if (chown(dir, 0, st.st_gid) == -1) {
+			fprinte(log_get_logfd(), "%s: chown(\"%s\")",
 			        log_get_progname(), dir);
 			goto out_free_dir;
 		}
-		if (chmod (dir, 0711) != 0) {
-			fprinte(log_get_logfd(), _("%s: Cannot change mode of %s"),
+		if (chmod(dir, 0711) == -1) {
+			fprinte(log_get_logfd(), "%s: chmod(\"%s\")",
 			        log_get_progname(), dir);
 			goto out_free_dir;
 		}
@@ -234,8 +233,8 @@ static shadowtcb_status unlink_suffs (const char *user)
 			OUT_OF_MEMORY;
 			return SHADOWTCB_FAILURE;
 		}
-		if ((unlink (tmp) != 0) && (errno != ENOENT)) {
-			fprinte(log_get_logfd(), "%s: unlink: %s", log_get_progname(), tmp);
+		if (unlink(tmp) == -1 && errno != ENOENT) {
+			fprinte(log_get_logfd(), "%s: unlink(\"%s\")", log_get_progname(), tmp);
 			free (tmp);
 			return SHADOWTCB_FAILURE;
 		}
@@ -263,8 +262,7 @@ rmdir_leading(const char *relpath)
 
 		if (rmdir(path) != 0) {
 			if (errno != ENOTEMPTY) {
-				fprinte(log_get_logfd(),
-				        _("%s: Cannot remove directory %s"),
+				fprinte(log_get_logfd(), "%s: rmdir(\"%s\")",
 				        log_get_progname(), path);
 				ret = SHADOWTCB_FAILURE;
 			}
@@ -296,9 +294,8 @@ static shadowtcb_status move_dir (const char *user_newname, uid_t user_newid)
 	if (olddir == NULL) {
 		goto out_free_nomem;
 	}
-	if (stat (olddir, &oldmode) != 0) {
-		fprinte(log_get_logfd(), _("%s: Cannot stat %s"),
-		        log_get_progname(), olddir);
+	if (stat(olddir, &oldmode) == -1) {
+		fprinte(log_get_logfd(), "%s: stat(\"%s\")", log_get_progname(), olddir);
 		goto out_free;
 	}
 	old_uid = oldmode.st_uid;
@@ -322,17 +319,16 @@ static shadowtcb_status move_dir (const char *user_newname, uid_t user_newid)
 	if (mkdir_leading (user_newname, the_newid) == SHADOWTCB_FAILURE) {
 		goto out_free;
 	}
-	if (rename (real_old_dir, real_new_dir) != 0) {
-		fprinte(log_get_logfd(), _("%s: Cannot rename %s to %s"),
+	if (rename(real_old_dir, real_new_dir) == -1) {
+		fprinte(log_get_logfd(), "%s: rename(\"%s\", \"%s\")",
 		        log_get_progname(), real_old_dir, real_new_dir);
 		goto out_free;
 	}
 	if (rmdir_leading (real_old_dir_rel) == SHADOWTCB_FAILURE) {
 		goto out_free;
 	}
-	if ((unlink (olddir) != 0) && (errno != ENOENT)) {
-		fprinte(log_get_logfd(), _("%s: Cannot remove %s"),
-		        log_get_progname(), olddir);
+	if (unlink(olddir) == -1 && errno != ENOENT) {
+		fprinte(log_get_logfd(), "%s: unlink(\"%s\")", log_get_progname(), olddir);
 		goto out_free;
 	}
 	newdir = aprintf(TCB_DIR "/%s", user_newname);
@@ -344,8 +340,8 @@ static shadowtcb_status move_dir (const char *user_newname, uid_t user_newid)
 		goto out_free;
 	}
 	if (   !streq(real_new_dir, newdir)
-	    && (symlink (real_new_dir_rel, newdir) != 0)) {
-		fprinte(log_get_logfd(), _("%s: Cannot create symbolic link %s"),
+	    && symlink(real_new_dir_rel, newdir) == -1) {
+		fprinte(log_get_logfd(), "%s: symlink(\"%s\")",
 		        log_get_progname(), real_new_dir_rel);
 		goto out_free;
 	}
@@ -458,24 +454,21 @@ shadowtcb_status shadowtcb_move (/*@NULL@*/const char *user_newname, uid_t user_
 		OUT_OF_MEMORY;
 		return SHADOWTCB_FAILURE;
 	}
-	if (stat (tcbdir, &dirmode) != 0) {
-		fprinte(log_get_logfd(), _("%s: Cannot stat %s"),
-		        log_get_progname(), tcbdir);
+	if (stat(tcbdir, &dirmode) == -1) {
+		fprinte(log_get_logfd(), "%s: stat(\"%s\")", log_get_progname(), tcbdir);
 		goto out_free;
 	}
-	if (chown (tcbdir, 0, 0) != 0) {
-		fprinte(log_get_logfd(), _("%s: Cannot change owners of %s"),
-		        log_get_progname(), tcbdir);
+	if (chown(tcbdir, 0, 0) == -1) {
+		fprinte(log_get_logfd(), "%s: chown(\"%s\")", log_get_progname(), tcbdir);
 		goto out_free;
 	}
-	if (chmod (tcbdir, 0700) != 0) {
-		fprinte(log_get_logfd(), _("%s: Cannot change mode of %s"),
-		        log_get_progname(), tcbdir);
+	if (chmod(tcbdir, 0700) == -1) {
+		fprinte(log_get_logfd(), "%s: chmod(\"%s\")", log_get_progname(), tcbdir);
 		goto out_free;
 	}
-	if (lstat (shadow, &filemode) != 0) {
+	if (lstat(shadow, &filemode) == -1) {
 		if (errno != ENOENT) {
-			fprinte(log_get_logfd(), _("%s: Cannot lstat %s"),
+			fprinte(log_get_logfd(), "%s: lstat(\"%s\")",
 			        log_get_progname(), shadow);
 			goto out_free;
 		}
@@ -492,13 +485,13 @@ shadowtcb_status shadowtcb_move (/*@NULL@*/const char *user_newname, uid_t user_
 			         log_get_progname(), user_newname);
 			goto out_free;
 		}
-		if (chown (shadow, user_newid, filemode.st_gid) != 0) {
-			fprinte(log_get_logfd(), _("%s: Cannot change owner of %s"),
+		if (chown(shadow, user_newid, filemode.st_gid) == -1) {
+			fprinte(log_get_logfd(), "%s: chown(\"%s\")",
 			        log_get_progname(), shadow);
 			goto out_free;
 		}
-		if (chmod (shadow, filemode.st_mode & 07777) != 0) {
-			fprinte(log_get_logfd(), _("%s: Cannot change mode of %s"),
+		if (chmod(shadow, filemode.st_mode & 07777) == -1) {
+			fprinte(log_get_logfd(), "%s: chmod(\"%s\")",
 			        log_get_progname(), shadow);
 			goto out_free;
 		}
@@ -506,14 +499,12 @@ shadowtcb_status shadowtcb_move (/*@NULL@*/const char *user_newname, uid_t user_
 	if (unlink_suffs (user_newname) == SHADOWTCB_FAILURE) {
 		goto out_free;
 	}
-	if (chown (tcbdir, user_newid, dirmode.st_gid) != 0) {
-		fprinte(log_get_logfd(), _("%s: Cannot change owner of %s"),
-		        log_get_progname(), tcbdir);
+	if (chown(tcbdir, user_newid, dirmode.st_gid) == -1) {
+		fprinte(log_get_logfd(), "%s: chown(\"%s\")", log_get_progname(), tcbdir);
 		goto out_free;
 	}
-	if (chmod (tcbdir, dirmode.st_mode & 07777) != 0) {
-		fprinte(log_get_logfd(), _("%s: Cannot change mode of %s"),
-		        log_get_progname(), tcbdir);
+	if (chmod(tcbdir, dirmode.st_mode & 07777) == -1) {
+		fprinte(log_get_logfd(), "%s: chmod(\"%s\")", log_get_progname(), tcbdir);
 		goto out_free;
 	}
 	ret = SHADOWTCB_SUCCESS;
@@ -535,9 +526,8 @@ shadowtcb_status shadowtcb_create (const char *name, uid_t uid)
 	if (!getdef_bool ("USE_TCB")) {
 		return SHADOWTCB_SUCCESS;
 	}
-	if (stat (TCB_DIR, &tcbdir_stat) != 0) {
-		fprinte(log_get_logfd(), _("%s: Cannot stat %s"),
-		        log_get_progname(), TCB_DIR);
+	if (stat(TCB_DIR, &tcbdir_stat) == -1) {
+		fprinte(log_get_logfd(), "%s: stat(\"%s\")", log_get_progname(), TCB_DIR);
 		return SHADOWTCB_FAILURE;
 	}
 	shadowgid = tcbdir_stat.st_gid;
@@ -559,34 +549,29 @@ shadowtcb_status shadowtcb_create (const char *name, uid_t uid)
 		OUT_OF_MEMORY;
 		return SHADOWTCB_FAILURE;
 	}
-	if (mkdir (dir, 0700) != 0) {
-		fprinte(log_get_logfd(), "%s: mkdir: %s", log_get_progname(), dir);
+	if (mkdir(dir, 0700) == -1) {
+		fprinte(log_get_logfd(), "%s: mkdir(\"%s\")", log_get_progname(), dir);
 		goto out_free;
 	}
 	fd = open (shadow, O_RDWR | O_CREAT | O_TRUNC, 0600);
-	if (fd < 0) {
-		fprinte(log_get_logfd(), _("%s: Cannot open %s"),
-		        log_get_progname(), shadow);
+	if (fd == -1) {
+		fprinte(log_get_logfd(), "%s: open(\"%s\")", log_get_progname(), shadow);
 		goto out_free;
 	}
-	if (fchown (fd, 0, authgid) != 0) {
-		fprinte(log_get_logfd(), _("%s: Cannot change owner of %s"),
-		        log_get_progname(), shadow);
+	if (fchown(fd, 0, authgid) == -1) {
+		fprinte(log_get_logfd(), "%s: fchown(\"%s\")", log_get_progname(), shadow);
 		goto out_free;
 	}
-	if (fchmod (fd, (mode_t) ((authgid == shadowgid) ? 0600 : 0640)) != 0) {
-		fprinte(log_get_logfd(), _("%s: Cannot change mode of %s"),
-		        log_get_progname(), shadow);
+	if (fchmod(fd, (mode_t) ((authgid == shadowgid) ? 0600 : 0640)) == -1) {
+		fprinte(log_get_logfd(), "%s: fchmod(\"%s\")", log_get_progname(), shadow);
 		goto out_free;
 	}
-	if (chown (dir, 0, authgid) != 0) {
-		fprinte(log_get_logfd(), _("%s: Cannot change owner of %s"),
-		        log_get_progname(), dir);
+	if (chown(dir, 0, authgid) == -1) {
+		fprinte(log_get_logfd(), "%s: chown(\"%s\")", log_get_progname(), dir);
 		goto out_free;
 	}
-	if (chmod (dir, (mode_t) ((authgid == shadowgid) ? 02700 : 02710)) != 0) {
-		fprinte(log_get_logfd(), _("%s: Cannot change mode of %s"),
-		        log_get_progname(), dir);
+	if (chmod(dir, (mode_t) ((authgid == shadowgid) ? 02700 : 02710)) == -1) {
+		fprinte(log_get_logfd(), "%s: chmod(\"%s\")", log_get_progname(), dir);
 		goto out_free;
 	}
 	if (   (shadowtcb_set_user (name) == SHADOWTCB_FAILURE)

--- a/lib/xgetXXbyYY.c
+++ b/lib/xgetXXbyYY.c
@@ -34,6 +34,7 @@
 
 #include "alloc/malloc.h"
 #include "alloc/realloc.h"
+#include "io/fprintf.h"
 #include "prototypes.h"
 #include "shadowlog.h"
 
@@ -113,8 +114,7 @@
 #endif
 
 oom:
-	fprintf (log_get_logfd(), _("%s: out of memory\n"),
-		 "x" STRINGIZE(FUNCTION_NAME));
+	fprinte(log_get_logfd(), "%s: malloc", "x" STRINGIZE(FUNCTION_NAME));
 	exit (13);
 }
 


### PR DESCRIPTION
---

Revisions:

<details>
<summary>v2</summary>

-  Fix includes.

```
$ git rd 
1:  08fc49206ec0 ! 1:  efc6f5c0d8c5 lib/: Simplify error handling
    @@ lib/salt.c
      
      #include "defines.h"
      #include "getdef.h"
    -+#include "io/fprintf/fprinte.h"
    ++#include "io/fprintf.h"
      #include "prototypes.h"
      #include "shadowlog.h"
      #include "string/sprintf/stprintf.h"
    @@ lib/setupenv.c
      #include "defines.h"
      #include "getdef.h"
      #include "io/fgets/fgets.h"
    -+#include "io/fprintf/fprinte.h"
    ++#include "io/fprintf.h"
      #include "shadowlog.h"
      #include "string/sprintf/aprintf.h"
      #include "string/strcmp/streq.h"
    @@ lib/xgetXXbyYY.c
      
      #include "alloc/malloc.h"
      #include "alloc/realloc.h"
    -+#include "io/fprintf/fprinte.h"
    ++#include "io/fprintf.h"
      #include "prototypes.h"
      #include "shadowlog.h"
      
```
</details>

<details>
<summary>v2b</summary>

-  Rebase

```
$ git rd 
1:  efc6f5c0d8c5 = 1:  bf7357d68d63 lib/: Simplify error handling
```
</details>