### PR TITLE
lib/utmp.c: Fix use of last utmp entry instead of patrial-match entry + Optimisations

### DIFF
--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -150,8 +150,8 @@ static /*@null@*/ /*@only@*/struct utmpx *
 get_current_utmp(pid_t main_pid)
 {
 	struct utmpx  *ut;
-	struct utmpx  *ut_by_pid  = NULL;
-	struct utmpx  *ut_by_line = NULL;
+	struct utmpx  *ut_copy = NULL;
+	bool          ut_copy_is_by_line_only = false;
 
 	setutxent();
 
@@ -162,38 +162,34 @@ get_current_utmp(pid_t main_pid)
 			continue;
 
 		if (main_pid == ut->ut_pid) {
-			if (is_my_tty(ut->ut_line))
+			bool has_tty_match;
+
+			has_tty_match = is_my_tty(ut->ut_line);
+
+			if (NULL == ut_copy) {
+				ut_copy = XMALLOC(1, struct utmpx);
+				*ut_copy = *ut;
+			} else if (   has_tty_match
+			           || ut_copy_is_by_line_only)
+				*ut_copy = *ut;
+
+			if (has_tty_match)
 				break; /* Perfect match, stop the search */
 
-			if (NULL == ut_by_pid) {
-				ut_by_pid = XMALLOC(1, struct utmpx);
-				*ut_by_pid = *ut;
-			}
+			ut_copy_is_by_line_only = false; /* Match by PID */
 
-		} else if (   (NULL == ut_by_line)
+		} else if (   (NULL == ut_copy)
 			   && (LOGIN_PROCESS == ut->ut_type) /* Be more picky when matching by 'ut_line' only */
 			   && (is_my_tty(ut->ut_line))) {
-			ut_by_line = XMALLOC(1, struct utmpx);
-			*ut_by_line = *ut;
+			ut_copy = XMALLOC(1, struct utmpx);
+			*ut_copy = *ut;
+			ut_copy_is_by_line_only = true;
 		}
 	}
 
-	if (NULL == ut)
-		ut = ut_by_pid ?: ut_by_line;
-
-	if (NULL != ut) {
-		struct utmpx  *ut_copy;
-
-		ut_copy = XMALLOC(1, struct utmpx);
-		memcpy(ut_copy, ut, sizeof(*ut));
-		ut = ut_copy;
-	}
-
-	free(ut_by_line);
-	free(ut_by_pid);
 	endutxent();
 
-	return ut;
+	return ut_copy;
 }
 
 


### PR DESCRIPTION
This is a correction for PR #1292 (and is an alternative version of PR https://github.com/shadow-maint/shadow/pull/1326; this PR includes some optimisations.)

After additional code and documentation analysis I found out that copy of the pointer is not enough, a deep copy must be used instead.
I also checked glibc sources to be absolutely sure.

As allocation is needed for every successful match (either full or partial), I restructured the code to avoid code duplication.

I think this kind of code could be improved with additional comments, as currently it is not fully clear that match by PID has priority over match by line (tty).