### PR TITLE
src/usermod.c: $user_home: Remove all trailing '/'s

### DIFF
--- a/src/usermod.c
+++ b/src/usermod.c
@@ -28,6 +28,7 @@
 #endif				/* ACCT_TOOLS_SETUID */
 #include <paths.h>
 #include <stdio.h>
+#include <string.h>
 #include <strings.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -68,6 +69,7 @@
 #include "string/strcmp/strprefix.h"
 #include "string/strdup/strdup.h"
 #include "string/strerrno.h"
+#include "string/strspn/stprspn.h"
 #include "time/day_to_str.h"
 #include "typetraits.h"
 
@@ -547,10 +549,8 @@ static void new_pwent (struct passwd *pwent, bool process_selinux)
 		         "change user '%s' home from '%s' to '%s'",
 		         pwent->pw_name, pwent->pw_dir, user_newhome));
 
-		if (strlen(user_newhome) > 1
-			&& '/' == user_newhome[strlen(user_newhome)-1]) {
-			user_newhome[strlen(user_newhome)-1]='\0';
-		}
+		if (!streq(user_newhome, ""))
+			stpcpy(stprspn(user_newhome + 1, "/"), "");
 
 		pwent->pw_dir = user_newhome;
 	}


### PR DESCRIPTION
FTR: I'm not entirely sure if an empty string can arrive here.  It might be that the streq() check is dead code, but I'm not sure, so I put it. It also makes the code more robust.

---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git rd 
1:  5290b783 ! 1:  e6df54ea src/usermod.c: $user_newhome: Remove all trailing '/'s
    @@ src/usermod.c
      #include "time/day_to_str.h"
      #include "typetraits.h"
      
    -@@ src/usermod.c: static void new_pwent (struct passwd *pwent)
    +@@ src/usermod.c: static void new_pwent (struct passwd *pwent, bool process_selinux)
                         "change user '%s' home from '%s' to '%s'",
                         pwent->pw_name, pwent->pw_dir, user_newhome));
      
```
</details>

<details>
<summary>v1c</summary>

-  Rebase

```
$ git rd 
1:  e6df54ea ! 1:  89a8623f src/usermod.c: $user_newhome: Remove all trailing '/'s
    @@ src/usermod.c
     @@
      #include "string/strcmp/streq.h"
      #include "string/strcmp/strprefix.h"
    - #include "string/strdup/xstrdup.h"
    + #include "string/strdup/strdup.h"
     +#include "string/strspn/stprspn.h"
      #include "time/day_to_str.h"
      #include "typetraits.h"
```
</details>

<details>
<summary>v1d</summary>

-  Rebase

```
$ git rd 
1:  89a8623f8 ! 1:  2bd9ba838 src/usermod.c: $user_newhome: Remove all trailing '/'s
    @@ src/usermod.c
      #include <sys/stat.h>
      #include <sys/types.h>
     @@
    - #include "string/strcmp/streq.h"
      #include "string/strcmp/strprefix.h"
      #include "string/strdup/strdup.h"
    + #include "string/strerrno.h"
     +#include "string/strspn/stprspn.h"
      #include "time/day_to_str.h"
      #include "typetraits.h"
```
</details>

<details>
<summary>v1e</summary>

-  Rebase

```
$ git rd 
1:  2bd9ba838 = 1:  d81d5a0c9 src/usermod.c: $user_newhome: Remove all trailing '/'s
```
</details>