### PR TITLE
lib/, src/: Remove dead calls to umask(2)

### DIFF
--- a/lib/commonio.c
+++ b/lib/commonio.c
@@ -245,11 +245,8 @@ static /*@null@*/ /*@dependent@*/FILE *fopen_set_perms (
 	const struct stat *sb)
 {
 	FILE *fp;
-	mode_t mask;
 
-	mask = umask (0777);
 	fp = fopen (name, mode);
-	(void) umask (mask);
 	if (NULL == fp) {
 		return NULL;
 	}
@@ -257,9 +254,8 @@ static /*@null@*/ /*@dependent@*/FILE *fopen_set_perms (
 	if (fchown (fileno (fp), sb->st_uid, sb->st_gid) != 0) {
 		goto fail;
 	}
-	if (fchmod (fileno (fp), sb->st_mode & 0664) != 0) {
+	if (fchmod(fileno (fp), sb->st_mode & 0664) != 0)
 		goto fail;
-	}
 
 	return fp;
 

--- a/src/vipw.c
+++ b/src/vipw.c
@@ -108,11 +108,8 @@ static int create_backup_file (FILE * fp, const char *backup, struct stat *sb)
 	struct utimbuf ub;
 	FILE *bkfp;
 	int c;
-	mode_t mask;
 
-	mask = umask (077);
 	bkfp = fopen (backup, "w");
-	(void) umask (mask);
 	if (NULL == bkfp) {
 		return -1;
 	}
@@ -142,7 +139,7 @@ static int create_backup_file (FILE * fp, const char *backup, struct stat *sb)
 	ub.actime = sb->st_atime;
 	ub.modtime = sb->st_mtime;
 	if (   (utime (backup, &ub) != 0)
-	    || (chmod (backup, sb->st_mode) != 0)
+	    || (chmod(backup, sb->st_mode) != 0)
 	    || (chown (backup, sb->st_uid, sb->st_gid) != 0)) {
 		unlink (backup);
 		return -1;


### PR DESCRIPTION
We're calling [f]chmod(2) right afterwards to set the mode, so it makes aboslutely no sense to set a umask(2) for calling fopen(3).

Not only it is dead code, it might even be dangerous, by creating a window of time where anyone can write to these files.