### PR TITLE
useradd: fix uninitialized flags causing aarch64 failure

### DIFF
--- a/src/useradd.c
+++ b/src/useradd.c
@@ -2440,7 +2440,10 @@ int main (int argc, char **argv)
 #endif
 	unsigned long subuid_count = 0;
 	unsigned long subgid_count = 0;
-	struct option_flags  flags;
+	struct option_flags  flags = {
+		.chroot = false,
+		.prefix = false,
+	};
 	bool process_selinux;
 
 	log_set_progname(Prog);


### PR DESCRIPTION
Initialize option_flags structure to prevent garbage memory values in `flags.chroot` and `flags.prefix` fields. Uninitialized memory caused architecture-specific failures where process_selinux evaluation differed between x86_64 and aarch64, leading to `pw_close()` failures when SELinux contexts weren't properly managed.

Fixes: c0c9485d (2025-04-25; "src/useradd.c: chroot or prefix SELinux file context")
Link: <https://bodhi.fedoraproject.org/updates/FEDORA-2025-3d835cfb15>