### PR TITLE
Use _Maxof() and _Minof() from GCC 16

### DIFF
--- a/lib/atoi/a2i.h
+++ b/lib/atoi/a2i.h
@@ -53,7 +53,7 @@
 #define a2ul(...)   a2i(unsigned long, __VA_ARGS__)
 #define a2ull(...)  a2i(unsigned long long, __VA_ARGS__)
 
-#define str2i(T, ...)  a2i(T, __VA_ARGS__, NULL, 0, type_min(T), type_max(T))
+#define str2i(T, ...)  a2i(T, __VA_ARGS__, NULL, 0, minof(T), maxof(T))
 
 #define str2sh(...)    str2i(short, __VA_ARGS__)
 #define str2si(...)    str2i(int, __VA_ARGS__)

--- a/lib/atoi/getnum.h
+++ b/lib/atoi/getnum.h
@@ -38,21 +38,21 @@ get_fd(const char *restrict fdstr, int *restrict fd)
 inline int
 get_gid(const char *restrict gidstr, gid_t *restrict gid)
 {
-	return a2i(gid_t, gid, gidstr, NULL, 10, type_min(gid_t), type_max(gid_t));
+	return a2i(gid_t, gid, gidstr, NULL, 10, minof(gid_t), maxof(gid_t));
 }
 
 
 inline int
 get_pid(const char *restrict pidstr, pid_t *restrict pid)
 {
-	return a2i(pid_t, pid, pidstr, NULL, 10, 1, type_max(pid_t));
+	return a2i(pid_t, pid, pidstr, NULL, 10, 1, maxof(pid_t));
 }
 
 
 inline int
 get_uid(const char *restrict uidstr, uid_t *restrict uid)
 {
-	return a2i(uid_t, uid, uidstr, NULL, 10, type_min(uid_t), type_max(uid_t));
+	return a2i(uid_t, uid, uidstr, NULL, 10, minof(uid_t), maxof(uid_t));
 }
 
 

--- a/lib/limits.c
+++ b/lib/limits.c
@@ -64,7 +64,7 @@ static int setrlimit_value (unsigned int resource,
 		limit = RLIM_INFINITY;
 
 	} else {
-		if (a2i(rlim_t, &l, value, NULL, 10, 0, type_max(rlim_t)) == -1
+		if (a2i(rlim_t, &l, value, NULL, 10, 0, maxof(rlim_t)) == -1
 		    && errno != ENOTSUP)
 		{
 			return 0;  // FIXME: we could instead throw an error, though.

--- a/lib/subordinateio.c
+++ b/lib/subordinateio.c
@@ -28,6 +28,7 @@
 #include "string/sprintf/stprintf.h"
 #include "string/strcmp/streq.h"
 #include "string/strtok/strsep2arr.h"
+#include "typetraits.h"
 
 
 #define ID_SIZE 31
@@ -1044,7 +1045,7 @@ bool new_subid_range(struct subordinate_range *range, enum subid_type id_type, b
 		}
 	}
 
-	start = find_free_range(db, range->start, -1, range->count);
+	start = find_free_range(db, range->start, maxof(id_t), range->count);
 	if (start == -1) {
 		ret = false;
 		goto out;

--- a/lib/typetraits.h
+++ b/lib/typetraits.h
@@ -11,36 +11,12 @@
 #include "sizeof.h"
 
 
-#define is_unsigned(x)                                                        \
-(                                                                             \
-	(typeof(x)) -1 > 1                                                    \
-)
-
-#define is_signed(x)                                                          \
-(                                                                             \
-	(typeof(x)) -1 < 1                                                    \
-)
-
-
-#define stype_max(T)                                                          \
-(                                                                             \
-	(T) (((((T) 1 << (WIDTHOF(T) - 2)) - 1) << 1) + 1)                    \
-)
-
-#define utype_max(T)                                                          \
-(                                                                             \
-	(T) -1                                                                \
-)
-
-#define type_max(T)                                                           \
-(                                                                             \
-	(T) (is_signed(T) ? stype_max(T) : utype_max(T))                      \
-)
-
-#define type_min(T)                                                           \
-(                                                                             \
-	(T) ~type_max(T)                                                      \
-)
+# define is_unsigned(x)  ((typeof(x)) -1 > 1)
+# define is_signed(x)    ((typeof(x)) -1 < 1)
+# define stype_max(T)    ((T) (((((T) 1 << (WIDTHOF(T) - 2)) - 1) << 1) + 1))
+# define utype_max(T)    ((T) -1)
+# define type_max(T)     ((T) (is_signed(T) ? stype_max(T) : utype_max(T)))
+# define type_min(T)     ((T) ~type_max(T))
 
 
 #define is_same_type(a, b)                                                    \

--- a/lib/typetraits.h
+++ b/lib/typetraits.h
@@ -15,8 +15,8 @@
 # define is_signed(x)    ((typeof(x)) -1 < 1)
 # define stype_max(T)    ((T) (((((T) 1 << (WIDTHOF(T) - 2)) - 1) << 1) + 1))
 # define utype_max(T)    ((T) -1)
-# define type_max(T)     ((T) (is_signed(T) ? stype_max(T) : utype_max(T)))
-# define type_min(T)     ((T) ~type_max(T))
+# define maxof(T)        ((T) (is_signed(T) ? stype_max(T) : utype_max(T)))
+# define minof(T)        ((T) ~maxof(T))
 
 
 #define is_same_type(a, b)                                                    \

--- a/lib/typetraits.h
+++ b/lib/typetraits.h
@@ -11,12 +11,17 @@
 #include "sizeof.h"
 
 
+#if (__GNUC__ >= 16)
+# define maxof(T)  _Maxof(T)
+# define minof(T)  _Minof(T)
+#else
 # define is_unsigned(x)  ((typeof(x)) -1 > 1)
 # define is_signed(x)    ((typeof(x)) -1 < 1)
 # define stype_max(T)    ((T) (((((T) 1 << (WIDTHOF(T) - 2)) - 1) << 1) + 1))
 # define utype_max(T)    ((T) -1)
 # define maxof(T)        ((T) (is_signed(T) ? stype_max(T) : utype_max(T)))
 # define minof(T)        ((T) ~maxof(T))
+#endif
 
 
 #define is_same_type(a, b)                                                    \

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -326,15 +326,15 @@ getid_range(const char *str)
 	id_t             first, last;
 	const char       *pos;
 	struct id_range  result = {
-		.first = type_max(id_t),
-		.last = type_min(id_t)
+		.first = maxof(id_t),
+		.last = minof(id_t)
 	};
 
 	static_assert(is_same_type(id_t, uid_t), "");
 	static_assert(is_same_type(id_t, gid_t), "");
 
-	first = type_min(id_t);
-	last = type_max(id_t);
+	first = minof(id_t);
+	last = maxof(id_t);
 
 	if (a2i(id_t, &first, str, &pos, 10, first, last) == -1
 	    && errno != ENOTSUP)

--- a/tests/unit/test_typetraits.c
+++ b/tests/unit/test_typetraits.c
@@ -13,16 +13,17 @@
 #include "typetraits.h"
 #include "attr.h"
 
-static void test_type_max(MAYBE_UNUSED void ** _1);
-static void test_type_min(MAYBE_UNUSED void ** _1);
+
+static void test_maxof(MAYBE_UNUSED void ** _1);
+static void test_minof(MAYBE_UNUSED void ** _1);
 
 
 int
 main(void)
 {
 	const struct CMUnitTest  tests[] = {
-		cmocka_unit_test(test_type_max),
-		cmocka_unit_test(test_type_min),
+		cmocka_unit_test(test_maxof),
+		cmocka_unit_test(test_minof),
 	};
 
 	return cmocka_run_group_tests(tests, NULL, NULL);
@@ -30,26 +31,26 @@ main(void)
 
 
 static void
-test_type_max(MAYBE_UNUSED void ** _1)
+test_maxof(MAYBE_UNUSED void ** _1)
 {
-	assert_true(type_max(long) == LONG_MAX);
-	assert_true(type_max(unsigned long) == ULONG_MAX);
-	assert_true(type_max(int) == INT_MAX);
-	assert_true(type_max(unsigned short) == USHRT_MAX);
-	assert_true(type_max(char) == CHAR_MAX);
-	assert_true(type_max(signed char) == SCHAR_MAX);
-	assert_true(type_max(unsigned char) == UCHAR_MAX);
+	assert_true(maxof(long) == LONG_MAX);
+	assert_true(maxof(unsigned long) == ULONG_MAX);
+	assert_true(maxof(int) == INT_MAX);
+	assert_true(maxof(unsigned short) == USHRT_MAX);
+	assert_true(maxof(char) == CHAR_MAX);
+	assert_true(maxof(signed char) == SCHAR_MAX);
+	assert_true(maxof(unsigned char) == UCHAR_MAX);
 }
 
 
 static void
-test_type_min(MAYBE_UNUSED void ** _1)
+test_minof(MAYBE_UNUSED void ** _1)
 {
-	assert_true(type_min(long) == LONG_MIN);
-	assert_true(type_min(unsigned long) == 0);
-	assert_true(type_min(int) == INT_MIN);
-	assert_true(type_min(unsigned short) == 0);
-	assert_true(type_min(char) == CHAR_MIN);
-	assert_true(type_min(signed char) == SCHAR_MIN);
-	assert_true(type_min(unsigned char) == 0);
+	assert_true(minof(long) == LONG_MIN);
+	assert_true(minof(unsigned long) == 0);
+	assert_true(minof(int) == INT_MIN);
+	assert_true(minof(unsigned short) == 0);
+	assert_true(minof(char) == CHAR_MIN);
+	assert_true(minof(signed char) == SCHAR_MIN);
+	assert_true(minof(unsigned char) == 0);
 }


### PR DESCRIPTION
---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git rd 
1:  55c2398fa = 1:  5c8d3a9da lib/typetraits.h: Compact macros
2:  9cdf46223 ! 2:  fff6a1660 */: Rename type_min() => minof(), type_max() => maxof()
    @@ Commit message
         Link: <https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3628.txt>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    + ## lib/atoi/a2i.h ##
    +@@
    + #define a2ul(...)   a2i(unsigned long, __VA_ARGS__)
    + #define a2ull(...)  a2i(unsigned long long, __VA_ARGS__)
    + 
    +-#define str2i(T, ...)  a2i(T, __VA_ARGS__, NULL, 0, type_min(T), type_max(T))
    ++#define str2i(T, ...)  a2i(T, __VA_ARGS__, NULL, 0, minof(T), maxof(T))
    + 
    + #define str2sh(...)    str2i(short, __VA_ARGS__)
    + #define str2si(...)    str2i(int, __VA_ARGS__)
    +
      ## lib/atoi/getnum.h ##
     @@ lib/atoi/getnum.h: get_fd(const char *restrict fdstr, int *restrict fd)
      inline int
    @@ lib/atoi/getnum.h: get_fd(const char *restrict fdstr, int *restrict fd)
      
      
     
    - ## lib/atoi/str2i.h ##
    -@@
    - #include "typetraits.h"
    - 
    - 
    --#define str2i(T, ...)  a2i(T, __VA_ARGS__, NULL, 0, type_min(T), type_max(T))
    -+#define str2i(T, ...)  a2i(T, __VA_ARGS__, NULL, 0, minof(T), maxof(T))
    - 
    - #define str2sh(...)    str2i(short, __VA_ARGS__)
    - #define str2si(...)    str2i(int, __VA_ARGS__)
    -
      ## lib/limits.c ##
     @@ lib/limits.c: static int setrlimit_value (unsigned int resource,
                limit = RLIM_INFINITY;
3:  094eb36a6 = 3:  d056a37ae lib/typetraits.h: maxof(), minof(): Use the compiler operators if available
```
</details>

<details>
<summary>v1c</summary>

-  Rebase

```
$ git rd 
1:  5c8d3a9da = 1:  bf096abbc lib/typetraits.h: Compact macros
2:  fff6a1660 ! 2:  8f306a93c */: Rename type_min() => minof(), type_max() => maxof()
    @@ tests/unit/test_typetraits.c
      #include "typetraits.h"
      
      
    --static void test_type_max(void **state);
    --static void test_type_min(void **state);
    -+static void test_maxof(void **state);
    -+static void test_minof(void **state);
    +-static void test_type_max(void **);
    +-static void test_type_min(void **);
    ++static void test_maxof(void **);
    ++static void test_minof(void **);
      
      
      int
    @@ tests/unit/test_typetraits.c: main(void)
      
      
      static void
    --test_type_max(void **state)
    -+test_maxof(void **state)
    +-test_type_max(void **)
    ++test_maxof(void **)
      {
     -  assert_true(type_max(long) == LONG_MAX);
     -  assert_true(type_max(unsigned long) == ULONG_MAX);
    @@ tests/unit/test_typetraits.c: main(void)
      
      
      static void
    --test_type_min(void **state)
    -+test_minof(void **state)
    +-test_type_min(void **)
    ++test_minof(void **)
      {
     -  assert_true(type_min(long) == LONG_MIN);
     -  assert_true(type_min(unsigned long) == 0);
3:  d056a37ae = 3:  a38023e4e lib/typetraits.h: maxof(), minof(): Use the compiler operators if available
```
</details>

<details>
<summary>v1d</summary>

-  Rebase.

```
$ git rd 
1:  bf096abbc = 1:  7d4b55153 lib/typetraits.h: Compact macros
2:  8f306a93c = 2:  63f484cfb */: Rename type_min() => minof(), type_max() => maxof()
3:  a38023e4e = 3:  26e3ba334 lib/typetraits.h: maxof(), minof(): Use the compiler operators if available
```
</details>

<details>
<summary>v1e</summary>

-  Rebase

```
$ git rd 
1:  7d4b55153 = 1:  c25640665 lib/typetraits.h: Compact macros
2:  63f484cfb ! 2:  f70ffdfde */: Rename type_min() => minof(), type_max() => maxof()
    @@ lib/limits.c: static int setrlimit_value (unsigned int resource,
     +          if (a2i(rlim_t, &l, value, NULL, 10, 0, maxof(rlim_t)) == -1
                    && errno != ENOTSUP)
                {
    -                   return 0;  // FIXME: We could instead throw an error, though.
    +                   return 0;  // FIXME: we could instead throw an error, though.
     
      ## lib/typetraits.h ##
     @@
3:  26e3ba334 = 3:  cb92d448a lib/typetraits.h: maxof(), minof(): Use the compiler operators if available
```
</details>

<details>
<summary>v1f</summary>

-  Rebase

```
$ git rd 
1:  c25640665 = 1:  169c43422 lib/typetraits.h: Compact macros
2:  f70ffdfde = 2:  6a1df0181 */: Rename type_min() => minof(), type_max() => maxof()
3:  cb92d448a = 3:  39cedea2d lib/typetraits.h: maxof(), minof(): Use the compiler operators if available
```
</details>

<details>
<summary>v1g</summary>

-  Rebase

```
$ git rd 
1:  169c434227f9 = 1:  bda786727787 lib/typetraits.h: Compact macros
2:  6a1df018178f = 2:  a82fa6f6d50c */: Rename type_min() => minof(), type_max() => maxof()
3:  39cedea2dd34 = 3:  76c45457a376 lib/typetraits.h: maxof(), minof(): Use the compiler operators if available
```
</details>

<details>
<summary>v1h</summary>

-  Rebase

```
$ git rd -U0
1:  bda78672 = 1:  dd4aa0ac lib/typetraits.h: Compact macros
2:  a82fa6f6 ! 2:  148a9a19 */: Rename type_min() => minof(), type_max() => maxof()
    @@ tests/unit/test_typetraits.c
    + #include "attr.h"
    @@ tests/unit/test_typetraits.c
    - 
    --static void test_type_max(void **);
    --static void test_type_min(void **);
    -+static void test_maxof(void **);
    -+static void test_minof(void **);
    +-static void test_type_max(MAYBE_UNUSED void ** _1);
    +-static void test_type_min(MAYBE_UNUSED void ** _1);
    ++
    ++static void test_maxof(MAYBE_UNUSED void ** _1);
    ++static void test_minof(MAYBE_UNUSED void ** _1);
    @@ tests/unit/test_typetraits.c: main(void)
    --test_type_max(void **)
    -+test_maxof(void **)
    +-test_type_max(MAYBE_UNUSED void ** _1)
    ++test_maxof(MAYBE_UNUSED void ** _1)
    @@ tests/unit/test_typetraits.c: main(void)
    --test_type_min(void **)
    -+test_minof(void **)
    +-test_type_min(MAYBE_UNUSED void ** _1)
    ++test_minof(MAYBE_UNUSED void ** _1)
3:  76c45457 = 3:  c0ff66f0 lib/typetraits.h: maxof(), minof(): Use the compiler operators if available
```
</details>

<details>
<summary>v1i</summary>

-  Rebase

```
$ git rd 
1:  dd4aa0ac999b = 1:  7ee5c7b05ea0 lib/typetraits.h: Compact macros
2:  148a9a196866 = 2:  6065f61c42ae */: Rename type_min() => minof(), type_max() => maxof()
3:  c0ff66f0c38e = 3:  0a6bb79adf70 lib/typetraits.h: maxof(), minof(): Use the compiler operators if available
```
</details>

<details>
<summary>v2</summary>

-  Add one more use of maxof().  [@hallyn ]

```
$ git rd 
1:  7ee5c7b05ea0 = 1:  7ee5c7b05ea0 lib/typetraits.h: Compact macros
2:  6065f61c42ae = 2:  6065f61c42ae */: Rename type_min() => minof(), type_max() => maxof()
3:  0a6bb79adf70 = 3:  0a6bb79adf70 lib/typetraits.h: maxof(), minof(): Use the compiler operators if available
-:  ------------ > 4:  c8036142b996 lib/subordinateio.c: Don't rely on id_t being unsigned
```
</details>

<details>
<summary>v2b</summary>

-  Rebase

```
$ git rd 
1:  7ee5c7b05ea0 = 1:  aba0f7e2a9d3 lib/typetraits.h: Compact macros
2:  6065f61c42ae = 2:  2ca7666b59eb */: Rename type_min() => minof(), type_max() => maxof()
3:  0a6bb79adf70 = 3:  6461a777bb2c lib/typetraits.h: maxof(), minof(): Use the compiler operators if available
4:  c8036142b996 = 4:  297600369f65 lib/subordinateio.c: Don't rely on id_t being unsigned
```
</details>

<details>
<summary>v2c</summary>

-  Reviewed-by: @hallyn 

```
$ git rd 
1:  aba0f7e2a9d3 ! 1:  9d70fc39cb1f lib/typetraits.h: Compact macros
    @@ Metadata
      ## Commit message ##
         lib/typetraits.h: Compact macros
     
    +    Reviewed-by: Serge Hallyn <serge@hallyn.com>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/typetraits.h ##
2:  2ca7666b59eb ! 2:  2a8e3919d1ed */: Rename type_min() => minof(), type_max() => maxof()
    @@ Commit message
         C Committee.
     
         Link: <https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3628.txt>
    +    Reviewed-by: Serge Hallyn <serge@hallyn.com>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/atoi/a2i.h ##
3:  6461a777bb2c ! 3:  f5f227b71f9b lib/typetraits.h: maxof(), minof(): Use the compiler operators if available
    @@ Metadata
      ## Commit message ##
         lib/typetraits.h: maxof(), minof(): Use the compiler operators if available
     
    +    Reviewed-by: Serge Hallyn <serge@hallyn.com>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/typetraits.h ##
4:  297600369f65 ! 4:  2ddb33dad19d lib/subordinateio.c: Don't rely on id_t being unsigned
    @@ Commit message
     
         Reported-by: Serge Hallyn <serge@hallyn.com>
         Fixes: de7f1c78f70f (2026-04-09; "lib/subordinateio.c: find_free_range(): Use id_t instead of u_long")
    +    Reviewed-by: Serge Hallyn <serge@hallyn.com>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/subordinateio.c ##
```
</details>