### PR TITLE
lib/, src/: Use strspn(3) and strcspn(3) instead of their patterns

### DIFF
--- a/lib/commonio.c
+++ b/lib/commonio.c
@@ -37,7 +37,6 @@
 #include "string/sprintf/aprintf.h"
 #include "string/sprintf/stprintf.h"
 #include "string/strcmp/streq.h"
-#include "string/strcmp/strprefix.h"
 #include "string/strtok/stpsep.h"
 
 #undef NDEBUG
@@ -488,7 +487,7 @@ static void add_one_entry (struct commonio_db *db,
 
 static bool name_is_nis (const char *name)
 {
-	return strprefix(name, "+") || strprefix(name, "-");
+	return !!strspn(name, "+-");
 }
 
 
@@ -684,8 +683,7 @@ commonio_sort (struct commonio_db *db, int (*cmp) (const void *, const void *))
 	        (NULL != ptr)
 #if KEEP_NIS_AT_END
 	     && ((NULL == ptr->line)
-	         || (('+' != ptr->line[0])
-	             && ('-' != ptr->line[0])))
+	         || !strspn(ptr->line, "+-"))
 #endif
 	     ;
 	     ptr = ptr->next) {

--- a/lib/console.c
+++ b/lib/console.c
@@ -50,7 +50,7 @@ is_listed(const char *cfgin, const char *tty, bool def)
 	 * console devices upon which root logins are allowed.
 	 */
 
-	if (*cons != '/') {
+	if (!strspn(cons, "/")) {
 		char *pbuf;
 
 		strtcpy_a(buf, cons);

--- a/lib/encrypt.c
+++ b/lib/encrypt.c
@@ -13,11 +13,11 @@
 
 #include <unistd.h>
 #include <stdio.h>
+#include <string.h>
 
 #include "prototypes.h"
 #include "defines.h"
 #include "shadowlog.h"
-#include "string/strcmp/strprefix.h"
 
 
 /*@exposed@*//*@null@*/char *pw_encrypt (const char *clear, const char *salt)
@@ -37,7 +37,7 @@
 
 	/* Some crypt() do not return NULL if the algorithm is not
 	 * supported, and return a DES encrypted password. */
-	if ((NULL != salt) && strprefix(salt, "$") && (strlen (cp) <= 13))
+	if ((NULL != salt) && strspn(salt, "$") && (strlen (cp) <= 13))
 	{
 		/*@observer@*/const char *method;
 		switch (salt[1])

--- a/lib/env.c
+++ b/lib/env.c
@@ -74,7 +74,7 @@ void initenv (void)
 
 void addenv (const char *string, /*@null@*/const char *value)
 {
-	char    *cp, *newstring;
+	char    *newstring;
 	size_t  i, n;
 
 	if (NULL != value) {
@@ -88,13 +88,12 @@ void addenv (const char *string, /*@null@*/const char *value)
 	 * just ignore the whole string.
 	 */
 
-	cp = strchr (newstring, '=');
-	if (NULL == cp) {
+	if (!strchr(newstring, '=')) {
 		free(newstring);
 		return;
 	}
 
-	n = (size_t) (cp - newstring);
+	n = strcspn(newstring, "=");
 
 	/*
 	 * If this environment variable is already set, change its value.

--- a/lib/env.c
+++ b/lib/env.c
@@ -101,7 +101,7 @@ void addenv (const char *string, /*@null@*/const char *value)
 	 */
 	for (i = 0; i < newenvc; i++) {
 		if (   (strncmp (newstring, newenvp[i], n) == 0)
-		    && (('=' == newenvp[i][n]) || ('\0' == newenvp[i][n]))) {
+		    && !strcspn(newenvp[i] + n, "=")) {
 			break;
 		}
 	}

--- a/lib/getdef.c
+++ b/lib/getdef.c
@@ -33,7 +33,6 @@
 #include "string/sprintf/aprintf.h"
 #include "string/strcmp/strcaseeq.h"
 #include "string/strcmp/streq.h"
-#include "string/strcmp/strprefix.h"
 #include "string/strspn/stpspn.h"
 #include "string/strspn/stprspn.h"
 #include "string/strtok/stpsep.h"
@@ -567,7 +566,7 @@ static void def_load (void)
 		 * Break the line into two fields.
 		 */
 		name = stpspn(buf, " \t");	/* first nonwhite */
-		if (streq(name, "") || strprefix(name, "#"))
+		if (!strcspn(name, "#"))
 			continue;	/* comment or empty */
 
 		s = stpsep(name, " \t");  /* next field */

--- a/lib/getrange.c
+++ b/lib/getrange.c
@@ -9,6 +9,7 @@
 
 #include <ctype.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "atoi/a2i.h"
 #include "defines.h"
@@ -39,7 +40,7 @@ getrange(const char *range,
 	*has_min = false;
 	*has_max = false;
 
-	if ('-' == range[0]) {
+	if (strspn(range, "-")) {
 		end = range + 1;
 		goto parse_max;
 	}

--- a/lib/hushed.c
+++ b/lib/hushed.c
@@ -61,7 +61,7 @@ bool hushed (const char *username)
 	 * file exists in the user's home directory.
 	 */
 
-	if (hushfile[0] != '/') {
+	if (!strspn(hushfile, "/")) {
 		stprintf_a(buf, "%s/%s", pw->pw_dir, hushfile);
 		return (access (buf, F_OK) == 0);
 	}

--- a/lib/limits.c
+++ b/lib/limits.c
@@ -363,9 +363,9 @@ static int setup_user_limits (const char *uname)
 	 * FIXME: a better (smarter) checking should be done
 	 */
 	while (fgets_a(buf, fil) != NULL) {
-		if (strprefix(buf, "#") || strprefix(buf, "\n")) {
+		if (!strcspn(buf, "#\n"))
 			continue;
-		}
+
 		memzero_a(tempbuf);
 		/* a valid line should have a username, then spaces,
 		 * then limits

--- a/lib/limits.c
+++ b/lib/limits.c
@@ -60,7 +60,7 @@ static int setrlimit_value (unsigned int resource,
 	/* The "-" is special, not belonging to a strange negative limit.
 	 * It is infinity, in a controlled way.
 	 */
-	if (strprefix(value, "-")) {
+	if (strspn(value, "-")) {
 		limit = RLIM_INFINITY;
 
 	} else {
@@ -394,7 +394,7 @@ static int setup_user_limits (const char *uname)
 				break;
 			} else if (streq(name, "*")) {
 				strcpy (deflimits, tempbuf);
-			} else if (strprefix(name, "@")) {
+			} else if (strspn(name, "@")) {
 				/* If the user is in the group, the group
 				 * limits apply unless later a line for
 				 * the specific user is found.

--- a/lib/nss.c
+++ b/lib/nss.c
@@ -17,7 +17,6 @@
 #include "string/sprintf/stprintf.h"
 #include "string/strcmp/strcaseprefix.h"
 #include "string/strcmp/streq.h"
-#include "string/strcmp/strprefix.h"
 #include "string/strspn/stpspn.h"
 #include "string/strtok/stpsep.h"
 
@@ -84,7 +83,7 @@ nss_init(const char *nsswitch_path) {
 			fprintf(log_get_logfd(), "%s: Non-text file.\n", nsswitch_path);
 			goto null_subid;
 		}
-		if (strprefix(line, "#"))
+		if (!strcspn(line, "#"))
 			continue;
 		if (strlen(line) < 7)
 			continue;

--- a/lib/port.c
+++ b/lib/port.c
@@ -277,11 +277,10 @@ next:
 			dtime = dtime * 10 + cp[i] - '0';
 		}
 
-		if (   ((',' != cp[i]) && ('\0' != cp[i]))
-		    || (dtime > 2400)
-		    || ((dtime % 100) > 59)) {
+		if (strcspn(cp + i, ","))
 			goto next;
-		}
+		if (dtime > 2400 || (dtime % 100) > 59)
+			goto next;
 
 		port.pt_times[j].t_end = dtime;
 		cp = cp + i + 1;

--- a/lib/port.c
+++ b/lib/port.c
@@ -22,7 +22,6 @@
 #include "prototypes.h"
 #include "string/ctype/isascii.h"
 #include "string/strcmp/streq.h"
-#include "string/strcmp/strprefix.h"
 #include "string/strtok/stpsep.h"
 #include "string/strtok/strsep2ls.h"
 
@@ -54,7 +53,7 @@ static int portcmp (const char *pattern, const char *port)
 	if (streq(orig, "SU"))
 		return 1;
 
-	return !strprefix(pattern, "*");
+	return !strspn(pattern, "*");
 }
 
 /*
@@ -145,7 +144,7 @@ next:
 		errno = saveerr;
 		return NULL;
 	}
-	if (strprefix(buf, "#"))
+	if (strspn(buf, "#"))
 		goto next;
 
 	stpsep(buf, "\n");
@@ -266,9 +265,11 @@ next:
 			dtime = dtime * 10 + cp[i] - '0';
 		}
 
-		if (('-' != cp[i]) || (dtime > 2400) || ((dtime % 100) > 59)) {
+		if (!strspn(cp + i, "-"))
 			goto next;
-		}
+		if (dtime > 2400 || (dtime % 100) > 59)
+			goto next;
+
 		port.pt_times[j].t_start = dtime;
 		cp = cp + i + 1;
 

--- a/lib/prefix_flag.c
+++ b/lib/prefix_flag.c
@@ -9,6 +9,7 @@
 
 #include <paths.h>
 #include <stdio.h>
+#include <string.h>
 
 #include "atoi/getnum.h"
 #include "defines.h"
@@ -100,7 +101,7 @@ extern const char* process_prefix_flag (const char* short_opt, int argc, char **
 			return ""; /* if prefix is "/" then we ignore the flag option */
 		/* should we prevent symbolic link from being used as a prefix? */
 
-		if ( prefix[0] != '/') {
+		if (!strspn(prefix, "/")) {
 			fprintf (log_get_logfd(),
 				 _("%s: prefix must be an absolute path\n"),
 				 log_get_progname());

--- a/lib/root_flag.c
+++ b/lib/root_flag.c
@@ -10,6 +10,7 @@
 #ident "$Id$"
 
 #include <stdio.h>
+#include <string.h>
 
 #include "defines.h"
 /*@-exitarg@*/
@@ -80,7 +81,7 @@ static void change_root (const char* newroot)
 		exit (EXIT_FAILURE);
 	}
 
-	if ('/' != newroot[0]) {
+	if (!strspn(newroot, "/")) {
 		fprintf (log_get_logfd(),
 		         _("%s: invalid chroot path '%s', only absolute paths are supported.\n"),
 		         log_get_progname(), newroot);

--- a/lib/setupenv.c
+++ b/lib/setupenv.c
@@ -16,9 +16,10 @@
 #include <ctype.h>
 #include <pwd.h>
 #include <stddef.h>
+#include <stdio.h>
+#include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <stdio.h>
 
 #include "prototypes.h"
 #include "defines.h"
@@ -27,10 +28,11 @@
 #include "shadowlog.h"
 #include "string/sprintf/aprintf.h"
 #include "string/strcmp/streq.h"
-#include "string/strcmp/strprefix.h"
 #include "string/strdup/strdup.h"
 #include "string/strspn/stpspn.h"
 #include "string/strtok/stpsep.h"
+
+#include <assert.h>
 
 
 #ifndef USE_PAM
@@ -61,9 +63,9 @@ static void read_env_file (const char *filename)
 		cp = buf;
 		/* ignore whitespace and comments */
 		cp = stpspn(cp, " \t");
-		if (streq(cp, "") || strprefix(cp, "#")) {
+		if (!strcspn(cp, "#"))
 			continue;
-		}
+
 		/*
 		 * ignore lines which don't follow the name=value format
 		 * (for example, the "export NAME" shell commands)

--- a/lib/sub.c
+++ b/lib/sub.c
@@ -8,13 +8,14 @@
 
 #include "config.h"
 
-#ident "$Id$"
-
 #include <pwd.h>
 #include <stdio.h>
+#include <string.h>
 #include <sys/types.h>
+
 #include "prototypes.h"
 #include "defines.h"
+
 #define	MAX_SUBROOT2	"maximum subsystem depth reached\n"
 #define	BAD_SUBROOT2	"invalid root `%s' for user `%s'\n"
 #define	NO_SUBROOT2	"no subsystem root `%s' for user `%s'\n"
@@ -45,7 +46,7 @@ void subsystem (const struct passwd *pw)
 	 * The new root directory must begin with a "/" character.
 	 */
 
-	if (pw->pw_dir[0] != '/') {
+	if (!strspn(pw->pw_dir, "/")) {
 		printf (_("Invalid root directory '%s'\n"), pw->pw_dir);
 		SYSLOG(LOG_WARN, BAD_SUBROOT2, pw->pw_dir, pw->pw_name);
 		closelog ();

--- a/lib/ttytype.c
+++ b/lib/ttytype.c
@@ -50,9 +50,8 @@ void ttytype (const char *line)
 		return;
 	}
 	while (fgets_a(buf, fp) != NULL) {
-		if (strprefix(buf, "#")) {
+		if (strspn(buf, "#"))
 			continue;
-		}
 
 		stpsep(buf, "\n");
 

--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -60,7 +60,7 @@ is_my_tty(const char tty[UTX_LINESIZE])
 	char  my_tty[countof(full_tty)];
 
 	stpcpy(full_tty, "");
-	if (tty[0] != '/')
+	if (!strspn(tty, "/"))
 		strcpy (full_tty, "/dev/");
 	strncat(full_tty, tty, UTX_LINESIZE);
 

--- a/lib/yesno.c
+++ b/lib/yesno.c
@@ -16,7 +16,6 @@
 #include <stdlib.h>
 
 #include "prototypes.h"
-#include "string/strcmp/strcaseprefix.h"
 
 
 /*
@@ -78,9 +77,9 @@ yes_or_no(bool read_only)
 static int
 rpmatch(const char *response)
 {
-	if (strcaseprefix(response, "y"))
+	if (strspn(response, "yY"))
 		return 1;
-	if (strcaseprefix(response, "n"))
+	if (strspn(response, "nN"))
 		return 0;
 
 	return -1;

--- a/src/check_subid_range.c
+++ b/src/check_subid_range.c
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <stdbool.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -18,7 +19,6 @@
 #include "idmapping.h"
 #include "prototypes.h"
 #include "shadowlog.h"
-#include "string/strcmp/strprefix.h"
 #include "subordinateio.h"
 
 
@@ -40,7 +40,7 @@ main(int argc, char **argv)
 		exit(1);
 
 	owner = argv[1];
-	check_uids = strprefix(argv[2], "u");
+	check_uids = strspn(argv[2], "u");
 	if (get_uid(argv[3], &start) == -1)
 		exit(1);
 	if (str2ul(&count, argv[4]) == -1)

--- a/src/chsh.c
+++ b/src/chsh.c
@@ -15,6 +15,7 @@
 #include <getopt.h>
 #include <pwd.h>
 #include <stdio.h>
+#include <string.h>
 #include <sys/types.h>
 
 #include "chkname.h"
@@ -533,7 +534,7 @@ int main (int argc, char **argv)
 		fail_exit (1, process_selinux);
 	}
 	if (!streq(loginsh, "")
-	    && (loginsh[0] != '/'
+	    && (!strspn(loginsh, "/")
 	        || is_restricted_shell (loginsh, process_selinux)
 	        || (access (loginsh, X_OK) != 0)))
 	{

--- a/src/grpck.c
+++ b/src/grpck.c
@@ -11,11 +11,12 @@
 #include "config.h"
 
 #include <fcntl.h>
+#include <getopt.h>
 #include <grp.h>
 #include <paths.h>
 #include <pwd.h>
 #include <stdio.h>
-#include <getopt.h>
+#include <string.h>
 
 #include "chkname.h"
 #include "commonio.h"
@@ -29,7 +30,6 @@
 #include "shadowlog.h"
 #include "sssd.h"
 #include "string/strcmp/streq.h"
-#include "string/strcmp/strprefix.h"
 
 #ifdef SHADOWGRP
 #include "sgroupio.h"
@@ -487,10 +487,8 @@ static void check_grp_file(bool *errors, bool *changed, const struct option_flag
 		/*
 		 * Skip all NIS entries.
 		 */
-
-		if (strprefix(gre->line, "+") || strprefix(gre->line, "-")) {
+		if (strspn(gre->line, "+-"))
 			continue;
-		}
 
 		/*
 		 * Start with the entries that are completely corrupt. They

--- a/src/login.c
+++ b/src/login.c
@@ -23,6 +23,7 @@
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/stat.h>
 #include <sys/ioctl.h>
 
@@ -44,7 +45,6 @@
 #include "string/sprintf/stprintf.h"
 #include "string/strcmp/streq.h"
 #include "string/strcmp/strneq.h"
-#include "string/strcmp/strprefix.h"
 #include "string/strcpy/strtcpy.h"
 #include "string/strdup/strdup.h"
 #include "string/strftime.h"
@@ -265,7 +265,7 @@ static void process_flags (int argc, char *const *argv)
 	 * clever telnet, and getty holes.
 	 */
 	for (arg = 1; arg < argc; arg++) {
-		if (strprefix(argv[arg], "-") && strlen(argv[arg]) > 2) {
+		if (strspn(argv[arg], "-") && strlen(argv[arg]) > 2) {
 			usage ();
 		}
 		if (streq(argv[arg], "--")) {
@@ -346,7 +346,7 @@ static void init_env (void)
 	else {
 		cp = getdef_str ("ENV_TZ");
 		if (NULL != cp) {
-			addenv(strprefix(cp, "/") ? tz(cp) : cp, NULL);
+			addenv(strspn(cp, "/") ? tz(cp) : cp, NULL);
 		}
 	}
 #endif				/* !USE_PAM */
@@ -855,10 +855,8 @@ int main (int argc, char **argv)
 			 * login, even if they have been
 			 * "pre-authenticated."
 			 */
-			if (   strprefix(user_passwd, "!")
-			    || strprefix(user_passwd, "*")) {
+			if (strspn(user_passwd, "*!"))
 				failed = true;
-			}
 
 			if (streq(user_passwd, "")) {
 				const char *prevent_no_auth = getdef_str("PREVENT_NO_AUTH");
@@ -1011,7 +1009,7 @@ int main (int argc, char **argv)
 		addenv ("IFS= \t\n", NULL);	/* ... instead, set a safe IFS */
 	}
 
-	if (strprefix(pwd->pw_shell, "*")) {  /* subsystem root */
+	if (strspn(pwd->pw_shell, "*")) {  /* subsystem root */
 		pwd->pw_shell++;	/* skip the '*' */
 		subsystem (pwd);	/* figure out what to execute */
 		subroot = true;	/* say I was here again */

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -114,9 +114,9 @@ login_access(const char *user, const char *from)
 					TABLE, lineno);
 				continue;
 			}
-			if (strprefix(line, "#")) {
-				continue;	/* comment line */
-			}
+			if (!strcspn(line, "#"))
+				continue;	/* comment or empty */
+
 			stpcpy(stprspn(line, " \t"), "");
 			if (streq(line, "")) {	/* skip blank lines */
 				continue;

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -130,7 +130,7 @@ login_access(const char *user, const char *from)
 				       TABLE, lineno);
 				continue;
 			}
-			if (perm[0] != '+' && perm[0] != '-') {
+			if (!strspn(perm, "+-")) {
 				SYSLOG(LOG_ERR, "%s: line %jd: bad first field",
 					TABLE, lineno);
 				continue;
@@ -142,7 +142,7 @@ login_access(const char *user, const char *from)
 	} else if (errno != ENOENT) {
 		SYSLOGE(LOG_ERR, "cannot open %s", TABLE);
 	}
-	return (!match || strprefix(line, "+"))?1:0;
+	return (!match || strspn(line, "+"))?1:0;
 }
 
 /* list_match - match an item against a list of tokens with exceptions */
@@ -226,7 +226,7 @@ static bool user_match (char *tok, const char *string)
 	if (host != NULL) {
 		return user_match(tok, string) && from_match(host, myhostname());
 #if HAVE_INNETGR
-	} else if (strprefix(tok, "@")) {	/* netgroup */
+	} else if (strspn(tok, "@")) {	/* netgroup */
 		return (netgroup_match (tok + 1, NULL, string));
 #endif
 	} else if (string_match (tok, string)) {	/* ALL or exact match */
@@ -299,13 +299,13 @@ static bool from_match (char *tok, const char *string)
 	 * if it matches the head of the string.
 	 */
 #if HAVE_INNETGR
-	if (strprefix(tok, "@")) {  /* netgroup */
+	if (strspn(tok, "@")) {  /* netgroup */
 		return (netgroup_match (tok + 1, string, NULL));
 	} else
 #endif
 	if (string_match (tok, string)) {	/* ALL or exact match */
 		return true;
-	} else if (strprefix(tok, ".")) {  /* domain: match last fields */
+	} else if (strspn(tok, ".")) {  /* domain: match last fields */
 		size_t  str_len, tok_len;
 
 		str_len = strlen (string);

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -476,7 +476,7 @@ int main (int argc, char **argv)
 		 * Do the command line for everything that is
 		 * not "newgrp".
 		 */
-		if ((argc > 0) && (argv[0][0] != '-')) {
+		if ((argc > 0) && !strspn(argv[0], "-")) {
 			if (!is_valid_group_name(argv[0])) {
 				eprintf(_("%s: provided group is not a valid group name\n"),
 					Prog);
@@ -508,7 +508,7 @@ int main (int argc, char **argv)
 		 * Do the command line for "newgrp". It's just making sure
 		 * there aren't any flags and getting the new group name.
 		 */
-		if ((argc > 0) && strprefix(argv[0], "-")) {
+		if ((argc > 0) && strspn(argv[0], "-")) {
 			usage ();
 			goto failure;
 		} else if (argv[0] != NULL) {

--- a/src/newusers.c
+++ b/src/newusers.c
@@ -1090,7 +1090,7 @@ int main (int argc, char **argv)
 /* FIXME: should check for directory */
 			mode_t mode = getdef_num ("HOME_MODE",
 			                          0777 & ~getdef_num ("UMASK", GETDEF_DEFAULT_UMASK));
-			if (newpw.pw_dir[0] != '/') {
+			if (!strspn(newpw.pw_dir, "/")) {
 				eprintf(_("%s: line %jd: homedir must be an absolute path\n"),
 					Prog, line);
 				fail_exit (EXIT_FAILURE, process_selinux);

--- a/src/passwd.c
+++ b/src/passwd.c
@@ -17,6 +17,7 @@
 #include <pwd.h>
 #include <signal.h>
 #include <stdio.h>
+#include <string.h>
 #include <sys/types.h>
 #include <time.h>
 
@@ -37,7 +38,6 @@
 #include "string/sprintf/aprintf.h"
 #include "string/sprintf/stprintf.h"
 #include "string/strcmp/streq.h"
-#include "string/strcmp/strprefix.h"
 #include "string/strcpy/strtcpy.h"
 #include "string/strdup/strdup.h"
 #include "time/day_to_str.h"
@@ -368,7 +368,7 @@ static void check_password (const struct passwd *pw, const struct spwd *sp, bool
 	 * locked may not be changed.
 	 * Passwords which have been inactive too long cannot be changed.
 	 */
-	if (   strprefix(sp->sp_pwdp, "!")
+	if (   strspn(sp->sp_pwdp, "!")
 	    || (exp_status > 1)) {
 		eprintf(_("The password for %s cannot be changed.\n"),
 		                sp->sp_namp);
@@ -380,9 +380,8 @@ static void check_password (const struct passwd *pw, const struct spwd *sp, bool
 
 static /*@observer@*/const char *pw_status (const char *pass)
 {
-	if (strprefix(pass, "*") || strprefix(pass, "!")) {
+	if (strspn(pass, "*!"))
 		return "L";
-	}
 	if (streq(pass, "")) {
 		return "NP";
 	}
@@ -526,7 +525,7 @@ static char *update_crypt_pw (char *cp, bool process_selinux)
 	if (dflg)
 		strcpy(cp, "");
 
-	if (uflg && strprefix(cp, "!")) {
+	if (uflg && strspn(cp, "!")) {
 		if (cp[1] == '\0') {
 			(void) eprintf(_("%s: unlocking the password would result in a passwordless account.\n"
 			                 "You should set a password with usermod -p to unlock the password of this account.\n"),
@@ -537,7 +536,7 @@ static char *update_crypt_pw (char *cp, bool process_selinux)
 		}
 	}
 
-	if (lflg && *cp != '!') {
+	if (lflg && !strspn(cp, "!")) {
 		char  *newpw;
 
 		newpw = xaprintf("!%s", cp);

--- a/src/pwck.c
+++ b/src/pwck.c
@@ -17,6 +17,7 @@
 #include <grp.h>
 #include <pwd.h>
 #include <stdio.h>
+#include <string.h>
 
 #include "chkname.h"
 #include "commonio.h"
@@ -30,7 +31,6 @@
 #include "shadowlog.h"
 #include "sssd.h"
 #include "string/strcmp/streq.h"
-#include "string/strcmp/strprefix.h"
 #ifdef WITH_TCB
 #include "tcbfuncs.h"
 #endif				/* WITH_TCB */
@@ -387,9 +387,8 @@ static void check_pw_file(bool *errors, bool *changed, const struct option_flags
 		 * If this is a NIS line, skip it. You can't "know" what NIS
 		 * is going to do without directly asking NIS ...
 		 */
-		if (strprefix(pfe->line, "+") || strprefix(pfe->line, "-")) {
+		if (strspn(pfe->line, "+-"))
 			continue;
-		}
 
 		/*
 		 * Start with the entries that are completely corrupt.  They
@@ -704,9 +703,8 @@ static void check_spw_file (bool *errors, bool *changed)
 		 * If this is a NIS line, skip it. You can't "know" what NIS
 		 * is going to do without directly asking NIS ...
 		 */
-		if (strprefix(spe->line, "+") || strprefix(spe->line, "-")) {
+		if (strspn(spe->line, "+-"))
 			continue;
-		}
 
 		/*
 		 * Start with the entries that are completely corrupt. They

--- a/src/su.c
+++ b/src/su.c
@@ -37,6 +37,7 @@
 #include <pwd.h>
 #include <signal.h>
 #include <stdio.h>
+#include <string.h>
 #include <sys/types.h>
 #include <unistd.h>
 #ifndef USE_PAM
@@ -63,7 +64,6 @@
 #include "shadowlog.h"
 #include "string/sprintf/aprintf.h"
 #include "string/strcmp/streq.h"
-#include "string/strcmp/strprefix.h"
 #include "string/strcpy/strtcpy.h"
 #include "string/strdup/strdup.h"
 
@@ -191,7 +191,7 @@ static bool restricted_shell (const char *shellname)
 
 	setusershell ();
 	while (NULL != (line = getusershell())) {
-		if (('#' != *line) && streq(line, shellname)) {
+		if (!strspn(line, "#") && streq(line, shellname)) {
 			endusershell ();
 			return false;
 		}
@@ -697,7 +697,7 @@ static /*@only@*/struct passwd * do_check_perms (void)
 	 * the shell specified in /etc/passwd (not the one specified with
 	 * --shell, which will be the one executed in the chroot later).
 	 */
-	if (strprefix(pw->pw_shell, "*")) {  /* subsystem root required */
+	if (strspn(pw->pw_shell, "*")) {  /* subsystem root required */
 		subsystem (pw);	/* change to the subsystem root */
 		endpwent ();		/* close the old password databases */
 		endspent ();
@@ -894,7 +894,7 @@ static void set_environment (struct passwd *pw)
 #ifndef USE_PAM
 		cp = getdef_str ("ENV_TZ");
 		if (NULL != cp) {
-			addenv(strprefix(cp, "/") ? tz(cp) : cp, NULL);
+			addenv(strspn(cp, "/") ? tz(cp) : cp, NULL);
 		}
 
 		/*

--- a/src/suauth.c
+++ b/src/suauth.c
@@ -22,7 +22,6 @@
 #include "io/syslog.h"
 #include "prototypes.h"
 #include "string/strcmp/streq.h"
-#include "string/strcmp/strprefix.h"
 #include "string/strspn/stpspn.h"
 #include "string/strspn/stprspn.h"
 #include "string/strtok/stpsep.h"
@@ -88,7 +87,7 @@ check_su_auth(const char *actual_id, const char *wanted_id, bool su_to_root)
 		stpcpy(stprspn(temp, " \t"), "");
 
 		p = stpspn(temp, " \t");
-		if (strprefix(p, "#") || streq(p, ""))
+		if (!strcspn(p, "#"))
 			continue;
 
 		to_users = strsep(&p, ":");

--- a/src/sulogin.c
+++ b/src/sulogin.c
@@ -15,6 +15,7 @@
 #include <pwd.h>
 #include <signal.h>
 #include <stdio.h>
+#include <string.h>
 #include <sys/ioctl.h>
 #include <sys/types.h>
 
@@ -28,7 +29,6 @@
 #include "exitcodes.h"
 #include "shadowlog.h"
 #include "string/strcmp/streq.h"
-#include "string/strcmp/strprefix.h"
 #include "string/strdup/strdup.h"
 
 
@@ -119,7 +119,7 @@ main(int argc, char *argv[])
 #ifndef USE_PAM
 	env = getdef_str ("ENV_TZ");
 	if (NULL != env) {
-		addenv(strprefix(env, "/") ? tz(env) : env, NULL);
+		addenv(strspn(env, "/") ? tz(env) : env, NULL);
 	}
 	env = getdef_str ("ENV_HZ");
 	if (NULL != env) {

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -1348,15 +1348,13 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 				break;
 			case 's':
 				if (   ( !VALID (optarg) )
-				    || (   !streq(optarg, "")
-				        && ('/'  != optarg[0])
-				        && ('*'  != optarg[0]) )) {
+				    || strcspn(optarg, "/*"))
+				{
 					eprintf(_("%s: invalid shell '%s'\n"),
 					         Prog, optarg);
 					exit (E_BAD_ARG);
 				}
-				if (!streq(optarg, "")
-				     && '*'  != optarg[0]
+				if (strcspn(optarg, "*")
 				     && !streq(optarg, "/sbin/nologin")
 				     && !streq(optarg, "/usr/sbin/nologin")
 				     && (   stat(optarg, &st) != 0

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -70,7 +70,6 @@
 #include "string/sprintf/stprintf.h"
 #include "string/strcmp/strcaseeq.h"
 #include "string/strcmp/streq.h"
-#include "string/strcmp/strprefix.h"
 #include "string/strdup/strdup.h"
 #include "string/strtok/stpsep.h"
 #include "sysconf.h"
@@ -1177,7 +1176,8 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 			switch (c) {
 			case 'b':
 				if (   ( !VALID (optarg) )
-				    || ( optarg[0] != '/' )) {
+				    || !strspn(optarg, "/"))
+				{
 					eprintf(_("%s: invalid base directory '%s'\n"),
 					         Prog, optarg);
 					exit (E_BAD_ARG);
@@ -1202,7 +1202,8 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 				break;
 			case 'd':
 				if (   ( !VALID (optarg) )
-				    || ( optarg[0] != '/' )) {
+				    || !strspn(optarg, "/"))
+				{
 					eprintf(_("%s: invalid home directory '%s'\n"),
 					         Prog, optarg);
 					exit (E_BAD_ARG);
@@ -2176,7 +2177,7 @@ static void create_home(const struct option_flags *flags)
 		bool  dir_created;
 
 		/* Avoid turning a relative path into an absolute path. */
-		if (strprefix(bhome, "/") || !streq(path, ""))
+		if (strspn(bhome, "/") || !streq(path, ""))
 			strcat(path, "/");
 
 		strcat(path, cp);

--- a/src/userdel.c
+++ b/src/userdel.c
@@ -683,9 +683,7 @@ static void user_cancel (const char *user)
 #ifdef EXTRA_CHECK_HOME_DIR
 static bool path_prefix (const char *s1, const char *s2)
 {
-	return (   strprefix(s2, s1)
-	        && (   ('\0' == s2[strlen (s1)])
-	            || ('/'  == s2[strlen (s1)])));
+	return strprefix(s2, s1) && !strcspn(s2 + strlen(s1), "/");
 }
 #endif				/* EXTRA_CHECK_HOME_DIR */
 

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -1092,7 +1092,7 @@ process_flags(int argc, char **argv, struct option_flags *flags)
 				}
 				dflg = true;
 				user_newhome = optarg;
-				if ((user_newhome[0] != '/') && !streq(user_newhome, "")) {
+				if (strcspn(user_newhome, "/")) {
 					eprintf(_("%s: homedir must be an absolute path\n"),
 					         Prog);
 					exit (E_BAD_ARG);
@@ -1179,15 +1179,13 @@ process_flags(int argc, char **argv, struct option_flags *flags)
 				break;
 			case 's':
 				if (   ( !VALID (optarg) )
-				    || (   !streq(optarg, "")
-				        && ('/'  != optarg[0])
-				        && ('*'  != optarg[0]) )) {
+				    || strcspn(optarg, "/*"))
+				{
 					eprintf(_("%s: invalid shell '%s'\n"),
 					         Prog, optarg);
 					exit (E_BAD_ARG);
 				}
-				if (!streq(optarg, "")
-				     && '*'  != optarg[0]
+				if (strcspn(optarg, "*")
 				     && !streq(optarg, "/sbin/nologin")
 				     && !streq(optarg, "/usr/sbin/nologin")
 				     && (   stat(optarg, &st) != 0

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -64,7 +64,6 @@
 #include "string/memset/memzero.h"
 #include "string/sprintf/aprintf.h"
 #include "string/strcmp/streq.h"
-#include "string/strcmp/strprefix.h"
 #include "string/strdup/strdup.h"
 #include "string/strspn/stprspn.h"
 #include "sysconf.h"
@@ -341,7 +340,7 @@ getid_range(const char *str)
 		return result;
 	}
 
-	if ('-' != *pos++)
+	if (!strspn(pos++, "-"))
 		return result;
 
 	if (a2i(id_t, &last, pos, NULL, 10, first, last) == -1)
@@ -469,14 +468,14 @@ usage (int status)
 static char *
 new_pw_passwd(char *pw_pass, bool process_selinux)
 {
-	if (Lflg && ('!' != pw_pass[0])) {
+	if (Lflg && !strspn(pw_pass, "!")) {
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_USER_CHAUTHTOK,
 		              "updating-passwd", user_newname, user_newid, 1);
 #endif
 		SYSLOG(LOG_INFO, "lock user '%s' password", user_newname);
 		pw_pass = xaprintf("!%s", pw_pass);
-	} else if (Uflg && strprefix(pw_pass, "!")) {
+	} else if (Uflg && strspn(pw_pass, "!")) {
 		if (pw_pass[1] == '\0') {
 			eprintf(_("%s: unlocking the user's password would result in a passwordless account.\n"
 			          "You should set a password with usermod -p to unlock this user's password.\n"),


### PR DESCRIPTION
---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git rd 
1:  fdd0ccd6 ! 1:  a66931f3 lib/, src/: Use strspn(3) instead of its pattern
    @@ src/grpck.c
      
      #ifdef SHADOWGRP
      #include "sgroupio.h"
    -@@ src/grpck.c: static void check_grp_file (bool *errors, bool *changed)
    +@@ src/grpck.c: static void check_grp_file (bool *errors, bool *changed, struct option_flags *fl
                /*
                 * Skip all NIS entries.
                 */
    @@ src/pwck.c
      #ifdef WITH_TCB
      #include "tcbfuncs.h"
      #endif                            /* WITH_TCB */
    -@@ src/pwck.c: static void check_pw_file (bool *errors, bool *changed)
    +@@ src/pwck.c: static void check_pw_file (bool *errors, bool *changed, struct option_flags *fla
                 * If this is a NIS line, skip it. You can't "know" what NIS
                 * is going to do without directly asking NIS ...
                 */
2:  5ac4f04b = 2:  0b0e6b2f lib/, src/: Use strcspn(3) instead of its pattern
```
</details>

<details>
<summary>v2</summary>

-  Replace more cases.

```
$ git range-diff shadow/master gh/strspn strspn 
1:  a66931f3 ! 1:  21f5239f lib/, src/: Use strspn(3) instead of its pattern
    @@ lib/commonio.c: static void add_one_entry (struct commonio_db *db,
      }
      
      
    +@@ lib/commonio.c: commonio_sort (struct commonio_db *db, int (*cmp) (const void *, const void *))
    +           (NULL != ptr)
    + #if KEEP_NIS_AT_END
    +        && ((NULL == ptr->line)
    +-           || (('+' != ptr->line[0])
    +-               && ('-' != ptr->line[0])))
    ++           || !strspn(ptr->line, "+-"))
    + #endif
    +        ;
    +        ptr = ptr->next) {
    +
    + ## lib/getrange.c ##
    +@@
    + 
    + #include <ctype.h>
    + #include <stdlib.h>
    ++#include <string.h>
    + 
    + #include "atoi/a2i/a2u.h"
    + #include "defines.h"
    +@@ lib/getrange.c: getrange(const char *range,
    +   *has_min = false;
    +   *has_max = false;
    + 
    +-  if ('-' == range[0]) {
    ++  if (strspn(range, "-")) {
    +           end = range + 1;
    +           goto parse_max;
    +   }
    +
    + ## lib/hushed.c ##
    +@@ lib/hushed.c: bool hushed (const char *username)
    +    * file exists in the user's home directory.
    +    */
    + 
    +-  if (hushfile[0] != '/') {
    ++  if (!strspn(hushfile, "/")) {
    +           SNPRINTF(buf, "%s/%s", pw->pw_dir, hushfile);
    +           return (access (buf, F_OK) == 0);
    +   }
    +
    + ## lib/prefix_flag.c ##
    +@@
    + 
    + #include <paths.h>
    + #include <stdio.h>
    ++#include <string.h>
    + 
    + #include <assert.h>
    + 
    +@@ lib/prefix_flag.c: extern const char* process_prefix_flag (const char* short_opt, int argc, char **
    +                   return ""; /* if prefix is "/" then we ignore the flag option */
    +           /* should we prevent symbolic link from being used as a prefix? */
    + 
    +-          if ( prefix[0] != '/') {
    ++          if (!strspn(prefix, "/")) {
    +                   fprintf (log_get_logfd(),
    +                            _("%s: prefix must be an absolute path\n"),
    +                            log_get_progname());
    +
    + ## lib/root_flag.c ##
    +@@
    + #ident "$Id$"
    + 
    + #include <stdio.h>
    ++#include <string.h>
    + 
    + #include "defines.h"
    + /*@-exitarg@*/
    +@@ lib/root_flag.c: static void change_root (const char* newroot)
    +           exit (EXIT_FAILURE);
    +   }
    + 
    +-  if ('/' != newroot[0]) {
    ++  if (!strspn(newroot, "/")) {
    +           fprintf (log_get_logfd(),
    +                    _("%s: invalid chroot path '%s', only absolute paths are supported.\n"),
    +                    log_get_progname(), newroot);
    +
    + ## lib/sub.c ##
    +@@
    + 
    + #include "config.h"
    + 
    +-#ident "$Id$"
    +-
    + #include <pwd.h>
    + #include <stdio.h>
    ++#include <string.h>
    + #include <sys/types.h>
    ++
    + #include "prototypes.h"
    + #include "defines.h"
    ++
    + #define   MAX_SUBROOT2    "maximum subsystem depth reached\n"
    + #define   BAD_SUBROOT2    "invalid root `%s' for user `%s'\n"
    + #define   NO_SUBROOT2     "no subsystem root `%s' for user `%s'\n"
    +@@ lib/sub.c: void subsystem (const struct passwd *pw)
    +    * The new root directory must begin with a "/" character.
    +    */
    + 
    +-  if (pw->pw_dir[0] != '/') {
    ++  if (!strspn(pw->pw_dir, "/")) {
    +           printf (_("Invalid root directory '%s'\n"), pw->pw_dir);
    +           SYSLOG ((LOG_WARN, BAD_SUBROOT2, pw->pw_dir, pw->pw_name));
    +           closelog ();
    +
    + ## src/chsh.c ##
    +@@
    + #include <getopt.h>
    + #include <pwd.h>
    + #include <stdio.h>
    ++#include <string.h>
    + #include <sys/types.h>
    + 
    + #include "chkname.h"
    +@@ src/chsh.c: int main (int argc, char **argv)
    +           fail_exit (1, process_selinux);
    +   }
    +   if (!streq(loginsh, "")
    +-      && (loginsh[0] != '/'
    ++      && (!strspn(loginsh, "/")
    +           || is_restricted_shell (loginsh)
    +           || (access (loginsh, X_OK) != 0)))
    +   {
     
      ## src/grpck.c ##
     @@
    @@ src/login.c: int main (int argc, char **argv)
                        if (streq(user_passwd, "")) {
                                const char *prevent_no_auth = getdef_str("PREVENT_NO_AUTH");
     
    + ## src/login_nopam.c ##
    +@@ src/login_nopam.c: login_access(const char *user, const char *from)
    +                                    TABLE, lineno));
    +                           continue;
    +                   }
    +-                  if (perm[0] != '+' && perm[0] != '-') {
    ++                  if (!strspn(perm, "+-")) {
    +                           SYSLOG ((LOG_ERR,
    +                                    "%s: line %jd: bad first field",
    +                                    TABLE, lineno));
    +
    + ## src/newgrp.c ##
    +@@ src/newgrp.c: int main (int argc, char **argv)
    +            * Do the command line for everything that is
    +            * not "newgrp".
    +            */
    +-          if ((argc > 0) && (argv[0][0] != '-')) {
    ++          if ((argc > 0) && !strspn(argv[0], "-")) {
    +                   if (!is_valid_group_name (argv[0])) {
    +                           fprintf (
    +                                   stderr, _("%s: provided group is not a valid group name\n"),
    +@@ src/newgrp.c: int main (int argc, char **argv)
    +            * Do the command line for "newgrp". It's just making sure
    +            * there aren't any flags and getting the new group name.
    +            */
    +-          if ((argc > 0) && strprefix(argv[0], "-")) {
    ++          if ((argc > 0) && strspn(argv[0], "-")) {
    +                   usage ();
    +                   goto failure;
    +           } else if (argv[0] != NULL) {
    +
    + ## src/newusers.c ##
    +@@ src/newusers.c: int main (int argc, char **argv)
    + /* FIXME: should check for directory */
    +                   mode_t mode = getdef_num ("HOME_MODE",
    +                                             0777 & ~getdef_num ("UMASK", GETDEF_DEFAULT_UMASK));
    +-                  if (newpw.pw_dir[0] != '/') {
    ++                  if (!strspn(newpw.pw_dir, "/")) {
    +                           fprintf(stderr,
    +                                   _("%s: line %jd: homedir must be an absolute path\n"),
    +                                   Prog, line);
    +
      ## src/passwd.c ##
     @@
      #include <pwd.h>
    @@ src/pwck.c: static void check_spw_file (bool *errors, bool *changed)
      
                /*
                 * Start with the entries that are completely corrupt. They
    +
    + ## src/useradd.c ##
    +@@ src/useradd.c: static void process_flags (int argc, char **argv, struct option_flags *flags)
    +                   switch (c) {
    +                   case 'b':
    +                           if (   ( !VALID (optarg) )
    +-                              || ( optarg[0] != '/' )) {
    ++                              || !strspn(optarg, "/")) {
    +                                   fprintf (stderr,
    +                                            _("%s: invalid base directory '%s'\n"),
    +                                            Prog, optarg);
    +@@ src/useradd.c: static void process_flags (int argc, char **argv, struct option_flags *flags)
    +                           break;
    +                   case 'd':
    +                           if (   ( !VALID (optarg) )
    +-                              || ( optarg[0] != '/' )) {
    ++                              || !strspn(optarg, "/")) {
    +                                   fprintf (stderr,
    +                                            _("%s: invalid home directory '%s'\n"),
    +                                            Prog, optarg);
    +
    + ## src/usermod.c ##
    +@@
    + #endif                            /* ACCT_TOOLS_SETUID */
    + #include <paths.h>
    + #include <stdio.h>
    ++#include <string.h>
    + #include <strings.h>
    + #include <sys/stat.h>
    + #include <sys/types.h>
    +@@ src/usermod.c: usage (int status)
    +  */
    + static char *new_pw_passwd (char *pw_pass)
    + {
    +-  if (Lflg && ('!' != pw_pass[0])) {
    ++  if (Lflg && !strspn(pw_pass, "!")) {
    + #ifdef WITH_AUDIT
    +           audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
    +                         "updating-passwd", user_newname, user_newid, 1);
2:  0b0e6b2f ! 2:  86c7c445 lib/, src/: Use strcspn(3) instead of its pattern
    @@ src/suauth.c: check_su_auth(const char *actual_id, const char *wanted_id, bool s
                        continue;
      
                to_users = strsep(&p, ":");
    +
    + ## src/useradd.c ##
    +@@ src/useradd.c: static void process_flags (int argc, char **argv, struct option_flags *flags)
    +                           break;
    +                   case 's':
    +                           if (   ( !VALID (optarg) )
    +-                              || (   !streq(optarg, "")
    +-                                  && ('/'  != optarg[0])
    +-                                  && ('*'  != optarg[0]) )) {
    ++                              || strcspn(optarg, "/*")) {
    +                                   fprintf (stderr,
    +                                            _("%s: invalid shell '%s'\n"),
    +                                            Prog, optarg);
    +                                   exit (E_BAD_ARG);
    +                           }
    +-                          if (!streq(optarg, "")
    +-                               && '*'  != optarg[0]
    ++                          if (strcspn(optarg, "*")
    +                                && !streq(optarg, "/sbin/nologin")
    +                                && !streq(optarg, "/usr/sbin/nologin")
    +                                && (   stat(optarg, &st) != 0
    +
    + ## src/usermod.c ##
    +@@ src/usermod.c: process_flags(int argc, char **argv, struct option_flags *flags)
    +                           }
    +                           dflg = true;
    +                           user_newhome = optarg;
    +-                          if ((user_newhome[0] != '/') && !streq(user_newhome, "")) {
    ++                          if (strcspn(user_newhome, "/")) {
    +                                   fprintf (stderr,
    +                                            _("%s: homedir must be an absolute path\n"),
    +                                            Prog);
    +@@ src/usermod.c: process_flags(int argc, char **argv, struct option_flags *flags)
    +                           break;
    +                   case 's':
    +                           if (   ( !VALID (optarg) )
    +-                              || (   !streq(optarg, "")
    +-                                  && ('/'  != optarg[0])
    +-                                  && ('*'  != optarg[0]) )) {
    ++                              || strcspn(optarg, "/*")) {
    +                                   fprintf (stderr,
    +                                            _("%s: invalid shell '%s'\n"),
    +                                            Prog, optarg);
    +                                   exit (E_BAD_ARG);
    +                           }
    +-                          if (!streq(optarg, "")
    +-                               && '*'  != optarg[0]
    ++                          if (strcspn(optarg, "*")
    +                                && !streq(optarg, "/sbin/nologin")
    +                                && !streq(optarg, "/usr/sbin/nologin")
    +                                && (   stat(optarg, &st) != 0
```
</details>

<details>
<summary>v3</summary>

-  Replace more cases.

```
$ git range-diff shadow/master gh/strspn strspn 
1:  21f5239f ! 1:  794f7f4d lib/, src/: Use strspn(3) instead of its pattern
    @@ lib/commonio.c: commonio_sort (struct commonio_db *db, int (*cmp) (const void *,
             ;
             ptr = ptr->next) {
     
    + ## lib/encrypt.c ##
    +@@
    + 
    + #include <unistd.h>
    + #include <stdio.h>
    ++#include <string.h>
    + 
    + #include "prototypes.h"
    + #include "defines.h"
    + #include "shadowlog_internal.h"
    +-#include "string/strcmp/strprefix.h"
    + 
    + 
    + /*@exposed@*//*@null@*/char *pw_encrypt (const char *clear, const char *salt)
    +@@
    + 
    +   /* Some crypt() do not return NULL if the algorithm is not
    +    * supported, and return a DES encrypted password. */
    +-  if ((NULL != salt) && strprefix(salt, "$") && (strlen (cp) <= 13))
    ++  if ((NULL != salt) && strspn(salt, "$") && (strlen (cp) <= 13))
    +   {
    +           /*@observer@*/const char *method;
    +           switch (salt[1])
    +
      ## lib/getrange.c ##
     @@
      
    @@ lib/hushed.c: bool hushed (const char *username)
                return (access (buf, F_OK) == 0);
        }
     
    + ## lib/limits.c ##
    +@@ lib/limits.c: static int setrlimit_value (unsigned int resource,
    +   /* The "-" is special, not belonging to a strange negative limit.
    +    * It is infinity, in a controlled way.
    +    */
    +-  if (strprefix(value, "-")) {
    ++  if (strspn(value, "-")) {
    +           limit = RLIM_INFINITY;
    + 
    +   } else {
    +@@ lib/limits.c: static int setup_user_limits (const char *uname)
    +                           break;
    +                   } else if (streq(name, "*")) {
    +                           strcpy (deflimits, tempbuf);
    +-                  } else if (strprefix(name, "@")) {
    ++                  } else if (strspn(name, "@")) {
    +                           /* If the user is in the group, the group
    +                            * limits apply unless later a line for
    +                            * the specific user is found.
    +
    + ## lib/port.c ##
    +@@
    + #include "port.h"
    + #include "prototypes.h"
    + #include "string/strcmp/streq.h"
    +-#include "string/strcmp/strprefix.h"
    + #include "string/strtok/stpsep.h"
    + #include "string/strtok/strsep2ls.h"
    + 
    +@@ lib/port.c: static int portcmp (const char *pattern, const char *port)
    +   if (streq(orig, "SU"))
    +           return 1;
    + 
    +-  return !strprefix(pattern, "*");
    ++  return !strspn(pattern, "*");
    + }
    + 
    + /*
    +@@ lib/port.c: next:
    +           errno = saveerr;
    +           return NULL;
    +   }
    +-  if (strprefix(buf, "#"))
    ++  if (strspn(buf, "#"))
    +           goto next;
    + 
    +   stpsep(buf, "\n");
    +
      ## lib/prefix_flag.c ##
     @@
      
    @@ lib/sub.c: void subsystem (const struct passwd *pw)
                SYSLOG ((LOG_WARN, BAD_SUBROOT2, pw->pw_dir, pw->pw_name));
                closelog ();
     
    + ## lib/ttytype.c ##
    +@@ lib/ttytype.c: void ttytype (const char *line)
    +           return;
    +   }
    +   while (fgets (buf, sizeof buf, fp) == buf) {
    +-          if (strprefix(buf, "#")) {
    ++          if (strspn(buf, "#"))
    +                   continue;
    +-          }
    + 
    +           stpsep(buf, "\n");
    + 
    +
    + ## lib/yesno.c ##
    +@@
    + #include <stdlib.h>
    + 
    + #include "prototypes.h"
    +-#include "string/strcmp/strcaseprefix.h"
    + 
    + 
    + /*
    +@@ lib/yesno.c: yes_or_no(bool read_only)
    + static int
    + rpmatch(const char *response)
    + {
    +-  if (strcaseprefix(response, "y"))
    ++  if (strspn(response, "yY"))
    +           return 1;
    +-  if (strcaseprefix(response, "n"))
    ++  if (strspn(response, "nN"))
    +           return 0;
    + 
    +   return -1;
    +
    + ## src/check_subid_range.c ##
    +@@
    + #include <string.h>
    + #include <stdbool.h>
    + #include <stdlib.h>
    ++#include <string.h>
    + #include <sys/types.h>
    + #include <sys/stat.h>
    + #include <fcntl.h>
    +@@
    + #include "idmapping.h"
    + #include "prototypes.h"
    + #include "shadowlog.h"
    +-#include "string/strcmp/strprefix.h"
    + #include "subordinateio.h"
    + 
    + 
    +@@ src/check_subid_range.c: main(int argc, char **argv)
    +           exit(1);
    + 
    +   owner = argv[1];
    +-  check_uids = strprefix(argv[2], "u");
    ++  check_uids = strspn(argv[2], "u");
    +   if (get_uid(argv[3], &start) == -1)
    +           exit(1);
    +   if (str2ul(&count, argv[4]) == -1)
    +
      ## src/chsh.c ##
     @@
      #include <getopt.h>
    @@ src/login.c
      #include <sys/stat.h>
      #include <sys/ioctl.h>
      #include <assert.h>
    +@@
    + #include "string/sprintf/snprintf.h"
    + #include "string/strcmp/streq.h"
    + #include "string/strcmp/strneq.h"
    +-#include "string/strcmp/strprefix.h"
    + #include "string/strcpy/strtcpy.h"
    + #include "string/strdup/xstrdup.h"
    + #include "string/strftime.h"
    +@@ src/login.c: static void process_flags (int argc, char *const *argv)
    +    * clever telnet, and getty holes.
    +    */
    +   for (arg = 1; arg < argc; arg++) {
    +-          if (strprefix(argv[arg], "-") && strlen(argv[arg]) > 2) {
    ++          if (strspn(argv[arg], "-") && strlen(argv[arg]) > 2) {
    +                   usage ();
    +           }
    +           if (streq(argv[arg], "--")) {
    +@@ src/login.c: static void init_env (void)
    +   else {
    +           cp = getdef_str ("ENV_TZ");
    +           if (NULL != cp) {
    +-                  addenv(strprefix(cp, "/") ? tz(cp) : cp, NULL);
    ++                  addenv(strspn(cp, "/") ? tz(cp) : cp, NULL);
    +           }
    +   }
    + #endif                            /* !USE_PAM */
     @@ src/login.c: int main (int argc, char **argv)
                         * login, even if they have been
                         * "pre-authenticated."
    @@ src/login.c: int main (int argc, char **argv)
      
                        if (streq(user_passwd, "")) {
                                const char *prevent_no_auth = getdef_str("PREVENT_NO_AUTH");
    +@@ src/login.c: int main (int argc, char **argv)
    +           addenv ("IFS= \t\n", NULL);     /* ... instead, set a safe IFS */
    +   }
    + 
    +-  if (strprefix(pwd->pw_shell, "*")) {  /* subsystem root */
    ++  if (strspn(pwd->pw_shell, "*")) {  /* subsystem root */
    +           pwd->pw_shell++;        /* skip the '*' */
    +           subsystem (pwd);        /* figure out what to execute */
    +           subroot = true; /* say I was here again */
     
      ## src/login_nopam.c ##
     @@ src/login_nopam.c: login_access(const char *user, const char *from)
    @@ src/login_nopam.c: login_access(const char *user, const char *from)
                                SYSLOG ((LOG_ERR,
                                         "%s: line %jd: bad first field",
                                         TABLE, lineno));
    +@@ src/login_nopam.c: login_access(const char *user, const char *from)
    +           int err = errno;
    +           SYSLOG ((LOG_ERR, "cannot open %s: %s", TABLE, strerror (err)));
    +   }
    +-  return (!match || strprefix(line, "+"))?1:0;
    ++  return (!match || strspn(line, "+"))?1:0;
    + }
    + 
    + /* list_match - match an item against a list of tokens with exceptions */
    +@@ src/login_nopam.c: static bool user_match (char *tok, const char *string)
    +   if (host != NULL) {
    +           return user_match(tok, string) && from_match(host, myhostname());
    + #if HAVE_INNETGR
    +-  } else if (strprefix(tok, "@")) {       /* netgroup */
    ++  } else if (strspn(tok, "@")) {  /* netgroup */
    +           return (netgroup_match (tok + 1, NULL, string));
    + #endif
    +   } else if (string_match (tok, string)) {        /* ALL or exact match */
    +@@ src/login_nopam.c: static bool from_match (char *tok, const char *string)
    +    * if it matches the head of the string.
    +    */
    + #if HAVE_INNETGR
    +-  if (strprefix(tok, "@")) {  /* netgroup */
    ++  if (strspn(tok, "@")) {  /* netgroup */
    +           return (netgroup_match (tok + 1, string, NULL));
    +   } else
    + #endif
    +   if (string_match (tok, string)) {       /* ALL or exact match */
    +           return true;
    +-  } else if (strprefix(tok, ".")) {  /* domain: match last fields */
    ++  } else if (strspn(tok, ".")) {  /* domain: match last fields */
    +           size_t  str_len, tok_len;
    + 
    +           str_len = strlen (string);
     
      ## src/newgrp.c ##
     @@ src/newgrp.c: int main (int argc, char **argv)
    @@ src/passwd.c
      #include <sys/types.h>
      #include <time.h>
      
    +@@
    + #include "string/memset/memzero.h"
    + #include "string/sprintf/xaprintf.h"
    + #include "string/strcmp/streq.h"
    +-#include "string/strcmp/strprefix.h"
    + #include "string/strcpy/strtcpy.h"
    + #include "string/strdup/xstrdup.h"
    + #include "time/day_to_str.h"
    +@@ src/passwd.c: static void check_password (const struct passwd *pw, const struct spwd *sp)
    +    * changed. Passwords which have been inactive too long cannot be
    +    * changed.
    +    */
    +-  if (   strprefix(sp->sp_pwdp, "!")
    ++  if (   strspn(sp->sp_pwdp, "!")
    +       || (exp_status > 1)
    +       || (   (sp->sp_max >= 0)
    +           && (sp->sp_min > sp->sp_max))) {
     @@ src/passwd.c: static void check_password (const struct passwd *pw, const struct spwd *sp)
      
      static /*@observer@*/const char *pw_status (const char *pass)
    @@ src/passwd.c: static void check_password (const struct passwd *pw, const struct
        if (streq(pass, "")) {
                return "NP";
        }
    +@@ src/passwd.c: static char *update_crypt_pw (char *cp, bool process_selinux)
    +   if (dflg)
    +           strcpy(cp, "");
    + 
    +-  if (uflg && strprefix(cp, "!")) {
    ++  if (uflg && strspn(cp, "!")) {
    +           if (cp[1] == '\0') {
    +                   (void) fprintf (stderr,
    +                                   _("%s: unlocking the password would result in a passwordless account.\n"
    +@@ src/passwd.c: static char *update_crypt_pw (char *cp, bool process_selinux)
    +           }
    +   }
    + 
    +-  if (lflg && *cp != '!') {
    ++  if (lflg && !strspn(cp, "!")) {
    +           char  *newpw;
    + 
    +           newpw = xaprintf("!%s", cp);
     
      ## src/pwck.c ##
     @@
    @@ src/pwck.c: static void check_spw_file (bool *errors, bool *changed)
                /*
                 * Start with the entries that are completely corrupt. They
     
    + ## src/su.c ##
    +@@
    + #include <pwd.h>
    + #include <signal.h>
    + #include <stdio.h>
    ++#include <string.h>
    + #include <sys/types.h>
    + #include <unistd.h>
    + #ifndef USE_PAM
    +@@
    + #include "string/sprintf/snprintf.h"
    + #include "string/sprintf/xaprintf.h"
    + #include "string/strcmp/streq.h"
    +-#include "string/strcmp/strprefix.h"
    + #include "string/strcpy/strtcpy.h"
    + #include "string/strdup/xstrdup.h"
    + 
    +@@ src/su.c: static bool restricted_shell (const char *shellname)
    + 
    +   setusershell ();
    +   while (NULL != (line = getusershell())) {
    +-          if (('#' != *line) && streq(line, shellname)) {
    ++          if (!strspn(line, "#") && streq(line, shellname)) {
    +                   endusershell ();
    +                   return false;
    +           }
    +@@ src/su.c: static /*@only@*/struct passwd * do_check_perms (void)
    +    * the shell specified in /etc/passwd (not the one specified with
    +    * --shell, which will be the one executed in the chroot later).
    +    */
    +-  if (strprefix(pw->pw_shell, "*")) {  /* subsystem root required */
    ++  if (strspn(pw->pw_shell, "*")) {  /* subsystem root required */
    +           subsystem (pw); /* change to the subsystem root */
    +           endpwent ();            /* close the old password databases */
    +           endspent ();
    +@@ src/su.c: static void set_environment (struct passwd *pw)
    + #ifndef USE_PAM
    +           cp = getdef_str ("ENV_TZ");
    +           if (NULL != cp) {
    +-                  addenv(strprefix(cp, "/") ? tz(cp) : cp, NULL);
    ++                  addenv(strspn(cp, "/") ? tz(cp) : cp, NULL);
    +           }
    + 
    +           /*
    +
    + ## src/sulogin.c ##
    +@@
    + #include <pwd.h>
    + #include <signal.h>
    + #include <stdio.h>
    ++#include <string.h>
    + #include <sys/ioctl.h>
    + #include <sys/types.h>
    + 
    +@@
    + #include "exitcodes.h"
    + #include "shadowlog.h"
    + #include "string/strcmp/streq.h"
    +-#include "string/strcmp/strprefix.h"
    + #include "string/strdup/xstrdup.h"
    + 
    + 
    +@@ src/sulogin.c: main(int argc, char *argv[])
    + #ifndef USE_PAM
    +   env = getdef_str ("ENV_TZ");
    +   if (NULL != env) {
    +-          addenv(strprefix(env, "/") ? tz(env) : env, NULL);
    ++          addenv(strspn(env, "/") ? tz(env) : env, NULL);
    +   }
    +   env = getdef_str ("ENV_HZ");
    +   if (NULL != env) {
    +
      ## src/useradd.c ##
    +@@
    + #include "string/sprintf/xaprintf.h"
    + #include "string/strcmp/strcaseeq.h"
    + #include "string/strcmp/streq.h"
    +-#include "string/strcmp/strprefix.h"
    + #include "string/strdup/xstrdup.h"
    + #include "string/strtok/stpsep.h"
    + 
     @@ src/useradd.c: static void process_flags (int argc, char **argv, struct option_flags *flags)
                        switch (c) {
                        case 'b':
    @@ src/useradd.c: static void process_flags (int argc, char **argv, struct option_f
                                        fprintf (stderr,
                                                 _("%s: invalid home directory '%s'\n"),
                                                 Prog, optarg);
    +@@ src/useradd.c: static void create_home (struct option_flags *flags)
    +    */
    +   for (cp = strtok(bhome, "/"); cp != NULL; cp = strtok(NULL, "/")) {
    +           /* Avoid turning a relative path into an absolute path. */
    +-          if (strprefix(bhome, "/") || !streq(path, ""))
    ++          if (strspn(bhome, "/") || !streq(path, ""))
    +                   strcat(path, "/");
    + 
    +           strcat(path, cp);
     
      ## src/usermod.c ##
     @@
    @@ src/usermod.c
      #include <strings.h>
      #include <sys/stat.h>
      #include <sys/types.h>
    +@@
    + #include "string/memset/memzero.h"
    + #include "string/sprintf/xaprintf.h"
    + #include "string/strcmp/streq.h"
    +-#include "string/strcmp/strprefix.h"
    + #include "string/strdup/xstrdup.h"
    + #include "time/day_to_str.h"
    + #include "typetraits.h"
    +@@ src/usermod.c: getid_range(const char *str)
    +           return result;
    +   }
    + 
    +-  if ('-' != *pos++)
    ++  if (!strspn(pos++, "-"))
    +           return result;
    + 
    +   if (a2i(id_t, &last, pos, NULL, 10, first, last) == -1)
     @@ src/usermod.c: usage (int status)
       */
      static char *new_pw_passwd (char *pw_pass)
    @@ src/usermod.c: usage (int status)
      #ifdef WITH_AUDIT
                audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
                              "updating-passwd", user_newname, user_newid, 1);
    + #endif
    +           SYSLOG ((LOG_INFO, "lock user '%s' password", user_newname));
    +           pw_pass = xaprintf("!%s", pw_pass);
    +-  } else if (Uflg && strprefix(pw_pass, "!")) {
    ++  } else if (Uflg && strspn(pw_pass, "!")) {
    +           if (pw_pass[1] == '\0') {
    +                   fprintf (stderr,
    +                            _("%s: unlocking the user's password would result in a passwordless account.\n"
2:  86c7c445 = 2:  173b93f8 lib/, src/: Use strcspn(3) instead of its pattern
```
</details>

<details>
<summary>v3b</summary>

-  Rebase

```
$ git range-diff shadow/master gh/strspn strspn 
1:  794f7f4d ! 1:  ededb876 lib/, src/: Use strspn(3) instead of its pattern
    @@ src/login.c
      #include "string/strcmp/strneq.h"
     -#include "string/strcmp/strprefix.h"
      #include "string/strcpy/strtcpy.h"
    - #include "string/strdup/xstrdup.h"
    + #include "string/strdup/strdup.h"
      #include "string/strftime.h"
     @@ src/login.c: static void process_flags (int argc, char *const *argv)
         * clever telnet, and getty holes.
    @@ src/passwd.c
      
     @@
      #include "string/memset/memzero.h"
    - #include "string/sprintf/xaprintf.h"
    + #include "string/sprintf/aprintf.h"
      #include "string/strcmp/streq.h"
     -#include "string/strcmp/strprefix.h"
      #include "string/strcpy/strtcpy.h"
    - #include "string/strdup/xstrdup.h"
    + #include "string/strdup/strdup.h"
      #include "time/day_to_str.h"
     @@ src/passwd.c: static void check_password (const struct passwd *pw, const struct spwd *sp)
         * changed. Passwords which have been inactive too long cannot be
    @@ src/su.c
      #include <unistd.h>
      #ifndef USE_PAM
     @@
    + #include "string/sprintf/aprintf.h"
      #include "string/sprintf/snprintf.h"
    - #include "string/sprintf/xaprintf.h"
      #include "string/strcmp/streq.h"
     -#include "string/strcmp/strprefix.h"
      #include "string/strcpy/strtcpy.h"
    - #include "string/strdup/xstrdup.h"
    + #include "string/strdup/strdup.h"
      
     @@ src/su.c: static bool restricted_shell (const char *shellname)
      
    @@ src/sulogin.c
      #include "shadowlog.h"
      #include "string/strcmp/streq.h"
     -#include "string/strcmp/strprefix.h"
    - #include "string/strdup/xstrdup.h"
    + #include "string/strdup/strdup.h"
      
      
     @@ src/sulogin.c: main(int argc, char *argv[])
    @@ src/sulogin.c: main(int argc, char *argv[])
     
      ## src/useradd.c ##
     @@
    - #include "string/sprintf/xaprintf.h"
    + #include "string/sprintf/snprintf.h"
      #include "string/strcmp/strcaseeq.h"
      #include "string/strcmp/streq.h"
     -#include "string/strcmp/strprefix.h"
    - #include "string/strdup/xstrdup.h"
    + #include "string/strdup/strdup.h"
      #include "string/strtok/stpsep.h"
      
     @@ src/useradd.c: static void process_flags (int argc, char **argv, struct option_flags *flags)
    @@ src/usermod.c
      #include <sys/types.h>
     @@
      #include "string/memset/memzero.h"
    - #include "string/sprintf/xaprintf.h"
    + #include "string/sprintf/aprintf.h"
      #include "string/strcmp/streq.h"
     -#include "string/strcmp/strprefix.h"
    - #include "string/strdup/xstrdup.h"
    + #include "string/strdup/strdup.h"
      #include "time/day_to_str.h"
      #include "typetraits.h"
     @@ src/usermod.c: getid_range(const char *str)
2:  173b93f8 ! 2:  0eefff6e lib/, src/: Use strcspn(3) instead of its pattern
    @@ Commit message
     
      ## lib/getdef.c ##
     @@
    - #include "string/sprintf/xaprintf.h"
    + #include "string/sprintf/aprintf.h"
      #include "string/strcmp/strcaseeq.h"
      #include "string/strcmp/streq.h"
     -#include "string/strcmp/strprefix.h"
    @@ lib/setupenv.c
      #include "defines.h"
     @@
      #include "shadowlog.h"
    - #include "string/sprintf/xaprintf.h"
    + #include "string/sprintf/aprintf.h"
      #include "string/strcmp/streq.h"
     -#include "string/strcmp/strprefix.h"
    - #include "string/strdup/xstrdup.h"
    + #include "string/strdup/strdup.h"
      #include "string/strspn/stpspn.h"
      #include "string/strtok/stpsep.h"
      
```
</details>

<details>
<summary>v3c</summary>

-  Rebase

```
$ git rd 
1:  ededb876e ! 1:  d9b5ffbad lib/, src/: Use strspn(3) instead of its pattern
    @@ lib/commonio.c
      #include "string/sprintf/snprintf.h"
      #include "string/strcmp/streq.h"
     -#include "string/strcmp/strprefix.h"
    + #include "string/strerrno.h"
      #include "string/strtok/stpsep.h"
      
    - 
     @@ lib/commonio.c: static void add_one_entry (struct commonio_db *db,
      
      static bool name_is_nis (const char *name)
    @@ src/login.c
     -#include "string/strcmp/strprefix.h"
      #include "string/strcpy/strtcpy.h"
      #include "string/strdup/strdup.h"
    - #include "string/strftime.h"
    + #include "string/strerrno.h"
     @@ src/login.c: static void process_flags (int argc, char *const *argv)
         * clever telnet, and getty holes.
         */
    @@ src/passwd.c
     -#include "string/strcmp/strprefix.h"
      #include "string/strcpy/strtcpy.h"
      #include "string/strdup/strdup.h"
    - #include "time/day_to_str.h"
    + #include "string/strerrno.h"
     @@ src/passwd.c: static void check_password (const struct passwd *pw, const struct spwd *sp)
         * changed. Passwords which have been inactive too long cannot be
         * changed.
    @@ src/useradd.c
      #include "string/strcmp/streq.h"
     -#include "string/strcmp/strprefix.h"
      #include "string/strdup/strdup.h"
    + #include "string/strerrno.h"
      #include "string/strtok/stpsep.h"
    - 
     @@ src/useradd.c: static void process_flags (int argc, char **argv, struct option_flags *flags)
                        switch (c) {
                        case 'b':
    @@ src/usermod.c
      #include "string/strcmp/streq.h"
     -#include "string/strcmp/strprefix.h"
      #include "string/strdup/strdup.h"
    + #include "string/strerrno.h"
      #include "time/day_to_str.h"
    - #include "typetraits.h"
     @@ src/usermod.c: getid_range(const char *str)
                return result;
        }
    @@ src/usermod.c: usage (int status)
     -  if (Lflg && ('!' != pw_pass[0])) {
     +  if (Lflg && !strspn(pw_pass, "!")) {
      #ifdef WITH_AUDIT
    -           audit_logger (AUDIT_USER_CHAUTHTOK, Prog,
    +           audit_logger (AUDIT_USER_CHAUTHTOK,
                              "updating-passwd", user_newname, user_newid, 1);
      #endif
                SYSLOG ((LOG_INFO, "lock user '%s' password", user_newname));
2:  0eefff6ec = 2:  3af9216c0 lib/, src/: Use strcspn(3) instead of its pattern
```
</details>

<details>
<summary>v4</summary>

-  Replace another case.

```
$ git rd 
1:  d9b5ffbad = 1:  d9b5ffbad lib/, src/: Use strspn(3) instead of its pattern
2:  3af9216c0 = 2:  3af9216c0 lib/, src/: Use strcspn(3) instead of its pattern
-:  --------- > 3:  ca0cc9906 lib/env.c: Use strcspn(3) to calculate the length of a substring
```
</details>

<details>
<summary>v4b</summary>

-  Fix typo from v4.

```
$ git rd 
1:  d9b5ffbad = 1:  d9b5ffbad lib/, src/: Use strspn(3) instead of its pattern
2:  3af9216c0 = 2:  3af9216c0 lib/, src/: Use strcspn(3) instead of its pattern
3:  ca0cc9906 ! 3:  94c890b1c lib/env.c: Use strcspn(3) to calculate the length of a substring
    @@ lib/env.c: void addenv (const char *string, /*@null@*/const char *value)
      
     -  cp = strchr (newstring, '=');
     -  if (NULL == cp) {
    -+  if (!strchr(newstring, '='))
    ++  if (!strchr(newstring, '=')) {
                free(newstring);
                return;
        }
```
</details>

<details>
<summary>v4c</summary>

-  Rebase

```
$ git rd 
1:  d9b5ffbad ! 1:  8f608a3f5 lib/, src/: Use strspn(3) instead of its pattern
    @@ lib/getrange.c
      #include <stdlib.h>
     +#include <string.h>
      
    - #include "atoi/a2i/a2u.h"
    + #include "atoi/a2i.h"
      #include "defines.h"
     @@ lib/getrange.c: getrange(const char *range,
        *has_min = false;
    @@ lib/hushed.c: bool hushed (const char *username)
      
     -  if (hushfile[0] != '/') {
     +  if (!strspn(hushfile, "/")) {
    -           SNPRINTF(buf, "%s/%s", pw->pw_dir, hushfile);
    +           stprintf_a(buf, "%s/%s", pw->pw_dir, hushfile);
                return (access (buf, F_OK) == 0);
        }
     
2:  3af9216c0 ! 2:  7346ed4c4 lib/, src/: Use strcspn(3) instead of its pattern
    @@ lib/limits.c: static int setup_user_limits (const char *uname)
                        continue;
     -          }
     +
    -           MEMZERO(tempbuf);
    +           memzero_a(tempbuf);
                /* a valid line should have a username, then spaces,
                 * then limits
     
3:  94c890b1c = 3:  401db5feb lib/env.c: Use strcspn(3) to calculate the length of a substring
```
</details>

<details>
<summary>v4d</summary>

-  Rebase

```
$ git rd 
1:  8f608a3f5 ! 1:  3e1d0f06a lib/, src/: Use strspn(3) instead of its pattern
    @@ lib/ttytype.c
     @@ lib/ttytype.c: void ttytype (const char *line)
                return;
        }
    -   while (fgets (buf, sizeof buf, fp) == buf) {
    +   while (fgets(buf, sizeof(buf), fp) != NULL) {
     -          if (strprefix(buf, "#")) {
     +          if (strspn(buf, "#"))
                        continue;
2:  7346ed4c4 ! 2:  5ce766074 lib/, src/: Use strcspn(3) instead of its pattern
    @@ lib/setupenv.c
      
     -#include <assert.h>
     +#include <ctype.h>
    ++#include <pwd.h>
    + #include <stddef.h>
     +#include <stdio.h>
     +#include <string.h>
      #include <sys/types.h>
    @@ lib/setupenv.c
      
      #include "prototypes.h"
      #include "defines.h"
    -@@
    +-#include <pwd.h>
    + #include "getdef.h"
      #include "shadowlog.h"
      #include "string/sprintf/aprintf.h"
      #include "string/strcmp/streq.h"
3:  401db5feb = 3:  fa9e937d6 lib/env.c: Use strcspn(3) to calculate the length of a substring
```
</details>

<details>
<summary>v4e</summary>

-  Rebase

```
$ git rd 
1:  3e1d0f06a ! 1:  1e030671b lib/, src/: Use strspn(3) instead of its pattern
    @@ src/useradd.c: static void create_home (struct option_flags *flags)
                strcat(path, cp);
     
      ## src/usermod.c ##
    -@@
    - #endif                            /* ACCT_TOOLS_SETUID */
    - #include <paths.h>
    - #include <stdio.h>
    -+#include <string.h>
    - #include <strings.h>
    - #include <sys/stat.h>
    - #include <sys/types.h>
     @@
      #include "string/memset/memzero.h"
      #include "string/sprintf/aprintf.h"
    @@ src/usermod.c
     -#include "string/strcmp/strprefix.h"
      #include "string/strdup/strdup.h"
      #include "string/strerrno.h"
    - #include "time/day_to_str.h"
    + #include "string/strspn/stprspn.h"
     @@ src/usermod.c: getid_range(const char *str)
                return result;
        }
2:  5ce766074 = 2:  a5d020d94 lib/, src/: Use strcspn(3) instead of its pattern
3:  fa9e937d6 = 3:  18a800c93 lib/env.c: Use strcspn(3) to calculate the length of a substring
```
</details>

<details>
<summary>v4f</summary>

-  Rebase

```
$ git rd 
1:  1e030671b ! 1:  3ccc9aa3e lib/, src/: Use strspn(3) instead of its pattern
    @@ src/grpck.c
      
      #ifdef SHADOWGRP
      #include "sgroupio.h"
    -@@ src/grpck.c: static void check_grp_file (bool *errors, bool *changed, struct option_flags *fl
    +@@ src/grpck.c: static void check_grp_file(bool *errors, bool *changed, const struct option_flag
                /*
                 * Skip all NIS entries.
                 */
    @@ src/pwck.c
      #ifdef WITH_TCB
      #include "tcbfuncs.h"
      #endif                            /* WITH_TCB */
    -@@ src/pwck.c: static void check_pw_file (bool *errors, bool *changed, struct option_flags *fla
    +@@ src/pwck.c: static void check_pw_file(bool *errors, bool *changed, const struct option_flags
                 * If this is a NIS line, skip it. You can't "know" what NIS
                 * is going to do without directly asking NIS ...
                 */
    @@ src/useradd.c: static void process_flags (int argc, char **argv, struct option_f
                                        fprintf (stderr,
                                                 _("%s: invalid home directory '%s'\n"),
                                                 Prog, optarg);
    -@@ src/useradd.c: static void create_home (struct option_flags *flags)
    +@@ src/useradd.c: static void create_home(const struct option_flags *flags)
         */
        for (cp = strtok(bhome, "/"); cp != NULL; cp = strtok(NULL, "/")) {
                /* Avoid turning a relative path into an absolute path. */
2:  a5d020d94 = 2:  e0b6fcf8b lib/, src/: Use strcspn(3) instead of its pattern
3:  18a800c93 = 3:  3b7c6bf0e lib/env.c: Use strcspn(3) to calculate the length of a substring
```
</details>

<details>
<summary>v4g</summary>

-  Rebase

```
$ git rd 
1:  3ccc9aa3e ! 1:  50073d544 lib/, src/: Use strspn(3) instead of its pattern
    @@ src/chsh.c: int main (int argc, char **argv)
        if (!streq(loginsh, "")
     -      && (loginsh[0] != '/'
     +      && (!strspn(loginsh, "/")
    -           || is_restricted_shell (loginsh)
    +           || is_restricted_shell (loginsh, process_selinux)
                || (access (loginsh, X_OK) != 0)))
        {
     
    @@ src/passwd.c
      #include "string/strcpy/strtcpy.h"
      #include "string/strdup/strdup.h"
      #include "string/strerrno.h"
    -@@ src/passwd.c: static void check_password (const struct passwd *pw, const struct spwd *sp)
    +@@ src/passwd.c: static void check_password (const struct passwd *pw, const struct spwd *sp, bool
         * changed. Passwords which have been inactive too long cannot be
         * changed.
         */
    @@ src/passwd.c: static void check_password (const struct passwd *pw, const struct
            || (exp_status > 1)
            || (   (sp->sp_max >= 0)
                && (sp->sp_min > sp->sp_max))) {
    -@@ src/passwd.c: static void check_password (const struct passwd *pw, const struct spwd *sp)
    +@@ src/passwd.c: static void check_password (const struct passwd *pw, const struct spwd *sp, bool
      
      static /*@observer@*/const char *pw_status (const char *pass)
      {
2:  e0b6fcf8b ! 2:  c7246c541 lib/, src/: Use strcspn(3) instead of its pattern
    @@ lib/getdef.c: static void def_load (void)
     
      ## lib/limits.c ##
     @@ lib/limits.c: static int setup_user_limits (const char *uname)
    -    * FIXME: A better (smarter) checking should be done
    +    * FIXME: a better (smarter) checking should be done
         */
        while (fgets (buf, 1024, fil) != NULL) {
     -          if (strprefix(buf, "#") || strprefix(buf, "\n")) {
3:  3b7c6bf0e = 3:  668cc7a69 lib/env.c: Use strcspn(3) to calculate the length of a substring
```
</details>

<details>
<summary>v5</summary>

-  Replace a few more cases.

```
$ git rd 
1:  50073d544 ! 1:  5ed7768d0 lib/, src/: Use strspn(3) instead of its pattern
    @@ lib/commonio.c: commonio_sort (struct commonio_db *db, int (*cmp) (const void *,
             ;
             ptr = ptr->next) {
     
    + ## lib/console.c ##
    +@@ lib/console.c: is_listed(const char *cfgin, const char *tty, bool def)
    +    * console devices upon which root logins are allowed.
    +    */
    + 
    +-  if (*cons != '/') {
    ++  if (!strspn(cons, "/")) {
    +           char *pbuf;
    + 
    +           strtcpy_a(buf, cons);
    +
      ## lib/encrypt.c ##
     @@
      
    @@ lib/port.c: next:
                goto next;
      
        stpsep(buf, "\n");
    +@@ lib/port.c: next:
    +                   dtime = dtime * 10 + cp[i] - '0';
    +           }
    + 
    +-          if (('-' != cp[i]) || (dtime > 2400) || ((dtime % 100) > 59)) {
    ++          if (!strspn(cp + i, "-"))
    +                   goto next;
    +-          }
    ++          if (dtime > 2400 || (dtime % 100) > 59)
    ++                  goto next;
    ++
    +           port.pt_times[j].t_start = dtime;
    +           cp = cp + i + 1;
    + 
     
      ## lib/prefix_flag.c ##
     @@
2:  c7246c541 ! 2:  55eccb716 lib/, src/: Use strcspn(3) instead of its pattern
    @@ lib/nss.c: nss_init(const char *nsswitch_path) {
                if (strlen(line) < 8)
                        continue;
     
    + ## lib/port.c ##
    +@@ lib/port.c: next:
    +                   dtime = dtime * 10 + cp[i] - '0';
    +           }
    + 
    +-          if (   ((',' != cp[i]) && ('\0' != cp[i]))
    +-              || (dtime > 2400)
    +-              || ((dtime % 100) > 59)) {
    ++          if (strcspn(cp + i, ","))
    ++                  goto next;
    ++          if (dtime > 2400 || (dtime % 100) > 59)
    +                   goto next;
    +-          }
    + 
    +           port.pt_times[j].t_end = dtime;
    +           cp = cp + i + 1;
    +
      ## lib/setupenv.c ##
     @@
      
3:  668cc7a69 = 3:  8f7313588 lib/env.c: Use strcspn(3) to calculate the length of a substring
```
</details>

<details>
<summary>v6</summary>

-  Replace a few more cases.

```
$ git rd 
1:  5ed7768d0 = 1:  5ed7768d0 lib/, src/: Use strspn(3) instead of its pattern
2:  55eccb716 ! 2:  0725088af lib/, src/: Use strcspn(3) instead of its pattern
    @@ Commit message
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    + ## lib/env.c ##
    +@@ lib/env.c: void addenv (const char *string, /*@null@*/const char *value)
    +    */
    +   for (i = 0; i < newenvc; i++) {
    +           if (   (strncmp (newstring, newenvp[i], n) == 0)
    +-              && (('=' == newenvp[i][n]) || ('\0' == newenvp[i][n]))) {
    ++              && !strcspn(newenvp[i] + n, "=")) {
    +                   break;
    +           }
    +   }
    +
      ## lib/getdef.c ##
     @@
      #include "string/sprintf/aprintf.h"
    @@ src/useradd.c: static void process_flags (int argc, char **argv, struct option_f
                                     && !streq(optarg, "/usr/sbin/nologin")
                                     && (   stat(optarg, &st) != 0
     
    + ## src/userdel.c ##
    +@@ src/userdel.c: static void user_cancel (const char *user)
    + #ifdef EXTRA_CHECK_HOME_DIR
    + static bool path_prefix (const char *s1, const char *s2)
    + {
    +-  return (   strprefix(s2, s1)
    +-          && (   ('\0' == s2[strlen (s1)])
    +-              || ('/'  == s2[strlen (s1)])));
    ++  return strprefix(s2, s1) && !strcspn(s2 + strlen(s1), "/");
    + }
    + #endif                            /* EXTRA_CHECK_HOME_DIR */
    + 
    +
      ## src/usermod.c ##
     @@ src/usermod.c: process_flags(int argc, char **argv, struct option_flags *flags)
                                }
3:  8f7313588 = 3:  fea4c8c07 lib/env.c: Use strcspn(3) to calculate the length of a substring
```
</details>

<details>
<summary>v6b</summary>

-  Rebase

```
$ git rd -U0
1:  5ed7768d03ed ! 1:  093df048163e lib/, src/: Use strspn(3) instead of its pattern
    @@ lib/encrypt.c
    - #include "shadowlog_internal.h"
    + #include "shadowlog.h"
    @@ src/passwd.c
    - #include "string/memset/memzero.h"
    @@ src/passwd.c
    + #include "string/sprintf/snprintf.h"
    @@ src/su.c
    + #include "shadowlog.h"
    @@ src/su.c
    - #include "string/sprintf/snprintf.h"
    @@ src/usermod.c: usage (int status)
    -  */
    - static char *new_pw_passwd (char *pw_pass)
    + static char *
    + new_pw_passwd(char *pw_pass, bool process_selinux)
2:  0725088afd31 = 2:  db65689bb482 lib/, src/: Use strcspn(3) instead of its pattern
3:  fea4c8c0739c = 3:  488a3faf34c8 lib/env.c: Use strcspn(3) to calculate the length of a substring
```
</details>

<details>
<summary>v7</summary>

-  Replace one more case by strspn(3).

```
$ git rd
1:  093df048 ! 1:  15567cf0 lib/, src/: Use strspn(3) instead of its pattern
    @@ lib/ttytype.c: void ttytype (const char *line)
                stpsep(buf, "\n");
      
     
    + ## lib/utmp.c ##
    +@@ lib/utmp.c: is_my_tty(const char tty[UTX_LINESIZE])
    +   char  my_tty[countof(full_tty)];
    + 
    +   stpcpy(full_tty, "");
    +-  if (tty[0] != '/')
    ++  if (!strspn(tty, "/"))
    +           strcpy (full_tty, "/dev/");
    +   strncat(full_tty, tty, UTX_LINESIZE);
    + 
    +
      ## lib/yesno.c ##
     @@
      #include <stdlib.h>
2:  db65689b = 2:  19c11518 lib/, src/: Use strcspn(3) instead of its pattern
3:  488a3faf = 3:  356f6f29 lib/env.c: Use strcspn(3) to calculate the length of a substring
```
</details>

<details>
<summary>v7b</summary>

-  Rebase

```
$ git rd 
1:  15567cf0 ! 1:  d26153a4 lib/, src/: Use strspn(3) instead of its pattern
    @@ lib/sub.c: void subsystem (const struct passwd *pw)
     -  if (pw->pw_dir[0] != '/') {
     +  if (!strspn(pw->pw_dir, "/")) {
                printf (_("Invalid root directory '%s'\n"), pw->pw_dir);
    -           SYSLOG ((LOG_WARN, BAD_SUBROOT2, pw->pw_dir, pw->pw_name));
    +           SYSLOG(LOG_WARN, BAD_SUBROOT2, pw->pw_dir, pw->pw_name);
                closelog ();
     
      ## lib/ttytype.c ##
    @@ src/login.c: int main (int argc, char **argv)
     
      ## src/login_nopam.c ##
     @@ src/login_nopam.c: login_access(const char *user, const char *from)
    -                                    TABLE, lineno));
    +                                  TABLE, lineno);
                                continue;
                        }
     -                  if (perm[0] != '+' && perm[0] != '-') {
     +                  if (!strspn(perm, "+-")) {
    -                           SYSLOG ((LOG_ERR,
    -                                    "%s: line %jd: bad first field",
    -                                    TABLE, lineno));
    +                           SYSLOG(LOG_ERR, "%s: line %jd: bad first field",
    +                                   TABLE, lineno);
    +                           continue;
     @@ src/login_nopam.c: login_access(const char *user, const char *from)
                int err = errno;
    -           SYSLOG ((LOG_ERR, "cannot open %s: %s", TABLE, strerror (err)));
    +           SYSLOG(LOG_ERR, "cannot open %s: %s", TABLE, strerror(err));
        }
     -  return (!match || strprefix(line, "+"))?1:0;
     +  return (!match || strspn(line, "+"))?1:0;
    @@ src/usermod.c: usage (int status)
                audit_logger (AUDIT_USER_CHAUTHTOK,
                              "updating-passwd", user_newname, user_newid, 1);
      #endif
    -           SYSLOG ((LOG_INFO, "lock user '%s' password", user_newname));
    +           SYSLOG(LOG_INFO, "lock user '%s' password", user_newname);
                pw_pass = xaprintf("!%s", pw_pass);
     -  } else if (Uflg && strprefix(pw_pass, "!")) {
     +  } else if (Uflg && strspn(pw_pass, "!")) {
2:  19c11518 ! 2:  32ce45c9 lib/, src/: Use strcspn(3) instead of its pattern
    @@ lib/setupenv.c: static void read_env_file (const char *filename)
     
      ## src/login_nopam.c ##
     @@ src/login_nopam.c: login_access(const char *user, const char *from)
    -                                    TABLE, lineno));
    +                                   TABLE, lineno);
                                continue;
                        }
     -                  if (strprefix(line, "#")) {
3:  356f6f29 = 3:  ff672745 lib/env.c: Use strcspn(3) to calculate the length of a substring
```
</details>

<details>
<summary>v7c</summary>

-  Rebase

```
$ git rd 
1:  d26153a4 = 1:  889d9452 lib/, src/: Use strspn(3) instead of its pattern
2:  32ce45c9 = 2:  3d1e8858 lib/, src/: Use strcspn(3) instead of its pattern
3:  ff672745 = 3:  0b2e4eaa lib/env.c: Use strcspn(3) to calculate the length of a substring
```
</details>

<details>
<summary>v7d</summary>

-  Rebase

```
$ git rd 
1:  889d9452 ! 1:  f7165ef5 lib/, src/: Use strspn(3) instead of its pattern
    @@ lib/prefix_flag.c
      #include <stdio.h>
     +#include <string.h>
      
    - #include <assert.h>
    - 
    + #include "atoi/getnum.h"
    + #include "defines.h"
     @@ lib/prefix_flag.c: extern const char* process_prefix_flag (const char* short_opt, int argc, char **
                        return ""; /* if prefix is "/" then we ignore the flag option */
                /* should we prevent symbolic link from being used as a prefix? */
    @@ lib/ttytype.c
     @@ lib/ttytype.c: void ttytype (const char *line)
                return;
        }
    -   while (fgets(buf, sizeof(buf), fp) != NULL) {
    +   while (fgets_a(buf, fp) != NULL) {
     -          if (strprefix(buf, "#")) {
     +          if (strspn(buf, "#"))
                        continue;
    @@ src/login.c
     +#include <string.h>
      #include <sys/stat.h>
      #include <sys/ioctl.h>
    - #include <assert.h>
    + 
     @@
      #include "string/sprintf/snprintf.h"
      #include "string/strcmp/streq.h"
2:  3d1e8858 ! 2:  c43da936 lib/, src/: Use strcspn(3) instead of its pattern
    @@ lib/limits.c
     @@ lib/limits.c: static int setup_user_limits (const char *uname)
         * FIXME: a better (smarter) checking should be done
         */
    -   while (fgets (buf, 1024, fil) != NULL) {
    +   while (fgets_a(buf, fil) != NULL) {
     -          if (strprefix(buf, "#") || strprefix(buf, "\n")) {
     +          if (!strcspn(buf, "#\n"))
                        continue;
    @@ lib/port.c: next:
     
      ## lib/setupenv.c ##
     @@
    - 
    - #ident "$Id$"
    - 
    --#include <assert.h>
    -+#include <ctype.h>
    -+#include <pwd.h>
    + #include <ctype.h>
    + #include <pwd.h>
      #include <stddef.h>
     +#include <stdio.h>
     +#include <string.h>
      #include <sys/types.h>
      #include <sys/stat.h>
     -#include <stdio.h>
    --#include <ctype.h>
      
      #include "prototypes.h"
      #include "defines.h"
    --#include <pwd.h>
    - #include "getdef.h"
    +@@
      #include "shadowlog.h"
      #include "string/sprintf/aprintf.h"
      #include "string/strcmp/streq.h"
    @@ src/login_nopam.c: login_access(const char *user, const char *from)
     
      ## src/suauth.c ##
     @@
    - #include "defines.h"
    + #include "io/fgets/fgets.h"
      #include "prototypes.h"
      #include "string/strcmp/streq.h"
     -#include "string/strcmp/strprefix.h"
3:  0b2e4eaa = 3:  fbc94cbf lib/env.c: Use strcspn(3) to calculate the length of a substring
```
</details>

<details>
<summary>v7e</summary>

-  Rebase

```
$ git rd 
1:  f7165ef57d13 ! 1:  d909b7fdbd16 lib/, src/: Use strspn(3) instead of its pattern
    @@ Commit message
      ## lib/commonio.c ##
     @@
      #include "string/sprintf/aprintf.h"
    - #include "string/sprintf/snprintf.h"
    + #include "string/sprintf/stprintf.h"
      #include "string/strcmp/streq.h"
     -#include "string/strcmp/strprefix.h"
      #include "string/strerrno.h"
    @@ lib/limits.c: static int setup_user_limits (const char *uname)
     
      ## lib/port.c ##
     @@
    - #include "port.h"
      #include "prototypes.h"
    + #include "string/ctype/isascii.h"
      #include "string/strcmp/streq.h"
     -#include "string/strcmp/strprefix.h"
      #include "string/strtok/stpsep.h"
    @@ src/login.c
      #include <sys/ioctl.h>
      
     @@
    - #include "string/sprintf/snprintf.h"
    + #include "string/sprintf/stprintf.h"
      #include "string/strcmp/streq.h"
      #include "string/strcmp/strneq.h"
     -#include "string/strcmp/strprefix.h"
    @@ src/passwd.c
      
     @@
      #include "string/sprintf/aprintf.h"
    - #include "string/sprintf/snprintf.h"
    + #include "string/sprintf/stprintf.h"
      #include "string/strcmp/streq.h"
     -#include "string/strcmp/strprefix.h"
      #include "string/strcpy/strtcpy.h"
    @@ src/sulogin.c: main(int argc, char *argv[])
     
      ## src/useradd.c ##
     @@
    - #include "string/sprintf/snprintf.h"
    + #include "string/sprintf/stprintf.h"
      #include "string/strcmp/strcaseeq.h"
      #include "string/strcmp/streq.h"
     -#include "string/strcmp/strprefix.h"
    @@ src/useradd.c: static void process_flags (int argc, char **argv, struct option_f
                                                 _("%s: invalid home directory '%s'\n"),
                                                 Prog, optarg);
     @@ src/useradd.c: static void create_home(const struct option_flags *flags)
    -    */
    -   for (cp = strtok(bhome, "/"); cp != NULL; cp = strtok(NULL, "/")) {
    +           bool  dir_created;
    + 
                /* Avoid turning a relative path into an absolute path. */
     -          if (strprefix(bhome, "/") || !streq(path, ""))
     +          if (strspn(bhome, "/") || !streq(path, ""))
2:  c43da9364266 ! 2:  73b541f33526 lib/, src/: Use strcspn(3) instead of its pattern
    @@ lib/limits.c: static int setup_user_limits (const char *uname)
     
      ## lib/nss.c ##
     @@
    - #include "string/sprintf/snprintf.h"
    + #include "string/sprintf/stprintf.h"
      #include "string/strcmp/strcaseprefix.h"
      #include "string/strcmp/streq.h"
     -#include "string/strcmp/strprefix.h"
    @@ lib/nss.c
      #include "string/strtok/stpsep.h"
      
     @@ lib/nss.c: nss_init(const char *nsswitch_path) {
    -   }
    -   p = NULL;
    -   while (getline(&line, &len, nssfp) != -1) {
    +                   fprintf(log_get_logfd(), "%s: Non-text file.\n", nsswitch_path);
    +                   goto null_subid;
    +           }
     -          if (strprefix(line, "#"))
     +          if (!strcspn(line, "#"))
                        continue;
    -           if (strlen(line) < 8)
    +           if (strlen(line) < 7)
                        continue;
     
      ## lib/port.c ##
3:  fbc94cbfc126 = 3:  2e25711d15d3 lib/env.c: Use strcspn(3) to calculate the length of a substring
```
</details>

<details>
<summary>v7f</summary>

-  Rebase

```
$ git rd -U0
1:  d909b7fdbd16 ! 1:  d706cb2ab6ae lib/, src/: Use strspn(3) instead of its pattern
    @@ lib/commonio.c
    - #include "string/strerrno.h"
    @@ lib/commonio.c
    + #undef NDEBUG
    @@ src/login.c
    - #include "string/strerrno.h"
    + #include "string/strftime.h"
    @@ src/login_nopam.c: login_access(const char *user, const char *from)
    -           int err = errno;
    -           SYSLOG(LOG_ERR, "cannot open %s: %s", TABLE, strerror(err));
    +   } else if (errno != ENOENT) {
    +           SYSLOGE(LOG_ERR, "cannot open %s", TABLE);
    @@ src/newgrp.c: int main (int argc, char **argv)
    -                   if (!is_valid_group_name (argv[0])) {
    -                           fprintf (
    -                                   stderr, _("%s: provided group is not a valid group name\n"),
    +                   if (!is_valid_group_name(argv[0])) {
    +                           eprintf(_("%s: provided group is not a valid group name\n"),
    +                                   Prog);
    @@ src/newusers.c: int main (int argc, char **argv)
    -                           fprintf(stderr,
    -                                   _("%s: line %jd: homedir must be an absolute path\n"),
    +                           eprintf(_("%s: line %jd: homedir must be an absolute path\n"),
    @@ src/newusers.c: int main (int argc, char **argv)
    +                           fail_exit (EXIT_FAILURE, process_selinux);
    @@ src/passwd.c
    - #include "string/strerrno.h"
    + #include "time/day_to_str.h"
    @@ src/passwd.c: static void check_password (const struct passwd *pw, const struct
    -    * changed. Passwords which have been inactive too long cannot be
    -    * changed.
    +    * locked may not be changed.
    +    * Passwords which have been inactive too long cannot be changed.
    @@ src/passwd.c: static void check_password (const struct passwd *pw, const struct
    -       || (exp_status > 1)
    -       || (   (sp->sp_max >= 0)
    -           && (sp->sp_min > sp->sp_max))) {
    +       || (exp_status > 1)) {
    +           eprintf(_("The password for %s cannot be changed.\n"),
    +                           sp->sp_namp);
    @@ src/passwd.c: static char *update_crypt_pw (char *cp, bool process_selinux)
    -                   (void) fprintf (stderr,
    -                                   _("%s: unlocking the password would result in a passwordless account.\n"
    +                   (void) eprintf(_("%s: unlocking the password would result in a passwordless account.\n"
    +                                    "You should set a password with usermod -p to unlock the password of this account.\n"),
    @@ src/useradd.c
    - #include "string/strerrno.h"
    @@ src/useradd.c
    + #include "sysconf.h"
    @@ src/useradd.c: static void process_flags (int argc, char **argv, struct option_f
    -+                              || !strspn(optarg, "/")) {
    -                                   fprintf (stderr,
    -                                            _("%s: invalid base directory '%s'\n"),
    ++                              || !strspn(optarg, "/"))
    ++                          {
    +                                   eprintf(_("%s: invalid base directory '%s'\n"),
    @@ src/useradd.c: static void process_flags (int argc, char **argv, struct option_f
    +                                   exit (E_BAD_ARG);
    @@ src/useradd.c: static void process_flags (int argc, char **argv, struct option_f
    -+                              || !strspn(optarg, "/")) {
    -                                   fprintf (stderr,
    -                                            _("%s: invalid home directory '%s'\n"),
    ++                              || !strspn(optarg, "/"))
    ++                          {
    +                                   eprintf(_("%s: invalid home directory '%s'\n"),
    @@ src/useradd.c: static void process_flags (int argc, char **argv, struct option_f
    +                                   exit (E_BAD_ARG);
    @@ src/usermod.c
    - #include "string/strerrno.h"
    @@ src/usermod.c
    + #include "sysconf.h"
    @@ src/usermod.c: usage (int status)
    -                   fprintf (stderr,
    -                            _("%s: unlocking the user's password would result in a passwordless account.\n"
    +                   eprintf(_("%s: unlocking the user's password would result in a passwordless account.\n"
    +                             "You should set a password with usermod -p to unlock this user's password.\n"),
2:  73b541f33526 ! 2:  597026fd9301 lib/, src/: Use strcspn(3) instead of its pattern
    @@ src/suauth.c
    - #include "io/fgets/fgets.h"
    + #include "io/syslog.h"
    @@ src/useradd.c: static void process_flags (int argc, char **argv, struct option_f
    -+                              || strcspn(optarg, "/*")) {
    -                                   fprintf (stderr,
    -                                            _("%s: invalid shell '%s'\n"),
    ++                              || strcspn(optarg, "/*"))
    ++                          {
    +                                   eprintf(_("%s: invalid shell '%s'\n"),
    @@ src/usermod.c: process_flags(int argc, char **argv, struct option_flags *flags)
    -                                   fprintf (stderr,
    -                                            _("%s: homedir must be an absolute path\n"),
    +                                   eprintf(_("%s: homedir must be an absolute path\n"),
    @@ src/usermod.c: process_flags(int argc, char **argv, struct option_flags *flags)
    +                                   exit (E_BAD_ARG);
    @@ src/usermod.c: process_flags(int argc, char **argv, struct option_flags *flags)
    -+                              || strcspn(optarg, "/*")) {
    -                                   fprintf (stderr,
    -                                            _("%s: invalid shell '%s'\n"),
    ++                              || strcspn(optarg, "/*"))
    ++                          {
    +                                   eprintf(_("%s: invalid shell '%s'\n"),
3:  2e25711d15d3 = 3:  3360d3a2b870 lib/env.c: Use strcspn(3) to calculate the length of a substring
```
</details>

<details>
<summary>v7g</summary>

-  Rebase

```
$ git rd 
1:  d706cb2ab6ae ! 1:  982af40c9089 lib/, src/: Use strspn(3) instead of its pattern
    @@ src/login.c
      #include <sys/ioctl.h>
      
     @@
    + #include "shadowlog.h"
      #include "string/sprintf/stprintf.h"
      #include "string/strcmp/streq.h"
    - #include "string/strcmp/strneq.h"
     -#include "string/strcmp/strprefix.h"
      #include "string/strcpy/strtcpy.h"
      #include "string/strdup/strdup.h"
    @@ src/passwd.c
     -#include "string/strcmp/strprefix.h"
      #include "string/strcpy/strtcpy.h"
      #include "string/strdup/strdup.h"
    - #include "time/day_to_str.h"
    + #include "string/strzero/strzero.h"
     @@ src/passwd.c: static void check_password (const struct passwd *pw, const struct spwd *sp, bool
         * locked may not be changed.
         * Passwords which have been inactive too long cannot be changed.
    @@ src/useradd.c: static void create_home(const struct option_flags *flags)
     
      ## src/usermod.c ##
     @@
    - #include "string/memset/memzero.h"
    + #include "sssd.h"
      #include "string/sprintf/aprintf.h"
      #include "string/strcmp/streq.h"
     -#include "string/strcmp/strprefix.h"
2:  597026fd9301 = 2:  b7b9003ff4d5 lib/, src/: Use strcspn(3) instead of its pattern
3:  3360d3a2b870 = 3:  482d419f170a lib/env.c: Use strcspn(3) to calculate the length of a substring
```
</details>