### PR TITLE
lib/chkname.c, src/: Strictly disallow the baddest names

### DIFF
--- a/src/newusers.c
+++ b/src/newusers.c
@@ -398,7 +398,7 @@ static int add_user (const char *name, uid_t uid, gid_t gid)
 
 	/* Check if this is a valid user name */
 	if (!is_valid_user_name(name)) {
-		if (errno == EINVAL) {
+		if (errno == EILSEQ) {
 			fprintf(stderr,
 			        _("%s: invalid user name '%s': use --badname to ignore\n"),
 			        Prog, name);

--- a/src/pwck.c
+++ b/src/pwck.c
@@ -492,7 +492,7 @@ static void check_pw_file(bool *errors, bool *changed, const struct option_flags
 		 */
 
 		if (!is_valid_user_name(pwd->pw_name)) {
-			if (errno == EINVAL) {
+			if (errno == EILSEQ) {
 				printf(_("invalid user name '%s': use --badname to ignore\n"),
 				       pwd->pw_name);
 			} else {

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -1498,7 +1498,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 
 		user_name = argv[optind];
 		if (!is_valid_user_name(user_name)) {
-			if (errno == EINVAL) {
+			if (errno == EILSEQ) {
 				fprintf(stderr,
 				        _("%s: invalid user name '%s': use --badname to ignore\n"),
 				        Prog, user_name);

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -1137,7 +1137,7 @@ process_flags(int argc, char **argv, struct option_flags *flags)
 				/*@notreached@*/break;
 			case 'l':
 				if (!is_valid_user_name(optarg)) {
-					if (errno == EINVAL) {
+					if (errno == EILSEQ) {
 						fprintf(stderr,
 						        _("%s: invalid user name '%s': use --badname to ignore\n"),
 						        Prog, optarg);


### PR DESCRIPTION
 
    Some names are bad, and some names are really bad.  '--badname' should
    only allow the mildly bad ones, which we can handle.  Some names are too
    bad, and it's not possible to deal with them.  Reject them
    unconditionally.
    
    -  A leading '-' is too dangerous.  It breaks things like execve(2), and
       almost every command.
    
    -  Spaces are used for delimiting lists of users and groups.
    
    -  '"' is special in many languages, including the shell.  Having it in
       user names would be unnecessarily dangerous.
    
    -  '#' is used for delimiting comments in several of our config files.
       Having it in usernames could result in incorrect configuration files.
    
    -  ',' is used for delimiting lists of users and groups.
    
    -  '/' is used for delimiting files, and thus could result in incorrect
       handling of users and groups.
    
    -  ':' is the main delimiter in /etc/shadow and /etc/passwd.
    
    -  ';' is special in many languages, including the shell.  Having it in
       user names would be unnecessarily dangerous.
    
    There are other characters that we should disallow, but they need more
    research to make sure we don't introduce regressions.  This set should
    be less problematic.

Acked-by: @zeha
Acked-by: @stoeckmann
Cc: @zugschlus
Cc: @ikerexxe 
Cc: @hallyn

---

-  This is a subset of <https://github.com/shadow-maint/shadow/pull/1158> at v14.

---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase
-  Reviewed-by @ikerexxe , @zeha 

```
$ git rd 
1:  1d2c5ea5e ! 1:  e3d835320 lib/chkname.c, src/: Strictly disallow really bad names
    @@ Commit message
         research to make sure we don't introduce regressions.  This set should
         be less problematic.
     
    -    Acked-by: Chris Hofstaedtler <zeha@debian.org>
         Acked-by: Tobias Stoeckmann <tobias@stoeckmann.org>
    +    Reviewed-by: Iker Pedrosa <ipedrosa@redhat.com>
    +    Reviewed-by: Chris Hofstaedtler <zeha@debian.org>
         Cc: Marc 'Zugschlus' Haber <mh+githubvisible@zugschlus.de>
    -    Cc: Iker Pedrosa <ipedrosa@redhat.com>
         Cc: Serge Hallyn <serge@hallyn.com>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
```
</details>

<details>
<summary>v2</summary>

-  Ban `'`.

```
$ git rd 
1:  e3d835320 ! 1:  266308458 lib/chkname.c, src/: Strictly disallow really bad names
    @@ Commit message
         -  '#' is used for delimiting comments in several of our config files.
            Having it in usernames could result in incorrect configuration files.
     
    +    -  "'" is special in many languages, including the shell.  Having it in
    +       user names would be unnecessarily dangerous.
    +
         -  ',' is used for delimiting lists of users and groups.
     
         -  '/' is used for delimiting files, and thus could result in incorrect
    @@ lib/chkname.c: login_name_max_size(void)
     +   || streq(name, ".")
     +   || streq(name, "..")
     +   || strspn(name, "-")
    -+   || strpbrk(name, " \"#,/:;")
    ++   || strpbrk(name, " \"#',/:;")
     +   || strchriscntrl(name)
     +   || strisdigit(name))
     +  {
```
</details>

<details>
<summary>v2b</summary>

-  Rebase

```
$ git rd 
1:  266308458 ! 1:  defdaa950 lib/chkname.c, src/: Strictly disallow really bad names
    @@ lib/chkname.c: login_name_max_size(void)
                return true;
        }
     @@ lib/chkname.c: is_valid_name(const char *name)
    -          *
    -          * as a non-POSIX, extension, allow "$" as the last char for
    -          * sake of Samba 3.x "add machine script"
    --         *
    --         * Also do not allow fully numeric names or just "." or "..".
    -          */
    +    *
    +    * as a non-POSIX, extension, allow "$" as the last char for
    +    * sake of Samba 3.x "add machine script"
    +-   *
    +-   * Also do not allow fully numeric names or just "." or "..".
    +    */
      
     -  if (strisdigit(name)) {
     -          errno = EINVAL;
```
</details>