### PR TITLE
lib/commonio.c: create_backup(): Remove dead call to fseek(3)

### DIFF
--- a/lib/commonio.c
+++ b/lib/commonio.c
@@ -289,13 +289,12 @@ static int create_backup (const char *backup, FILE * fp)
 
 	/* TODO: faster copy, not one-char-at-a-time.  --marekm */
 	c = 0;
-	if (fseek (fp, 0, SEEK_SET) == 0) {
-		while ((c = getc (fp)) != EOF) {
-			if (putc (c, bkfp) == EOF) {
-				break;
-			}
+	while ((c = getc (fp)) != EOF) {
+		if (putc (c, bkfp) == EOF) {
+			break;
 		}
 	}
+
 	if ((c != EOF) || (ferror (fp) != 0) || (fflush (bkfp) != 0)) {
 		(void) fclose (bkfp);
 		/* FIXME: unlink the backup file? */


### PR DESCRIPTION
fopen(, "w") already guarantees that the stream is positioned at the beginning of the file.