### PR TITLE
Generalize const_cast(), and use it more.

### DIFF
--- a/lib/atoi/a2i.h
+++ b/lib/atoi/a2i.h
@@ -13,6 +13,7 @@
 
 #include "atoi/strtoi/strtoi.h"
 #include "atoi/strtoi/strtou_noneg.h"
+#include "cast.h"
 #include "typetraits.h"
 
 
@@ -35,7 +36,7 @@
 		unsigned int:       strtou_noneg,                     \
 		unsigned long:      strtou_noneg,                     \
 		unsigned long long: strtou_noneg                      \
-	)(s, (char **) endp_, base, min_, max_, &status);             \
+	)(s, const_cast(char **, endp_), base, min_, max_, &status);  \
 	                                                              \
 	if (status != 0)                                              \
 		errno = status;                                       \

--- a/lib/cast.h
+++ b/lib/cast.h
@@ -9,7 +9,7 @@
 #include "config.h"
 
 
-#define const_cast(T, p)  _Generic(p, const T:  (T) (p))
+#define const_cast(T, p)  _Generic(p, const T: (T) (p), default: (p))
 
 
 #endif  // include guard

--- a/lib/string/strcmp/strcaseprefix.h
+++ b/lib/string/strcmp/strcaseprefix.h
@@ -13,22 +13,14 @@
 
 #include "attr.h"
 #include "cast.h"
+#include "typetraits.h"
 
 
-// string case-insensitive prefix
+// strcaseprefix - string case-insensitive prefix
 #define strcaseprefix(s, prefix)                                      \
-({                                                                    \
-	const char  *p_;                                              \
-	                                                              \
-	p_ = strcaseprefix_(s, prefix);                               \
-	                                                              \
-	_Generic(s,                                                   \
-		const char *:                     p_,                 \
-		const void *:                     p_,                 \
-		char *:        const_cast(char *, p_),                \
-		void *:        const_cast(char *, p_)                 \
-	);                                                            \
-})
+(                                                                     \
+	const_cast(QChar_of(s) *, strcaseprefix_(s, prefix))          \
+)
 
 
 ATTR_STRING(1) ATTR_STRING(2)

--- a/lib/string/strcmp/strprefix.h
+++ b/lib/string/strcmp/strprefix.h
@@ -13,22 +13,14 @@
 
 #include "attr.h"
 #include "cast.h"
+#include "typetraits.h"
 
 
-// string prefix
+// strprefix - string prefix
 #define strprefix(s, prefix)                                          \
-({                                                                    \
-	const char  *p_;                                              \
-	                                                              \
-	p_ = strprefix_(s, prefix);                                   \
-	                                                              \
-	_Generic(s,                                                   \
-		const char *:                     p_,                 \
-		const void *:                     p_,                 \
-		char *:        const_cast(char *, p_),                \
-		void *:        const_cast(char *, p_)                 \
-	);                                                            \
-})
+(                                                                     \
+	const_cast(QChar_of(s) *, strprefix_(s, prefix))              \
+)
 
 
 ATTR_STRING(1)


### PR DESCRIPTION
---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git rd 
1:  ce42f9144 = 1:  2c3f13ec1 lib/cast.h: const_cast(): Pass through other types
2:  76d74d912 = 2:  fea4e1cea lib/atoi/a2i.h: Use const_cast() instead of a raw cast
3:  64085c62c = 3:  e92c7e61f lib/string/: Use QChar_of() to simplify some macros
```
</details>

<details>
<summary>v1c</summary>

-  Rebase

```
$ git rd 
1:  2c3f13ec1 = 1:  f03098a32 lib/cast.h: const_cast(): Pass through other types
2:  fea4e1cea = 2:  74b8aa829 lib/atoi/a2i.h: Use const_cast() instead of a raw cast
3:  e92c7e61f = 3:  226fc059e lib/string/: Use QChar_of() to simplify some macros
```
</details>

<details>
<summary>v1d</summary>

-  Rebase

```
$ git rd 
1:  f03098a32 = 1:  36b190225 lib/cast.h: const_cast(): Pass through other types
2:  74b8aa829 ! 2:  92d03967c lib/atoi/a2i.h: Use const_cast() instead of a raw cast
    @@ lib/atoi/a2i.h
                unsigned long long: strtou_noneg                      \
     -  )(s, (char **) endp_, base, min_, max_, &status);             \
     +  )(s, const_cast(char **, endp_), base, min_, max_, &status);  \
    -                                                                       \
    +                                                                 \
        if (status != 0)                                              \
                errno = status;                                       \
3:  226fc059e ! 3:  b55a55aeb lib/string/: Use QChar_of() to simplify some macros
    @@ lib/string/strcmp/strcaseprefix.h
      #define strcaseprefix(s, prefix)                                      \
     -({                                                                    \
     -  const char  *p_;                                              \
    --                                                                      \
    +-                                                                \
     -  p_ = strcaseprefix_(s, prefix);                               \
    --                                                                      \
    +-                                                                \
     -  _Generic(s,                                                   \
     -          const char *:                     p_,                 \
     -          const void *:                     p_,                 \
    @@ lib/string/strcmp/strprefix.h
      #define strprefix(s, prefix)                                          \
     -({                                                                    \
     -  const char  *p_;                                              \
    --                                                                      \
    +-                                                                \
     -  p_ = strprefix_(s, prefix);                                   \
    --                                                                      \
    +-                                                                \
     -  _Generic(s,                                                   \
     -          const char *:                     p_,                 \
     -          const void *:                     p_,                 \
```
</details>

<details>
<summary>v1e</summary>

-  Rebase

```
$ git rd 
1:  36b190225452 = 1:  dbedfb1d387a lib/cast.h: const_cast(): Pass through other types
2:  92d03967cf26 = 2:  ec48e1275c11 lib/atoi/a2i.h: Use const_cast() instead of a raw cast
3:  b55a55aebc5d = 3:  95240c20c060 lib/string/: Use QChar_of() to simplify some macros
```
</details>

<details>
<summary>v1f</summary>

-  Rebase

```
$ git rd 
1:  dbedfb1d = 1:  c2bb0e09 lib/cast.h: const_cast(): Pass through other types
2:  ec48e127 = 2:  e4cdcf42 lib/atoi/a2i.h: Use const_cast() instead of a raw cast
3:  95240c20 = 3:  4f994530 lib/string/: Use QChar_of() to simplify some macros
```
</details>

<details>
<summary>v1g</summary>

-  Rebase

```
$ git rd 
1:  c2bb0e09 = 1:  087bcb12 lib/cast.h: const_cast(): Pass through other types
2:  e4cdcf42 = 2:  555dbd8f lib/atoi/a2i.h: Use const_cast() instead of a raw cast
3:  4f994530 = 3:  e37687a5 lib/string/: Use QChar_of() to simplify some macros
```
</details>

<details>
<summary>v1h</summary>

-  Rebase

```
$ git rd 
1:  087bcb12 = 1:  a998e043 lib/cast.h: const_cast(): Pass through other types
2:  555dbd8f = 2:  a7f84707 lib/atoi/a2i.h: Use const_cast() instead of a raw cast
3:  e37687a5 = 3:  396b3b1a lib/string/: Use QChar_of() to simplify some macros
```
</details>

<details>
<summary>v1i</summary>

-  Rebase

```
$ git rd 
1:  a998e043848e = 1:  6c5402fee0b8 lib/cast.h: const_cast(): Pass through other types
2:  a7f84707d424 = 2:  facb44cc2119 lib/atoi/a2i.h: Use const_cast() instead of a raw cast
3:  396b3b1aba8e = 3:  aa4a07b21fcf lib/string/: Use QChar_of() to simplify some macros
```
</details>