### PR TITLE
lib/utmp.c: is_my_tty(): Simplify

### DIFF
--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -44,6 +44,9 @@
 
 #define UTX_LINESIZE  countof(memberof(struct utmpx, ut_line))
 
+// ttyname_ra - tty name re-entrant array
+#define ttyname_ra(fd, buf)  ttyname_r(fd, buf, countof(buf))
+
 
 /*
  * is_my_tty -- determine if "tty" is the same TTY stdin is using
@@ -59,7 +62,7 @@ is_my_tty(const char tty[UTX_LINESIZE])
 		strcpy (full_tty, "/dev/");
 	strncat(full_tty, tty, UTX_LINESIZE);
 
-	if (ttyname_r(STDIN_FILENO, my_tty, countof(my_tty)) != 0) {
+	if (ttyname_ra(STDIN_FILENO, my_tty) != 0) {
 		(void) puts (_("Unable to determine your tty name."));
 		exit (EXIT_FAILURE);
 	}


### PR DESCRIPTION
Let's keep it simple.

---

Revisions:

<details>
<summary>v2</summary>

-  Fix intermediate commit.  [@hallyn ]

```
$ git rd 
1:  0d6e5f800 = 1:  0d6e5f800 lib/utmp.c: is_my_tty(): Don't cache ttyname(3).
2:  fa3a25919 ! 2:  120ad06c1 lib/utmp.c: is_my_tty(): Rename local variable
    @@ lib/utmp.c: static bool
        strncat(full_tty, tty, UTX_LINESIZE);
      
     -  tmptty = ttyname(STDIN_FILENO);
    +-  if (NULL != tmptty)
     +  my_tty = ttyname(STDIN_FILENO);
    -   if (NULL != tmptty)
    ++  if (NULL != my_tty)
                (void) puts (_("Unable to determine your tty name."));
                exit (EXIT_FAILURE);
        }
3:  b7b40d6a5 ! 3:  379d10c2d lib/utmp.c: is_my_tty(): Use ttyname_r(3) to make it re-entrant
    @@ lib/utmp.c
        strncat(full_tty, tty, UTX_LINESIZE);
      
     -  my_tty = ttyname(STDIN_FILENO);
    --  if (NULL != tmptty)
    +-  if (NULL != my_tty)
     +  if (ttyname_r(STDIN_FILENO, my_tty, countof(my_tty)) != 0) {
                (void) puts (_("Unable to determine your tty name."));
                exit (EXIT_FAILURE);
4:  993fc4e7f = 4:  2fc993adb lib/utmp.c: ttyname_ra(): Add macro
```
</details>

<details>
<summary>v2b</summary>

-  Reviewed-by @hallyn 

```
$ git rd 
1:  0d6e5f800 ! 1:  a1cb667e7 lib/utmp.c: is_my_tty(): Don't cache ttyname(3).
    @@ Commit message
         ttyname(3), we use it directly, without needing a temporary copy, which
         removes opportunities for bugs.
     
    +    Reviewed-by: Serge Hallyn <serge@hallyn.com>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/utmp.c ##
2:  120ad06c1 ! 2:  c4ca166ba lib/utmp.c: is_my_tty(): Rename local variable
    @@ Commit message
     
         This name makes the function definition more readable.
     
    +    Reviewed-by: Serge Hallyn <serge@hallyn.com>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/utmp.c ##
3:  379d10c2d ! 3:  6ac300300 lib/utmp.c: is_my_tty(): Use ttyname_r(3) to make it re-entrant
    @@ Metadata
      ## Commit message ##
         lib/utmp.c: is_my_tty(): Use ttyname_r(3) to make it re-entrant
     
    +    Reviewed-by: Serge Hallyn <serge@hallyn.com>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/utmp.c ##
4:  2fc993adb ! 4:  7d02a222d lib/utmp.c: ttyname_ra(): Add macro
    @@ Commit message
     
         This macro enforces correct use of ttyname_r(3) with arrays.
     
    +    Reviewed-by: Serge Hallyn <serge@hallyn.com>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/utmp.c ##
```
</details>