### PR TITLE
src/: Fix uninitialized flags, and use const appropriately

### DIFF
--- a/src/chage.c
+++ b/src/chage.c
@@ -86,9 +86,9 @@ static void print_day_as_date (long day);
 static void list_fields (void);
 static void process_flags (int argc, char **argv, struct option_flags *flags);
 static void check_flags (int argc, int opt_index);
-static void check_perms (struct option_flags *flags);
-static void open_files (bool readonly, struct option_flags *flags);
-static void close_files (struct option_flags *flags);
+static void check_perms(const struct option_flags *flags);
+static void open_files(bool readonly, const struct option_flags *flags);
+static void close_files(const struct option_flags *flags);
 NORETURN static void fail_exit (int code, bool process_selinux);
 
 /*
@@ -479,7 +479,7 @@ static void check_flags (int argc, int opt_index)
  *
  *	It will not return if the user is not allowed.
  */
-static void check_perms (struct option_flags *flags)
+static void check_perms(const struct option_flags *flags)
 {
 	bool process_selinux;
 
@@ -503,7 +503,7 @@ static void check_perms (struct option_flags *flags)
  *	In read-only mode, the databases are not locked and are opened
  *	only for reading.
  */
-static void open_files (bool readonly, struct option_flags *flags)
+static void open_files(bool readonly, const struct option_flags *flags)
 {
 	bool process_selinux;
 
@@ -555,7 +555,7 @@ static void open_files (bool readonly, struct option_flags *flags)
 /*
  * close_files - close and unlock the password/shadow databases
  */
-static void close_files (struct option_flags *flags)
+static void close_files(const struct option_flags *flags)
 {
 	bool process_selinux;
 
@@ -732,7 +732,7 @@ int main (int argc, char **argv)
 	uid_t ruid;
 	gid_t rgid;
 	const struct passwd *pw;
-	struct option_flags  flags;
+	struct option_flags  flags = {.chroot = false, .prefix = false};
 	bool process_selinux;
 
 	sanitize_env ();

--- a/src/chfn.c
+++ b/src/chfn.c
@@ -73,7 +73,7 @@ static bool may_change_field (int);
 static void new_fields (void);
 static void process_flags (int argc, char **argv, struct option_flags *flags);
 static void check_perms (const struct passwd *pw);
-static void update_gecos (const char *user, char *gecos, struct option_flags *flags);
+static void update_gecos(const char *user, char *gecos, const struct option_flags *flags);
 static void get_old_fields (const char *gecos);
 
 /*
@@ -387,7 +387,7 @@ static void check_perms (const struct passwd *pw)
  *
  *	Commit the user's entry after changing her gecos field.
  */
-static void update_gecos (const char *user, char *gecos, struct option_flags *flags)
+static void update_gecos(const char *user, char *gecos, const struct option_flags *flags)
 {
 	const struct passwd *pw;	/* The user's password file entry */
 	struct passwd pwent;		/* modified password file entry */
@@ -572,7 +572,7 @@ int main (int argc, char **argv)
 	char                 new_gecos[80];
 	char                 *user, *p, *e;
 	const struct passwd  *pw;
-	struct option_flags  flags;
+	struct option_flags  flags = {.chroot = false};
 	bool                 process_selinux;
 
 	sanitize_env ();

--- a/src/chgpasswd.c
+++ b/src/chgpasswd.c
@@ -82,7 +82,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags);
 static void check_flags (void);
 static void check_perms (void);
 static void open_files (bool process_selinux);
-static void close_files (struct option_flags *flags);
+static void close_files(const struct option_flags *flags);
 
 /*
  * fail_exit - exit with a failure code after unlocking the files
@@ -386,7 +386,7 @@ static void open_files (bool process_selinux)
 /*
  * close_files - close and unlock the group databases
  */
-static void close_files (struct option_flags *flags)
+static void close_files(const struct option_flags *flags)
 {
 	bool process_selinux;
 
@@ -440,7 +440,7 @@ int main (int argc, char **argv)
 	struct group newgr;
 	bool errors = false;
 	intmax_t line = 0;
-	struct option_flags  flags;
+	struct option_flags  flags = {.chroot = false};
 	bool process_selinux;
 
 	log_set_progname(Prog);

--- a/src/chpasswd.c
+++ b/src/chpasswd.c
@@ -80,8 +80,8 @@ NORETURN static void usage (int status);
 static void process_flags (int argc, char **argv, struct option_flags *flags);
 static void check_flags (void);
 static void check_perms (void);
-static void open_files (struct option_flags *flags);
-static void close_files (struct option_flags *flags);
+static void open_files(const struct option_flags *flags);
+static void close_files(const struct option_flags *flags);
 
 /*
  * fail_exit - exit with a failure code after unlocking the files
@@ -345,7 +345,7 @@ static void check_perms (void)
 /*
  * open_files - lock and open the password databases
  */
-static void open_files (struct option_flags *flags)
+static void open_files(const struct option_flags *flags)
 {
 	bool process_selinux;
 
@@ -389,7 +389,7 @@ static void open_files (struct option_flags *flags)
 /*
  * close_files - close and unlock the password databases
  */
-static void close_files (struct option_flags *flags)
+static void close_files(const struct option_flags *flags)
 {
 	bool process_selinux;
 
@@ -472,7 +472,7 @@ int main (int argc, char **argv)
 
 	bool errors = false;
 	intmax_t line = 0;
-	struct option_flags  flags;
+	struct option_flags  flags = {.chroot = false, .prefix = false};
 	bool process_selinux;
 
 	log_set_progname(Prog);

--- a/src/chsh.c
+++ b/src/chsh.c
@@ -70,9 +70,9 @@ static void new_fields (void);
 static bool shell_is_listed (const char *);
 static bool is_restricted_shell (const char *);
 static void process_flags (int argc, char **argv, struct option_flags *flags);
-static void check_perms (const struct passwd *pw, struct option_flags *flags);
+static void check_perms(const struct passwd *pw, const struct option_flags *flags);
 static void update_shell (const char *user, char *loginsh,
-                          struct option_flags *flags);
+                          const struct option_flags *flags);
 
 /*
  * fail_exit - do some cleanup and exit with the given error code
@@ -268,7 +268,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
  *
  *	It will not return if the user is not allowed.
  */
-static void check_perms (const struct passwd *pw, struct option_flags *flags)
+static void check_perms(const struct passwd *pw, const struct option_flags *flags)
 {
 #ifdef USE_PAM
 	pam_handle_t *pamh = NULL;
@@ -367,7 +367,7 @@ static void check_perms (const struct passwd *pw, struct option_flags *flags)
  *
  *	It will not return in case of error.
  */
-static void update_shell (const char *user, char *newshell, struct option_flags *flags)
+static void update_shell (const char *user, char *newshell, const struct option_flags *flags)
 {
 	const struct passwd *pw;	/* Password entry from /etc/passwd   */
 	struct passwd pwent;		/* New password entry                */
@@ -462,7 +462,7 @@ int main (int argc, char **argv)
 {
 	char *user;		/* User name                         */
 	const struct passwd *pw;	/* Password entry from /etc/passwd   */
-	struct option_flags  flags;
+	struct option_flags  flags = {.chroot = false};
 	bool process_selinux;
 
 	sanitize_env ();

--- a/src/gpasswd.c
+++ b/src/gpasswd.c
@@ -96,14 +96,14 @@ static bool is_valid_user_list (const char *users);
 static void process_flags (int argc, char **argv, struct option_flags *flags);
 static void check_flags (int argc, int opt_index);
 static void open_files (void);
-static void close_files (struct option_flags *flags);
+static void close_files(const struct option_flags *flags);
 #ifdef SHADOWGRP
-static void get_group (struct group *gr, struct sgrp *sg, struct option_flags *flags);
+static void get_group(struct group *gr, struct sgrp *sg, const struct option_flags *flags);
 static void check_perms(const struct sgrp *sg);
 static void update_group (struct group *gr, struct sgrp *sg);
 static void change_passwd (struct group *gr, struct sgrp *sg);
 #else
-static void get_group (struct group *gr, struct option_flags *flags);
+static void get_group(struct group *gr, const struct option_flags *flags);
 static void check_perms(void);
 static void update_group (struct group *gr);
 static void change_passwd (struct group *gr);
@@ -598,7 +598,7 @@ static void log_gpasswd_success_group (MAYBE_UNUSED void *arg)
  *
  *	It will call exit in case of error.
  */
-static void close_files (struct option_flags *flags)
+static void close_files(const struct option_flags *flags)
 {
 	bool process_selinux;
 
@@ -706,9 +706,9 @@ static void update_group (struct group *gr)
  *	Note: If !is_shadowgrp, *sg will not be initialized.
  */
 #ifdef SHADOWGRP
-static void get_group (struct group *gr, struct sgrp *sg, struct option_flags *flags)
+static void get_group(struct group *gr, struct sgrp *sg, const struct option_flags *flags)
 #else
-static void get_group (struct group *gr, struct option_flags *flags)
+static void get_group(struct group *gr, const struct option_flags *flags)
 #endif
 {
 	struct group const*tmpgr = NULL;
@@ -878,7 +878,7 @@ int main (int argc, char **argv)
 	struct sgrp sgent;
 #endif
 	struct passwd *pw = NULL;
-	struct option_flags  flags;
+	struct option_flags  flags = {.chroot = false};
 
 #ifdef WITH_AUDIT
 	audit_help_open ();

--- a/src/groupadd.c
+++ b/src/groupadd.c
@@ -95,8 +95,8 @@ static void new_sgent (struct sgrp *sgent);
 #endif
 static void grp_update (void);
 static void check_new_name (void);
-static void close_files (struct option_flags *flags);
-static void open_files (struct option_flags *flags);
+static void close_files(const struct option_flags *flags);
+static void open_files(const struct option_flags *flags);
 static void process_flags (int argc, char **argv, struct option_flags *flags);
 static void check_flags (void);
 static void check_perms (void);
@@ -282,7 +282,7 @@ check_new_name(void)
  *	close_files() closes all of the files that were opened for this new
  *	group. This causes any modified entries to be written out.
  */
-static void close_files (struct option_flags *flags)
+static void close_files(const struct option_flags *flags)
 {
 	bool process_selinux;
 
@@ -341,7 +341,7 @@ static void close_files (struct option_flags *flags)
  *
  *	open_files() opens the two group files.
  */
-static void open_files (struct option_flags *flags)
+static void open_files(const struct option_flags *flags)
 {
 	bool process_selinux;
 
@@ -604,7 +604,7 @@ static void check_perms (void)
  */
 int main (int argc, char **argv)
 {
-	struct option_flags flags;
+	struct option_flags  flags = {.chroot = false, .prefix = false};
 
 	log_set_progname(Prog);
 	log_set_logfd(stderr);

--- a/src/groupdel.c
+++ b/src/groupdel.c
@@ -67,8 +67,8 @@ static bool is_shadow_grp;
 /* local function prototypes */
 NORETURN static void usage (int status);
 static void grp_update (void);
-static void close_files (struct option_flags *flags);
-static void open_files (struct option_flags *flags);
+static void close_files(const struct option_flags *flags);
+static void open_files(const struct option_flags *flags);
 static void group_busy (gid_t gid);
 static void process_flags (int argc, char **argv, struct option_flags *flags);
 
@@ -152,7 +152,7 @@ static void grp_update (void)
  *	close_files() closes all of the files that were opened for this
  *	new group.  This causes any modified entries to be written out.
  */
-static void close_files (struct option_flags *flags)
+static void close_files(const struct option_flags *flags)
 {
 	bool process_selinux;
 
@@ -214,7 +214,7 @@ static void close_files (struct option_flags *flags)
  *
  *	open_files() opens the two group files.
  */
-static void open_files (struct option_flags *flags)
+static void open_files(const struct option_flags *flags)
 {
 	bool process_selinux;
 
@@ -368,7 +368,7 @@ int main (int argc, char **argv)
 	int retval;
 #endif				/* USE_PAM */
 #endif				/* ACCT_TOOLS_SETUID */
-	struct option_flags  flags;
+	struct option_flags  flags = {.chroot = false, .prefix = false};
 
 	log_set_progname(Prog);
 	log_set_logfd(stderr);

--- a/src/groupmems.c
+++ b/src/groupmems.c
@@ -533,7 +533,7 @@ static void open_files (bool process_selinux)
 #endif
 }
 
-static void close_files (struct option_flags *flags)
+static void close_files(const struct option_flags *flags)
 {
 	bool process_selinux;
 
@@ -576,7 +576,7 @@ int main (int argc, char **argv)
 {
 	char *name;
 	const struct group *grp;
-	struct option_flags  flags;
+	struct option_flags  flags = {.chroot = false};
 	bool process_selinux;
 
 	log_set_progname(Prog);

--- a/src/groupmod.c
+++ b/src/groupmod.c
@@ -108,10 +108,10 @@ static void grp_update (void);
 static void check_new_gid (void);
 static void check_new_name (void);
 static void process_flags (int, char **, struct option_flags *);
-static void lock_files (struct option_flags *flags);
+static void lock_files(const struct option_flags *flags);
 static void prepare_failure_reports (void);
 static void open_files (void);
-static void close_files (struct option_flags *flags);
+static void close_files(const struct option_flags *flags);
 static void update_primary_groups (gid_t ogid, gid_t ngid);
 
 
@@ -487,7 +487,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
  *	close_files() closes all of the files that were opened for this new
  *	group. This causes any modified entries to be written out.
  */
-static void close_files (struct option_flags *flags)
+static void close_files(const struct option_flags *flags)
 {
 	bool process_selinux;
 
@@ -669,7 +669,7 @@ static void prepare_failure_reports (void)
  *
  *	lock_files() locks the group, gshadow, and passwd databases.
  */
-static void lock_files (struct option_flags *flags)
+static void lock_files(const struct option_flags *flags)
 {
 	bool process_selinux;
 
@@ -787,7 +787,7 @@ int main (int argc, char **argv)
 	int retval;
 #endif				/* USE_PAM */
 #endif				/* ACCT_TOOLS_SETUID */
-	struct option_flags  flags;
+	struct option_flags  flags = {.chroot = false, .prefix = false};
 
 	log_set_progname(Prog);
 	log_set_logfd(stderr);

--- a/src/grpck.c
+++ b/src/grpck.c
@@ -80,7 +80,7 @@ NORETURN static void usage (int status);
 static void delete_member (char **, const char *);
 static void process_flags (int argc, char **argv, struct option_flags *flags);
 static void open_files (bool process_selinux);
-static void close_files (bool changed, struct option_flags *flags);
+static void close_files(bool changed, const struct option_flags *flags);
 static int check_members (const char *groupname,
                           char **members,
                           const char *fmt_info,
@@ -88,7 +88,7 @@ static int check_members (const char *groupname,
                           const char *fmt_syslog,
                           bool *errors);
 static void check_grp_file (bool *errors, bool *changed,
-                            struct option_flags *flags);
+                            const struct option_flags *flags);
 #ifdef SHADOWGRP
 static void compare_members_lists (const char *groupname,
                                    char **members,
@@ -327,7 +327,7 @@ static void open_files (bool process_selinux)
  *	changes are committed in the databases. The databases are
  *	unlocked anyway.
  */
-static void close_files (bool changed, struct option_flags *flags)
+static void close_files(bool changed, const struct option_flags *flags)
 {
 	bool process_selinux;
 
@@ -472,7 +472,7 @@ static void compare_members_lists (const char *groupname,
 /*
  * check_grp_file - check the content of the group file
  */
-static void check_grp_file (bool *errors, bool *changed, struct option_flags *flags)
+static void check_grp_file(bool *errors, bool *changed, const struct option_flags *flags)
 {
 	struct commonio_entry *gre, *tgre;
 	struct group *grp;
@@ -839,7 +839,7 @@ int main (int argc, char **argv)
 {
 	bool errors = false;
 	bool changed = false;
-	struct option_flags  flags;
+	struct option_flags  flags = {.chroot = false};
 	bool process_selinux;
 
 	log_set_progname(Prog);

--- a/src/grpconv.c
+++ b/src/grpconv.c
@@ -137,7 +137,7 @@ int main (int argc, char **argv)
 	struct group grent;
 	const struct sgrp *sg;
 	struct sgrp sgent;
-	struct option_flags  flags;
+	struct option_flags  flags = {.chroot = false};
 	bool process_selinux;
 
 	log_set_progname(Prog);

--- a/src/grpunconv.c
+++ b/src/grpunconv.c
@@ -135,7 +135,7 @@ int main (int argc, char **argv)
 	const struct group *gr;
 	struct group grent;
 	const struct sgrp *sg;
-	struct option_flags  flags;
+	struct option_flags  flags = {.chroot = false};
 	bool process_selinux;
 
 	log_set_progname(Prog);

--- a/src/newusers.c
+++ b/src/newusers.c
@@ -117,9 +117,9 @@ static int update_passwd (struct passwd *, const char *);
 static int add_passwd (struct passwd *, const char *);
 static void process_flags (int argc, char **argv, struct option_flags *flags);
 static void check_flags (void);
-static void check_perms (struct option_flags *flags);
+static void check_perms(const struct option_flags *flags);
 static void open_files (bool process_selinux);
-static void close_files (struct option_flags *flags);
+static void close_files(const struct option_flags *flags);
 
 extern int allow_bad_names;
 
@@ -797,7 +797,7 @@ static void check_flags (void)
  *
  *	It will not return if the user is not allowed.
  */
-static void check_perms (struct option_flags *flags)
+static void check_perms(const struct option_flags *flags)
 {
 #ifdef ACCT_TOOLS_SETUID
 #ifdef USE_PAM
@@ -947,7 +947,7 @@ static void open_files (bool process_selinux)
 /*
  * close_files - close and unlock the password, group and shadow databases
  */
-static void close_files (struct option_flags *flags)
+static void close_files(const struct option_flags *flags)
 {
 	bool process_selinux;
 
@@ -1068,7 +1068,7 @@ int main (int argc, char **argv)
 	char **passwords = NULL;
 	size_t nusers = 0;
 #endif				/* USE_PAM */
-	struct option_flags  flags;
+	struct option_flags  flags = {.chroot = false};
 	bool process_selinux;
 
 	log_set_progname(Prog);

--- a/src/passwd.c
+++ b/src/passwd.c
@@ -138,9 +138,8 @@ static void print_status (const struct passwd *);
 NORETURN static void fail_exit (int, bool);
 NORETURN static void oom (bool process_selinux);
 static char *update_crypt_pw (char *, bool);
-static void update_noshadow (struct option_flags *flags);
-
-static void update_shadow (struct option_flags *flags);
+static void update_noshadow(const struct option_flags *flags);
+static void update_shadow(const struct option_flags *flags);
 
 /*
  * usage - print command usage and exit
@@ -556,7 +555,7 @@ static char *update_crypt_pw (char *cp, bool process_selinux)
 }
 
 
-static void update_noshadow (struct option_flags *flags)
+static void update_noshadow(const struct option_flags *flags)
 {
 	const struct passwd *pw;
 	struct passwd *npw;
@@ -613,7 +612,7 @@ static void update_noshadow (struct option_flags *flags)
 	pw_locked = false;
 }
 
-static void update_shadow (struct option_flags *flags)
+static void update_shadow(const struct option_flags *flags)
 {
 	const struct spwd *sp;
 	struct spwd *nsp;
@@ -746,7 +745,7 @@ main(int argc, char **argv)
 	char *cp;		/* Miscellaneous character pointing  */
 
 	const struct spwd *sp;	/* Shadow file entry for user   */
-	struct option_flags  flags;
+	struct option_flags  flags = {.chroot = false, .prefix = false};
 	bool process_selinux;
 
 	sanitize_env ();

--- a/src/pwck.c
+++ b/src/pwck.c
@@ -76,10 +76,10 @@ static bool quiet = false;		/* don't report warnings, only errors */
 static void fail_exit (int code, bool process_selinux);
 NORETURN static void usage (int status);
 static void process_flags (int argc, char **argv, struct option_flags *flags);
-static void open_files (struct option_flags *flags);
-static void close_files (bool changed, struct option_flags *flags);
+static void open_files(const struct option_flags *flags);
+static void close_files(bool changed, const struct option_flags *flags);
 static void check_pw_file (bool *errors, bool *changed,
-                           struct option_flags *flags);
+                           const struct option_flags *flags);
 static void check_spw_file (bool *errors, bool *changed);
 
 extern int allow_bad_names;
@@ -246,7 +246,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
  *	In read-only mode, the databases are not locked and are opened
  *	only for reading.
  */
-static void open_files (struct option_flags *flags)
+static void open_files(const struct option_flags *flags)
 {
 	bool use_tcb = false;
 #ifdef WITH_TCB
@@ -311,7 +311,7 @@ static void open_files (struct option_flags *flags)
  *	changes are committed in the databases. The databases are
  *	unlocked anyway.
  */
-static void close_files (bool changed, struct option_flags *flags)
+static void close_files(bool changed, const struct option_flags *flags)
 {
 	bool process_selinux;
 
@@ -381,7 +381,7 @@ static void close_files (bool changed, struct option_flags *flags)
 /*
  * check_pw_file - check the content of the passwd file
  */
-static void check_pw_file (bool *errors, bool *changed, struct option_flags *flags)
+static void check_pw_file(bool *errors, bool *changed, const struct option_flags *flags)
 {
 	struct commonio_entry *pfe, *tpfe;
 	struct passwd *pwd;
@@ -856,7 +856,7 @@ int main (int argc, char **argv)
 {
 	bool errors = false;
 	bool changed = false;
-	struct option_flags  flags;
+	struct option_flags  flags = {.chroot = false};
 	bool process_selinux;
 
 	log_set_progname(Prog);

--- a/src/pwconv.c
+++ b/src/pwconv.c
@@ -162,7 +162,7 @@ int main (int argc, char **argv)
 	struct passwd pwent;
 	const struct spwd *sp;
 	struct spwd spent;
-	struct option_flags  flags;
+	struct option_flags  flags = {.chroot = false};
 	bool process_selinux;
 
 	log_set_progname(Prog);

--- a/src/pwunconv.c
+++ b/src/pwunconv.c
@@ -121,7 +121,7 @@ int main (int argc, char **argv)
 	const struct passwd *pw;
 	struct passwd pwent;
 	const struct spwd *spwd;
-	struct option_flags  flags;
+	struct option_flags  flags = {.chroot = false};
 	bool process_selinux;
 
 	log_set_progname(Prog);

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -226,10 +226,10 @@ static bool home_added = false;
 
 /* local function prototypes */
 NORETURN static void fail_exit (int, bool);
-static void get_defaults (struct option_flags *);
+static void get_defaults(const struct option_flags *);
 static void show_defaults (void);
 static int set_defaults (void);
-static int get_groups (char *, struct option_flags *);
+static int get_groups(char *, const struct option_flags *);
 static struct group * get_local_group (char * grp_name, bool process_selinux);
 NORETURN static void usage (int status);
 static void new_pwent (struct passwd *);
@@ -238,7 +238,7 @@ static void new_spent (struct spwd *);
 static void grp_update (bool);
 
 static void process_flags (int argc, char **argv, struct option_flags *flags);
-static void close_files (struct option_flags *flags);
+static void close_files(const struct option_flags *flags);
 static void close_group_files (bool process_selinux);
 static void unlock_group_files (bool process_selinux);
 static void open_files (bool process_selinux);
@@ -250,9 +250,9 @@ static void lastlog_reset (uid_t);
 #endif /* ENABLE_LASTLOG */
 static void tallylog_reset (const char *);
 static void usr_update (unsigned long subuid_count, unsigned long subgid_count,
-                        struct option_flags *flags);
-static void create_home (struct option_flags *flags);
-static void create_mail (struct option_flags *flags);
+                        const struct option_flags *flags);
+static void create_home(const struct option_flags *flags);
+static void create_mail(const struct option_flags *flags);
 static void check_uid_range(int rflg, uid_t user_id);
 
 
@@ -329,7 +329,7 @@ static void fail_exit (int code, bool process_selinux)
  *	file does not exist.
  */
 static void
-get_defaults(struct option_flags *flags)
+get_defaults(const struct option_flags *flags)
 {
 	FILE        *fp;
 	char        *default_file = USER_DEFAULTS_FILE;
@@ -740,7 +740,7 @@ err_free_new:
  *	converts it to a NULL-terminated array. Any unknown group
  *	names are reported as errors.
  */
-static int get_groups (char *list, struct option_flags *flags)
+static int get_groups(char *list, const struct option_flags *flags)
 {
 	struct group *grp;
 	bool errors = false;
@@ -1573,7 +1573,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
  *	close_files() closes all of the files that were opened for this
  *	new user. This causes any modified entries to be written out.
  */
-static void close_files (struct option_flags *flags)
+static void close_files(const struct option_flags *flags)
 {
 	bool process_selinux;
 
@@ -2091,7 +2091,7 @@ static void tallylog_reset (const char *user_name)
  */
 static void
 usr_update (unsigned long subuid_count, unsigned long subgid_count,
-            struct option_flags *flags)
+            const struct option_flags *flags)
 {
 	struct passwd pwent;
 	struct spwd spent;
@@ -2194,7 +2194,7 @@ usr_update (unsigned long subuid_count, unsigned long subgid_count,
  *	already exist. It will be created mode 755 owned by the user
  *	with the user's default group.
  */
-static void create_home (struct option_flags *flags)
+static void create_home(const struct option_flags *flags)
 {
 	char    path[strlen(prefix_user_home) + 2];
 	char    *bhome, *cp;
@@ -2322,7 +2322,7 @@ static void create_home (struct option_flags *flags)
  *	exist. It will be created mode 660 owned by the user and group
  *	'mail'
  */
-static void create_mail (struct option_flags *flags)
+static void create_mail(const struct option_flags *flags)
 {
 	int           fd;
 	char          *file;
@@ -2443,10 +2443,7 @@ int main (int argc, char **argv)
 #endif
 	unsigned long subuid_count = 0;
 	unsigned long subgid_count = 0;
-	struct option_flags  flags = {
-		.chroot = false,
-		.prefix = false,
-	};
+	struct option_flags  flags = {.chroot = false, .prefix = false};
 	bool process_selinux;
 
 	log_set_progname(Prog);

--- a/src/userdel.c
+++ b/src/userdel.c
@@ -119,7 +119,7 @@ static const char* prefix = "";
 static void usage (int status);
 static void update_groups (bool process_selinux);
 static void remove_usergroup (bool process_selinux);
-static void close_files (struct option_flags *flags);
+static void close_files(const struct option_flags *flags);
 static void fail_exit (int, bool);
 static void open_files (bool process_selinux);
 static void update_user (bool process_selinux);
@@ -396,7 +396,7 @@ static void remove_usergroup (bool process_selinux)
  *	close_files() closes all of the files that were opened for this
  *	new user. This causes any modified entries to be written out.
  */
-static void close_files (struct option_flags *flags)
+static void close_files(const struct option_flags *flags)
 {
 	bool process_selinux;
 
@@ -915,7 +915,7 @@ int main (int argc, char **argv)
 	int retval;
 #endif				/* USE_PAM */
 #endif				/* ACCT_TOOLS_SETUID */
-	struct option_flags  flags;
+	struct option_flags  flags = {.chroot = false, .prefix = false};
 	bool process_selinux;
 
 	log_set_progname(Prog);

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -207,9 +207,9 @@ static void update_gshadow(const struct sgrp *sgrp, bool process_selinux);
 static void grp_update (bool process_selinux);
 
 static void process_flags (int, char **, struct option_flags *);
-static void close_files (struct option_flags *);
+static void close_files(const struct option_flags *);
 static void open_files (bool process_selinux);
-static void usr_update (struct option_flags *flags);
+static void usr_update(const struct option_flags *flags);
 static void move_home (bool process_selinux);
 #ifdef ENABLE_LASTLOG
 static void update_lastlog (void);
@@ -1436,7 +1436,7 @@ process_flags(int argc, char **argv, struct option_flags *flags)
  *	close_files() closes all of the files that were opened for this new
  *	user. This causes any modified entries to be written out.
  */
-static void close_files (struct option_flags *flags)
+static void close_files(const struct option_flags *flags)
 {
 	bool process_selinux;
 
@@ -1680,7 +1680,7 @@ static void open_files (bool process_selinux)
  *	usr_update() creates the password file entries for this user and
  *	will update the group entries if required.
  */
-static void usr_update (struct option_flags *flags)
+static void usr_update(const struct option_flags *flags)
 {
 	struct passwd pwent;
 	const struct passwd *pwd;
@@ -2134,7 +2134,7 @@ int main (int argc, char **argv)
 	int retval;
 #endif				/* USE_PAM */
 #endif				/* ACCT_TOOLS_SETUID */
-	struct option_flags  flags;
+	struct option_flags  flags = {.chroot = false, .prefix = false};
 	bool process_selinux;
 
 	log_set_progname(Prog);


### PR DESCRIPTION
Fixes: c0c9485d9a5a (2025-10-07; "src/useradd.c: chroot or prefix SELinux file context")
Link: <https://github.com/shadow-maint/shadow/pull/1396>
Cc: Iker Pedrosa <ipedrosa@redhat.com>