### PR TITLE
lib/chkname.c: Don't allow '$' in user/group names

### DIFF
--- a/lib/chkname.c
+++ b/lib/chkname.c
@@ -67,21 +67,6 @@ is_valid_name(const char *name)
 		return true;
 	}
 
-	/*
-	 * User/group names must match BRE regex:
-	 *    [a-zA-Z0-9_.][a-zA-Z0-9_.-]*
-	 */
-
-	if (!((*name >= 'a' && *name <= 'z') ||
-	      (*name >= 'A' && *name <= 'Z') ||
-	      (*name >= '0' && *name <= '9') ||
-	      *name == '_' ||
-	      *name == '.'))
-	{
-		errno = EILSEQ;
-		return false;
-	}
-
 	while (!streq(++name, "")) {
 		if (!((*name >= 'a' && *name <= 'z') ||
 		      (*name >= 'A' && *name <= 'Z') ||

--- a/lib/chkname.c
+++ b/lib/chkname.c
@@ -69,10 +69,7 @@ is_valid_name(const char *name)
 
 	/*
 	 * User/group names must match BRE regex:
-	 *    [a-zA-Z0-9_.][a-zA-Z0-9_.-]*$\?
-	 *
-	 * as a non-POSIX, extension, allow "$" as the last char for
-	 * sake of Samba 3.x "add machine script"
+	 *    [a-zA-Z0-9_.][a-zA-Z0-9_.-]*
 	 */
 
 	if (!((*name >= 'a' && *name <= 'z') ||
@@ -91,8 +88,7 @@ is_valid_name(const char *name)
 		      (*name >= '0' && *name <= '9') ||
 		      *name == '_' ||
 		      *name == '.' ||
-		      *name == '-' ||
-		      streq(name, "$")
+		      *name == '-'
 		     ))
 		{
 			errno = EILSEQ;

--- a/lib/chkname.c
+++ b/lib/chkname.c
@@ -63,10 +63,7 @@ is_valid_name(const char *name, bool badnames)
 
 	/*
 	 * User/group names must match BRE regex:
-	 *    [a-zA-Z0-9_.][a-zA-Z0-9_.-]*$\?
-	 *
-	 * as a non-POSIX, extension, allow "$" as the last char for
-	 * sake of Samba 3.x "add machine script"
+	 *    [a-zA-Z0-9_.][a-zA-Z0-9_.-]*
 	 */
 
 	if (!((*name >= 'a' && *name <= 'z') ||
@@ -85,8 +82,7 @@ is_valid_name(const char *name, bool badnames)
 		      (*name >= '0' && *name <= '9') ||
 		      *name == '_' ||
 		      *name == '.' ||
-		      *name == '-' ||
-		      streq(name, "$")
+		      *name == '-'
 		     ))
 		{
 			errno = EILSEQ;

--- a/lib/chkname.c
+++ b/lib/chkname.c
@@ -61,21 +61,6 @@ is_valid_name(const char *name, bool badnames)
 	if (badnames)
 		return true;
 
-	/*
-	 * User/group names must match BRE regex:
-	 *    [a-zA-Z0-9_.][a-zA-Z0-9_.-]*
-	 */
-
-	if (!((*name >= 'a' && *name <= 'z') ||
-	      (*name >= 'A' && *name <= 'Z') ||
-	      (*name >= '0' && *name <= '9') ||
-	      *name == '_' ||
-	      *name == '.'))
-	{
-		errno = EILSEQ;
-		return false;
-	}
-
 	while (!streq(++name, "")) {
 		if (!((*name >= 'a' && *name <= 'z') ||
 		      (*name >= 'A' && *name <= 'Z') ||


### PR DESCRIPTION
The dollar is dangerous.  Require users to use --badname to allow it.

Cc: @zeha , @thesamesam , @jubalh , @Zugschlus , @stoeckmann 

---

Revisions:

<details>
<summary>v1b</summary>

-  Expand commit message.

```
$ git rd 
1:  91f74f912 ! 1:  895b1b420 lib/chkname.c: Don't allow '$' in user/group names
    @@ Metadata
      ## Commit message ##
         lib/chkname.c: Don't allow '$' in user/group names
     
    -    The dollar is dangerous.  Require users to use --badname to allow it.
    +    The dollar is dangerous.  Most languages use it as a special character,
    +    such as the shell --which uses it with many different meanings,
    +    depending on the context--.
    +
    +    Require users to use --badname to allow it.
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
```
</details>

<details>
<summary>v1c</summary>

-  Rebase

```
$ git rd 
1:  895b1b420 ! 1:  0d058ad4e lib/chkname.c: Don't allow '$' in user/group names
    @@ Commit message
     
      ## lib/chkname.c ##
     @@ lib/chkname.c: is_valid_name(const char *name)
    +    * User/group names must match BRE regex:
    +    *    [a-zA-Z0-9_.][a-zA-Z0-9_.-]*$\?
    +    *
    +-   * as a non-POSIX, extension, allow "$" as the last char for
    +-   * sake of Samba 3.x "add machine script"
    +-   *
    +    * Also do not allow fully numeric names or just "." or "..".
    +    */
      
    -   /*
    -          * User/group names must match BRE regex:
    --         *    [a-zA-Z0-9_.][a-zA-Z0-9_.-]*$\?
    --         *
    --         * as a non-POSIX, extension, allow "$" as the last char for
    --         * sake of Samba 3.x "add machine script"
    -+         *    [a-zA-Z0-9_.][a-zA-Z0-9_.-]*
    -          *
    -          * Also do not allow fully numeric names or just "." or "..".
    -          */
     @@ lib/chkname.c: is_valid_name(const char *name)
                      (*name >= '0' && *name <= '9') ||
                      *name == '_' ||
```
</details>

<details>
<summary>v1d</summary>

-  Rebase

```
$ git rd 
1:  0d058ad4e ! 1:  54148256a lib/chkname.c: Don't allow '$' in user/group names
    @@ Commit message
     
      ## lib/chkname.c ##
     @@ lib/chkname.c: is_valid_name(const char *name)
    +   /*
         * User/group names must match BRE regex:
         *    [a-zA-Z0-9_.][a-zA-Z0-9_.-]*$\?
    -    *
    +-   *
     -   * as a non-POSIX, extension, allow "$" as the last char for
     -   * sake of Samba 3.x "add machine script"
    --   *
    -    * Also do not allow fully numeric names or just "." or "..".
         */
      
    +   if (!((*name >= 'a' && *name <= 'z') ||
     @@ lib/chkname.c: is_valid_name(const char *name)
                      (*name >= '0' && *name <= '9') ||
                      *name == '_' ||
    @@ lib/chkname.c: is_valid_name(const char *name)
     +                *name == '-'
                     ))
                {
    -                   errno = EINVAL;
    +                   errno = EILSEQ;
```
</details>

<details>
<summary>v1e</summary>

-  Update regex in comment.

```
$ git rd 
1:  54148256a ! 1:  8ea2d9305 lib/chkname.c: Don't allow '$' in user/group names
    @@ Commit message
     
      ## lib/chkname.c ##
     @@ lib/chkname.c: is_valid_name(const char *name)
    + 
        /*
         * User/group names must match BRE regex:
    -    *    [a-zA-Z0-9_.][a-zA-Z0-9_.-]*$\?
    +-   *    [a-zA-Z0-9_.][a-zA-Z0-9_.-]*$\?
     -   *
     -   * as a non-POSIX, extension, allow "$" as the last char for
     -   * sake of Samba 3.x "add machine script"
    ++   *    [a-zA-Z0-9_.][a-zA-Z0-9_.-]*
         */
      
        if (!((*name >= 'a' && *name <= 'z') ||
```
</details>

<details>
<summary>v1f</summary>

-  Rebase

```
$ git rd 
1:  8ea2d9305 = 1:  af9046e15 lib/chkname.c: Don't allow '$' in user/group names
```
</details>

<details>
<summary>v2</summary>

-  Simplify code.

```
$ git rd 
1:  af9046e15 = 1:  af9046e15 lib/chkname.c: Don't allow '$' in user/group names
-:  --------- > 2:  7ec47ae50 lib/chkname.c: is_valid_name(): Remove redundant check
```
</details>

<details>
<summary>v2b</summary>

-  Rebase

```
$ git rd 
1:  af9046e151bd = 1:  0f83b0974622 lib/chkname.c: Don't allow '$' in user/group names
2:  7ec47ae50d3b = 2:  804a53b752a2 lib/chkname.c: is_valid_name(): Remove redundant check
```
</details>

<details>
<summary>v2c</summary>

-  Rebase

```
$ git rd 
1:  0f83b097 = 1:  857fc154 lib/chkname.c: Don't allow '$' in user/group names
2:  804a53b7 = 2:  a6291708 lib/chkname.c: is_valid_name(): Remove redundant check
```
</details>

<details>
<summary>v2d</summary>

-  Rebase

```
$ git rd 
1:  857fc154a73b = 1:  deaa24a47538 lib/chkname.c: Don't allow '$' in user/group names
2:  a6291708ea75 = 2:  dc8375b3e4b4 lib/chkname.c: is_valid_name(): Remove redundant check
```
</details>

<details>
<summary>v2e</summary>

-  Rebase

```
$ git rd 
1:  deaa24a47538 ! 1:  9f815584853b lib/chkname.c: Don't allow '$' in user/group names
    @@ Commit message
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/chkname.c ##
    -@@ lib/chkname.c: is_valid_name(const char *name)
    +@@ lib/chkname.c: is_valid_name(const char *name, bool badnames)
      
        /*
         * User/group names must match BRE regex:
    @@ lib/chkname.c: is_valid_name(const char *name)
         */
      
        if (!((*name >= 'a' && *name <= 'z') ||
    -@@ lib/chkname.c: is_valid_name(const char *name)
    +@@ lib/chkname.c: is_valid_name(const char *name, bool badnames)
                      (*name >= '0' && *name <= '9') ||
                      *name == '_' ||
                      *name == '.' ||
2:  dc8375b3e4b4 ! 2:  3616cbd48581 lib/chkname.c: is_valid_name(): Remove redundant check
    @@ Commit message
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/chkname.c ##
    -@@ lib/chkname.c: is_valid_name(const char *name)
    +@@ lib/chkname.c: is_valid_name(const char *name, bool badnames)
    +   if (badnames)
                return true;
    -   }
      
     -  /*
     -   * User/group names must match BRE regex:
```
</details>