### PR TITLE
clarify -U option in groupadd help output

### DIFF
--- a/src/groupadd.c
+++ b/src/groupadd.c
@@ -125,7 +125,8 @@ usage (int status)
 	(void) fputs (_("  -r, --system                  create a system account\n"), usageout);
 	(void) fputs (_("  -R, --root CHROOT_DIR         directory to chroot into\n"), usageout);
 	(void) fputs (_("  -P, --prefix PREFIX_DIR       directory prefix\n"), usageout);
-	(void) fputs (_("  -U, --users USERS             list of user members of this group\n"), usageout);
+	(void) fputs (_("  -U, --users USERS             comma-separated list of users to add as\n"
+			"	                         members of this group\n"), usageout);
 	(void) fputs ("\n", usageout);
 	exit (status);
 }


### PR DESCRIPTION
This PR updates the help text for the -U option in groupadd to improve clarity and reduce ambiguity.

Old text:
-U, --users USERS             list of user members of this group
New text:
-U, --users USERS             list of users to assign to the group

The previous phrasing could be misinterpreted as querying existing group members. The updated version makes it clear that this option is used to assign users when creating a new group.

This change affects only the English help output in src/groupadd.c. No functional behavior is modified
