### PR TITLE
Date simplifications

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -96,7 +96,6 @@ libshadow_la_SOURCES = \
 	getdef.h \
 	getgr_nam_gid.c \
 	getrange.c \
-	gettime.c \
 	groupio.c \
 	groupmem.c \
 	groupio.h \
@@ -264,6 +263,7 @@ libshadow_la_SOURCES = \
 	sulog.c \
 	sysconf.c \
 	sysconf.h \
+	time/date.c \
 	time/date.h \
 	time/day_to_str.c \
 	time/day_to_str.h \

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -264,6 +264,7 @@ libshadow_la_SOURCES = \
 	sulog.c \
 	sysconf.c \
 	sysconf.h \
+	time/date.h \
 	time/day_to_str.c \
 	time/day_to_str.h \
 	ttytype.c \

--- a/lib/gettime.c
+++ b/lib/gettime.c
@@ -5,7 +5,7 @@
 
 #include "config.h"
 
-#ident "$Id$"
+#include "time/date.h"
 
 #include <errno.h>
 #include <limits.h>

--- a/lib/prototypes.h
+++ b/lib/prototypes.h
@@ -143,9 +143,6 @@ extern int getrange (const char *range,
                      unsigned long *min, bool *has_min,
                      unsigned long *max, bool *has_max);
 
-/* gettime.c */
-extern time_t gettime (void);
-
 /* groupio.c */
 extern void __gr_del_entry (const struct commonio_entry *ent);
 extern /*@observer@*/const struct commonio_db *__gr_get_db (void);

--- a/lib/time/date.c
+++ b/lib/time/date.c
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2017, Chris Lamb
-// SPDX-FileCopyrightText: 2023-2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-FileCopyrightText: 2023-2025, Alejandro Colomar <alx@kernel.org>
 // SPDX-License-Identifier: BSD-3-Clause
 
 
@@ -16,6 +16,9 @@
 #include "prototypes.h"
 #include "shadowlog.h"
 #include "string/strerrno.h"
+
+
+extern inline long date_or_SDE(void);
 
 
 /*

--- a/lib/time/date.c
+++ b/lib/time/date.c
@@ -21,30 +21,25 @@
 extern inline long date_or_SDE(void);
 
 
-/*
- * gettime() returns the time as the number of seconds since the Epoch
- *
- * Like time(), gettime() returns the time as the number of seconds since the
- * Epoch, 1970-01-01 00:00:00 +0000 (UTC), except that if the SOURCE_DATE_EPOCH
- * environment variable is exported it will use that instead.
- */
-/*@observer@*/time_t
-gettime(void)
+// time(2) or SOURCE_DATE_EPOCH
+time_t
+time_or_SDE(void)
 {
-	char    *source_date_epoch;
-	time_t  fallback, epoch;
+	char    *env;
+	time_t  t, sde;
 
-	fallback = time (NULL);
-	source_date_epoch = shadow_getenv ("SOURCE_DATE_EPOCH");
+	t = time(NULL);
 
-	if (!source_date_epoch)
-		return fallback;
+	env = shadow_getenv("SOURCE_DATE_EPOCH");
+	if (env == NULL)
+		return t;
 
-	if (a2i(time_t, &epoch, source_date_epoch, NULL, 10, 0, fallback) == -1) {
+	if (a2i(time_t, &sde, env, NULL, 10, 0, t) == -1) {
 		fprintf(log_get_logfd(),
 		        _("Environment variable $SOURCE_DATE_EPOCH: a2i(\"%s\"): %s"),
-		        source_date_epoch, strerrno());
-		return fallback;
+		        env, strerrno());
+		return t;
 	}
-	return epoch;
+
+	return sde;
 }

--- a/lib/time/date.h
+++ b/lib/time/date.h
@@ -14,14 +14,14 @@
 
 
 inline long date_or_SDE(void);
-time_t gettime(void);
+time_t time_or_SDE(void);
 
 
 // Like time_or_SDE(), but return a date, not a time.
 inline long
 date_or_SDE(void)
 {
-	return gettime() / DAY;
+	return time_or_SDE() / DAY;
 }
 
 

--- a/lib/time/date.h
+++ b/lib/time/date.h
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#ifndef SHADOW_INCLUDE_LIB_TIME_DATE_H_
+#define SHADOW_INCLUDE_LIB_TIME_DATE_H_
+
+
+#include "config.h"
+
+#include <time.h>
+
+#include "defines.h"
+
+
+time_t gettime(void);
+
+
+#endif  // include guard

--- a/lib/time/date.h
+++ b/lib/time/date.h
@@ -13,7 +13,16 @@
 #include "defines.h"
 
 
+inline long date_or_SDE(void);
 time_t gettime(void);
+
+
+// Like time_or_SDE(), but return a date, not a time.
+inline long
+date_or_SDE(void)
+{
+	return gettime() / DAY;
+}
 
 
 #endif  // include guard

--- a/src/chpasswd.c
+++ b/src/chpasswd.c
@@ -9,8 +9,6 @@
 
 #include "config.h"
 
-#ident "$Id$"
-
 #include <fcntl.h>
 #include <getopt.h>
 #include <pwd.h>
@@ -38,6 +36,7 @@
 #include "string/strcmp/streq.h"
 #include "string/strerrno.h"
 #include "string/strtok/stpsep.h"
+#include "time/date.h"
 
 
 #define IS_CRYPT_METHOD(str) ((crypt_method != NULL && streq(crypt_method, str)) ? true : false)

--- a/src/chpasswd.c
+++ b/src/chpasswd.c
@@ -555,12 +555,7 @@ int main (int argc, char **argv)
 		if (NULL != sp) {
 			newsp = *sp;
 			newsp.sp_pwdp = cp;
-			newsp.sp_lstchg = gettime () / DAY;
-			if (0 == newsp.sp_lstchg) {
-				/* Better disable aging than requiring a
-				 * password change */
-				newsp.sp_lstchg = -1;
-			}
+			newsp.sp_lstchg = date_or_SDE();
 		}
 
 		if (   (NULL == sp)

--- a/src/newusers.c
+++ b/src/newusers.c
@@ -17,8 +17,6 @@
 
 #include "config.h"
 
-#ident "$Id$"
-
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <stdio.h>
@@ -59,6 +57,7 @@
 #include "string/strerrno.h"
 #include "string/strtok/stpsep.h"
 #include "string/strtok/strsep2arr.h"
+#include "time/date.h"
 
 struct option_flags {
 	bool chroot;

--- a/src/newusers.c
+++ b/src/newusers.c
@@ -536,12 +536,7 @@ add_passwd(struct passwd *pwd, MAYBE_UNUSED const char *password)
 			}
 			spent.sp_pwdp = cp;
 		}
-		spent.sp_lstchg = gettime () / DAY;
-		if (0 == spent.sp_lstchg) {
-			/* Better disable aging than requiring a password
-			 * change */
-			spent.sp_lstchg = -1;
-		}
+		spent.sp_lstchg = date_or_SDE();
 		return (spw_update (&spent) == 0);
 	}
 
@@ -593,11 +588,7 @@ add_passwd(struct passwd *pwd, MAYBE_UNUSED const char *password)
 	 */
 	spent.sp_pwdp = "!";
 #endif
-	spent.sp_lstchg = gettime () / DAY;
-	if (0 == spent.sp_lstchg) {
-		/* Better disable aging than requiring a password change */
-		spent.sp_lstchg = -1;
-	}
+	spent.sp_lstchg = date_or_SDE();
 	spent.sp_min    = -1;
 	spent.sp_max    = getdef_num ("PASS_MAX_DAYS", -1);
 	spent.sp_warn   = getdef_num ("PASS_WARN_AGE", -1);

--- a/src/passwd.c
+++ b/src/passwd.c
@@ -9,8 +9,6 @@
 
 #include "config.h"
 
-#ident "$Id$"
-
 #include <errno.h>
 #include <fcntl.h>
 #include <getopt.h>
@@ -40,6 +38,7 @@
 #include "string/strcpy/strtcpy.h"
 #include "string/strdup/strdup.h"
 #include "string/strerrno.h"
+#include "time/date.h"
 #include "time/day_to_str.h"
 
 

--- a/src/passwd.c
+++ b/src/passwd.c
@@ -669,14 +669,8 @@ static void update_shadow(bool process_selinux)
 	}
 	if (!use_pam)
 	{
-		if (do_update_age) {
-			nsp->sp_lstchg = gettime () / DAY;
-			if (0 == nsp->sp_lstchg) {
-				/* Better disable aging than requiring a password
-				 * change */
-				nsp->sp_lstchg = -1;
-			}
-		}
+		if (do_update_age)
+			nsp->sp_lstchg = date_or_SDE();
 	}
 
 	/*

--- a/src/pwck.c
+++ b/src/pwck.c
@@ -10,8 +10,6 @@
 
 #include "config.h"
 
-#ident "$Id$"
-
 #include <fcntl.h>
 #include <getopt.h>
 #include <grp.h>
@@ -30,6 +28,7 @@
 #include "sssd.h"
 #include "string/strcmp/streq.h"
 #include "string/strcmp/strprefix.h"
+#include "time/date.h"
 #ifdef WITH_TCB
 #include "tcbfuncs.h"
 #endif				/* WITH_TCB */

--- a/src/pwck.c
+++ b/src/pwck.c
@@ -627,13 +627,7 @@ static void check_pw_file(bool *errors, bool *changed, const struct option_flags
 					sp.sp_inact  = -1;
 					sp.sp_expire = -1;
 					sp.sp_flag   = SHADOW_SP_FLAG_UNSET;
-					sp.sp_lstchg = gettime () / DAY;
-					if (0 == sp.sp_lstchg) {
-						/* Better disable aging than
-						 * requiring a password change
-						 */
-						sp.sp_lstchg = -1;
-					}
+					sp.sp_lstchg = date_or_SDE();
 					*changed = true;
 
 					if (spw_update (&sp) == 0) {

--- a/src/pwconv.c
+++ b/src/pwconv.c
@@ -32,8 +32,6 @@
 
 #include "config.h"
 
-#ident "$Id$"
-
 #include <errno.h>
 #include <fcntl.h>
 #include <pwd.h>
@@ -54,6 +52,7 @@
 #include "shadowio.h"
 #include "shadowlog.h"
 #include "string/strcmp/streq.h"
+#include "time/date.h"
 
 
 /*

--- a/src/pwconv.c
+++ b/src/pwconv.c
@@ -258,12 +258,7 @@ int main (int argc, char **argv)
 			spent.sp_flag   = SHADOW_SP_FLAG_UNSET;
 		}
 		spent.sp_pwdp = pw->pw_passwd;
-		spent.sp_lstchg = gettime () / DAY;
-		if (0 == spent.sp_lstchg) {
-			/* Better disable aging than requiring a password
-			 * change */
-			spent.sp_lstchg = -1;
-		}
+		spent.sp_lstchg = date_or_SDE();
 		if (spw_update (&spent) == 0) {
 			fprintf (stderr,
 			         _("%s: failed to prepare the new %s entry '%s'\n"),

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -978,11 +978,7 @@ static void new_spent (struct spwd *spent)
 	memzero(spent, sizeof(*spent));
 	spent->sp_namp = (char *) user_name;
 	spent->sp_pwdp = (char *) user_pass;
-	spent->sp_lstchg = gettime () / DAY;
-	if (0 == spent->sp_lstchg) {
-		/* Better disable aging than requiring a password change */
-		spent->sp_lstchg = -1;
-	}
+	spent->sp_lstchg = date_or_SDE();
 	spent->sp_min = -1;
 	if (!rflg) {
 		spent->sp_max = getdef_num ("PASS_MAX_DAYS", -1);

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -73,6 +73,7 @@
 #include "string/strerrno.h"
 #include "string/strtok/stpsep.h"
 #include "sysconf.h"
+#include "time/date.h"
 
 #undef NDEBUG
 #include <assert.h>

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -649,14 +649,8 @@ static void new_spent (struct spwd *spent, bool process_selinux)
 	 */
 	spent->sp_pwdp = new_pw_passwd(spent->sp_pwdp, process_selinux);
 
-	if (pflg) {
-		spent->sp_lstchg = gettime () / DAY;
-		if (0 == spent->sp_lstchg) {
-			/* Better disable aging than requiring a password
-			 * change. */
-			spent->sp_lstchg = -1;
-		}
-	}
+	if (pflg)
+		spent->sp_lstchg = date_or_SDE();
 }
 
 /*
@@ -1782,12 +1776,7 @@ static void usr_update(const struct option_flags *flags)
 			spent.sp_pwdp   = xstrdup (pwent.pw_passwd);
 			pwent.pw_passwd = xstrdup (SHADOW_PASSWD_STRING);
 
-			spent.sp_lstchg = gettime () / DAY;
-			if (0 == spent.sp_lstchg) {
-				/* Better disable aging than
-				 * requiring a password change */
-				spent.sp_lstchg = -1;
-			}
+			spent.sp_lstchg = date_or_SDE();
 			spent.sp_min    = -1;
 			spent.sp_max    = getdef_num ("PASS_MAX_DAYS", -1);
 			spent.sp_warn   = getdef_num ("PASS_WARN_AGE", -1);

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -9,8 +9,6 @@
 
 #include "config.h"
 
-#ident "$Id$"
-
 #include <ctype.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -67,6 +65,7 @@
 #include "string/strerrno.h"
 #include "string/strspn/stprspn.h"
 #include "sysconf.h"
+#include "time/date.h"
 #include "time/day_to_str.h"
 #include "typetraits.h"
 


### PR DESCRIPTION
---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git rd 
1:  8d32b23b = 1:  0955b770 lib/, src/: Move gettime() prototype to "date.h"
2:  10a3ac17 = 2:  517a0bb7 lib/: date(): Add function
3:  86119094 = 3:  dfbfeb8f lib/, src/: Use date() instead of its pattern
```
</details>

<details>
<summary>v2</summary>

-  Move "date.h" to "time/date.h".
-  Minor include tidying.

```
$ git range-diff --creation-factor=99 shadow/master gh/date date 
1:  0955b770 ! 1:  fe1a5c10 lib/, src/: Move gettime() prototype to "date.h"
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/, src/: Move gettime() prototype to "date.h"
    +    lib/, src/: Move gettime() prototype to "time/date.h"
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/Makefile.am ##
     @@ lib/Makefile.am: libshadow_la_SOURCES = \
    -   console.c \
    -   copydir.c \
    -   csrand.c \
    -+  date.h \
    -   defines.h \
    -   encrypt.c \
    -   env.c \
    -
    - ## lib/date.h (new) ##
    -@@
    -+// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
    -+// SPDX-License-Identifier: BSD-3-Clause
    -+
    -+
    -+#ifndef SHADOW_INCLUDE_LIB_DATE_H_
    -+#define SHADOW_INCLUDE_LIB_DATE_H_
    -+
    -+
    -+#include "config.h"
    -+
    -+#include <time.h>
    -+
    -+#include "defines.h"
    -+
    -+
    -+time_t gettime(void);
    -+
    -+
    -+#endif  // include guard
    +   subordinateio.h \
    +   subordinateio.c \
    +   sulog.c \
    ++  time/date.h \
    +   time/day_to_str.c \
    +   time/day_to_str.h \
    +   ttytype.c \
     
      ## lib/gettime.c ##
     @@
    @@ lib/gettime.c
      #include "config.h"
      
     -#ident "$Id$"
    -+#include "date.h"
    ++#include "time/date.h"
      
      #include <errno.h>
      #include <limits.h>
    @@ lib/prototypes.h: extern int getrange (const char *range,
      ## lib/pwd2spwd.c ##
     @@
      
    - #ident "$Id$"
    + #include "config.h"
      
    +-#ident "$Id$"
    +-
     -#include <sys/types.h>
     -#include "prototypes.h"
     -#include "defines.h"
      #include <pwd.h>
     +#include <sys/types.h>
     +
    -+#include "prototypes.h"
    -+#include "date.h"
     +#include "defines.h"
    ++#include "prototypes.h"
    ++#include "time/date.h"
      
      /*
       * pwd_to_spwd - create entries for new spwd structure
     
    + ## lib/time/date.h (new) ##
    +@@
    ++// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
    ++// SPDX-License-Identifier: BSD-3-Clause
    ++
    ++
    ++#ifndef SHADOW_INCLUDE_LIB_TIME_DATE_H_
    ++#define SHADOW_INCLUDE_LIB_TIME_DATE_H_
    ++
    ++
    ++#include "config.h"
    ++
    ++#include <time.h>
    ++
    ++#include "defines.h"
    ++
    ++
    ++time_t gettime(void);
    ++
    ++
    ++#endif  // include guard
    +
      ## src/chpasswd.c ##
     @@
    - #endif                            /* USE_PAM */
    - #include "atoi/str2i.h"
    - #include "chkhash.h"
    -+#include "date.h"
    - #include "defines.h"
    - #include "nscd.h"
    - #include "sssd.h"
    + 
    + #include "config.h"
    + 
    +-#ident "$Id$"
    +-
    + #include <fcntl.h>
    + #include <getopt.h>
    + #include <pwd.h>
    +@@
    + #include "shadowlog.h"
    + #include "string/strcmp/streq.h"
    + #include "string/strtok/stpsep.h"
    ++#include "time/date.h"
    + 
    + 
    + #define IS_CRYPT_METHOD(str) ((crypt_method != NULL && streq(crypt_method, str)) ? true : false)
     
      ## src/newusers.c ##
     @@
    - #endif                            /* USE_PAM */
    - #endif                            /* ACCT_TOOLS_SETUID */
    - #include "chkname.h"
    -+#include "date.h"
    - #include "defines.h"
    - #include "getdef.h"
    - #include "groupio.h"
    + 
    + #include "config.h"
    + 
    +-#ident "$Id$"
    +-
    + #include <sys/types.h>
    + #include <sys/stat.h>
    + #include <stdio.h>
    +@@
    + #include "string/strdup/xstrdup.h"
    + #include "string/strtok/stpsep.h"
    + #include "string/strtok/strsep2arr.h"
    ++#include "time/date.h"
    + 
    + 
    + /*
     
      ## src/passwd.c ##
     @@
    - #include "agetpass.h"
    - #include "atoi/a2i/a2s.h"
    - #include "chkname.h"
    -+#include "date.h"
    - #include "defines.h"
    - #include "getdef.h"
    - #include "nscd.h"
    + 
    + #include "config.h"
    + 
    +-#ident "$Id$"
    +-
    + #include <errno.h>
    + #include <fcntl.h>
    + #include <getopt.h>
    +@@
    + #include "string/strcmp/strprefix.h"
    + #include "string/strcpy/strtcpy.h"
    + #include "string/strdup/xstrdup.h"
    ++#include "time/date.h"
    + #include "time/day_to_str.h"
    + 
    + 
     
      ## src/pwck.c ##
     @@
      
    - #include "chkname.h"
    - #include "commonio.h"
    -+#include "date.h"
    - #include "defines.h"
    - #include "getdef.h"
    - #include "nscd.h"
    + #include "config.h"
    + 
    +-#ident "$Id$"
    +-
    + #include <fcntl.h>
    + #include <getopt.h>
    + #include <grp.h>
    +@@
    + #include "sssd.h"
    + #include "string/strcmp/streq.h"
    + #include "string/strcmp/strprefix.h"
    ++#include "time/date.h"
    + #ifdef WITH_TCB
    + #include "tcbfuncs.h"
    + #endif                            /* WITH_TCB */
     
      ## src/pwconv.c ##
     @@
    - #include <unistd.h>
    - #include <getopt.h>
      
    -+#include "date.h"
    - #include "defines.h"
    - #include "getdef.h"
    - #include "nscd.h"
    + #include "config.h"
    + 
    +-#ident "$Id$"
    +-
    + #include <errno.h>
    + #include <fcntl.h>
    + #include <pwd.h>
    +@@
    + #include "shadowio.h"
    + #include "shadowlog.h"
    + #include "string/strcmp/streq.h"
    ++#include "time/date.h"
    + 
    + 
    + /*
     
      ## src/useradd.c ##
     @@
    - #include "atoi/a2i/a2s.h"
    - #include "atoi/getnum.h"
    - #include "chkname.h"
    -+#include "date.h"
    - #include "defines.h"
    - #include "faillog.h"
    - #include "fs/mkstemp/fmkomstemp.h"
    + 
    + #include "config.h"
    + 
    +-#ident "$Id$"
    +-
    + #include <assert.h>
    + #include <ctype.h>
    + #include <errno.h>
    +@@
    + #include "string/strcmp/strprefix.h"
    + #include "string/strdup/xstrdup.h"
    + #include "string/strtok/stpsep.h"
    ++#include "time/date.h"
    + 
    + 
    + #ifndef SKEL_DIR
     
      ## src/usermod.c ##
     @@
    - #include "atoi/a2i/a2s.h"
    - #include "atoi/getnum.h"
    - #include "chkname.h"
    -+#include "date.h"
    - #include "defines.h"
    - #include "faillog.h"
    - #include "getdef.h"
    + 
    + #include "config.h"
    + 
    +-#ident "$Id$"
    +-
    + #include <assert.h>
    + #include <ctype.h>
    + #include <errno.h>
    +@@
    + #include "string/strcmp/streq.h"
    + #include "string/strcmp/strprefix.h"
    + #include "string/strdup/xstrdup.h"
    ++#include "time/date.h"
    + #include "time/day_to_str.h"
    + #include "typetraits.h"
    + 
2:  517a0bb7 ! 2:  9f3e3425 lib/: date(): Add function
    @@ Commit message
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/Makefile.am ##
    -@@ lib/Makefile.am: libshadow_la_SOURCES = \
    -   console.c \
    -   copydir.c \
    -   csrand.c \
    -+  date.c \
    -   date.h \
    -   defines.h \
    -   encrypt.c \
     @@ lib/Makefile.am: libshadow_la_SOURCES = \
        getdef.h \
        getgr_nam_gid.c \
    @@ lib/Makefile.am: libshadow_la_SOURCES = \
        groupio.c \
        groupmem.c \
        groupio.h \
    +@@ lib/Makefile.am: libshadow_la_SOURCES = \
    +   subordinateio.h \
    +   subordinateio.c \
    +   sulog.c \
    ++  time/date.c \
    +   time/date.h \
    +   time/day_to_str.c \
    +   time/day_to_str.h \
     
    - ## lib/gettime.c => lib/date.c ##
    + ## lib/gettime.c => lib/time/date.c ##
     @@
      // SPDX-FileCopyrightText: 2017, Chris Lamb
     -// SPDX-FileCopyrightText: 2023-2024, Alejandro Colomar <alx@kernel.org>
    @@ lib/gettime.c => lib/date.c
       * gettime() returns the time as the number of seconds since the Epoch
       *
     
    - ## lib/date.h ##
    + ## lib/time/date.h ##
     @@
      #include "defines.h"
      
3:  dfbfeb8f = 3:  751b6736 lib/, src/: Use date() instead of its pattern
```
</details>

<details>
<summary>v3</summary>

-  Rename functions.

```
$ git range-diff shadow/master gh/date date 
1:  fe1a5c10 = 1:  fe1a5c10 lib/, src/: Move gettime() prototype to "time/date.h"
2:  9f3e3425 = 2:  9f3e3425 lib/: date(): Add function
3:  751b6736 = 3:  751b6736 lib/, src/: Use date() instead of its pattern
-:  -------- > 4:  48b5d40e lib/date.*: Rename gettime() => time_or_SDE()
-:  -------- > 5:  8a6047ab lib/, src/: Rename date() => date_or_SDE()
```
</details>

<details>
<summary>v3b</summary>

-  Reorder commits.

```
$ git range-diff shadow/master gh/date date 
1:  fe1a5c10 = 1:  fe1a5c10 lib/, src/: Move gettime() prototype to "time/date.h"
2:  9f3e3425 = 2:  9f3e3425 lib/: date(): Add function
3:  751b6736 = 3:  751b6736 lib/, src/: Use date() instead of its pattern
5:  8a6047ab ! 4:  9df65362 lib/, src/: Rename date() => date_or_SDE()
    @@ lib/time/date.c
     +extern inline long date_or_SDE(void);
      
      
    - // time(2) or SOURCE_DATE_EPOCH
    + /*
     
      ## lib/time/date.h ##
     @@
    @@ lib/time/date.h
      
     -inline long date(void);
     +inline long date_or_SDE(void);
    - time_t time_or_SDE(void);
    + time_t gettime(void);
      
      
     +// Like time_or_SDE(), but return a date, not a time.
4:  48b5d40e ! 5:  71b7f4a7 lib/date.*: Rename gettime() => time_or_SDE()
    @@ Commit message
     
      ## lib/time/date.c ##
     @@
    - extern inline long date(void);
    + extern inline long date_or_SDE(void);
      
      
     -/*
    @@ lib/time/date.h
     @@
      
      
    - inline long date(void);
    + inline long date_or_SDE(void);
     -time_t gettime(void);
     +time_t time_or_SDE(void);
      
      
    - inline long
    -@@ lib/time/date.h: date(void)
    + // Like time_or_SDE(), but return a date, not a time.
    +@@ lib/time/date.h: date_or_SDE(void)
      {
        time_t  t;
      
```
</details>

<details>
<summary>v4</summary>

-  Merge commits.

```
$ git range-diff shadow/master gh/date date 
1:  fe1a5c10 = 1:  fe1a5c10 lib/, src/: Move gettime() prototype to "time/date.h"
2:  9f3e3425 ! 2:  3d70bc3c lib/: date(): Add function
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/: date(): Add function
    +    lib/: date_or_SDE(): Add function
     
         This wrapper around gettime() returns a date (days since Epoch) instead
         of a time (seconds since Epoch).
     
    +    The name reminds that this uses SOURCE_DATE_EPOCH if available.
    +
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/Makefile.am ##
    @@ lib/gettime.c => lib/time/date.c
      #include "shadowlog.h"
      
      
    -+extern inline long date(void);
    ++extern inline long date_or_SDE(void);
     +
     +
      /*
    @@ lib/time/date.h
      #include "defines.h"
      
      
    -+inline long date(void);
    ++inline long date_or_SDE(void);
      time_t gettime(void);
      
      
    ++// Like time_or_SDE(), but return a date, not a time.
     +inline long
    -+date(void)
    ++date_or_SDE(void)
     +{
     +  time_t  t;
     +
3:  751b6736 ! 3:  f42ba6ee lib/, src/: Use date() instead of its pattern
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/, src/: Use date() instead of its pattern
    +    lib/, src/: Use date_or_SDE() instead of its pattern
     
         The checks changing 0 into -1 were probably added because gettime()/DAY
         transformed a gettime() error code (-1) into 0, due to integer division.
     
    -    Now that we use date(), which reports errors with -1, this won't happen.
    +    Now that we use date_or_SDE(), which reports errors with -1, this won't
    +    happen.
     
         It could also happen that the date is 0 (so the day is the Epoch), but
         this is unlikely, and anyway, I don't see any reasons to special-case
    @@ lib/pwd2spwd.c: struct spwd *pwd_to_spwd (const struct passwd *pw)
     -                   * change */
     -                  sp.sp_lstchg = -1;
     -          }
    -+          sp.sp_lstchg = date();
    ++          sp.sp_lstchg = date_or_SDE();
        }
      
        /*
    @@ src/chpasswd.c: int main (int argc, char **argv)
     -                           * password change */
     -                          newsp.sp_lstchg = -1;
     -                  }
    -+                  newsp.sp_lstchg = date();
    ++                  newsp.sp_lstchg = date_or_SDE();
                }
      
                if (   (NULL == sp)
    @@ src/newusers.c: static int add_passwd (struct passwd *pwd, const char *password)
     -                   * change */
     -                  spent.sp_lstchg = -1;
     -          }
    -+          spent.sp_lstchg = date();
    ++          spent.sp_lstchg = date_or_SDE();
                return (spw_update (&spent) == 0);
        }
      
    @@ src/newusers.c: static int add_passwd (struct passwd *pwd, const char *password)
     -          /* Better disable aging than requiring a password change */
     -          spent.sp_lstchg = -1;
     -  }
    -+  spent.sp_lstchg = date();
    ++  spent.sp_lstchg = date_or_SDE();
        spent.sp_min    = getdef_num ("PASS_MIN_DAYS", 0);
        /* 10000 is infinity this week */
        spent.sp_max    = getdef_num ("PASS_MAX_DAYS", 10000);
    @@ src/passwd.c: static void update_shadow (void)
     -                  }
     -          }
     +          if (do_update_age)
    -+                  nsp->sp_lstchg = date();
    ++                  nsp->sp_lstchg = date_or_SDE();
        }
      
        /*
    @@ src/pwck.c: static void check_pw_file (bool *errors, bool *changed)
     -                                           */
     -                                          sp.sp_lstchg = -1;
     -                                  }
    -+                                  sp.sp_lstchg = date();
    ++                                  sp.sp_lstchg = date_or_SDE();
                                        *changed = true;
      
                                        if (spw_update (&sp) == 0) {
    @@ src/pwconv.c: int main (int argc, char **argv)
     -                   * change */
     -                  spent.sp_lstchg = -1;
     -          }
    -+          spent.sp_lstchg = date();
    ++          spent.sp_lstchg = date_or_SDE();
                if (spw_update (&spent) == 0) {
                        fprintf (stderr,
                                 _("%s: failed to prepare the new %s entry '%s'\n"),
    @@ src/useradd.c: static void new_spent (struct spwd *spent)
     -          /* Better disable aging than requiring a password change */
     -          spent->sp_lstchg = -1;
     -  }
    -+  spent->sp_lstchg = date();
    ++  spent->sp_lstchg = date_or_SDE();
        if (!rflg) {
                spent->sp_min = getdef_num ("PASS_MIN_DAYS", -1);
                spent->sp_max = getdef_num ("PASS_MAX_DAYS", -1);
    @@ src/usermod.c: static void new_spent (struct spwd *spent)
     -          }
     -  }
     +  if (pflg)
    -+          spent->sp_lstchg = date();
    ++          spent->sp_lstchg = date_or_SDE();
      }
      
      /*
    @@ src/usermod.c: static void usr_update (void)
     -                           * requiring a password change */
     -                          spent.sp_lstchg = -1;
     -                  }
    -+                  spent.sp_lstchg = date();
    ++                  spent.sp_lstchg = date_or_SDE();
                        spent.sp_min    = getdef_num ("PASS_MIN_DAYS", -1);
                        spent.sp_max    = getdef_num ("PASS_MAX_DAYS", -1);
                        spent.sp_warn   = getdef_num ("PASS_WARN_AGE", -1);
4:  9df65362 < -:  -------- lib/, src/: Rename date() => date_or_SDE()
5:  71b7f4a7 = 4:  ec089fed lib/date.*: Rename gettime() => time_or_SDE()
```
```diff
$ git diff gh/date..date 
$
```
</details>

<details>
<summary>v5</summary>

-  gettime() can't fail.

```
$ git range-diff shadow/master gh/date date 
1:  fe1a5c10 = 1:  fe1a5c10 lib/, src/: Move gettime() prototype to "time/date.h"
2:  3d70bc3c ! 2:  30c33f86 lib/: date_or_SDE(): Add function
    @@ lib/time/date.h
     +inline long
     +date_or_SDE(void)
     +{
    -+  time_t  t;
    -+
    -+  t = gettime();
    -+  if (t == -1)
    -+          return -1;
    -+
    -+  return t / DAY;
    ++  return gettime() / DAY;
     +}
     +
     +
3:  f42ba6ee ! 3:  aae1c104 lib/, src/: Use date_or_SDE() instead of its pattern
    @@ Commit message
     
         The checks changing 0 into -1 were probably added because gettime()/DAY
         transformed a gettime() error code (-1) into 0, due to integer division.
    -
    -    Now that we use date_or_SDE(), which reports errors with -1, this won't
    -    happen.
    +    That was dead code: gettime() can't fail.
     
         It could also happen that the date is 0 (so the day is the Epoch), but
         this is unlikely, and anyway, I don't see any reasons to special-case
4:  ec089fed ! 4:  580ff8ed lib/date.*: Rename gettime() => time_or_SDE()
    @@ lib/time/date.h
      
      
      // Like time_or_SDE(), but return a date, not a time.
    -@@ lib/time/date.h: date_or_SDE(void)
    + inline long
    + date_or_SDE(void)
      {
    -   time_t  t;
    +-  return gettime() / DAY;
    ++  return time_or_SDE() / DAY;
    + }
      
    --  t = gettime();
    -+  t = time_or_SDE();
    -   if (t == -1)
    -           return -1;
      
```
</details>

<details>
<summary>v5b</summary>


```
$ git range-diff fe1a5c104041^..gh/date shadow/master..date
1:  fe1a5c10 = 1:  c80e8eb8 lib/, src/: Move gettime() prototype to "time/date.h"
2:  30c33f86 = 2:  26caef76 lib/: date_or_SDE(): Add function
3:  aae1c104 = 3:  580255bb lib/, src/: Use date_or_SDE() instead of its pattern
4:  580ff8ed = 4:  572c7fd2 lib/date.*: Rename gettime() => time_or_SDE()
```
</details>

<details>
<summary>v5c</summary>

-  Rebase

```
$ git rd
1:  c80e8eb8 = 1:  7eb728fc lib/, src/: Move gettime() prototype to "time/date.h"
2:  26caef76 = 2:  77fcba01 lib/: date_or_SDE(): Add function
3:  580255bb = 3:  e16e5bc9 lib/, src/: Use date_or_SDE() instead of its pattern
4:  572c7fd2 = 4:  5707a9d5 lib/date.*: Rename gettime() => time_or_SDE()
```
</details>

<details>
<summary>v5d</summary>

-  Rebase

```
$ git rd 
1:  7eb728fc ! 1:  6be3fffc lib/, src/: Move gettime() prototype to "time/date.h"
    @@ src/newusers.c
      #include "string/strtok/strsep2arr.h"
     +#include "time/date.h"
      
    - 
    - /*
    + struct option_flags {
    +   bool chroot;
     
      ## src/passwd.c ##
     @@
2:  77fcba01 = 2:  ca1063a0 lib/: date_or_SDE(): Add function
3:  e16e5bc9 ! 3:  e5254378 lib/, src/: Use date_or_SDE() instead of its pattern
    @@ src/newusers.c: static int add_passwd (struct passwd *pwd, const char *password)
        spent.sp_max    = getdef_num ("PASS_MAX_DAYS", 10000);
     
      ## src/passwd.c ##
    -@@ src/passwd.c: static void update_shadow (void)
    +@@ src/passwd.c: static void update_shadow (struct option_flags *flags)
        }
        if (!use_pam)
        {
    @@ src/passwd.c: static void update_shadow (void)
        /*
     
      ## src/pwck.c ##
    -@@ src/pwck.c: static void check_pw_file (bool *errors, bool *changed)
    +@@ src/pwck.c: static void check_pw_file (bool *errors, bool *changed, struct option_flags *fla
                                        sp.sp_inact  = -1;
                                        sp.sp_expire = -1;
                                        sp.sp_flag   = SHADOW_SP_FLAG_UNSET;
    @@ src/useradd.c: static void new_spent (struct spwd *spent)
                spent->sp_max = getdef_num ("PASS_MAX_DAYS", -1);
     
      ## src/usermod.c ##
    -@@ src/usermod.c: static void new_spent (struct spwd *spent)
    +@@ src/usermod.c: static void new_spent (struct spwd *spent, bool process_selinux)
         */
        spent->sp_pwdp = new_pw_passwd (spent->sp_pwdp);
      
    @@ src/usermod.c: static void new_spent (struct spwd *spent)
      }
      
      /*
    -@@ src/usermod.c: static void usr_update (void)
    +@@ src/usermod.c: static void usr_update (struct option_flags *flags)
                        spent.sp_pwdp   = xstrdup (pwent.pw_passwd);
                        pwent.pw_passwd = xstrdup (SHADOW_PASSWD_STRING);
      
4:  5707a9d5 = 4:  a63d4992 lib/date.*: Rename gettime() => time_or_SDE()
```
</details>

<details>
<summary>v5e</summary>

-  Rebase

```
$ git rd 
1:  6be3fffc4 ! 1:  72a266088 lib/, src/: Move gettime() prototype to "time/date.h"
    @@ src/newusers.c
      #include <sys/stat.h>
      #include <stdio.h>
     @@
    - #include "string/strdup/xstrdup.h"
    + #include "string/strdup/strdup.h"
      #include "string/strtok/stpsep.h"
      #include "string/strtok/strsep2arr.h"
     +#include "time/date.h"
    @@ src/passwd.c
     @@
      #include "string/strcmp/strprefix.h"
      #include "string/strcpy/strtcpy.h"
    - #include "string/strdup/xstrdup.h"
    + #include "string/strdup/strdup.h"
     +#include "time/date.h"
      #include "time/day_to_str.h"
      
    @@ src/useradd.c
      #include <errno.h>
     @@
      #include "string/strcmp/strprefix.h"
    - #include "string/strdup/xstrdup.h"
    + #include "string/strdup/strdup.h"
      #include "string/strtok/stpsep.h"
     +#include "time/date.h"
      
    @@ src/usermod.c
     @@
      #include "string/strcmp/streq.h"
      #include "string/strcmp/strprefix.h"
    - #include "string/strdup/xstrdup.h"
    + #include "string/strdup/strdup.h"
     +#include "time/date.h"
      #include "time/day_to_str.h"
      #include "typetraits.h"
2:  ca1063a0d = 2:  e5885598a lib/: date_or_SDE(): Add function
3:  e5254378e = 3:  7ec8268fb lib/, src/: Use date_or_SDE() instead of its pattern
4:  a63d49922 = 4:  81d44a507 lib/date.*: Rename gettime() => time_or_SDE()
```
</details>

<details>
<summary>v5f</summary>

-  Rebase

```
$ git rd 
1:  72a266088 ! 1:  5c8da7cfa lib/, src/: Move gettime() prototype to "time/date.h"
    @@ src/chpasswd.c
      #include <getopt.h>
      #include <pwd.h>
     @@
    - #include "shadowlog.h"
      #include "string/strcmp/streq.h"
    + #include "string/strerrno.h"
      #include "string/strtok/stpsep.h"
     +#include "time/date.h"
      
    @@ src/newusers.c
      #include <sys/stat.h>
      #include <stdio.h>
     @@
    - #include "string/strdup/strdup.h"
    + #include "string/strerrno.h"
      #include "string/strtok/stpsep.h"
      #include "string/strtok/strsep2arr.h"
     +#include "time/date.h"
    @@ src/passwd.c
      #include <fcntl.h>
      #include <getopt.h>
     @@
    - #include "string/strcmp/strprefix.h"
      #include "string/strcpy/strtcpy.h"
      #include "string/strdup/strdup.h"
    + #include "string/strerrno.h"
     +#include "time/date.h"
      #include "time/day_to_str.h"
      
    @@ src/useradd.c
      #include <ctype.h>
      #include <errno.h>
     @@
    - #include "string/strcmp/strprefix.h"
      #include "string/strdup/strdup.h"
    + #include "string/strerrno.h"
      #include "string/strtok/stpsep.h"
     +#include "time/date.h"
      
    @@ src/usermod.c
      #include <ctype.h>
      #include <errno.h>
     @@
    - #include "string/strcmp/streq.h"
      #include "string/strcmp/strprefix.h"
      #include "string/strdup/strdup.h"
    + #include "string/strerrno.h"
     +#include "time/date.h"
      #include "time/day_to_str.h"
      #include "typetraits.h"
2:  e5885598a ! 2:  d7115d94c lib/: date_or_SDE(): Add function
    @@ lib/gettime.c => lib/time/date.c
      
      
     @@
    - #include "shadowlog.h"
    + #include "string/strerrno.h"
      
      
     +extern inline long date_or_SDE(void);
3:  7ec8268fb = 3:  59da3f47f lib/, src/: Use date_or_SDE() instead of its pattern
4:  81d44a507 ! 4:  977d00d2b lib/date.*: Rename gettime() => time_or_SDE()
    @@ lib/time/date.c
     +  if (a2i(time_t, &sde, env, NULL, 10, 0, t) == -1) {
                fprintf(shadow_logfd,
                        _("Environment variable $SOURCE_DATE_EPOCH: a2i(\"%s\"): %s"),
    --                  source_date_epoch, strerror(errno));
    +-                  source_date_epoch, strerrno());
     -          return fallback;
    -+                  env, strerror(errno));
    ++                  env, strerrno());
     +          return t;
        }
     -  return epoch;
```
</details>

<details>
<summary>v5g</summary>

-  Rebase

```
$ git rd 
1:  5c8da7cfa = 1:  65b461e47 lib/, src/: Move gettime() prototype to "time/date.h"
2:  d7115d94c = 2:  61fb7155b lib/: date_or_SDE(): Add function
3:  59da3f47f = 3:  4855657e1 lib/, src/: Use date_or_SDE() instead of its pattern
4:  977d00d2b = 4:  9116ed42e lib/date.*: Rename gettime() => time_or_SDE()
```
</details>

<details>
<summary>v5h</summary>

-  Rebase

```
$ git rd 
1:  65b461e47 ! 1:  9eea8c4fa lib/, src/: Move gettime() prototype to "time/date.h"
    @@ src/usermod.c
      #include <ctype.h>
      #include <errno.h>
     @@
    - #include "string/strcmp/strprefix.h"
      #include "string/strdup/strdup.h"
      #include "string/strerrno.h"
    + #include "string/strspn/stprspn.h"
     +#include "time/date.h"
      #include "time/day_to_str.h"
      #include "typetraits.h"
2:  61fb7155b = 2:  de8bda9b7 lib/: date_or_SDE(): Add function
3:  4855657e1 ! 3:  c8b1f93b7 lib/, src/: Use date_or_SDE() instead of its pattern
    @@ src/chpasswd.c: int main (int argc, char **argv)
                if (   (NULL == sp)
     
      ## src/newusers.c ##
    -@@ src/newusers.c: static int add_passwd (struct passwd *pwd, const char *password)
    +@@ src/newusers.c: add_passwd(struct passwd *pwd, MAYBE_UNUSED const char *password)
                        }
                        spent.sp_pwdp = cp;
                }
    @@ src/newusers.c: static int add_passwd (struct passwd *pwd, const char *password)
                return (spw_update (&spent) == 0);
        }
      
    -@@ src/newusers.c: static int add_passwd (struct passwd *pwd, const char *password)
    +@@ src/newusers.c: add_passwd(struct passwd *pwd, MAYBE_UNUSED const char *password)
         */
        spent.sp_pwdp = "!";
      #endif
    @@ src/newusers.c: static int add_passwd (struct passwd *pwd, const char *password)
        spent.sp_max    = getdef_num ("PASS_MAX_DAYS", 10000);
     
      ## src/passwd.c ##
    -@@ src/passwd.c: static void update_shadow (struct option_flags *flags)
    +@@ src/passwd.c: static void update_shadow(const struct option_flags *flags)
        }
        if (!use_pam)
        {
    @@ src/passwd.c: static void update_shadow (struct option_flags *flags)
        /*
     
      ## src/pwck.c ##
    -@@ src/pwck.c: static void check_pw_file (bool *errors, bool *changed, struct option_flags *fla
    +@@ src/pwck.c: static void check_pw_file(bool *errors, bool *changed, const struct option_flags
                                        sp.sp_inact  = -1;
                                        sp.sp_expire = -1;
                                        sp.sp_flag   = SHADOW_SP_FLAG_UNSET;
    @@ src/pwconv.c: int main (int argc, char **argv)
     
      ## src/useradd.c ##
     @@ src/useradd.c: static void new_spent (struct spwd *spent)
    -   memzero (spent, sizeof *spent);
    +   memzero(spent, sizeof(*spent));
        spent->sp_namp = (char *) user_name;
        spent->sp_pwdp = (char *) user_pass;
     -  spent->sp_lstchg = gettime () / DAY;
    @@ src/usermod.c: static void new_spent (struct spwd *spent, bool process_selinux)
      }
      
      /*
    -@@ src/usermod.c: static void usr_update (struct option_flags *flags)
    +@@ src/usermod.c: static void usr_update(const struct option_flags *flags)
                        spent.sp_pwdp   = xstrdup (pwent.pw_passwd);
                        pwent.pw_passwd = xstrdup (SHADOW_PASSWD_STRING);
      
4:  9116ed42e = 4:  bdbec117c lib/date.*: Rename gettime() => time_or_SDE()
```
</details>

<details>
<summary>v5i</summary>

-  Rebase

```
$ git rd 
1:  9eea8c4fa ! 1:  1945f1435 lib/, src/: Move gettime() prototype to "time/date.h"
    @@ lib/prototypes.h: extern int getrange (const char *range,
     -/* gettime.c */
     -extern time_t gettime (void);
     -
    - /* fputsx.c */
    - ATTR_ACCESS(write_only, 1, 2)
    - extern /*@null@*/char *fgetsx(/*@returned@*/char *restrict, int, FILE *restrict);
    + /* groupio.c */
    + extern void __gr_del_entry (const struct commonio_entry *ent);
    + extern /*@observer@*/const struct commonio_db *__gr_get_db (void);
     
      ## lib/pwd2spwd.c ##
     @@
2:  de8bda9b7 = 2:  6d205299f lib/: date_or_SDE(): Add function
3:  c8b1f93b7 = 3:  3429b1603 lib/, src/: Use date_or_SDE() instead of its pattern
4:  bdbec117c = 4:  7e92d90b2 lib/date.*: Rename gettime() => time_or_SDE()
```
</details>

<details>
<summary>v5j</summary>

-  Rebase

```
$ git rd 
1:  1945f1435 = 1:  20e99b9e7 lib/, src/: Move gettime() prototype to "time/date.h"
2:  6d205299f = 2:  d340837bc lib/: date_or_SDE(): Add function
3:  3429b1603 = 3:  5843f8a94 lib/, src/: Use date_or_SDE() instead of its pattern
4:  7e92d90b2 = 4:  b2e71b266 lib/date.*: Rename gettime() => time_or_SDE()
```
</details>

<details>
<summary>v6</summary>

-  Rebase

```
$ git rd 
1:  20e99b9e7 ! 1:  98e58ca1c lib/, src/: Move gettime() prototype to "time/date.h"
    @@ lib/prototypes.h: extern int getrange (const char *range,
      extern void __gr_del_entry (const struct commonio_entry *ent);
      extern /*@observer@*/const struct commonio_db *__gr_get_db (void);
     
    - ## lib/pwd2spwd.c ##
    -@@
    - 
    - #include "config.h"
    - 
    --#ident "$Id$"
    --
    --#include <sys/types.h>
    --#include "prototypes.h"
    --#include "defines.h"
    - #include <pwd.h>
    -+#include <sys/types.h>
    -+
    -+#include "defines.h"
    -+#include "prototypes.h"
    -+#include "time/date.h"
    - 
    - /*
    -  * pwd_to_spwd - create entries for new spwd structure
    -
      ## lib/time/date.h (new) ##
     @@
     +// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
2:  d340837bc = 2:  a4e0998e5 lib/: date_or_SDE(): Add function
3:  5843f8a94 ! 3:  dc361dd28 lib/, src/: Use date_or_SDE() instead of its pattern
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/, src/: Use date_or_SDE() instead of its pattern
    +    src/: Use date_or_SDE() instead of its pattern
     
         The checks changing 0 into -1 were probably added because gettime()/DAY
         transformed a gettime() error code (-1) into 0, due to integer division.
    @@ Commit message
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    - ## lib/pwd2spwd.c ##
    -@@ lib/pwd2spwd.c: struct spwd *pwd_to_spwd (const struct passwd *pw)
    -            */
    -           sp.sp_min = 0;
    -           sp.sp_max = 10000;
    --          sp.sp_lstchg = gettime () / DAY;
    --          if (0 == sp.sp_lstchg) {
    --                  /* Better disable aging than requiring a password
    --                   * change */
    --                  sp.sp_lstchg = -1;
    --          }
    -+          sp.sp_lstchg = date_or_SDE();
    -   }
    - 
    -   /*
    -
      ## src/chpasswd.c ##
     @@ src/chpasswd.c: int main (int argc, char **argv)
                if (NULL != sp) {
    @@ src/newusers.c: add_passwd(struct passwd *pwd, MAYBE_UNUSED const char *password
     -  }
     +  spent.sp_lstchg = date_or_SDE();
        spent.sp_min    = getdef_num ("PASS_MIN_DAYS", 0);
    -   /* 10000 is infinity this week */
    -   spent.sp_max    = getdef_num ("PASS_MAX_DAYS", 10000);
    +   spent.sp_max    = getdef_num ("PASS_MAX_DAYS", -1);
    +   spent.sp_warn   = getdef_num ("PASS_WARN_AGE", -1);
     
      ## src/passwd.c ##
    -@@ src/passwd.c: static void update_shadow(const struct option_flags *flags)
    +@@ src/passwd.c: static void update_shadow(bool process_selinux)
        }
        if (!use_pam)
        {
4:  b2e71b266 = 4:  24ec1884e lib/date.*: Rename gettime() => time_or_SDE()
```
</details>

<details>
<summary>v6b</summary>

-  Rebase

```
$ git rd 
1:  98e58ca1c660 = 1:  22f96709eb60 lib/, src/: Move gettime() prototype to "time/date.h"
2:  a4e0998e5301 = 2:  feee6728bb14 lib/: date_or_SDE(): Add function
3:  dc361dd280aa ! 3:  1089c96978d5 src/: Use date_or_SDE() instead of its pattern
    @@ src/useradd.c: static void new_spent (struct spwd *spent)
      ## src/usermod.c ##
     @@ src/usermod.c: static void new_spent (struct spwd *spent, bool process_selinux)
         */
    -   spent->sp_pwdp = new_pw_passwd (spent->sp_pwdp);
    +   spent->sp_pwdp = new_pw_passwd(spent->sp_pwdp, process_selinux);
      
     -  if (pflg) {
     -          spent->sp_lstchg = gettime () / DAY;
4:  24ec1884e128 ! 4:  2180c3a0ad04 lib/date.*: Rename gettime() => time_or_SDE()
    @@ lib/time/date.c
     +time_or_SDE(void)
      {
     -  char    *source_date_epoch;
    -+  char    *env;
    -   FILE    *shadow_logfd = log_get_logfd();
     -  time_t  fallback, epoch;
    ++  char    *env;
     +  time_t  t, sde;
      
     -  fallback = time (NULL);
    @@ lib/time/date.c
      
     -  if (a2i(time_t, &epoch, source_date_epoch, NULL, 10, 0, fallback) == -1) {
     +  if (a2i(time_t, &sde, env, NULL, 10, 0, t) == -1) {
    -           fprintf(shadow_logfd,
    +           fprintf(log_get_logfd(),
                        _("Environment variable $SOURCE_DATE_EPOCH: a2i(\"%s\"): %s"),
     -                  source_date_epoch, strerrno());
     -          return fallback;
```
</details>

<details>
<summary>v6c</summary>

-  Rebase

```
$ git rd 
1:  22f96709 = 1:  c9d4f3f8 lib/, src/: Move gettime() prototype to "time/date.h"
2:  feee6728 = 2:  41b003e0 lib/: date_or_SDE(): Add function
3:  1089c969 = 3:  60df6697 src/: Use date_or_SDE() instead of its pattern
4:  2180c3a0 = 4:  28fae8f1 lib/date.*: Rename gettime() => time_or_SDE()
```
</details>

<details>
<summary>v6d</summary>

-  Rebase

```
$ git rd -U0
1:  c9d4f3f8 ! 1:  37ed3b9b lib/, src/: Move gettime() prototype to "time/date.h"
    @@ lib/Makefile.am: libshadow_la_SOURCES = \
    -   subordinateio.h \
    -   subordinateio.c \
    @@ lib/Makefile.am: libshadow_la_SOURCES = \
    +   sysconf.c \
    +   sysconf.h \
    @@ src/useradd.c
    - 
    - #include "config.h"
    - 
    --#ident "$Id$"
    --
    - #include <assert.h>
    - #include <ctype.h>
    - #include <errno.h>
    -@@
    - #include "string/strdup/strdup.h"
    @@ src/useradd.c
    + #include "sysconf.h"
    @@ src/useradd.c
    - 
    - #ifndef SKEL_DIR
    + #undef NDEBUG
    + #include <assert.h>
    @@ src/usermod.c
    - #include <assert.h>
    @@ src/usermod.c
    + #include <fcntl.h>
    @@ src/usermod.c
    - #include "string/strdup/strdup.h"
    @@ src/usermod.c
    + #include "sysconf.h"
2:  41b003e0 ! 2:  20139bbd lib/: date_or_SDE(): Add function
    @@ lib/Makefile.am: libshadow_la_SOURCES = \
    -   subordinateio.h \
    -   subordinateio.c \
    @@ lib/Makefile.am: libshadow_la_SOURCES = \
    +   sysconf.c \
    +   sysconf.h \
3:  60df6697 = 3:  631c01ac src/: Use date_or_SDE() instead of its pattern
4:  28fae8f1 = 4:  0dfe3807 lib/date.*: Rename gettime() => time_or_SDE()
```
</details>

<details>
<summary>v6e</summary>

-  Rebase

```
$ git rd 
1:  37ed3b9b162e = 1:  a30a77264469 lib/, src/: Move gettime() prototype to "time/date.h"
2:  20139bbd3b6d = 2:  05dc32f26699 lib/: date_or_SDE(): Add function
3:  631c01ac44fa ! 3:  c758279a9a0d src/: Use date_or_SDE() instead of its pattern
    @@ src/newusers.c: add_passwd(struct passwd *pwd, MAYBE_UNUSED const char *password
     -          spent.sp_lstchg = -1;
     -  }
     +  spent.sp_lstchg = date_or_SDE();
    -   spent.sp_min    = getdef_num ("PASS_MIN_DAYS", 0);
    +   spent.sp_min    = -1;
        spent.sp_max    = getdef_num ("PASS_MAX_DAYS", -1);
        spent.sp_warn   = getdef_num ("PASS_WARN_AGE", -1);
     
    @@ src/useradd.c: static void new_spent (struct spwd *spent)
     -          spent->sp_lstchg = -1;
     -  }
     +  spent->sp_lstchg = date_or_SDE();
    +   spent->sp_min = -1;
        if (!rflg) {
    -           spent->sp_min = getdef_num ("PASS_MIN_DAYS", -1);
                spent->sp_max = getdef_num ("PASS_MAX_DAYS", -1);
     
      ## src/usermod.c ##
    @@ src/usermod.c: static void usr_update(const struct option_flags *flags)
     -                          spent.sp_lstchg = -1;
     -                  }
     +                  spent.sp_lstchg = date_or_SDE();
    -                   spent.sp_min    = getdef_num ("PASS_MIN_DAYS", -1);
    +                   spent.sp_min    = -1;
                        spent.sp_max    = getdef_num ("PASS_MAX_DAYS", -1);
                        spent.sp_warn   = getdef_num ("PASS_WARN_AGE", -1);
4:  0dfe38079af3 = 4:  de5287ffbfb1 lib/date.*: Rename gettime() => time_or_SDE()
```
</details>