### PR TITLE
src/su.c: Fix incorrect (non-matching) parentheses

### DIFF
--- a/src/su.c
+++ b/src/su.c
@@ -1031,10 +1031,8 @@ int main (int argc, char **argv)
 #ifdef USE_PAM
 	ret = pam_start (Prog, name, &conv, &pamh);
 	if (PAM_SUCCESS != ret) {
-		SYSLOG ((LOG_ERR, "pam_start: error %d", ret);
-		fprintf (stderr,
-		         _("%s: pam_start: error %d\n"),
-		         Prog, ret));
+		SYSLOG((LOG_ERR, "pam_start: error %d", ret));
+		fprintf(stderr, _("%s: pam_start: error %d\n"), Prog, ret);
 		exit (1);
 	}
 


### PR DESCRIPTION
Fixes: 45c6603cc86c (2007-10-07; "[svn-upgrade] Integrating new upstream version, shadow (19990709)")
Closes: <https://github.com/shadow-maint/shadow/issues/1310>