### PR TITLE
Make sure that logind is enabled if requested, make --enable-logind/--disable-logind mandatory

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -18,6 +18,7 @@ CFLAGS="$CFLAGS -Wno-unknown-warning-option"
 "$(dirname "$0")"/configure \
 	CFLAGS="$CFLAGS" \
 	--enable-lastlog \
+	--disable-logind \
 	--enable-man \
 	--enable-maintainer-mode \
 	--enable-shared \

--- a/configure.ac
+++ b/configure.ac
@@ -153,7 +153,7 @@ AC_ARG_ENABLE([lastlog],
 
 AC_ARG_ENABLE([logind],
 	[AS_HELP_STRING([--enable-logind],
-		[enable logind @<:@default=yes if found@:>@])],
+		[enable logind support])],
 	[
 		AS_CASE([${enableval}],
 			[yes],[],
@@ -161,7 +161,9 @@ AC_ARG_ENABLE([logind],
 			[AC_MSG_ERROR([bad parameter value for --enable-logind=${enableval}])]
 		)
 	],
-	[enable_logind="yes"]
+	[
+		AC_MSG_ERROR([neither --enable-logind nor --disable-logind specified. One of these two parameters must be set explicitly.])
+	]
 )
 
 AC_ARG_WITH([audit],
@@ -344,18 +346,17 @@ fi
 AM_CONDITIONAL([ENABLE_LASTLOG], [test "x$enable_lastlog" != "xno"])
 
 AC_SUBST([LIBSYSTEMD])
-if test "X$enable_logind" = "Xyes"; then
+if test "x$enable_logind" = "xyes"; then
 	AC_CHECK_LIB([systemd], [sd_session_get_remote_host],
 		[
-			enable_logind="yes"
 			LIBSYSTEMD=-lsystemd
 			AC_DEFINE([ENABLE_LOGIND], [1], [Define to manage session support with logind.])
 		],[
-			enable_logind="no"
+			AC_MSG_ERROR([libsystemd not found, but logind is requested. Consider installing systemd or disable logind by --disable-logind.])
 		]
 	)
 fi
-AM_CONDITIONAL([ENABLE_LOGIND], [test "x$enable_logind" != "xno"])
+AM_CONDITIONAL([ENABLE_LOGIND], [test "x$enable_logind" = "xyes"])
 
 AC_CHECK_LIB([crypt], [crypt], [LIBCRYPT=-lcrypt],
 	[AC_MSG_ERROR([crypt() not found])])


### PR DESCRIPTION
This is alternative version of #1283

This PR:
* Fix silent disable of logind if `--enable-logind` is requested, but libsystemd is missing
* Make mandatory one of --enable-logind/--disable-logind configure parameters. If none is specified, then `configure` stops with error and asks user to provide one of them.

@alejandro-colomar The code does not assume anything. It asks user to specify explicitly, whether logind is needed or not.