### PR TITLE
tests/unit/test_exit_if_null.c: Test through XMALLOC() instead of xaprintf()

### DIFF
--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -132,7 +132,7 @@ test_typetraits_LDADD = \
 test_exit_if_null_SOURCES = \
     ../../lib/exit_if_null.c \
     ../../lib/shadowlog.c \
-    ../../lib/string/sprintf/aprintf.c \
+    ../../lib/alloc/malloc.c \
     ../../lib/string/strcmp/streq.c \
     test_exit_if_null.c \
     $(NULL)
@@ -140,7 +140,6 @@ test_exit_if_null_CFLAGS = \
     $(AM_CFLAGS) \
     $(NULL)
 test_exit_if_null_LDFLAGS = \
-    -Wl,-wrap,vasprintf \
     -Wl,-wrap,exit \
     $(NULL)
 test_exit_if_null_LDADD = \


### PR DESCRIPTION
This is a subset of <https://github.com/shadow-maint/shadow/pull/1383>.

@ikerexxe This is the minimum fix.

---

```
tests/unit/test_exit_if_null.c: Test through XMALLOC() instead of xaprintf()

Both are indirect tests for exit_if_null(), but through XMALLOC() we
can test it more robustly, as we don't need to wrap vasprintf(3) to
make it fail.  It's trivial to make MALLOC(3) fail: pass a huge size.

The tests with xaprintf() were failing on Nix.  I suspect the compiler
was inlining aggressively, and as a result, the interposition of
vasprintf(3) in cmocka wasn't actually working.  The approach with
XMALLOC() seems to work on Nix, as we don't need to interpose malloc(3).
We still need to interpose exit(3), but for some reason that works fine.
```

Closes: <https://github.com/shadow-maint/shadow/issues/1382>
Reported-by: @infinisil
Tested-by: @infinisil

---

Revisions:

<details>
<summary>v2</summary>

-  Test that pointer is not null.

```
$ git rd 
1:  b0291e99e = 1:  b0291e99e tests/unit/: Use more generic strings and names for testing exit_if_null()
2:  04617ca48 ! 2:  aed741a4c tests/unit/test_exit_if_null.c: Test through XMALLOC() instead of xaprintf()
    @@ tests/unit/test_exit_if_null.c: test_exit_if_null_ok(void **state)
        free(p);
     +
     +  p = XMALLOC(0, char);
    ++  assert_true(p != NULL);
     +  free(p);
      }
```
</details>

<details>
<summary>v2b</summary>

-  Reviewed-by: @ikerexxe 

```
$ git rd 
1:  b0291e99e ! 1:  569d9787c tests/unit/: Use more generic strings and names for testing exit_if_null()
    @@ Commit message
         test file and functions, and make strings more generic.
     
         Tested-by: Silvan Mosberger <github@infinisil.com>
    +    Reviewed-by: Iker Pedrosa <ipedrosa@redhat.com>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## tests/unit/Makefile.am ##
2:  aed741a4c ! 2:  517e01961 tests/unit/test_exit_if_null.c: Test through XMALLOC() instead of xaprintf()
    @@ Commit message
         Closes: <https://github.com/shadow-maint/shadow/issues/1382>
         Reported-by: Silvan Mosberger <github@infinisil.com>
         Tested-by: Silvan Mosberger <github@infinisil.com>
    +    Reviewed-by: Iker Pedrosa <ipedrosa@redhat.com>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## tests/unit/Makefile.am ##
```
</details>