### PR TITLE
lib/shadow/group/sgetgrent.c: Move free(3) call outside of helper

### DIFF
--- a/lib/shadow/group/sgetgrent.c
+++ b/lib/shadow/group/sgetgrent.c
@@ -38,11 +38,8 @@
 static char **
 list(char *s)
 {
-	static char **members = NULL;
-
+	char    **members;
 	size_t  n;
-
-	free(members);
 
 	members = astrsep2ls(s, ",", &n);
 	if (members == NULL)
@@ -60,7 +57,7 @@ struct group *
 sgetgrent(const char *s)
 {
 	static char         *dup = NULL;
-	static struct group grent;
+	static struct group grent = {};
 
 	char  *fields[4];
 
@@ -82,6 +79,9 @@ sgetgrent(const char *s)
 	if (get_gid(fields[2], &grent.gr_gid) == -1) {
 		return NULL;
 	}
+
+	free(grent.gr_mem);
+
 	grent.gr_mem = list(fields[3]);
 	if (NULL == grent.gr_mem) {
 		return NULL;	/* out of memory */


### PR DESCRIPTION
```
This is for consistency with how this is done in
sgetsgent().

Now we need to make sure that the list is NULL before
the first call, which means that the 'grent' structure must
be cleared.  Since it's a static object, it's already true, but
let's be explicit about it.

Since we remember the address of the list in
grent.gr_mem (which is static), we don't need to keep
'members' being static too, so we get rid of one static
thing.
```

This removes a `static` variable.

---

-  This is a subset of <https://github.com/shadow-maint/shadow/pull/1272> at v3c.

---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git rd 
1:  93eb0220f = 1:  11c744777 lib/shadow/group/sgetgrent.c: Move free(3) call outside of helper
```
</details>

<details>
<summary>v1c</summary>

-  Rebase

```
$ git rd 
1:  11c744777 = 1:  afd79dccd lib/shadow/group/sgetgrent.c: Move free(3) call outside of helper
```
</details>

<details>
<summary>v1d</summary>

-  Rebase

```
$ git rd 
1:  afd79dccda91 = 1:  79461654c670 lib/shadow/group/sgetgrent.c: Move free(3) call outside of helper
```
</details>

<details>
<summary>v1e</summary>

-  Rebase

```
$ git rd 
1:  79461654 = 1:  dae0a256 lib/shadow/group/sgetgrent.c: Move free(3) call outside of helper
```
</details>

<details>
<summary>v1f</summary>

-  Rebase

```
$ git rd 
1:  dae0a256 = 1:  4effd2f1 lib/shadow/group/sgetgrent.c: Move free(3) call outside of helper
```
</details>

<details>
<summary>v1g</summary>

-  Rebase

```
$ git rd 
1:  4effd2f1 = 1:  a0d2d7e9 lib/shadow/group/sgetgrent.c: Move free(3) call outside of helper
```
</details>

<details>
<summary>v1h</summary>

-  Rebase

```
$ git rd 
1:  a0d2d7e9d20f = 1:  86789d22680c lib/shadow/group/sgetgrent.c: Move free(3) call outside of helper
```
</details>

<details>
<summary>v1i</summary>

-  Rebase

```
$ git rd 
1:  86789d22680c = 1:  a8c5dbf6b997 lib/shadow/group/sgetgrent.c: Move free(3) call outside of helper
```
</details>