### PR TITLE
Add strtcat[_a](), and use it instead of its pattern

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -227,6 +227,8 @@ libshadow_la_SOURCES = \
 	string/strcpy/strncat.h \
 	string/strcpy/strncpy.c \
 	string/strcpy/strncpy.h \
+	string/strcpy/strtcat.c \
+	string/strcpy/strtcat.h \
 	string/strcpy/strtcpy.c \
 	string/strcpy/strtcpy.h \
 	string/strdup/memdup.c \

--- a/lib/salt.c
+++ b/lib/salt.c
@@ -25,6 +25,7 @@
 #include "shadowlog.h"
 #include "string/sprintf/stprintf.h"
 #include "string/strcmp/streq.h"
+#include "string/strcpy/strtcat.h"
 
 #undef NDEBUG
 #include <assert.h>
@@ -405,12 +406,8 @@ sha512:
 
 	return retval;
 #else /* USE_XCRYPT_GENSALT */
-	/* Check if the result buffer is long enough. */
-	assert (GENSALT_SETTING_SIZE > strlen (result) + salt_len);
 
-	/* Concatenate a pseudo random salt. */
-	strncat (result, gensalt (salt_len),
-		 GENSALT_SETTING_SIZE - strlen (result) - 1);
+	assert(strtcat_a(result, gensalt(salt_len)) != -1);
 
 	return result;
 #endif /* USE_XCRYPT_GENSALT */

--- a/lib/string/README
+++ b/lib/string/README
@@ -199,10 +199,10 @@ strcpy/ - String copying
     strtcpy_a()
 	Like strtcpy(), but takes an array.
 
-    strtcat()  // Unimplemented
+    strtcat()
 	Catenate a string after an existing string, with truncation.
 	Rarely useful.  Consider using stpecpy() instead.
-    STRTCAT()  // Unimplemented
+    strtcat_a()
 	Like strtcat(), but takes an array.
 
     stpecpy()

--- a/lib/string/README
+++ b/lib/string/README
@@ -194,10 +194,10 @@ strcpy/ - String copying
     strtcpy_a()
 	Like strtcpy(), but takes an array.
 
-    strtcat()  // Unimplemented
+    strtcat()
 	Catenate a string after an existing string, with truncation.
 	Rarely useful.  Consider using stpecpy() instead.
-    STRTCAT()  // Unimplemented
+    strtcat_a()
 	Like strtcat(), but takes an array.
 
     stpecpy()

--- a/lib/string/strcpy/strtcat.c
+++ b/lib/string/strcpy/strtcat.c
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#include "config.h"
+
+#include "string/strcpy/strtcat.h"
+
+#include <stddef.h>
+
+
+extern inline ssize_t strtcat(char *restrict dst, const char *restrict src,
+    size_t dsize);

--- a/lib/string/strcpy/strtcat.h
+++ b/lib/string/strcpy/strtcat.h
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#ifndef SHADOW_INCLUDE_LIB_STRING_STRCPY_STRTCAT_H_
+#define SHADOW_INCLUDE_LIB_STRING_STRCPY_STRTCAT_H_
+
+
+#include "config.h"
+
+#include <stddef.h>
+
+#include "attr.h"
+#include "sizeof.h"
+#include "string/strchr/strnul.h"
+#include "string/strcpy/stpecpy.h"
+
+
+// strtcat_a - string truncate catenate array
+#define strtcat_a(dst, src)  strtcat(dst, src, countof(dst))
+
+
+ATTR_STRING(2)
+inline ssize_t strtcat(char *restrict dst, const char *restrict src,
+    size_t dsize);
+
+
+// strtcat - string truncate catenate
+inline ssize_t
+strtcat(char *restrict dst, const char *restrict src, size_t dsize)
+{
+	char  *p, *end;
+
+	end = dst + dsize;
+
+	p = stpecpy(strnul(dst), end, src);
+	if (p == NULL)
+		return -1;
+
+	return p - dst;
+}
+
+
+#endif  // include guard

--- a/lib/string/strcpy/strtcat.h
+++ b/lib/string/strcpy/strtcat.h
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#ifndef SHADOW_INCLUDE_LIB_STRING_STRCPY_STRTCAT_H_
+#define SHADOW_INCLUDE_LIB_STRING_STRCPY_STRTCAT_H_
+
+
+#include "config.h"
+
+#include <stddef.h>
+
+#include "attr.h"
+#include "sizeof.h"
+#include "string/strchr/strnul.h"
+#include "string/strcpy/stpecpy.h"
+
+
+// strtcat_a - string truncate catenate array
+#define strtcat_a(dst, src)  strtcat(dst, src, countof(dst))
+
+
+ATTR_STRING(2)
+inline ssize_t strtcat(char *restrict dst, const char *restrict src,
+    size_t dsize);
+
+
+// strtcat - string truncate catenate
+inline ssize_t
+strtcat(char *restrict dst, const char *restrict src, size_t dsize)
+{
+	char  *p;
+
+	p = stpecpy(strnul(dst), dst + dsize, src);
+	if (p == NULL)
+		return -1;
+
+	return p - dst;
+}
+
+
+#endif  // include guard


### PR DESCRIPTION
Cc: @uecker 

---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git rd 
1:  34bbd688 = 1:  b70d59b7 lib/string/strcpy/: strtcat(), STRTCAT(): Add APIs
2:  79541620 = 2:  1b15cf5d lib/salt.c: gensalt(): Use STRTCPY() instead of its pattern
```
</details>

<details>
<summary>v2</summary>

-  Reimplement in terms of stpecpy().  This is much simpler, and thus safer.  It also allows us using size_t instead of ssize_t in the input, which is more common (it was weird to need ssize_t in the input, just to avoid compiler diangostics).

```
$ git range-diff shadow/master gh/strtcat strtcat 
1:  b70d59b7 ! 1:  3f2d3a8e lib/string/strcpy/: strtcat(), STRTCAT(): Add APIs
    @@ lib/string/strcpy/strtcat.c (new)
     +
     +#include "string/strcpy/strtcat.h"
     +
    -+#include <sys/types.h>
    ++#include <stddef.h>
     +
     +
     +extern inline ssize_t strtcat(char *restrict dst, const char *restrict src,
    -+    ssize_t dsize);
    ++    size_t dsize);
     
      ## lib/string/strcpy/strtcat.h (new) ##
     @@
    @@ lib/string/strcpy/strtcat.h (new)
     +
     +#include "config.h"
     +
    -+#include <string.h>
    -+#include <sys/types.h>
    ++#include <stddef.h>
     +
     +#include "attr.h"
     +#include "sizeof.h"
    -+#include "string/strcpy/strtcpy.h"
    ++#include "string/strchr/strnul.h"
    ++#include "string/strcpy/stpecpy.h"
     +
     +
     +#define STRTCAT(dst, src)  strtcat(dst, src, countof(dst))
    @@ lib/string/strcpy/strtcat.h (new)
     +
     +ATTR_STRING(2)
     +inline ssize_t strtcat(char *restrict dst, const char *restrict src,
    -+    ssize_t dsize);
    ++    size_t dsize);
     +
     +
     +// string truncate catenate
     +// Returns new length, or -1 on truncation.
     +inline ssize_t
    -+strtcat(char *restrict dst, const char *restrict src, ssize_t dsize)
    ++strtcat(char *restrict dst, const char *restrict src, size_t dsize)
     +{
    -+  ssize_t  oldlen, n;
    ++  char  *p, *end;
     +
    -+  oldlen = strlen(dst);
    ++  end = dst + dsize;
     +
    -+  n = strtcpy(dst + oldlen, src, dsize - oldlen);
    -+  if (n == -1)
    ++  p = stpecpy(strnul(dst), end, src);
    ++  if (p == NULL)
     +          return -1;
     +
    -+  return oldlen + n;
    ++  return p - dst;
     +}
     +
     +
2:  1b15cf5d = 2:  ae41236f lib/salt.c: gensalt(): Use STRTCPY() instead of its pattern
```
</details>

<details>
<summary>v2b</summary>

-  Update lib/string/README.

```
$ git range-diff shadow/master gh/strtcat strtcat 
1:  3f2d3a8e ! 1:  8fd61b28 lib/string/strcpy/: strtcat(), STRTCAT(): Add APIs
    @@ lib/Makefile.am: libshadow_la_SOURCES = \
        string/strcpy/strtcpy.h \
        string/strdup/strndupa.c \
     
    + ## lib/string/README ##
    +@@ lib/string/README: strcpy/ - String copying
    +     STRTCPY()
    +   Like strtcpy(), but takes an array.
    + 
    +-    strtcat()  // Unimplemented
    ++    strtcat()
    +   Catenate a string after an existing string, with truncation.
    +   Rarely useful.  Consider using stpecpy() instead.
    +-    STRTCAT()  // Unimplemented
    ++    STRTCAT()
    +   Like strtcat(), but takes an array.
    + 
    +     stpecpy()
    +
      ## lib/string/strcpy/strtcat.c (new) ##
     @@
     +// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
2:  ae41236f = 2:  72e56458 lib/salt.c: gensalt(): Use STRTCPY() instead of its pattern
```
</details>

<details>
<summary>v2c</summary>

-  Rebase

```
$ git rd 
1:  8fd61b28 = 1:  f229c84c lib/string/strcpy/: strtcat(), STRTCAT(): Add APIs
2:  72e56458 = 2:  7700f0fc lib/salt.c: gensalt(): Use STRTCPY() instead of its pattern
```
</details>

<details>
<summary>v2d</summary>

-  Rebase

```
$ git rd 
1:  f229c84c ! 1:  e25872f9 lib/string/strcpy/: strtcat(), STRTCAT(): Add APIs
    @@ lib/Makefile.am: libshadow_la_SOURCES = \
     +  string/strcpy/strtcat.h \
        string/strcpy/strtcpy.c \
        string/strcpy/strtcpy.h \
    -   string/strdup/strndupa.c \
    +   string/strdup/strdup.c \
     
      ## lib/string/README ##
     @@ lib/string/README: strcpy/ - String copying
2:  7700f0fc = 2:  bf414636 lib/salt.c: gensalt(): Use STRTCPY() instead of its pattern
```
</details>

<details>
<summary>v3</summary>

-  `s/STRTCAT/strtcat_a/`

```
$ git rd 
1:  e25872f90 ! 1:  01e32cebf lib/string/strcpy/: strtcat(), STRTCAT(): Add APIs
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/string/strcpy/: strtcat(), STRTCAT(): Add APIs
    +    lib/string/strcpy/: strtcat[_a](): Add APIs
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    @@ lib/string/README: strcpy/ - String copying
        Catenate a string after an existing string, with truncation.
        Rarely useful.  Consider using stpecpy() instead.
     -    STRTCAT()  // Unimplemented
    -+    STRTCAT()
    ++    strtcat_a()
        Like strtcat(), but takes an array.
      
          stpecpy()
    @@ lib/string/strcpy/strtcat.h (new)
     +#include "string/strcpy/stpecpy.h"
     +
     +
    -+#define STRTCAT(dst, src)  strtcat(dst, src, countof(dst))
    ++// strtcat_a - string truncate catenate array
    ++#define strtcat_a(dst, src)  strtcat(dst, src, countof(dst))
     +
     +
     +ATTR_STRING(2)
    @@ lib/string/strcpy/strtcat.h (new)
     +    size_t dsize);
     +
     +
    -+// string truncate catenate
    ++// strtcat - string truncate catenate
     +// Returns new length, or -1 on truncation.
     +inline ssize_t
     +strtcat(char *restrict dst, const char *restrict src, size_t dsize)
2:  bf4146369 ! 2:  b1906dffc lib/salt.c: gensalt(): Use STRTCPY() instead of its pattern
    @@ lib/salt.c: static /*@observer@*/const char *gensalt (size_t salt_size)
     -  /* Concatenate a pseudo random salt. */
     -  strncat (result, gensalt (salt_len),
     -           GENSALT_SETTING_SIZE - strlen (result) - 1);
    -+  assert(STRTCAT(result, gensalt(salt_len)) != -1);
    ++  assert(strtcat_a(result, gensalt(salt_len)) != -1);
      
        return result;
      #endif /* USE_XCRYPT_GENSALT */
```
</details>

<details>
<summary>v3b</summary>

-  Fix commit message.

```
$ git rd 
1:  01e32cebf = 1:  01e32cebf lib/string/strcpy/: strtcat[_a](): Add APIs
2:  b1906dffc ! 2:  1f2e22317 lib/salt.c: gensalt(): Use STRTCPY() instead of its pattern
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/salt.c: gensalt(): Use STRTCPY() instead of its pattern
    +    lib/salt.c: gensalt(): Use strtcat_a() instead of its pattern
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
```
</details>

<details>
<summary>v3c</summary>

-  Rebase

```
$ git rd 
1:  01e32cebf = 1:  10a4fe3f9 lib/string/strcpy/: strtcat[_a](): Add APIs
2:  1f2e22317 = 2:  f7faeaab3 lib/salt.c: gensalt(): Use strtcat_a() instead of its pattern
```
</details>

<details>
<summary>v3d</summary>

-  Rebase

```
$ git rd 
1:  10a4fe3f9 = 1:  370109241 lib/string/strcpy/: strtcat[_a](): Add APIs
2:  f7faeaab3 = 2:  5c3dce3fc lib/salt.c: gensalt(): Use strtcat_a() instead of its pattern
```
</details>

<details>
<summary>v3c</summary>

-  Rebase on top of #1387.

```
$ git range-diff shadow/master..gh/strtcat gh/se..strtcat 
1:  370109241 = 1:  df05c46c3 lib/string/strcpy/: strtcat[_a](): Add APIs
2:  5c3dce3fc ! 2:  14f666539 lib/salt.c: gensalt(): Use strtcat_a() instead of its pattern
    @@ Commit message
     
      ## lib/salt.c ##
     @@
    - #include "prototypes.h"
      #include "shadowlog.h"
    + #include "string/sprintf/stprintf.h"
      #include "string/strcmp/streq.h"
     +#include "string/strcpy/strtcat.h"
      
```
</details>

<details>
<summary>v3d</summary>

-  Rebase

```
$ git range-diff gh/se..gh/strtcat se..strtcat 
1:  df05c46c3 = 1:  96af59655 lib/string/strcpy/: strtcat[_a](): Add APIs
2:  14f666539 = 2:  3234b0822 lib/salt.c: gensalt(): Use strtcat_a() instead of its pattern
```
</details>

<details>
<summary>v3e</summary>

-  Rebase

```
$ git range-diff gh/se..gh/strtcat se..strtcat 
1:  96af59655 ! 1:  6bde48e54 lib/string/strcpy/: strtcat[_a](): Add APIs
    @@ lib/Makefile.am: libshadow_la_SOURCES = \
     
      ## lib/string/README ##
     @@ lib/string/README: strcpy/ - String copying
    -     STRTCPY()
    +     strtcpy_a()
        Like strtcpy(), but takes an array.
      
     -    strtcat()  // Unimplemented
2:  3234b0822 = 2:  b3c064f50 lib/salt.c: gensalt(): Use strtcat_a() instead of its pattern
```
</details>

<details>
<summary>v3f</summary>

-  Rebase

```
$ git range-diff gh/se..gh/strtcat se..strtcat 
1:  6bde48e54 = 1:  d155aa3d6 lib/string/strcpy/: strtcat[_a](): Add APIs
2:  b3c064f50 = 2:  0fa703e0e lib/salt.c: gensalt(): Use strtcat_a() instead of its pattern
```
</details>

<details>
<summary>v3g</summary>

-  Rebase

```
$ git range-diff gh/se..gh/strtcat se..strtcat 
1:  d155aa3d6 = 1:  eee6da9d9 lib/string/strcpy/: strtcat[_a](): Add APIs
2:  0fa703e0e = 2:  cabae6c07 lib/salt.c: gensalt(): Use strtcat_a() instead of its pattern
```
</details>

<details>
<summary>v3h</summary>

-  Rebase

```
$ git range-diff gh/se..gh/strtcat se..strtcat 
1:  eee6da9d9 = 1:  a2879def9 lib/string/strcpy/: strtcat[_a](): Add APIs
2:  cabae6c07 = 2:  9d2fd3930 lib/salt.c: gensalt(): Use strtcat_a() instead of its pattern
```
</details>

<details>
<summary>v3i</summary>

-  Rebase

```
$ git range-diff gh/se..gh/strtcat se..strtcat 
1:  a2879def9 = 1:  116ed8874 lib/string/strcpy/: strtcat[_a](): Add APIs
2:  9d2fd3930 = 2:  2b97b7d6f lib/salt.c: gensalt(): Use strtcat_a() instead of its pattern
```
</details>

<details>
<summary>v3j</summary>

-  Rebase

```
$ git range-diff gh/se..gh/strtcat se..strtcat 
1:  116ed8874 = 1:  306cb0f7a lib/string/strcpy/: strtcat[_a](): Add APIs
2:  2b97b7d6f = 2:  9ea22bd2a lib/salt.c: gensalt(): Use strtcat_a() instead of its pattern
```
</details>

<details>
<summary>v3k</summary>

-  Rebase

```
$ git range-diff gh/se..gh/strtcat se..strtcat 
1:  306cb0f7a = 1:  e950460b0 lib/string/strcpy/: strtcat[_a](): Add APIs
2:  9ea22bd2a = 2:  02028247e lib/salt.c: gensalt(): Use strtcat_a() instead of its pattern
```
</details>

<details>
<summary>v3l</summary>

-  Rebase

```
$ git range-diff gh/se..gh/strtcat se..strtcat
1:  e950460b0 = 1:  4e36fd47b lib/string/strcpy/: strtcat[_a](): Add APIs
2:  02028247e = 2:  2d2211bac lib/salt.c: gensalt(): Use strtcat_a() instead of its pattern
```
</details>

<details>
<summary>v3m</summary>

-  Rebase

```
$ git range-diff gh/se..gh/strtcat se..strtcat 
1:  4e36fd47b = 1:  7e547a42e lib/string/strcpy/: strtcat[_a](): Add APIs
2:  2d2211bac = 2:  9e302ce04 lib/salt.c: gensalt(): Use strtcat_a() instead of its pattern
```
</details>

<details>
<summary>v3n</summary>

-  Rebase

```
$ git range-diff gh/se..gh/strtcat se..strtcat 
1:  7e547a42e = 1:  4514dc9a8 lib/string/strcpy/: strtcat[_a](): Add APIs
2:  9e302ce04 = 2:  9b4e3e3bf lib/salt.c: gensalt(): Use strtcat_a() instead of its pattern
```
</details>

<details>
<summary>v3o</summary>

-  Rebase

```
$ git range-diff gh/se..gh/strtcat se..strtcat 
1:  4514dc9a8 = 1:  419f8eef5 lib/string/strcpy/: strtcat[_a](): Add APIs
2:  9b4e3e3bf = 2:  3be13bd09 lib/salt.c: gensalt(): Use strtcat_a() instead of its pattern
```
</details>

<details>
<summary>v3p</summary>

-  Rebase

```
$ git range-diff gh/se..gh/strtcat se..strtcat 
1:  419f8eef5 = 1:  325127542 lib/string/strcpy/: strtcat[_a](): Add APIs
2:  3be13bd09 = 2:  6983ad616 lib/salt.c: gensalt(): Use strtcat_a() instead of its pattern
```
</details>

<details>
<summary>v3q</summary>

-  Rebase

```
$ git range-diff gh/se..gh/strtcat se..strtcat 
1:  325127542279 = 1:  f78ba59f973d lib/string/strcpy/: strtcat[_a](): Add APIs
2:  6983ad6160fb = 2:  189ae8b8cb5a lib/salt.c: gensalt(): Use strtcat_a() instead of its pattern
```
</details>

<details>
<summary>v3r</summary>

-  Rebase.

```
$ git range-diff gh/se..gh/strtcat se..strtcat 
1:  f78ba59f973d = 1:  7830fde09514 lib/string/strcpy/: strtcat[_a](): Add APIs
2:  189ae8b8cb5a = 2:  1d52512f5b7a lib/salt.c: gensalt(): Use strtcat_a() instead of its pattern
```
</details>

<details>
<summary>v3s</summary>

-  Rebase

```
$ git range-diff gh/se..gh/strtcat se..strtcat 
1:  7830fde09514 ! 1:  8b05ce7c0a8c lib/string/strcpy/: strtcat[_a](): Add APIs
    @@ lib/Makefile.am: libshadow_la_SOURCES = \
     +  string/strcpy/strtcat.h \
        string/strcpy/strtcpy.c \
        string/strcpy/strtcpy.h \
    -   string/strdup/strdup.c \
    +   string/strdup/memdup.c \
     
      ## lib/string/README ##
     @@ lib/string/README: strcpy/ - String copying
2:  1d52512f5b7a = 2:  007e4f529f6c lib/salt.c: gensalt(): Use strtcat_a() instead of its pattern
```
</details>

<details>
<summary>v3t</summary>

-  Rebase

```
$ git range-diff gh/se..gh/strtcat se..strtcat 
1:  8b05ce7c = 1:  6938cc4b lib/string/strcpy/: strtcat[_a](): Add APIs
2:  007e4f52 = 2:  817c08e2 lib/salt.c: gensalt(): Use strtcat_a() instead of its pattern
```
</details>

<details>
<summary>v3u</summary>

-  Rebase

```
$ git range-diff gh/se..gh/strtcat se..strtcat 
1:  6938cc4b = 1:  d64b4e5a lib/string/strcpy/: strtcat[_a](): Add APIs
2:  817c08e2 ! 2:  e628f6a3 lib/salt.c: gensalt(): Use strtcat_a() instead of its pattern
    @@ lib/salt.c
      #include "string/strcmp/streq.h"
     +#include "string/strcpy/strtcat.h"
      
    - 
    - #if (defined CRYPT_GENSALT_IMPLEMENTS_AUTO_ENTROPY && \
    + #undef NDEBUG
    + #include <assert.h>
     @@ lib/salt.c: static /*@observer@*/const char *gensalt (size_t salt_size)
      
        return retval;
```
</details>

<details>
<summary>v3v</summary>

-  Rebase

```
$ git range-diff gh/se..gh/strtcat se..strtcat 
1:  d64b4e5a = 1:  84b39982 lib/string/strcpy/: strtcat[_a](): Add APIs
2:  e628f6a3 = 2:  3823f3ed lib/salt.c: gensalt(): Use strtcat_a() instead of its pattern
```
</details>

<details>
<summary>v4</summary>

-  Rebase (#1387 has been merged already).

```
$ git rd 
 1:  c959c7dd <  -:  -------- lib/string/: vsnprintf_(), strtcpy(): Set errno = E2BIG on truncation
 2:  e3e1ee7f <  -:  -------- lib/string/sprintf/: snprintf_(): Use ssize_t instead of size_t in $2
 3:  2438c99a <  -:  -------- lib/string/: vsnprintf_(), strtcpy(): abort() if size==0
 4:  088136be <  -:  -------- lib/string/: Redesign stpecpy() and stpeprintf()
 5:  2339f5dd <  -:  -------- lib/string/: Compact documentation
 6:  a3725c9b <  -:  -------- lib/, src/, tests/: Rename snprintf_() => stprintf()
 7:  d5bdfe85 <  -:  -------- lib/, po/, src/: Rename stpeprintf() => seprintf()
 8:  fba5ab1e <  -:  -------- lib/string/: seprintf(), stpecpy(): Add missing const
 9:  893d3302 <  -:  -------- lib/string/strcpy/: stpecpy(): Use strtcpy() instead of its pattern
10:  784c370a <  -:  -------- lib/salt.c: Use stprintf() instead of snprintf(3)
11:  84b39982 =  1:  a92238c4 lib/string/strcpy/: strtcat[_a](): Add APIs
12:  3823f3ed =  2:  c99ba4ec lib/salt.c: gensalt(): Use strtcat_a() instead of its pattern
```
</details>

<details>
<summary>v4b</summary>

-  Remove comment.

```
$ git rd 
1:  a92238c4 ! 1:  527821c0 lib/string/strcpy/: strtcat[_a](): Add APIs
    @@ lib/string/strcpy/strtcat.h (new)
     +
     +
     +// strtcat - string truncate catenate
    -+// Returns new length, or -1 on truncation.
     +inline ssize_t
     +strtcat(char *restrict dst, const char *restrict src, size_t dsize)
     +{
2:  c99ba4ec = 2:  77a41059 lib/salt.c: gensalt(): Use strtcat_a() instead of its pattern
```
</details>

<details>
<summary>v4c</summary>

-  Rebase

```
$ git rd -U0
1:  527821c05977 = 1:  14045a27ea9f lib/string/strcpy/: strtcat[_a](): Add APIs
2:  77a41059c6d3 ! 2:  d6d8e4a025f8 lib/salt.c: gensalt(): Use strtcat_a() instead of its pattern
    @@ lib/salt.c
    -@@ lib/salt.c: static /*@observer@*/const char *gensalt (size_t salt_size)
    +@@ lib/salt.c: sha512:
```
</details>

<details>
<summary>v4d</summary>

-  Rebase

```
$ git rd 
1:  14045a27ea9f = 1:  a0fa4dfac099 lib/string/strcpy/: strtcat[_a](): Add APIs
2:  d6d8e4a025f8 = 2:  02eaca4d25db lib/salt.c: gensalt(): Use strtcat_a() instead of its pattern
```
</details>

<details>
<summary>v5</summary>

-  Remove unnecessary local variable that was used only once.  This simplifies the implementation of strtcat() a little bit.

```
$ git rd 
1:  a0fa4dfac099 ! 1:  236a6c30d766 lib/string/strcpy/: strtcat[_a](): Add APIs
    @@ lib/string/strcpy/strtcat.h (new)
     +inline ssize_t
     +strtcat(char *restrict dst, const char *restrict src, size_t dsize)
     +{
    -+  char  *p, *end;
    ++  char  *p;
     +
    -+  end = dst + dsize;
    -+
    -+  p = stpecpy(strnul(dst), end, src);
    ++  p = stpecpy(strnul(dst), dst + dsize, src);
     +  if (p == NULL)
     +          return -1;
     +
2:  02eaca4d25db = 2:  9c87c9c6da7c lib/salt.c: gensalt(): Use strtcat_a() instead of its pattern
```
</details>