### PR TITLE
lib/, src/: Use _Generic(3) instead of __builtin_types_compatible_p()

### DIFF
--- a/lib/typetraits.h
+++ b/lib/typetraits.h
@@ -24,12 +24,6 @@
 #endif
 
 
-#define is_same_type(a, b)                                                    \
-(                                                                             \
-	__builtin_types_compatible_p(a, b)                                    \
-)
-
-
 #define QChar_of(s)  typeof                                           \
 (                                                                     \
 	_Generic(s,                                                   \

--- a/lib/typetraits.h
+++ b/lib/typetraits.h
@@ -29,11 +29,6 @@
 	__builtin_types_compatible_p(a, b)                                    \
 )
 
-#define is_same_typeof(a, b)                                                  \
-(                                                                             \
-	is_same_type(typeof(a), typeof(b))                                    \
-)
-
 
 #define QChar_of(s)  typeof                                           \
 (                                                                     \

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -9,8 +9,6 @@
 
 #include "config.h"
 
-#ident "$Id$"
-
 #include <ctype.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -329,8 +327,8 @@ getid_range(const char *str)
 		.last = minof(id_t)
 	};
 
-	static_assert(is_same_type(id_t, uid_t), "");
-	static_assert(is_same_type(id_t, gid_t), "");
+	_Generic((id_t){0}, uid_t: (void)0);
+	_Generic((id_t){0}, gid_t: (void)0);
 
 	first = minof(id_t);
 	last = maxof(id_t);


### PR DESCRIPTION
_Generic(3) is standard C since ISO C11, so let's avoid unnecessarily using this GNU C extension.

---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git rd 
1:  ab202253b = 1:  39263c9e1 lib/typetraits.h: is_same_typeof(): Remove unused macro
2:  868a522ff = 2:  44a9d50a5 lib/, src/: Use _Generic(3) instead of __builtin_types_compatible_p()
```
</details>

<details>
<summary>v1c</summary>

-  Rebase

```
$ git rd 
1:  39263c9e1 = 1:  d05c9337d lib/typetraits.h: is_same_typeof(): Remove unused macro
2:  44a9d50a5 = 2:  3351d3d4a lib/, src/: Use _Generic(3) instead of __builtin_types_compatible_p()
```
</details>

<details>
<summary>v1d</summary>

-  Rebase

```
$ git rd 
1:  d05c9337d744 = 1:  0f3399838860 lib/typetraits.h: is_same_typeof(): Remove unused macro
2:  3351d3d4accc = 2:  70c6f100f1df lib/, src/: Use _Generic(3) instead of __builtin_types_compatible_p()
```
</details>

<details>
<summary>v1e</summary>

-  Rebase

```
$ git rd 
1:  0f339983 = 1:  c26ea690 lib/typetraits.h: is_same_typeof(): Remove unused macro
2:  70c6f100 = 2:  452c354d lib/, src/: Use _Generic(3) instead of __builtin_types_compatible_p()
```
</details>

<details>
<summary>v1f</summary>

-  Rebase

```
$ git rd 
1:  c26ea690 = 1:  00680d8c lib/typetraits.h: is_same_typeof(): Remove unused macro
2:  452c354d ! 2:  a45fa2fd lib/, src/: Use _Generic(3) instead of __builtin_types_compatible_p()
    @@ src/usermod.c
      
     -#ident "$Id$"
     -
    --#include <assert.h>
      #include <ctype.h>
      #include <errno.h>
      #include <fcntl.h>
```
</details>

<details>
<summary>v2</summary>

-  Fix build with old GCC.

```
$ git rd 
1:  00680d8c = 1:  00680d8c lib/typetraits.h: is_same_typeof(): Remove unused macro
2:  a45fa2fd ! 2:  e0a1bceb lib/, src/: Use _Generic(3) instead of __builtin_types_compatible_p()
    @@ src/usermod.c: getid_range(const char *str)
      
     -  static_assert(is_same_type(id_t, uid_t), "");
     -  static_assert(is_same_type(id_t, gid_t), "");
    -+  _Generic((id_t){}, uid_t: (void)0);
    -+  _Generic((id_t){}, gid_t: (void)0);
    ++  _Generic((id_t){0}, uid_t: (void)0);
    ++  _Generic((id_t){0}, gid_t: (void)0);
      
        first = type_min(id_t);
        last = type_max(id_t);
```
</details>

<details>
<summary>v2b</summary>

-  Rebase

```
$ git rd 
1:  00680d8c5819 = 1:  8e58a9aba072 lib/typetraits.h: is_same_typeof(): Remove unused macro
2:  e0a1bceb0eed ! 2:  28ba303d6467 lib/, src/: Use _Generic(3) instead of __builtin_types_compatible_p()
    @@ Commit message
     
      ## lib/typetraits.h ##
     @@
    - )
    + #endif
      
      
     -#define is_same_type(a, b)                                                    \
    @@ src/usermod.c
      #include <errno.h>
      #include <fcntl.h>
     @@ src/usermod.c: getid_range(const char *str)
    -           .last = type_min(id_t)
    +           .last = minof(id_t)
        };
      
     -  static_assert(is_same_type(id_t, uid_t), "");
    @@ src/usermod.c: getid_range(const char *str)
     +  _Generic((id_t){0}, uid_t: (void)0);
     +  _Generic((id_t){0}, gid_t: (void)0);
      
    -   first = type_min(id_t);
    -   last = type_max(id_t);
    +   first = minof(id_t);
    +   last = maxof(id_t);
```
</details>

<details>
<summary>v2c</summary>

-  Rebase

```
$ git rd
1:  8e58a9aba072 = 1:  9f5b920df00c lib/typetraits.h: is_same_typeof(): Remove unused macro
2:  28ba303d6467 = 2:  5f4a3627e971 lib/, src/: Use _Generic(3) instead of __builtin_types_compatible_p()
```
</details>