### PR TITLE
lib/agetpass.c: Pass "" instead of NULL as an ignored prompt

### DIFF
--- a/lib/agetpass.c
+++ b/lib/agetpass.c
@@ -135,7 +135,7 @@ agetpass(const char *prompt)
 char *
 agetpass_stdin()
 {
-	return agetpass_internal(NULL, RPP_STDIN);
+	return agetpass_internal("", RPP_STDIN);
 }
 
 void


### PR DESCRIPTION
This is safer, since in general, readpassphrase(3) does not accept a null pointer as input.

This was discovered thanks to @chrisbazley's _Optional qualifier, which I'm testing at the moment.