### PR TITLE
configure.ac, lib/, src/: Use _PATH_BSHELL instead of our own setting

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -578,8 +578,6 @@ fi
 
 AC_CHECK_FUNCS([fgetpwent_r])
 
-AC_DEFINE_UNQUOTED([SHELL], ["$SHELL"], [The default shell.])
-
 AM_GNU_GETTEXT_VERSION([0.19])
 AM_GNU_GETTEXT([external], [need-ngettext])
 AM_CONDITIONAL([USE_NLS], [test "x$USE_NLS" = "xyes"])

--- a/configure.ac
+++ b/configure.ac
@@ -575,8 +575,6 @@ fi
 
 AC_CHECK_FUNCS([fgetpwent_r])
 
-AC_DEFINE_UNQUOTED([SHELL], ["$SHELL"], [The default shell.])
-
 AM_GNU_GETTEXT_VERSION([0.19])
 AM_GNU_GETTEXT([external], [need-ngettext])
 AM_CONDITIONAL([USE_NLS], [test "x$USE_NLS" = "xyes"])

--- a/lib/setupenv.c
+++ b/lib/setupenv.c
@@ -14,6 +14,7 @@
 #include "config.h"
 
 #include <ctype.h>
+#include <paths.h>
 #include <pwd.h>
 #include <stddef.h>
 #include <sys/types.h>
@@ -136,7 +137,7 @@ void setup_env (struct passwd *info)
 
 	if ((NULL == info->pw_shell) || streq(info->pw_shell, "")) {
 		free (info->pw_shell);
-		info->pw_shell = xstrdup (SHELL);
+		info->pw_shell = xstrdup(_PATH_BSHELL);
 	}
 
 	addenv ("SHELL", info->pw_shell);

--- a/lib/shell.c
+++ b/lib/shell.c
@@ -9,10 +9,10 @@
 
 #include "config.h"
 
-#ident "$Id$"
-
-#include <stdio.h>
 #include <errno.h>
+#include <paths.h>
+#include <stdio.h>
+
 #include "prototypes.h"
 #include "defines.h"
 #include "string/sprintf/stprintf.h"
@@ -65,7 +65,7 @@ int shell (const char *file, /*@null@*/const char *arg, char *const envp[])
 		 * Assume this is a shell script (with no shebang).
 		 * Interpret it with /bin/sh
 		 */
-		(void) execle (SHELL, "sh", "-", file, (char *) NULL, envp);
+		(void) execle(_PATH_BSHELL, "sh", "-", file, (char *) NULL, envp);
 		err = errno;
 	}
 

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -12,6 +12,7 @@
 
 #include <errno.h>
 #include <grp.h>
+#include <paths.h>
 #include <pwd.h>
 #include <stdio.h>
 #include <sys/types.h>
@@ -713,13 +714,13 @@ int main (int argc, char **argv)
 	 */
 	if (cflag) {
 		closelog ();
-		execl (SHELL, "sh", "-c", command, (char *) NULL);
+		execl(_PATH_BSHELL, "sh", "-c", command, (char *) NULL);
 #ifdef WITH_AUDIT
 		stprintf_a(audit_buf, "changing new_gid=%lu", (unsigned long) gid);
 		audit_logger (AUDIT_CHGRP_ID,
 		              audit_buf, NULL, getuid (), SHADOW_AUDIT_FAILURE);
 #endif
-		perror (SHELL);
+		perror(_PATH_BSHELL);
 		exit ((errno == ENOENT) ? E_CMD_NOTFOUND : E_CMD_NOEXEC);
 	}
 
@@ -746,7 +747,7 @@ int main (int argc, char **argv)
 	} else if ((NULL != pwd->pw_shell) && !streq(pwd->pw_shell, "")) {
 		prog = pwd->pw_shell;
 	} else {
-		prog = SHELL;
+		prog = _PATH_BSHELL;
 	}
 
 	/*

--- a/src/su.c
+++ b/src/su.c
@@ -34,6 +34,7 @@
 
 #include <getopt.h>
 #include <grp.h>
+#include <paths.h>
 #include <pwd.h>
 #include <signal.h>
 #include <stdio.h>
@@ -263,7 +264,7 @@ static void execve_shell (const char *shellname,
 			n_args--;
 		}
 
-		(void) execve (SHELL, targs, envp);
+		(void) execve(_PATH_BSHELL, targs, envp);
 	} else {
 		errno = err;
 	}
@@ -1078,7 +1079,7 @@ int main (int argc, char **argv)
 	 * Set the default shell.
 	 */
 	if ((NULL == shellstr) || streq(shellstr, "")) {
-		shellstr = SHELL;
+		shellstr = _PATH_BSHELL;
 	}
 
 	sulog (caller_tty, true, caller_name, name);	/* save SU information */


### PR DESCRIPTION
Let's respect the system default.

---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git rd 
1:  bd8b801fb = 1:  6848cb5b5 configure.ac, lib/, src/: Use _PATH_BSHELL instead of our own setting
```
</details>

<details>
<summary>v1c</summary>

-  Rebase

```
$ git rd 
1:  6848cb5b5 = 1:  f59d7a291 configure.ac, lib/, src/: Use _PATH_BSHELL instead of our own setting
```
</details>

<details>
<summary>v1d</summary>

-  Rebase

```
$ git rd 
1:  f59d7a291 = 1:  2c6c8b00d configure.ac, lib/, src/: Use _PATH_BSHELL instead of our own setting
```
</details>

<details>
<summary>v1e</summary>

-  Rebase

```
$ git rd 
1:  2c6c8b00d = 1:  651fa9c75 configure.ac, lib/, src/: Use _PATH_BSHELL instead of our own setting
```
</details>

<details>
<summary>v1f</summary>

-  Rebase

```
$ git rd 
1:  651fa9c758b4 ! 1:  3e84fe8bd252 configure.ac, lib/, src/: Use _PATH_BSHELL instead of our own setting
    @@ Commit message
      ## configure.ac ##
     @@ configure.ac: fi
      
    - AC_CHECK_FUNC([fgetpwent_r], [AC_DEFINE([HAVE_FGETPWENT_R], [1], [Defined to 1 if you have the declaration of 'fgetpwent_r'])])
    + AC_CHECK_FUNCS([fgetpwent_r])
      
     -AC_DEFINE_UNQUOTED([SHELL], ["$SHELL"], [The default shell.])
     -
```
</details>

<details>
<summary>v1g</summary>

-  Rebase

```
$ git rd 
1:  3e84fe8b = 1:  376d1c7e configure.ac, lib/, src/: Use _PATH_BSHELL instead of our own setting
```
</details>

<details>
<summary>v1h</summary>

-  Rebase

```
$ git rd 
1:  376d1c7e ! 1:  0976c764 configure.ac, lib/, src/: Use _PATH_BSHELL instead of our own setting
    @@ configure.ac: fi
     
      ## lib/setupenv.c ##
     @@
    - #ident "$Id$"
    + #include "config.h"
      
    - #include <assert.h>
    -+#include <ctype.h>
    + #include <ctype.h>
     +#include <paths.h>
    + #include <pwd.h>
      #include <stddef.h>
      #include <sys/types.h>
    - #include <sys/stat.h>
    - #include <stdio.h>
    --#include <ctype.h>
    - 
    - #include "prototypes.h"
    - #include "defines.h"
     @@ lib/setupenv.c: void setup_env (struct passwd *info)
      
        if ((NULL == info->pw_shell) || streq(info->pw_shell, "")) {
```
</details>

<details>
<summary>v1i</summary>

-  Rebase

```
$ git rd 
1:  0976c7642521 ! 1:  9c8d281b445f configure.ac, lib/, src/: Use _PATH_BSHELL instead of our own setting
    @@ lib/shell.c
     +
      #include "prototypes.h"
      #include "defines.h"
    - #include "string/sprintf/snprintf.h"
    + #include "string/sprintf/stprintf.h"
     @@ lib/shell.c: int shell (const char *file, /*@null@*/const char *arg, char *const envp[])
                 * Assume this is a shell script (with no shebang).
                 * Interpret it with /bin/sh
    @@ src/su.c: static void execve_shell (const char *shellname,
                errno = err;
        }
     @@ src/su.c: static void usage (int status)
    -            "  -m, -p,\n"
    -            "  --preserve-environment        do not reset environment variables, and\n"
    -            "                                keep the same shell\n"
    --           "  -s, --shell SHELL             use SHELL instead of the default in passwd\n"
    -+           "  -s, --shell SHELL             use SHELL instead of the system default\n"
    -            "\n"
    -            "If no username is given, assume root.\n"), (E_SUCCESS != status) ? stderr : stdout);
    +   fputs(_("  -m, -p,\n"
    +           "  --preserve-environment        do not reset environment variables, and\n"
    +           "                                keep the same shell\n"), stream);
    +-  fputs(_("  -s, --shell SHELL             use SHELL instead of the default in passwd\n"), stream);
    ++  fputs(_("  -s, --shell SHELL             use SHELL instead of the system default\n"), stream);
    +   fputs("\n", stream);
    +   fputs(_("If no username is given, assume root.\n"), stream);
        exit (status);
     @@ src/su.c: int main (int argc, char **argv)
         * Set the default shell.
```
</details>

<details>
<summary>v2</summary>

-  Revert bogus change to usage() text.

```
$ git rd 
1:  9c8d281b445f ! 1:  6340b627064a configure.ac, lib/, src/: Use _PATH_BSHELL instead of our own setting
    @@ src/su.c: static void execve_shell (const char *shellname,
        } else {
                errno = err;
        }
    -@@ src/su.c: static void usage (int status)
    -   fputs(_("  -m, -p,\n"
    -           "  --preserve-environment        do not reset environment variables, and\n"
    -           "                                keep the same shell\n"), stream);
    --  fputs(_("  -s, --shell SHELL             use SHELL instead of the default in passwd\n"), stream);
    -+  fputs(_("  -s, --shell SHELL             use SHELL instead of the system default\n"), stream);
    -   fputs("\n", stream);
    -   fputs(_("If no username is given, assume root.\n"), stream);
    -   exit (status);
     @@ src/su.c: int main (int argc, char **argv)
         * Set the default shell.
         */
```
</details>

<details>
<summary>v2b</summary>

-  Rebase

```
$ git rd 
1:  6340b627064a = 1:  6670569d9148 configure.ac, lib/, src/: Use _PATH_BSHELL instead of our own setting
```
</details>