### PR TITLE
share/ansible/: fix Debian 13 build

### DIFF
--- a/share/ansible/roles/ci_run/tasks/debian.yml
+++ b/share/ansible/roles/ci_run/tasks/debian.yml
@@ -9,6 +9,7 @@
 - name: Ensure dependencies are installed
   ansible.builtin.apt:
     name:
+      - gpg
       - libbsd-dev
       - libcmocka-dev
       - libltdl-dev


### PR DESCRIPTION
Install `gpg` package as Debian 13 container image stopped installing it by default, making the CI fail.

Closes: <https://github.com/shadow-maint/shadow/issues/1335>