### PR TITLE
ut-match algorithm improvements.

### DIFF
--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -156,9 +156,8 @@ get_current_utmp(pid_t main_pid)
 		UT_MATCH_BY_PID_AND_LINE
 	};
 
+	struct utmpx   ut_copy;
 	struct utmpx   *ut;
-	struct utmpx   *ut_by_pid  = NULL;
-	struct utmpx   *ut_by_line = NULL;
 	enum ut_match  match;
 
 	setutxent();
@@ -173,13 +172,13 @@ get_current_utmp(pid_t main_pid)
 		if (main_pid == ut->ut_pid) {
 			if (is_my_tty(ut->ut_line)) {
 				match = UT_MATCH_BY_PID_AND_LINE;
+				ut_copy = *ut;
 				break;
 			}
 
 			if (match < UT_MATCH_BY_PID) {
 				match = UT_MATCH_BY_PID;
-				ut_by_pid = xmalloc_T(1, struct utmpx);
-				*ut_by_pid = *ut;
+				ut_copy = *ut;
 			}
 
 		} else if (   LOGIN_PROCESS == ut->ut_type /* Be more picky when matching by 'ut_line' only */
@@ -187,20 +186,13 @@ get_current_utmp(pid_t main_pid)
 		{
 			if (match < UT_MATCH_BY_LINE) {
 				match = UT_MATCH_BY_LINE;
-				ut_by_line = xmalloc_T(1, struct utmpx);
-				*ut_by_line = *ut;
+				ut_copy = *ut;
 			}
 		}
 	}
 
-	if (NULL == ut)
-		ut = ut_by_pid ?: ut_by_line;
+	ut = match ? memdup_T(&ut_copy, struct utmpx) : NULL;
 
-	if (NULL != ut)
-		ut = memdup_T(ut, struct utmpx);
-
-	free(ut_by_line);
-	free(ut_by_pid);
 	endutxent();
 
 	return ut;

--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -170,11 +170,13 @@ get_current_utmp(pid_t main_pid)
 				*ut_by_pid = *ut;
 			}
 
-		} else if (   (NULL == ut_by_line)
-			   && (LOGIN_PROCESS == ut->ut_type) /* Be more picky when matching by 'ut_line' only */
-			   && (is_my_tty(ut->ut_line))) {
-			ut_by_line = xmalloc_T(1, struct utmpx);
-			*ut_by_line = *ut;
+		} else if (   LOGIN_PROCESS == ut->ut_type /* Be more picky when matching by 'ut_line' only */
+			   && is_my_tty(ut->ut_line))
+		{
+			if (NULL == ut_by_line) {
+				ut_by_line = xmalloc_T(1, struct utmpx);
+				*ut_by_line = *ut;
+			}
 		}
 	}
 

--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -149,23 +149,35 @@ ATTR_MALLOC(free)
 static /*@null@*/ /*@only@*/struct utmpx *
 get_current_utmp(pid_t main_pid)
 {
-	struct utmpx  *ut;
-	struct utmpx  *ut_by_pid  = NULL;
-	struct utmpx  *ut_by_line = NULL;
+	enum ut_match {
+		UT_NO_MATCH = 0,
+		UT_MATCH_BY_LINE,
+		UT_MATCH_BY_PID,
+		UT_MATCH_BY_PID_AND_LINE
+	};
+
+	struct utmpx   *ut;
+	struct utmpx   *ut_by_pid  = NULL;
+	struct utmpx   *ut_by_line = NULL;
+	enum ut_match  match;
 
 	setutxent();
 
 	/* First, try to find a valid utmp entry for this process.  */
+	match = 0;
 	while (NULL != (ut = getutxent())) {
 		if (   (LOGIN_PROCESS != ut->ut_type)
 		    && (USER_PROCESS  != ut->ut_type))
 			continue;
 
 		if (main_pid == ut->ut_pid) {
-			if (is_my_tty(ut->ut_line))
-				break; /* Perfect match, stop the search */
+			if (is_my_tty(ut->ut_line)) {
+				match = UT_MATCH_BY_PID_AND_LINE;
+				break;
+			}
 
-			if (NULL == ut_by_pid) {
+			if (match < UT_MATCH_BY_PID) {
+				match = UT_MATCH_BY_PID;
 				ut_by_pid = xmalloc_T(1, struct utmpx);
 				*ut_by_pid = *ut;
 			}
@@ -173,7 +185,8 @@ get_current_utmp(pid_t main_pid)
 		} else if (   LOGIN_PROCESS == ut->ut_type /* Be more picky when matching by 'ut_line' only */
 			   && is_my_tty(ut->ut_line))
 		{
-			if (NULL == ut_by_line) {
+			if (match < UT_MATCH_BY_LINE) {
+				match = UT_MATCH_BY_LINE;
 				ut_by_line = xmalloc_T(1, struct utmpx);
 				*ut_by_line = *ut;
 			}

--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -191,11 +191,9 @@ get_current_utmp(pid_t main_pid)
 		}
 	}
 
-	ut = match ? memdup_T(&ut_copy, struct utmpx) : NULL;
-
 	endutxent();
 
-	return ut;
+	return match ? memdup_T(&ut_copy, struct utmpx) : NULL;
 }
 
 


### PR DESCRIPTION
I've optimized the algorithm in several ways (both performance and readability):

-  If there's a match-by-pid, we don't spend time copying a match-by-line, which is considered worse.
-  By using the stack, we don't have superfluous allocations.
-  The enum and the ordered levels of matching make the algorithm much more readable than it originally was.


Reported-by: @Karlson2k


Queued after #1296 .

---

Revisions:

<details>
<summary>v2</summary>

-  Bring in the MEMDUP() changes from #1296, as they're just to make this more readable.
-  endutxent() earlier.

```
$ git range-diff shadow/master gh/ut  ut
1:  722a3baa = 1:  722a3baa lib/utmp.c: get_current_utmp(): Rename local variable
2:  34b2ed3b = 2:  34b2ed3b lib/utmp.c: get_current_utmp(): Refactor conditional
3:  8d47dcb6 = 3:  8d47dcb6 lib/utmp.c: get_current_utmp(): Use an enum for readability
4:  9e8fd525 = 4:  9e8fd525 lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
-:  -------- > 5:  9a3e362e lib/string/strdup/: memdup(), MEMDUP(): Add APIs
-:  -------- > 6:  1e72a0b8 lib/utmp.c: get_current_utmp(): Don't exit(3) from library code
-:  -------- > 7:  eb01f5ac lib/utmp.c: get_current_utmp(): Use MEMDUP() instead of its pattern
-:  -------- > 8:  9f55b18b lib/utmp.c: get_current_utmp(): Move MEMDUP() to the return statement
```
</details>

<details>
<summary>v2b</summary>

-  Rebase

```
$ git rd 
1:  722a3baa = 1:  4750a0d2 lib/utmp.c: get_current_utmp(): Rename local variable
2:  34b2ed3b = 2:  d6d8b16f lib/utmp.c: get_current_utmp(): Refactor conditional
3:  8d47dcb6 = 3:  544d7b16 lib/utmp.c: get_current_utmp(): Use an enum for readability
4:  9e8fd525 = 4:  1c8dc8d1 lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
5:  9a3e362e = 5:  8624ca55 lib/string/strdup/: memdup(), MEMDUP(): Add APIs
6:  1e72a0b8 = 6:  36941b6b lib/utmp.c: get_current_utmp(): Don't exit(3) from library code
7:  eb01f5ac = 7:  e1a28feb lib/utmp.c: get_current_utmp(): Use MEMDUP() instead of its pattern
8:  9f55b18b = 8:  791e81b9 lib/utmp.c: get_current_utmp(): Move MEMDUP() to the return statement
```
</details>

<details>
<summary>v2c</summary>

-  Rebase

```
$ git rd 
1:  4750a0d2 = 1:  c5b432f6 lib/utmp.c: get_current_utmp(): Rename local variable
2:  d6d8b16f = 2:  0d98f40b lib/utmp.c: get_current_utmp(): Refactor conditional
3:  544d7b16 = 3:  38661891 lib/utmp.c: get_current_utmp(): Use an enum for readability
4:  1c8dc8d1 = 4:  eb3f0659 lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
5:  8624ca55 = 5:  c1820b1b lib/string/strdup/: memdup(), MEMDUP(): Add APIs
6:  36941b6b = 6:  6d10069a lib/utmp.c: get_current_utmp(): Don't exit(3) from library code
7:  e1a28feb = 7:  b9702a86 lib/utmp.c: get_current_utmp(): Use MEMDUP() instead of its pattern
8:  791e81b9 = 8:  7e0ea2a8 lib/utmp.c: get_current_utmp(): Move MEMDUP() to the return statement
```
</details>

<details>
<summary>v2d</summary>

-  Rebase

```
$ git rd 
1:  c5b432f6 = 1:  2ac8ca73 lib/utmp.c: get_current_utmp(): Rename local variable
2:  0d98f40b = 2:  e3c226af lib/utmp.c: get_current_utmp(): Refactor conditional
3:  38661891 = 3:  a210a977 lib/utmp.c: get_current_utmp(): Use an enum for readability
4:  eb3f0659 = 4:  a0b06c75 lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
5:  c1820b1b ! 5:  e96d999c lib/string/strdup/: memdup(), MEMDUP(): Add APIs
    @@ lib/Makefile.am: libshadow_la_SOURCES = \
        string/strcpy/strtcpy.h \
     +  string/strdup/memdup.c \
     +  string/strdup/memdup.h \
    +   string/strdup/strdup.c \
    +   string/strdup/strdup.h \
        string/strdup/strndupa.c \
    -   string/strdup/strndupa.h \
    -   string/strdup/xstrdup.c \
     
      ## lib/string/strdup/memdup.c (new) ##
     @@
6:  6d10069a ! 6:  c67333a5 lib/utmp.c: get_current_utmp(): Don't exit(3) from library code
    @@ Commit message
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/utmp.c ##
    -@@
    - #include <string.h>
    - #include <fcntl.h>
    - 
    -+#include "alloc/malloc.h"
    - #include "alloc/x/xcalloc.h"
    --#include "alloc/x/xmalloc.h"
    - #include "attr.h"
    - #include "sizeof.h"
    - #include "string/strchr/strnul.h"
     @@ lib/utmp.c: get_current_utmp(pid_t main_pid)
        }
      
7:  b9702a86 ! 7:  832bfc52 lib/utmp.c: get_current_utmp(): Use MEMDUP() instead of its pattern
    @@ Commit message
     
      ## lib/utmp.c ##
     @@
    - #include <string.h>
      #include <fcntl.h>
      
    + #include "alloc/calloc.h"
     -#include "alloc/malloc.h"
    - #include "alloc/x/xcalloc.h"
      #include "attr.h"
      #include "sizeof.h"
    + #include "string/strchr/strnul.h"
     @@
      #include "string/strcmp/strprefix.h"
      #include "string/strcpy/strncpy.h"
      #include "string/strcpy/strtcpy.h"
     +#include "string/strdup/memdup.h"
    - #include "string/strdup/xstrdup.h"
    - #include "string/strdup/xstrndup.h"
    + #include "string/strdup/strdup.h"
    + #include "string/strdup/strndup.h"
      
     @@ lib/utmp.c: get_current_utmp(pid_t main_pid)
                }
8:  7e0ea2a8 = 8:  a9f85f1b lib/utmp.c: get_current_utmp(): Move MEMDUP() to the return statement
```
</details>

<details>
<summary>v3</summary>

-  Rebase on top of #1296 .

```
$ git range-diff shadow/master..gh/ut gh/memdup..ut 
1:  2ac8ca73c < -:  --------- lib/utmp.c: get_current_utmp(): Rename local variable
2:  e3c226af5 = 1:  84d29f190 lib/utmp.c: get_current_utmp(): Refactor conditional
3:  a210a9773 = 2:  579b7aaa4 lib/utmp.c: get_current_utmp(): Use an enum for readability
4:  a0b06c75e ! 3:  ecee78c80 lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
    @@ lib/utmp.c: get_current_utmp(pid_t main_pid)
      
     -  if (NULL == ut)
     -          ut = ut_by_pid ?: ut_by_line;
    --
    --  if (NULL != ut) {
    --          struct utmpx  *dup;
    --
    --          dup = XMALLOC(1, struct utmpx);
    --          memcpy(dup, ut, sizeof(*ut));
    --          ut = dup;
    -+  if (match) {
    -+          ut = XMALLOC(1, struct utmpx);
    -+          *ut = ut_copy;
    -+  } else {
    -+          ut = NULL;
    -   }
    ++  ut = match ? MEMDUP(&ut_copy, struct utmpx) : NULL;
      
    +-  if (NULL != ut)
    +-          ut = MEMDUP(ut, struct utmpx);
    +-
     -  free(ut_by_line);
     -  free(ut_by_pid);
        endutxent();
5:  e96d999c3 < -:  --------- lib/string/strdup/: memdup(), MEMDUP(): Add APIs
6:  c67333a54 < -:  --------- lib/utmp.c: get_current_utmp(): Don't exit(3) from library code
7:  832bfc52f < -:  --------- lib/utmp.c: get_current_utmp(): Use MEMDUP() instead of its pattern
8:  a9f85f1b1 = 4:  7c64a9b26 lib/utmp.c: get_current_utmp(): Move MEMDUP() to the return statement
```
```diff
$ git diff gh/ut..ut 
diff --git a/lib/string/strdup/memdup.h b/lib/string/strdup/memdup.h
index df21d624b..cff575b9a 100644
--- a/lib/string/strdup/memdup.h
+++ b/lib/string/strdup/memdup.h
@@ -22,7 +22,7 @@ ATTR_MALLOC(free)
 inline void *memdup(const void *p, size_t size);
 
 
-// memory duplicate
+// memdup - memory duplicate
 inline void *
 memdup(const void *p, size_t size)
 {
diff --git a/lib/utmp.c b/lib/utmp.c
index a965bfa1d..7c0c1cc10 100644
--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -27,6 +27,7 @@
 #include <fcntl.h>
 
 #include "alloc/calloc.h"
+#include "alloc/malloc.h"
 #include "attr.h"
 #include "sizeof.h"
 #include "string/strchr/strnul.h"
```
</details>

<details>
<summary>v3b</summary>

-  Rebase

```
$ git range-diff gh/memdup..gh/ut memdup..ut 
1:  84d29f190 = 1:  52fd9f2ee lib/utmp.c: get_current_utmp(): Refactor conditional
2:  579b7aaa4 = 2:  d155aaf74 lib/utmp.c: get_current_utmp(): Use an enum for readability
3:  ecee78c80 = 3:  ed88a77dd lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
4:  7c64a9b26 = 4:  0a76cb494 lib/utmp.c: get_current_utmp(): Move MEMDUP() to the return statement
```
</details>

<details>
<summary>v3c</summary>

-  Rebase

```
$ git range-diff gh/memdup..gh/ut memdup..ut 
1:  52fd9f2ee = 1:  e70da87fe lib/utmp.c: get_current_utmp(): Refactor conditional
2:  d155aaf74 = 2:  0bcdc48fb lib/utmp.c: get_current_utmp(): Use an enum for readability
3:  ed88a77dd = 3:  16bb342f7 lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
4:  0a76cb494 = 4:  7956194df lib/utmp.c: get_current_utmp(): Move MEMDUP() to the return statement
```
</details>

<details>
<summary>v4</summary>

-  Rebase

```
$ git range-diff gh/memdup..gh/ut memdup..ut 
1:  e70da87fe = 1:  43fc5699e lib/utmp.c: get_current_utmp(): Refactor conditional
2:  0bcdc48fb = 2:  159e6005f lib/utmp.c: get_current_utmp(): Use an enum for readability
3:  16bb342f7 = 3:  32babe5ce lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
4:  7956194df = 4:  cf6bb3530 lib/utmp.c: get_current_utmp(): Move MEMDUP() to the return statement
```
</details>

<details>
<summary>v4b</summary>

-  Rebase

```
$ git range-diff gh/memdup..gh/ut memdup..ut 
1:  43fc5699e = 1:  25748a7ed lib/utmp.c: get_current_utmp(): Refactor conditional
2:  159e6005f = 2:  ee9a8487e lib/utmp.c: get_current_utmp(): Use an enum for readability
3:  32babe5ce = 3:  c6aaad6fa lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
4:  cf6bb3530 = 4:  7ec1305db lib/utmp.c: get_current_utmp(): Move MEMDUP() to the return statement
```
</details>

<details>
<summary>v5</summary>

-  Rebase

```
$ git range-diff gh/memdup..gh/ut memdup..ut 
1:  25748a7ed ! 1:  dc6f979dd lib/utmp.c: get_current_utmp(): Refactor conditional
    @@ lib/utmp.c: get_current_utmp(pid_t main_pid)
     -          } else if (   (NULL == ut_by_line)
     -                     && (LOGIN_PROCESS == ut->ut_type) /* Be more picky when matching by 'ut_line' only */
     -                     && (is_my_tty(ut->ut_line))) {
    --                  ut_by_line = XMALLOC(1, struct utmpx);
    +-                  ut_by_line = xmalloc_T(1, struct utmpx);
     -                  *ut_by_line = *ut;
     +          } else if (   LOGIN_PROCESS == ut->ut_type /* Be more picky when matching by 'ut_line' only */
     +                     && is_my_tty(ut->ut_line))
     +          {
     +                  if (NULL == ut_by_line) {
    -+                          ut_by_line = XMALLOC(1, struct utmpx);
    ++                          ut_by_line = xmalloc_T(1, struct utmpx);
     +                          *ut_by_line = *ut;
     +                  }
                }
2:  ee9a8487e ! 2:  0b5030279 lib/utmp.c: get_current_utmp(): Use an enum for readability
    @@ lib/utmp.c: ATTR_MALLOC(free)
     -                  if (NULL == ut_by_pid) {
     +                  if (match < UT_MATCH_BY_PID) {
     +                          match = UT_MATCH_BY_PID;
    -                           ut_by_pid = XMALLOC(1, struct utmpx);
    +                           ut_by_pid = xmalloc_T(1, struct utmpx);
                                *ut_by_pid = *ut;
                        }
     @@ lib/utmp.c: get_current_utmp(pid_t main_pid)
    @@ lib/utmp.c: get_current_utmp(pid_t main_pid)
     -                  if (NULL == ut_by_line) {
     +                  if (match < UT_MATCH_BY_LINE) {
     +                          match = UT_MATCH_BY_LINE;
    -                           ut_by_line = XMALLOC(1, struct utmpx);
    +                           ut_by_line = xmalloc_T(1, struct utmpx);
                                *ut_by_line = *ut;
                        }
3:  c6aaad6fa ! 3:  68e1abc57 lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
    @@ lib/utmp.c: get_current_utmp(pid_t main_pid)
      
                        if (match < UT_MATCH_BY_PID) {
                                match = UT_MATCH_BY_PID;
    --                          ut_by_pid = XMALLOC(1, struct utmpx);
    +-                          ut_by_pid = xmalloc_T(1, struct utmpx);
     -                          *ut_by_pid = *ut;
     +                          ut_copy = *ut;
                        }
    @@ lib/utmp.c: get_current_utmp(pid_t main_pid)
                {
                        if (match < UT_MATCH_BY_LINE) {
                                match = UT_MATCH_BY_LINE;
    --                          ut_by_line = XMALLOC(1, struct utmpx);
    +-                          ut_by_line = xmalloc_T(1, struct utmpx);
     -                          *ut_by_line = *ut;
     +                          ut_copy = *ut;
                        }
    @@ lib/utmp.c: get_current_utmp(pid_t main_pid)
      
     -  if (NULL == ut)
     -          ut = ut_by_pid ?: ut_by_line;
    -+  ut = match ? MEMDUP(&ut_copy, struct utmpx) : NULL;
    ++  ut = match ? memdup_T(&ut_copy, struct utmpx) : NULL;
      
     -  if (NULL != ut)
    --          ut = MEMDUP(ut, struct utmpx);
    +-          ut = memdup_T(ut, struct utmpx);
     -
     -  free(ut_by_line);
     -  free(ut_by_pid);
4:  7ec1305db ! 4:  b8338efc1 lib/utmp.c: get_current_utmp(): Move MEMDUP() to the return statement
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/utmp.c: get_current_utmp(): Move MEMDUP() to the return statement
    +    lib/utmp.c: get_current_utmp(): Move memdup_T() to the return statement
     
         This removes the reuse of 'ut', with which I wasn't entirely happy.
         It also reduces the scope between setutxent()/endutxent().
    @@ lib/utmp.c: get_current_utmp(pid_t main_pid)
                }
        }
      
    --  ut = match ? MEMDUP(&ut_copy, struct utmpx) : NULL;
    +-  ut = match ? memdup_T(&ut_copy, struct utmpx) : NULL;
     -
        endutxent();
      
     -  return ut;
    -+  return match ? MEMDUP(&ut_copy, struct utmpx) : NULL;
    ++  return match ? memdup_T(&ut_copy, struct utmpx) : NULL;
      }
      
      
```
</details>

<details>
<summary>v5b</summary>

-  Rebase

```
$ git range-diff gh/memdup..gh/ut memdup..ut 
1:  dc6f979dd = 1:  cc02a4be8 lib/utmp.c: get_current_utmp(): Refactor conditional
2:  0b5030279 = 2:  ec17eaf5d lib/utmp.c: get_current_utmp(): Use an enum for readability
3:  68e1abc57 = 3:  509730966 lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
4:  b8338efc1 = 4:  cd921007f lib/utmp.c: get_current_utmp(): Move memdup_T() to the return statement
```
</details>

<details>
<summary>v5c</summary>

-  Rebase

```
$ git range-diff gh/memdup..gh/ut memdup..ut 
1:  cc02a4be8 = 1:  011c700e6 lib/utmp.c: get_current_utmp(): Refactor conditional
2:  ec17eaf5d = 2:  9f990fe97 lib/utmp.c: get_current_utmp(): Use an enum for readability
3:  509730966 = 3:  158b38e49 lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
4:  cd921007f = 4:  8ebd37062 lib/utmp.c: get_current_utmp(): Move memdup_T() to the return statement
```
</details>

<details>
<summary>v5d</summary>

-  Rebase

```
$ git range-diff gh/memdup..gh/ut memdup..ut 
1:  011c700e6 = 1:  e92dc65b4 lib/utmp.c: get_current_utmp(): Refactor conditional
2:  9f990fe97 = 2:  37f5e7c82 lib/utmp.c: get_current_utmp(): Use an enum for readability
3:  158b38e49 = 3:  a58c4bc9d lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
4:  8ebd37062 = 4:  1b33b6b07 lib/utmp.c: get_current_utmp(): Move memdup_T() to the return statement
```
</details>

<details>
<summary>v5e</summary>

-  Rebase

```
$ git range-diff gh/memdup..gh/ut memdup..ut 
1:  e92dc65b4 = 1:  74a691810 lib/utmp.c: get_current_utmp(): Refactor conditional
2:  37f5e7c82 = 2:  335118a2d lib/utmp.c: get_current_utmp(): Use an enum for readability
3:  a58c4bc9d = 3:  650097803 lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
4:  1b33b6b07 = 4:  cf983b2ed lib/utmp.c: get_current_utmp(): Move memdup_T() to the return statement
```
</details>

<details>
<summary>v5f</summary>

-  Rebase

```
$ git range-diff gh/memdup..gh/ut memdup..ut 
1:  74a691810 = 1:  ee403fb6d lib/utmp.c: get_current_utmp(): Refactor conditional
2:  335118a2d = 2:  2eb6e936c lib/utmp.c: get_current_utmp(): Use an enum for readability
3:  650097803 = 3:  2a945a205 lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
4:  cf983b2ed = 4:  051312b3b lib/utmp.c: get_current_utmp(): Move memdup_T() to the return statement
```
</details>

<details>
<summary>v5g</summary>

-  Rebase

```
$ git range-diff gh/memdup..gh/ut memdup..ut 
1:  ee403fb6d = 1:  d3c076a7e lib/utmp.c: get_current_utmp(): Refactor conditional
2:  2eb6e936c = 2:  93a5ecd45 lib/utmp.c: get_current_utmp(): Use an enum for readability
3:  2a945a205 = 3:  3bc4fcd5a lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
4:  051312b3b = 4:  a090ce529 lib/utmp.c: get_current_utmp(): Move memdup_T() to the return statement
```
</details>

<details>
<summary>v5h</summary>

-  Rebase

```
$ git range-diff gh/memdup..gh/ut memdup..ut 
1:  d3c076a7e = 1:  6f81847aa lib/utmp.c: get_current_utmp(): Refactor conditional
2:  93a5ecd45 = 2:  784ee759b lib/utmp.c: get_current_utmp(): Use an enum for readability
3:  3bc4fcd5a = 3:  ac6b7c299 lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
4:  a090ce529 = 4:  046d28e4b lib/utmp.c: get_current_utmp(): Move memdup_T() to the return statement
```
</details>

<details>
<summary>v5i</summary>

-  Rebase

```
$ git range-diff gh/memdup..gh/ut memdup..ut 
1:  6f81847aa = 1:  462661319 lib/utmp.c: get_current_utmp(): Refactor conditional
2:  784ee759b = 2:  ac7b22421 lib/utmp.c: get_current_utmp(): Use an enum for readability
3:  ac6b7c299 = 3:  0913b7ec1 lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
4:  046d28e4b = 4:  f785ceb79 lib/utmp.c: get_current_utmp(): Move memdup_T() to the return statement
```
</details>

<details>
<summary>v5j</summary>

-  Rebase

```
$ git range-diff gh/memdup..gh/ut memdup..ut 
1:  462661319 = 1:  d70af3c83 lib/utmp.c: get_current_utmp(): Refactor conditional
2:  ac7b22421 = 2:  a51498918 lib/utmp.c: get_current_utmp(): Use an enum for readability
3:  0913b7ec1 = 3:  140742c61 lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
4:  f785ceb79 = 4:  8a0223b3a lib/utmp.c: get_current_utmp(): Move memdup_T() to the return statement
```
</details>

<details>
<summary>v5k</summary>

-  Rebase

```
$ git range-diff gh/memdup..gh/ut memdup..ut 
1:  d70af3c83 = 1:  32c3ab1a6 lib/utmp.c: get_current_utmp(): Refactor conditional
2:  a51498918 = 2:  cd4c8642a lib/utmp.c: get_current_utmp(): Use an enum for readability
3:  140742c61 = 3:  00625f45e lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
4:  8a0223b3a = 4:  8e4f43ff2 lib/utmp.c: get_current_utmp(): Move memdup_T() to the return statement
```
</details>

<details>
<summary>v5l</summary>

-  Rebase

```
$ git range-diff gh/T..gh/memdup T..memdup 
1:  d2fb0444f = 1:  e4f14282f lib/string/strdup/: memdup{,_T}(): Add APIs
2:  ee58b30d6 = 2:  fa7692fd5 lib/utmp.c: get_current_utmp(): Don't exit(3) from library code
3:  94b4a8d61 = 3:  1cf10a6c6 lib/utmp.c: get_current_utmp(): Use memdup_T() instead of its pattern
```
</details>

<details>
<summary>v5m</summary>

-  Rebase

```
$ git range-diff gh/memdup..gh/ut memdup..ut 
1:  7d88f93f5 = 1:  8a0c113e2 lib/utmp.c: get_current_utmp(): Refactor conditional
2:  5bff54317 = 2:  9cfda2ff0 lib/utmp.c: get_current_utmp(): Use an enum for readability
3:  77ccdecba = 3:  09a2600b2 lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
4:  b1a45f3a6 = 4:  38a366138 lib/utmp.c: get_current_utmp(): Move memdup_T() to the return statement
```
</details>

<details>
<summary>v5n</summary>

-  Rebase

```
$ git range-diff gh/memdup..gh/ut memdup..ut 
1:  8a0c113e2 = 1:  c9dcf0f46 lib/utmp.c: get_current_utmp(): Refactor conditional
2:  9cfda2ff0 = 2:  77ed22d70 lib/utmp.c: get_current_utmp(): Use an enum for readability
3:  09a2600b2 = 3:  b9cb86d1c lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
4:  38a366138 = 4:  0a6b01d69 lib/utmp.c: get_current_utmp(): Move memdup_T() to the return statement
```
</details>

<details>
<summary>v5o</summary>

-  Rebase

```
$ git range-diff gh/memdup..gh/ut memdup..ut 
1:  c9dcf0f46 = 1:  9bbd49a69 lib/utmp.c: get_current_utmp(): Refactor conditional
2:  77ed22d70 = 2:  73c836ca1 lib/utmp.c: get_current_utmp(): Use an enum for readability
3:  b9cb86d1c = 3:  501f3b7b4 lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
4:  0a6b01d69 = 4:  b0fbed4f8 lib/utmp.c: get_current_utmp(): Move memdup_T() to the return statement
```
</details>

<details>
<summary>v5p</summary>

-  Rebase

```
$ git range-diff gh/memdup..gh/ut memdup..ut 
1:  9bbd49a69 = 1:  8a237fe05 lib/utmp.c: get_current_utmp(): Refactor conditional
2:  73c836ca1 = 2:  3e8151b03 lib/utmp.c: get_current_utmp(): Use an enum for readability
3:  501f3b7b4 = 3:  34c4a158d lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
4:  b0fbed4f8 = 4:  587682e6e lib/utmp.c: get_current_utmp(): Move memdup_T() to the return statement
```
</details>

<details>
<summary>v5q</summary>

-  Rebase

```
$ git range-diff gh/memdup..gh/ut memdup..ut 
1:  8a237fe05 = 1:  a90a3c339 lib/utmp.c: get_current_utmp(): Refactor conditional
2:  3e8151b03 = 2:  9ddbefcc3 lib/utmp.c: get_current_utmp(): Use an enum for readability
3:  34c4a158d = 3:  7e18adb79 lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
4:  587682e6e = 4:  778e4fa0b lib/utmp.c: get_current_utmp(): Move memdup_T() to the return statement
```
</details>

<details>
<summary>v5r</summary>

-  Rebase

```
$ git range-diff gh/memdup..gh/ut memdup..ut 
1:  a90a3c339 = 1:  46cbca75b lib/utmp.c: get_current_utmp(): Refactor conditional
2:  9ddbefcc3 = 2:  b35cb3f32 lib/utmp.c: get_current_utmp(): Use an enum for readability
3:  7e18adb79 = 3:  121f2d23c lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
4:  778e4fa0b = 4:  6efd55a10 lib/utmp.c: get_current_utmp(): Move memdup_T() to the return statement
```
</details>

<details>
<summary>v5s</summary>

-  Rebase

```
$ git range-diff gh/memdup..gh/ut memdup..ut 
1:  46cbca75b = 1:  bf6e12a1b lib/utmp.c: get_current_utmp(): Refactor conditional
2:  b35cb3f32 = 2:  9819650aa lib/utmp.c: get_current_utmp(): Use an enum for readability
3:  121f2d23c = 3:  b9dbea138 lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
4:  6efd55a10 = 4:  a3af5f642 lib/utmp.c: get_current_utmp(): Move memdup_T() to the return statement
```
</details>

<details>
<summary>v5t</summary>

-  Rebase

```
$ git range-diff gh/memdup..gh/ut memdup..ut 
1:  bf6e12a1b = 1:  b22cfb506 lib/utmp.c: get_current_utmp(): Refactor conditional
2:  9819650aa = 2:  2fdaa4296 lib/utmp.c: get_current_utmp(): Use an enum for readability
3:  b9dbea138 = 3:  8892825dd lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
4:  a3af5f642 = 4:  2bf2888cd lib/utmp.c: get_current_utmp(): Move memdup_T() to the return statement
```
</details>

<details>
<summary>v5u</summary>

-  Rebase

```
$ git range-diff gh/memdup..gh/ut memdup..ut 
1:  b22cfb506 = 1:  e4f267e24 lib/utmp.c: get_current_utmp(): Refactor conditional
2:  2fdaa4296 = 2:  4c4888876 lib/utmp.c: get_current_utmp(): Use an enum for readability
3:  8892825dd = 3:  02f7d601c lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
4:  2bf2888cd = 4:  1798ae336 lib/utmp.c: get_current_utmp(): Move memdup_T() to the return statement
```
</details>

<details>
<summary>v5v</summary>

-  Rebase

```
$ git range-diff gh/memdup..gh/ut memdup..ut 
1:  e4f267e24 = 1:  894add09c lib/utmp.c: get_current_utmp(): Refactor conditional
2:  4c4888876 = 2:  a3a3b5fb0 lib/utmp.c: get_current_utmp(): Use an enum for readability
3:  02f7d601c = 3:  0a8d0372a lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
4:  1798ae336 = 4:  98e358084 lib/utmp.c: get_current_utmp(): Move memdup_T() to the return statement
```
</details>

<details>
<summary>v5w</summary>

-  Rebase

```
$ git range-diff gh/memdup..gh/ut memdup..ut 
1:  894add09c = 1:  01dc3fb5f lib/utmp.c: get_current_utmp(): Refactor conditional
2:  a3a3b5fb0 = 2:  04b0882f1 lib/utmp.c: get_current_utmp(): Use an enum for readability
3:  0a8d0372a = 3:  4c86185d8 lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
4:  98e358084 = 4:  65ebba469 lib/utmp.c: get_current_utmp(): Move memdup_T() to the return statement
```
</details>

<details>
<summary>v5x</summary>

-  Rebase

```
$ git range-diff gh/memdup..gh/ut memdup..ut 
1:  01dc3fb5f = 1:  6d556b59a lib/utmp.c: get_current_utmp(): Refactor conditional
2:  04b0882f1 = 2:  1cdab006a lib/utmp.c: get_current_utmp(): Use an enum for readability
3:  4c86185d8 = 3:  d3e9ad8e7 lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
4:  65ebba469 = 4:  8bae5aed8 lib/utmp.c: get_current_utmp(): Move memdup_T() to the return statement
```
</details>

<details>
<summary>v5y</summary>

-  Rebase

```
$ git range-diff 6d556b59a^..gh/ut memdup..ut 
1:  6d556b59a = 1:  7a9f171ca lib/utmp.c: get_current_utmp(): Refactor conditional
2:  1cdab006a = 2:  eba007b57 lib/utmp.c: get_current_utmp(): Use an enum for readability
3:  d3e9ad8e7 = 3:  99f7a215a lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
4:  8bae5aed8 = 4:  a0f97eb66 lib/utmp.c: get_current_utmp(): Move memdup_T() to the return statement
```
</details>

<details>
<summary>v5z</summary>

-  Rebase

```
$ git range-diff gh/memdup..gh/ut memdup..ut 
1:  7a9f171ca = 1:  d10a56c42 lib/utmp.c: get_current_utmp(): Refactor conditional
2:  eba007b57 = 2:  a945c1d2e lib/utmp.c: get_current_utmp(): Use an enum for readability
3:  99f7a215a = 3:  d8ef953e3 lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
4:  a0f97eb66 = 4:  f2c603f8c lib/utmp.c: get_current_utmp(): Move memdup_T() to the return statement
```
</details>

<details>
<summary>v6</summary>

-  Rebase

```
$ git range-diff gh/memdup..gh/ut memdup..ut 
1:  d10a56c42a77 = 1:  eb21d9e50910 lib/utmp.c: get_current_utmp(): Refactor conditional
2:  a945c1d2e6bc = 2:  9db832da1569 lib/utmp.c: get_current_utmp(): Use an enum for readability
3:  d8ef953e3a92 = 3:  93e1b785a119 lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
4:  f2c603f8ca97 = 4:  cf96eab3d7bd lib/utmp.c: get_current_utmp(): Move memdup_T() to the return statement
```
</details>

<details>
<summary>v6b</summary>

-  Rebase

```
$ git range-diff gh/memdup..gh/ut memdup..ut 
1:  eb21d9e50910 = 1:  e98018c8d6e8 lib/utmp.c: get_current_utmp(): Refactor conditional
2:  9db832da1569 = 2:  159c2f11b4ce lib/utmp.c: get_current_utmp(): Use an enum for readability
3:  93e1b785a119 = 3:  d708f442d13a lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
4:  cf96eab3d7bd = 4:  07060ba7e3ea lib/utmp.c: get_current_utmp(): Move memdup_T() to the return statement
```
</details>

<details>
<summary>v7</summary>

-  Rebase on master.

```
$ git rd 
1:  7ebd221888d8 < -:  ------------ lib/utmp.c: get_current_utmp(): Don't exit(3) from library code
2:  6ab0fb3c35b8 < -:  ------------ lib/utmp.c: get_current_utmp(): Use simple assignment instead of memcpy(3)
3:  819c20b01f16 < -:  ------------ lib/string/strdup/: memdup_T(): Add API
4:  2782c9f682d7 < -:  ------------ lib/utmp.c: get_current_utmp(): Use memdup_T() instead of its pattern
5:  e98018c8d6e8 = 1:  0ec902b6db79 lib/utmp.c: get_current_utmp(): Refactor conditional
6:  159c2f11b4ce = 2:  42ca02c315af lib/utmp.c: get_current_utmp(): Use an enum for readability
7:  d708f442d13a = 3:  f775e0f4b8e9 lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
8:  07060ba7e3ea = 4:  fc9c4cf41795 lib/utmp.c: get_current_utmp(): Move memdup_T() to the return statement
```
</details>

<details>
<summary>v7b</summary>

-  Rebase

```
$ git rd 
1:  0ec902b6db79 = 1:  f6289f112e86 lib/utmp.c: get_current_utmp(): Refactor conditional
2:  42ca02c315af = 2:  72e913ba6597 lib/utmp.c: get_current_utmp(): Use an enum for readability
3:  f775e0f4b8e9 = 3:  2f6a4555d165 lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
4:  fc9c4cf41795 = 4:  19a106b0e66e lib/utmp.c: get_current_utmp(): Move memdup_T() to the return statement
```
</details>

<details>
<summary>v7c</summary>

-  Rebase

```
$ git rd 
1:  f6289f11 = 1:  66335a4f lib/utmp.c: get_current_utmp(): Refactor conditional
2:  72e913ba = 2:  b8f55531 lib/utmp.c: get_current_utmp(): Use an enum for readability
3:  2f6a4555 = 3:  f50ea3f5 lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
4:  19a106b0 = 4:  0fbcdcb9 lib/utmp.c: get_current_utmp(): Move memdup_T() to the return statement
```
</details>

<details>
<summary>v7d</summary>

-  Rebase

```
$ git rd 
1:  66335a4f = 1:  8489e15d lib/utmp.c: get_current_utmp(): Refactor conditional
2:  b8f55531 = 2:  09a416d5 lib/utmp.c: get_current_utmp(): Use an enum for readability
3:  f50ea3f5 = 3:  61f8d22b lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
4:  0fbcdcb9 = 4:  93b5de57 lib/utmp.c: get_current_utmp(): Move memdup_T() to the return statement
```
</details>

<details>
<summary>v7e</summary>

-  Rebase

```
$ git rd 
1:  8489e15d430f = 1:  3e7faf1606e8 lib/utmp.c: get_current_utmp(): Refactor conditional
2:  09a416d5d60c = 2:  ba6e73d4e89e lib/utmp.c: get_current_utmp(): Use an enum for readability
3:  61f8d22b5914 = 3:  b0accd30e12e lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
4:  93b5de57f69f = 4:  249a25b105b8 lib/utmp.c: get_current_utmp(): Move memdup_T() to the return statement
```
</details>

<details>
<summary>v7f</summary>

-  Rebase

```
$ git rd -U0
1:  3e7faf1606e8 = 1:  8bed493645a4 lib/utmp.c: get_current_utmp(): Refactor conditional
2:  ba6e73d4e89e = 2:  0345bf6f22e1 lib/utmp.c: get_current_utmp(): Use an enum for readability
3:  b0accd30e12e ! 3:  2e6bc4ccec67 lib/utmp.c: get_current_utmp(): Use the stack for temporary copies
    @@ lib/utmp.c: get_current_utmp(pid_t main_pid)
    -+  ut = match ? memdup_T(&ut_copy, struct utmpx) : NULL;
    ++  ut = match ? memdup_T(&ut_copy, 1, struct utmpx) : NULL;
    @@ lib/utmp.c: get_current_utmp(pid_t main_pid)
    --          ut = memdup_T(ut, struct utmpx);
    +-          ut = memdup_T(ut, 1, struct utmpx);
4:  249a25b105b8 ! 4:  8ae259038f19 lib/utmp.c: get_current_utmp(): Move memdup_T() to the return statement
    @@ lib/utmp.c: get_current_utmp(pid_t main_pid)
    --  ut = match ? memdup_T(&ut_copy, struct utmpx) : NULL;
    +-  ut = match ? memdup_T(&ut_copy, 1, struct utmpx) : NULL;
    @@ lib/utmp.c: get_current_utmp(pid_t main_pid)
    -+  return match ? memdup_T(&ut_copy, struct utmpx) : NULL;
    ++  return match ? memdup_T(&ut_copy, 1, struct utmpx) : NULL;
```
</details>