### PR TITLE
lib/string/: strerrno(): Use statement expression to perform lvalue conversion

### DIFF
--- a/lib/string/strerrno.h
+++ b/lib/string/strerrno.h
@@ -13,7 +13,7 @@
 
 
 // strerrno - string errno
-#define strerrno()  ((const char *){strerror(errno)})
+#define strerrno()  ({(const char *){strerror(errno)};})
 
 
 #endif  // include guard


### PR DESCRIPTION
    Compound literals are lvalues.  This means it's possible to take their
    address.  That is, it would be possible (albeit nonsensical) to do
    
            &strerrno();
    
    It is also possible to assign to them (albeit also nonsensical):
    
            strerrno() = NULL;
    
    The statement expression performs lvalue conversion, which turns the
    lvalue into an "rvalue", as expected, and disallows all those issues.


---

Revisions:

<details>
<summary>v2</summary>

-  Use a statement expression.  It's a non-standard extension, but it is safer, and produces better diagnostics.

```
$ git rd 
1:  79de0c814 ! 1:  885f4356f lib/string/: strerrno(): Use 'register' to forbid taking the address of the return value
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/string/: strerrno(): Use 'register' to forbid taking the address of the return value
    +    lib/string/: strerrno(): Use statement expression to perform lvalue conversion
     
         Compound literals are lvalues.  This means it's possible to take their
         address.  That is, it would be possible (albeit nonsensical) to do
     
                 &strerrno();
     
    -    The 'register' storage-class specifier converts such code into
    -    a compiler error.
    +    It is also possible to assign to them (albeit also nonsensical):
    +
    +            strerrno() = NULL;
    +
    +    The statement expression performs lvalue conversion, which turns the
    +    lvalue into an "rvalue", as expected, and disallows all those issues.
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    @@ lib/string/strerrno.h
      
      // strerrno - string errno
     -#define strerrno()  ((const char *){strerror(errno)})
    -+#define strerrno()  ((register const char *){strerror(errno)})
    ++#define strerrno()  ({(const char *){strerror(errno)};})
      
      
      #endif  // include guard
```
</details>