### PR TITLE
src/chgpasswd.c: fix handling of files without trailing newlines

### DIFF
--- a/src/chgpasswd.c
+++ b/src/chgpasswd.c
@@ -462,12 +462,22 @@ int main (int argc, char **argv)
 	 * file (gshadow or group) and the password changed.
 	 */
 	while (fgets (buf, (int) sizeof buf, stdin) != NULL) {
+		char *cp;
 		line++;
 		if (stpsep(buf, "\n") == NULL) {
-			fprintf (stderr, _("%s: line %jd: line too long\n"),
-			         Prog, line);
-			errors = true;
-			continue;
+			if (feof (stdin) == 0) {
+				// Drop all remaining characters on this line.
+				while (fgets (buf, sizeof buf, stdin) != NULL) {
+					cp = strchr (buf, '\n');
+					if (cp != NULL) {
+						break;
+					}
+				}
+				fprintf (stderr, _("%s: line %jd: line too long\n"),
+				         Prog, line);
+				errors = true;
+				continue;
+			}
 		}
 
 		/*


### PR DESCRIPTION
Fix chgpasswd to properly handle input files that don't end with a newline, similar to how chpasswd handles this case. Previously, chgpasswd would incorrectly report "line too long" errors when processing the last line of a file that didn't end with a newline character.

The fix adds proper end-of-file detection and long line handling logic consistent with chpasswd implementation.

I discovered this issue while developing `test_chgpasswd__change_passwords_from_file` from https://github.com/shadow-maint/shadow/pull/1357.