### PR TITLE
lib/atoi/strtoi/: strtou_noneg(): Don't clobber errno on success

### DIFF
--- a/lib/atoi/strtoi/strtou_noneg.h
+++ b/lib/atoi/strtoi/strtou_noneg.h
@@ -26,12 +26,15 @@ inline uintmax_t
 strtou_noneg(const char *s, char **restrict endp, int base,
     uintmax_t min, uintmax_t max, int *restrict status)
 {
-	int  st;
+	int  st, e;
 
 	if (status == NULL)
 		status = &st;
+
+	e = errno;
 	if (strtoi_(s, endp, base, 0, 1, status) == 0 && *status == ERANGE)
 		return min;
+	errno = e;
 
 	return strtou_(s, endp, base, min, max, status);
 }


### PR DESCRIPTION
The strtol(3) family of functions is not allowed to clobber errno on success.

Fixes: f2b240595b1c (2024-01-31; "lib/atoi/strtou_noneg.[ch]: Add strtou_noneg()")
Link: <https://softwareengineering.stackexchange.com/questions/251508/is-there-a-stricter-strtoull-in-any-ubiquitous-c-library/449060?noredirect=1#comment1016280_449060>
Reported-by: @CostantinoGrana