### PR TITLE
a2i(): Implement default arguments with macro magic

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -114,6 +114,7 @@ libshadow_la_SOURCES = \
 	list.c \
 	lockpw.c \
 	loginprompt.c \
+	macro.h \
 	mail.c \
 	memory/memcpy/strncpytail.c \
 	memory/memcpy/strncpytail.h \

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -114,6 +114,7 @@ libshadow_la_SOURCES = \
 	list.c \
 	lockpw.c \
 	loginprompt.c \
+	macro.h \
 	mail.c \
 	motd.c \
 	myname.c \

--- a/lib/atoi/a2i.h
+++ b/lib/atoi/a2i.h
@@ -13,6 +13,7 @@
 
 #include "atoi/strtoi/strtoi.h"
 #include "atoi/strtoi/strtou_noneg.h"
+#include "macro.h"
 #include "typetraits.h"
 
 
@@ -21,8 +22,8 @@
 ({                                                                    \
 	T            *n_ = n;                                         \
 	QChar_of(s)  **endp_ = endp;                                  \
-	T            min_ = min;                                      \
-	T            max_ = max;                                      \
+	T            min_ = DEFAULT(minof(T), min);                   \
+	T            max_ = DEFAULT(maxof(T), max);                   \
 	                                                              \
 	int  status;                                                  \
 	                                                              \
@@ -53,7 +54,7 @@
 #define a2ul(...)   a2i(unsigned long, __VA_ARGS__)
 #define a2ull(...)  a2i(unsigned long long, __VA_ARGS__)
 
-#define str2i(T, ...)  a2i(T, __VA_ARGS__, NULL, 0, minof(T), maxof(T))
+#define str2i(T, ...)  a2i(T, __VA_ARGS__, NULL, 0,,)
 
 #define str2sh(...)    str2i(short, __VA_ARGS__)
 #define str2si(...)    str2i(int, __VA_ARGS__)

--- a/lib/atoi/getnum.h
+++ b/lib/atoi/getnum.h
@@ -31,28 +31,28 @@ inline int get_uid(const char *restrict uidstr, uid_t *restrict uid);
 inline int
 get_fd(const char *restrict fdstr, int *restrict fd)
 {
-	return a2si(fd, fdstr, NULL, 10, 0, INT_MAX);
+	return a2si(fd, fdstr, NULL, 10, 0,);
 }
 
 
 inline int
 get_gid(const char *restrict gidstr, gid_t *restrict gid)
 {
-	return a2i(gid_t, gid, gidstr, NULL, 10, minof(gid_t), maxof(gid_t));
+	return a2i(gid_t, gid, gidstr, NULL, 10,,);
 }
 
 
 inline int
 get_pid(const char *restrict pidstr, pid_t *restrict pid)
 {
-	return a2i(pid_t, pid, pidstr, NULL, 10, 1, maxof(pid_t));
+	return a2i(pid_t, pid, pidstr, NULL, 10, 1,);
 }
 
 
 inline int
 get_uid(const char *restrict uidstr, uid_t *restrict uid)
 {
-	return a2i(uid_t, uid, uidstr, NULL, 10, minof(uid_t), maxof(uid_t));
+	return a2i(uid_t, uid, uidstr, NULL, 10,,);
 }
 
 

--- a/lib/getdef.c
+++ b/lib/getdef.c
@@ -259,7 +259,7 @@ getdef_num(const char *item, int dflt)
 		return dflt;
 	}
 
-	if (a2si(&val, d->value, NULL, 0, -1, INT_MAX) == -1) {
+	if (a2si(&val, d->value, NULL, 0, -1,) == -1) {
 		fprintf (log_get_logfd(),
 		         _("configuration error - cannot parse %s value: '%s'"),
 		         item, d->value);
@@ -293,7 +293,7 @@ getdef_unum(const char *item, unsigned int dflt)
 		return dflt;
 	}
 
-	if (a2ui(&val, d->value, NULL, 0, 0, UINT_MAX) == -1) {
+	if (a2ui(&val, d->value, NULL, 0,,) == -1) {
 		fprintf (log_get_logfd(),
 		         _("configuration error - cannot parse %s value: '%s'"),
 		         item, d->value);
@@ -326,7 +326,7 @@ long getdef_long (const char *item, long dflt)
 		return dflt;
 	}
 
-	if (a2sl(&val, d->value, NULL, 0, -1, LONG_MAX) == -1) {
+	if (a2sl(&val, d->value, NULL, 0, -1,) == -1) {
 		fprintf (log_get_logfd(),
 		         _("configuration error - cannot parse %s value: '%s'"),
 		         item, d->value);

--- a/lib/getrange.c
+++ b/lib/getrange.c
@@ -44,7 +44,7 @@ getrange(const char *range,
 		goto parse_max;
 	}
 
-	if (a2ul(min, range, &end, 10, 0, ULONG_MAX) == -1 && errno != ENOTSUP)
+	if (a2ul(min, range, &end, 10,,) == -1 && errno != ENOTSUP)
 		return -1;
 	*has_min = true;
 
@@ -61,7 +61,7 @@ parse_max:
 		if (!isdigit_c(*end))
 			return -1;
 
-		if (a2ul(max, end, NULL, 10, *min, ULONG_MAX) == -1)
+		if (a2ul(max, end, NULL, 10, *min,) == -1)
 			return -1;
 		*has_max = true;
 

--- a/lib/limits.c
+++ b/lib/limits.c
@@ -64,7 +64,7 @@ static int setrlimit_value (unsigned int resource,
 		limit = RLIM_INFINITY;
 
 	} else {
-		if (a2i(rlim_t, &l, value, NULL, 10, 0, maxof(rlim_t)) == -1
+		if (a2i(rlim_t, &l, value, NULL, 10, 0,) == -1
 		    && errno != ENOTSUP)
 		{
 			return 0;  // FIXME: we could instead throw an error, though.

--- a/lib/macro.h
+++ b/lib/macro.h
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#ifndef SHADOW_INCLUDE_LIB_MACRO_H_
+#define SHADOW_INCLUDE_LIB_MACRO_H_
+
+
+#include "config.h"
+
+
+#define VA_IFNOT_(...)       __VA_ARGS__
+#define VA_IFNOT_1(...)
+#define VA_IFNOT(cond, ...)  VA_IFNOT_ ## cond (__VA_ARGS__)
+
+#define DEFAULT_(def, ...)                                            \
+(                                                                     \
+	/* default:  */ VA_IFNOT(__VA_OPT__(1), def)                  \
+	/* override: */ __VA_OPT__(__VA_ARGS__)                       \
+)
+
+#define DEFAULT(def, ovr)  DEFAULT_(def, ovr)
+
+
+#endif  // include guard

--- a/lib/macro.h
+++ b/lib/macro.h
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#ifndef SHADOW_INCLUDE_LIB_MACRO_H_
+#define SHADOW_INCLUDE_LIB_MACRO_H_
+
+
+#include "config.h"
+
+
+#define VA_IFNOT_1(...)
+#define VA_IFNOT_(...)       __VA_ARGS__
+#define VA_IFNOT(cond, ...)  VA_IFNOT_ ## cond (__VA_ARGS__)
+
+#define DEFAULT_(def, ...)                                            \
+(                                                                     \
+	/* default:  */ VA_IFNOT(__VA_OPT__(1), def)                  \
+	/* override: */ __VA_OPT__(__VA_ARGS__)                       \
+)
+
+#define DEFAULT(def, ovr)  DEFAULT_(def, ovr)
+
+
+#endif  // include guard

--- a/lib/shadow/shadow/sgetspent.c
+++ b/lib/shadow/shadow/sgetspent.c
@@ -72,7 +72,7 @@ sgetspent(const char *s)
 
 	if (streq(fields[2], ""))
 		spwd.sp_lstchg = -1;
-	else if (a2sl(&spwd.sp_lstchg, fields[2], NULL, 0, 0, LONG_MAX) == -1)
+	else if (a2sl(&spwd.sp_lstchg, fields[2], NULL, 0, 0,) == -1)
 		return NULL;
 
 	spwd.sp_min = -1;
@@ -83,7 +83,7 @@ sgetspent(const char *s)
 
 	if (streq(fields[4], ""))
 		spwd.sp_max = -1;
-	else if (a2sl(&spwd.sp_max, fields[4], NULL, 0, 0, LONG_MAX) == -1)
+	else if (a2sl(&spwd.sp_max, fields[4], NULL, 0, 0,) == -1)
 		return NULL;
 
 	/*
@@ -106,7 +106,7 @@ sgetspent(const char *s)
 
 	if (streq(fields[5], ""))
 		spwd.sp_warn = -1;
-	else if (a2sl(&spwd.sp_warn, fields[5], NULL, 0, 0, LONG_MAX) == -1)
+	else if (a2sl(&spwd.sp_warn, fields[5], NULL, 0, 0,) == -1)
 		return NULL;
 
 	/*
@@ -116,7 +116,7 @@ sgetspent(const char *s)
 
 	if (streq(fields[6], ""))
 		spwd.sp_inact = -1;
-	else if (a2sl(&spwd.sp_inact, fields[6], NULL, 0, 0, LONG_MAX) == -1)
+	else if (a2sl(&spwd.sp_inact, fields[6], NULL, 0, 0,) == -1)
 		return NULL;
 
 	/*
@@ -126,7 +126,7 @@ sgetspent(const char *s)
 
 	if (streq(fields[7], ""))
 		spwd.sp_expire = -1;
-	else if (a2sl(&spwd.sp_expire, fields[7], NULL, 0, 0, LONG_MAX) == -1)
+	else if (a2sl(&spwd.sp_expire, fields[7], NULL, 0, 0,) == -1)
 		return NULL;
 
 	/*

--- a/src/chage.c
+++ b/src/chage.c
@@ -168,7 +168,7 @@ static int new_fields (void)
 
 	stprintf_a(buf, "%ld", maxdays);
 	change_field(buf, sizeof(buf), _("Maximum Password Age"));
-	if (a2sl(&maxdays, buf, NULL, 0, -1, LONG_MAX) == -1)
+	if (a2sl(&maxdays, buf, NULL, 0, -1,) == -1)
 		return 0;
 
 	if (-1 == lstchgdate || lstchgdate > LONG_MAX / DAY)
@@ -189,12 +189,12 @@ static int new_fields (void)
 
 	stprintf_a(buf, "%ld", warndays);
 	change_field(buf, sizeof(buf), _("Password Expiration Warning"));
-	if (a2sl(&warndays, buf, NULL, 0, -1, LONG_MAX) == -1)
+	if (a2sl(&warndays, buf, NULL, 0, -1,) == -1)
 		return 0;
 
 	stprintf_a(buf, "%ld", inactdays);
 	change_field(buf, sizeof(buf), _("Password Inactive"));
-	if (a2sl(&inactdays, buf, NULL, 0, -1, LONG_MAX) == -1)
+	if (a2sl(&inactdays, buf, NULL, 0, -1,) == -1)
 		return 0;
 
 	if (-1 == expdate || LONG_MAX / DAY < expdate)
@@ -371,7 +371,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 			break;
 		case 'I':
 			Iflg = true;
-			if (a2sl(&inactdays, optarg, NULL, 0, -1, LONG_MAX) == -1) {
+			if (a2sl(&inactdays, optarg, NULL, 0, -1,) == -1) {
 				eprintf(_("%s: invalid numeric argument '%s'\n"),
 				         Prog, optarg);
 				usage (E_USAGE);
@@ -382,7 +382,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 			break;
 		case 'M':
 			Mflg = true;
-			if (a2sl(&maxdays, optarg, NULL, 0, -1, LONG_MAX) == -1) {
+			if (a2sl(&maxdays, optarg, NULL, 0, -1,) == -1) {
 				eprintf(_("%s: invalid numeric argument '%s'\n"),
 				         Prog, optarg);
 				usage (E_USAGE);
@@ -396,7 +396,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 			break;
 		case 'W':
 			Wflg = true;
-			if (a2sl(&warndays, optarg, NULL, 0, -1, LONG_MAX) == -1) {
+			if (a2sl(&warndays, optarg, NULL, 0, -1,) == -1) {
 				eprintf(_("%s: invalid numeric argument '%s'\n"),
 				         Prog, optarg);
 				usage (E_USAGE);

--- a/src/passwd.c
+++ b/src/passwd.c
@@ -811,9 +811,7 @@ main(int argc, char **argv)
 				usage (E_SUCCESS);
 				/*@notreached@*/break;
 			case 'i':
-				if (a2sl(&inact, optarg, NULL, 0, -1, LONG_MAX)
-				    == -1)
-				{
+				if (a2sl(&inact, optarg, NULL, 0, -1,) == -1) {
 					eprintf(_("%s: invalid numeric argument '%s'\n"),
 					         Prog, optarg);
 					usage (E_BAD_ARG);
@@ -855,9 +853,7 @@ main(int argc, char **argv)
 				anyflag = true;
 				break;
 			case 'w':
-				if (a2sl(&warn, optarg, NULL, 0, -1, LONG_MAX)
-				    == -1)
-				{
+				if (a2sl(&warn, optarg, NULL, 0, -1,) == -1) {
 					(void) eprintf(_("%s: invalid numeric argument '%s'\n"),
 					                Prog, optarg);
 					usage (E_BAD_ARG);
@@ -866,9 +862,7 @@ main(int argc, char **argv)
 				anyflag = true;
 				break;
 			case 'x':
-				if (a2sl(&age_max, optarg, NULL, 0, -1, LONG_MAX)
-				    == -1)
-				{
+				if (a2sl(&age_max, optarg, NULL, 0, -1,) == -1) {
 					(void) eprintf(_("%s: invalid numeric argument '%s'\n"),
 					                Prog, optarg);
 					usage (E_BAD_ARG);

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -411,7 +411,7 @@ get_defaults(const struct option_flags *flags)
 		 * Default Password Inactive value
 		 */
 		else if (streq(buf, DINACT)) {
-			if (a2sl(&def_inactive, ccp, NULL, 0, -1, LONG_MAX) == -1) {
+			if (a2sl(&def_inactive, ccp, NULL, 0, -1,) == -1) {
 				eprintf(_("%s: invalid numeric argument '%s'\n"),
 				         Prog, ccp);
 				eprintf(_("%s: the %s= configuration in %s will be ignored\n"),
@@ -1263,9 +1263,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 				eflg = true;
 				break;
 			case 'f':
-				if (a2sl(&def_inactive, optarg, NULL, 0, -1, LONG_MAX)
-				    == -1)
-				{
+				if (a2sl(&def_inactive, optarg, NULL, 0, -1,) == -1) {
 					eprintf(_("%s: invalid numeric argument '%s'\n"),
 					         Prog, optarg);
 					exit (E_BAD_ARG);

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -411,7 +411,7 @@ get_defaults(const struct option_flags *flags)
 		 * Default Password Inactive value
 		 */
 		else if (streq(buf, DINACT)) {
-			if (a2sl(&def_inactive, ccp, NULL, 0, -1, LONG_MAX) == -1) {
+			if (a2sl(&def_inactive, ccp, NULL, 0, -1,) == -1) {
 				eprintf(_("%s: invalid numeric argument '%s'\n"),
 				         Prog, ccp);
 				eprintf(_("%s: the %s= configuration in %s will be ignored\n"),
@@ -1265,9 +1265,7 @@ static void process_flags (int argc, char **argv, struct option_flags *flags)
 				eflg = true;
 				break;
 			case 'f':
-				if (a2sl(&def_inactive, optarg, NULL, 0, -1, LONG_MAX)
-				    == -1)
-				{
+				if (a2sl(&def_inactive, optarg, NULL, 0, -1,) == -1) {
 					eprintf(_("%s: invalid numeric argument '%s'\n"),
 					         Prog, optarg);
 					exit (E_BAD_ARG);

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -1109,9 +1109,7 @@ process_flags(int argc, char **argv, struct option_flags *flags)
 				eflg = true;
 				break;
 			case 'f':
-				if (a2sl(&user_newinactive, optarg, NULL, 0, -1, LONG_MAX)
-				    == -1)
-				{
+				if (a2sl(&user_newinactive, optarg, NULL, 0, -1,) == -1) {
 					eprintf(_("%s: invalid numeric argument '%s'\n"),
 					         Prog, optarg);
 					exit (E_BAD_ARG);


### PR DESCRIPTION
This needs some ISO C23 feature (`__VA_OPT__`), but we're already using that in stprintf_a(), which we have since 4.15.0, so it should be fine.

```c
alx@devuan:~/src/shadow/shadow/master$ git blame -- lib/string/sprintf/snprintf.h | grep __VA_OPT__
ba3456c9fd lib/string/sprintf/snprintf.h (Alejandro Colomar       2025-05-21 13:33:37 +0200 22) 	snprintf_(s, countof(s), fmt __VA_OPT__(,) __VA_ARGS__)               \
alx@devuan:~/src/shadow/shadow/master$ git show ba3456c9fd | grep __VA_OPT__
-	snprintf_(s, NITEMS(s), fmt __VA_OPT__(,) __VA_ARGS__)                \
+	snprintf_(s, countof(s), fmt __VA_OPT__(,) __VA_ARGS__)               \
alx@devuan:~/src/shadow/shadow/master$ git blame ba3456c9fd^ -- lib/string/sprintf/snprintf.h | grep __VA_OPT__
22272347b6 lib/string/sprintf/snprintf.h (Alejandro Colomar 2024-06-27 11:29:56 +0200 21) 	snprintf_(s, NITEMS(s), fmt __VA_OPT__(,) __VA_ARGS__)                \
alx@devuan:~/src/shadow/shadow/master$ git show 22272347b6 | grep -e __VA_OPT__ -e ^diff | grep -B1 -e ^- -e ^+
diff --git a/lib/string/sprintf.h b/lib/string/sprintf/snprintf.h
-	snprintf_(s, NITEMS(s), fmt __VA_OPT__(,) __VA_ARGS__)
+	snprintf_(s, NITEMS(s), fmt __VA_OPT__(,) __VA_ARGS__)                \
alx@devuan:~/src/shadow/shadow/master$ git blame 22272347b6^ -- lib/string/sprintf.h | grep __VA_OPT__
8c6634d9bc lib/string/sprintf.h (Alejandro Colomar 2023-08-26 14:54:44 +0200 23) 	snprintf_(s, NITEMS(s), fmt __VA_OPT__(,) __VA_ARGS__)
alx@devuan:~/src/shadow/shadow/master$ git show 8c6634d9bc | grep -e __VA_OPT__ -e ^diff | grep -B1 -e ^- -e ^+
diff --git a/lib/string/sprintf.h b/lib/string/sprintf.h
-	len_ = snprintf(s, sz_, fmt __VA_OPT__(,) __VA_ARGS__);               \
+	snprintf_(s, NITEMS(s), fmt __VA_OPT__(,) __VA_ARGS__)
alx@devuan:~/src/shadow/shadow/master$ git blame 8c6634d9bc^ -- lib/string/sprintf.h | grep __VA_OPT__
ce4c4d4ad5 lib/string/sprintf.h (Alejandro Colomar 2023-08-26 12:11:59 +0200 27) 	len_ = snprintf(s, sz_, fmt __VA_OPT__(,) __VA_ARGS__);               \
alx@devuan:~/src/shadow/shadow/master$ git show ce4c4d4ad5 | grep -e __VA_OPT__ -e ^diff | grep -B1 -e ^- -e ^+
diff --git a/lib/string/sprintf.h b/lib/string/sprintf.h
+	len_ = snprintf(s, sz_, fmt __VA_OPT__(,) __VA_ARGS__);               \
alx@devuan:~/src/shadow/shadow/master$ git ref ce4c4d4ad5
ce4c4d4ad592 (2023-12-15; "lib/string/sprintf.h: Add SNPRINTF() macro")
alx@devuan:~/src/shadow/shadow/master$ git describe --contains ce4c4d4ad5
4.15.0-rc1~73
``` 

I've tested this in liba2i, and it works like a charm.

---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git rd 
1:  71ee7d526 = 1:  a4ce7786a lib/macro.h: DEFAULT(): Add macro
2:  439ccd4ae ! 2:  1d838ce38 lib/atoi/a2i.h: a2i(): Specify default parameter values
    @@ lib/atoi/a2i.h
     -  T            max_ = max;                                      \
     +  T            min_ = DEFAULT(type_min(T), min);                \
     +  T            max_ = DEFAULT(type_max(T), max);                \
    -                                                                       \
    +                                                                 \
        int  status;                                                  \
    -                                                                       \
    +                                                                 \
     @@
      #define a2ul(...)   a2i(unsigned long, __VA_ARGS__)
      #define a2ull(...)  a2i(unsigned long long, __VA_ARGS__)
3:  5e3800fcf ! 3:  6316a8396 lib/, src/: Use default argument values in a2i() calls
    @@ lib/limits.c: static int setrlimit_value (unsigned int resource,
     +          if (a2i(rlim_t, &l, value, NULL, 10, 0,) == -1
                    && errno != ENOTSUP)
                {
    -                   return 0;  // FIXME: We could instead throw an error, though.
    +                   return 0;  // FIXME: we could instead throw an error, though.
     
      ## lib/shadow/shadow/sgetspent.c ##
     @@ lib/shadow/shadow/sgetspent.c: sgetspent(const char *s)
```
</details>

<details>
<summary>v1c</summary>

-  Rebase

```
$ git rd 
1:  a4ce7786a815 = 1:  b1001816b6cb lib/macro.h: DEFAULT(): Add macro
2:  1d838ce38c17 = 2:  a20b4db001cc lib/atoi/a2i.h: a2i(): Specify default parameter values
3:  6316a8396d31 ! 3:  7efe7636a106 lib/, src/: Use default argument values in a2i() calls
    @@ lib/getdef.c: getdef_num(const char *item, int dflt)
      
     -  if (a2si(&val, d->value, NULL, 0, -1, INT_MAX) == -1) {
     +  if (a2si(&val, d->value, NULL, 0, -1,) == -1) {
    -           fprintf (shadow_logfd,
    +           fprintf (log_get_logfd(),
                         _("configuration error - cannot parse %s value: '%s'"),
                         item, d->value);
     @@ lib/getdef.c: getdef_unum(const char *item, unsigned int dflt)
    @@ lib/getdef.c: getdef_unum(const char *item, unsigned int dflt)
      
     -  if (a2ui(&val, d->value, NULL, 0, 0, UINT_MAX) == -1) {
     +  if (a2ui(&val, d->value, NULL, 0,,) == -1) {
    -           fprintf (shadow_logfd,
    +           fprintf (log_get_logfd(),
                         _("configuration error - cannot parse %s value: '%s'"),
                         item, d->value);
     @@ lib/getdef.c: long getdef_long (const char *item, long dflt)
    @@ lib/getdef.c: long getdef_long (const char *item, long dflt)
      
     -  if (a2sl(&val, d->value, NULL, 0, -1, LONG_MAX) == -1) {
     +  if (a2sl(&val, d->value, NULL, 0, -1,) == -1) {
    -           fprintf (shadow_logfd,
    +           fprintf (log_get_logfd(),
                         _("configuration error - cannot parse %s value: '%s'"),
                         item, d->value);
     
```
</details>

<details>
<summary>v1d</summary>

-  Rebase

```
$ git rd 
1:  b1001816 = 1:  eb0c8561 lib/macro.h: DEFAULT(): Add macro
2:  a20b4db0 = 2:  f52653c5 lib/atoi/a2i.h: a2i(): Specify default parameter values
3:  7efe7636 = 3:  6c779df5 lib/, src/: Use default argument values in a2i() calls
```
</details>

<details>
<summary>v1e</summary>

-  Rebase

```
$ git rd 
1:  eb0c8561 = 1:  1190ea99 lib/macro.h: DEFAULT(): Add macro
2:  f52653c5 = 2:  84804c9b lib/atoi/a2i.h: a2i(): Specify default parameter values
3:  6c779df5 = 3:  d8b198e1 lib/, src/: Use default argument values in a2i() calls
```
</details>

<details>
<summary>v1f</summary>

-  Rebase

```
$ git rd 
1:  1190ea9995cb = 1:  56b5e9646c17 lib/macro.h: DEFAULT(): Add macro
2:  84804c9b0e50 = 2:  9a5eda54eb55 lib/atoi/a2i.h: a2i(): Specify default parameter values
3:  d8b198e1d9c8 ! 3:  c076db404d04 lib/, src/: Use default argument values in a2i() calls
    @@ lib/getrange.c: getrange(const char *range,
        *has_min = true;
      
     @@ lib/getrange.c: parse_max:
    -           if (!isdigit((unsigned char) *end))
    +           if (!isdigit_c(*end))
                        return -1;
      
     -          if (a2ul(max, end, NULL, 10, *min, ULONG_MAX) == -1)
```
</details>

<details>
<summary>v2</summary>

-  Rebase

```
$ git rd -U0
1:  56b5e9646c17 = 1:  ea4bf6b054cc lib/macro.h: DEFAULT(): Add macro
2:  9a5eda54eb55 ! 2:  c114b015be68 lib/atoi/a2i.h: a2i(): Specify default parameter values
    @@ lib/atoi/a2i.h
    --#define str2i(T, ...)  a2i(T, __VA_ARGS__, NULL, 0, type_min(T), type_max(T))
    +-#define str2i(T, ...)  a2i(T, __VA_ARGS__, NULL, 0, minof(T), maxof(T))
3:  c076db404d04 ! 3:  4a8f504824a5 lib/, src/: Use default argument values in a2i() calls
    @@ lib/atoi/getnum.h: inline int get_uid(const char *restrict uidstr, uid_t *restri
    --  return a2i(gid_t, gid, gidstr, NULL, 10, type_min(gid_t), type_max(gid_t));
    +-  return a2i(gid_t, gid, gidstr, NULL, 10, minof(gid_t), maxof(gid_t));
    @@ lib/atoi/getnum.h: inline int get_uid(const char *restrict uidstr, uid_t *restri
    --  return a2i(pid_t, pid, pidstr, NULL, 10, 1, type_max(pid_t));
    +-  return a2i(pid_t, pid, pidstr, NULL, 10, 1, maxof(pid_t));
    @@ lib/atoi/getnum.h: inline int get_uid(const char *restrict uidstr, uid_t *restri
    --  return a2i(uid_t, uid, uidstr, NULL, 10, type_min(uid_t), type_max(uid_t));
    +-  return a2i(uid_t, uid, uidstr, NULL, 10, minof(uid_t), maxof(uid_t));
    @@ lib/limits.c: static int setrlimit_value (unsigned int resource,
    --          if (a2i(rlim_t, &l, value, NULL, 10, 0, type_max(rlim_t)) == -1
    +-          if (a2i(rlim_t, &l, value, NULL, 10, 0, maxof(rlim_t)) == -1
    @@ lib/shadow/shadow/sgetspent.c: sgetspent(const char *s)
    -   /*
    -@@ lib/shadow/shadow/sgetspent.c: sgetspent(const char *s)
    - 
    -   if (streq(fields[3], ""))
    -           spwd.sp_min = -1;
    --  else if (a2sl(&spwd.sp_min, fields[3], NULL, 0, 0, LONG_MAX) == -1)
    -+  else if (a2sl(&spwd.sp_min, fields[3], NULL, 0, 0,) == -1)
    -           return NULL;
    - 
    -   /*
    +   spwd.sp_min = -1;
    @@ src/chage.c: static int new_fields (void)
    -   stprintf_a(buf, "%ld", mindays);
    -   change_field(buf, sizeof(buf), _("Minimum Password Age"));
    --  if (a2sl(&mindays, buf, NULL, 0, -1, LONG_MAX) == -1)
    -+  if (a2sl(&mindays, buf, NULL, 0, -1,) == -1)
    -           return 0;
    - 
    @@ src/chage.c: static void process_flags (int argc, char **argv, struct option_fla
    -                           fprintf (stderr,
    -                                    _("%s: invalid numeric argument '%s'\n"),
    -                                    Prog, optarg);
    -@@ src/chage.c: static void process_flags (int argc, char **argv, struct option_flags *flags)
    -                   break;
    -           case 'm':
    -                   mflg = true;
    --                  if (a2sl(&mindays, optarg, NULL, 0, -1, LONG_MAX) == -1) {
    -+                  if (a2sl(&mindays, optarg, NULL, 0, -1,) == -1) {
    -                           fprintf (stderr,
    -                                    _("%s: invalid numeric argument '%s'\n"),
    +                           eprintf(_("%s: invalid numeric argument '%s'\n"),
    @@ src/chage.c: static void process_flags (int argc, char **argv, struct option_fla
    +                           usage (E_USAGE);
    @@ src/chage.c: static void process_flags (int argc, char **argv, struct option_fla
    -                           fprintf (stderr,
    -                                    _("%s: invalid numeric argument '%s'\n"),
    +                           eprintf(_("%s: invalid numeric argument '%s'\n"),
    @@ src/chage.c: static void process_flags (int argc, char **argv, struct option_fla
    +                           usage (E_USAGE);
    @@ src/chage.c: static void process_flags (int argc, char **argv, struct option_fla
    -                           fprintf (stderr,
    -                                    _("%s: invalid numeric argument '%s'\n"),
    +                           eprintf(_("%s: invalid numeric argument '%s'\n"),
    @@ src/chage.c: static void process_flags (int argc, char **argv, struct option_fla
    +                           usage (E_USAGE);
    @@ src/passwd.c: main(int argc, char **argv)
    -                                   fprintf (stderr,
    -                                            _("%s: invalid numeric argument '%s'\n"),
    -                                            Prog, optarg);
    -@@ src/passwd.c: main(int argc, char **argv)
    -                           anyflag = true;
    -                           break;
    -                   case 'n':
    --                          if (a2sl(&age_min, optarg, NULL, 0, -1, LONG_MAX)
    --                              == -1)
    --                          {
    -+                          if (a2sl(&age_min, optarg, NULL, 0, -1,) == -1) {
    -                                   fprintf (stderr,
    -                                            _("%s: invalid numeric argument '%s'\n"),
    +                                   eprintf(_("%s: invalid numeric argument '%s'\n"),
    @@ src/passwd.c: main(int argc, char **argv)
    +                                   usage (E_BAD_ARG);
    @@ src/passwd.c: main(int argc, char **argv)
    -                                   (void) fprintf (stderr,
    -                                                   _("%s: invalid numeric argument '%s'\n"),
    +                                   (void) eprintf(_("%s: invalid numeric argument '%s'\n"),
    @@ src/passwd.c: main(int argc, char **argv)
    +                                   usage (E_BAD_ARG);
    @@ src/passwd.c: main(int argc, char **argv)
    -                                   (void) fprintf (stderr,
    -                                                   _("%s: invalid numeric argument '%s'\n"),
    +                                   (void) eprintf(_("%s: invalid numeric argument '%s'\n"),
    @@ src/passwd.c: main(int argc, char **argv)
    +                                   usage (E_BAD_ARG);
    @@ src/useradd.c: get_defaults(const struct option_flags *flags)
    -                           fprintf (stderr,
    -                                    _("%s: invalid numeric argument '%s'\n"),
    +                           eprintf(_("%s: invalid numeric argument '%s'\n"),
    @@ src/useradd.c: get_defaults(const struct option_flags *flags)
    +                           eprintf(_("%s: the %s= configuration in %s will be ignored\n"),
    @@ src/useradd.c: static void process_flags (int argc, char **argv, struct option_f
    -                                   fprintf (stderr,
    -                                            _("%s: invalid numeric argument '%s'\n"),
    +                                   eprintf(_("%s: invalid numeric argument '%s'\n"),
    @@ src/useradd.c: static void process_flags (int argc, char **argv, struct option_f
    +                                   exit (E_BAD_ARG);
    @@ src/usermod.c: process_flags(int argc, char **argv, struct option_flags *flags)
    -                                   fprintf (stderr,
    -                                            _("%s: invalid numeric argument '%s'\n"),
    +                                   eprintf(_("%s: invalid numeric argument '%s'\n"),
    @@ src/usermod.c: process_flags(int argc, char **argv, struct option_flags *flags)
    +                                   exit (E_BAD_ARG);
```
</details>

<details>
<summary>v2b</summary>

-  Update name of maxof/minof after rebase.

```
$ git rd 
1:  ea4bf6b054cc = 1:  ea4bf6b054cc lib/macro.h: DEFAULT(): Add macro
2:  c114b015be68 ! 2:  ffcac9c38420 lib/atoi/a2i.h: a2i(): Specify default parameter values
    @@ lib/atoi/a2i.h
        QChar_of(s)  **endp_ = endp;                                  \
     -  T            min_ = min;                                      \
     -  T            max_ = max;                                      \
    -+  T            min_ = DEFAULT(type_min(T), min);                \
    -+  T            max_ = DEFAULT(type_max(T), max);                \
    ++  T            min_ = DEFAULT(minof(T), min);                   \
    ++  T            max_ = DEFAULT(maxof(T), max);                   \
                                                                      \
        int  status;                                                  \
                                                                      \
3:  4a8f504824a5 = 3:  26aef1369c50 lib/, src/: Use default argument values in a2i() calls
```
</details>

<details>
<summary>v2c</summary>

-  Rebase

```
$ git rd 
1:  ea4bf6b054cc = 1:  7b5fc14ac337 lib/macro.h: DEFAULT(): Add macro
2:  ffcac9c38420 = 2:  2ce9ca981598 lib/atoi/a2i.h: a2i(): Specify default parameter values
3:  26aef1369c50 = 3:  db29c9f94567 lib/, src/: Use default argument values in a2i() calls
```
</details>

<details>
<summary>v2d</summary>

-  Rebase

```
$ git rd 
1:  7b5fc14ac337 ! 1:  c663d5af27a7 lib/macro.h: DEFAULT(): Add macro
    @@ lib/Makefile.am: libshadow_la_SOURCES = \
        loginprompt.c \
     +  macro.h \
        mail.c \
    -   motd.c \
    -   myname.c \
    +   memory/memcpy/strncpytail.c \
    +   memory/memcpy/strncpytail.h \
     
      ## lib/macro.h (new) ##
     @@
2:  2ce9ca981598 = 2:  9530ab6d97ab lib/atoi/a2i.h: a2i(): Specify default parameter values
3:  db29c9f94567 = 3:  c1bfa98bf374 lib/, src/: Use default argument values in a2i() calls
```
</details>

<details>
<summary>v2e</summary>

-  Reorder macro definitions, for alignment reasons (readability).

```
$ git rd 
1:  c663d5af27a7 ! 1:  ac3c26f299ee lib/macro.h: DEFAULT(): Add macro
    @@ lib/macro.h (new)
     +#include "config.h"
     +
     +
    -+#define VA_IFNOT_(...)       __VA_ARGS__
     +#define VA_IFNOT_1(...)
    ++#define VA_IFNOT_(...)       __VA_ARGS__
     +#define VA_IFNOT(cond, ...)  VA_IFNOT_ ## cond (__VA_ARGS__)
     +
     +#define DEFAULT_(def, ...)                                            \
2:  9530ab6d97ab = 2:  34e38eeb60b9 lib/atoi/a2i.h: a2i(): Specify default parameter values
3:  c1bfa98bf374 = 3:  be223c254a94 lib/, src/: Use default argument values in a2i() calls
```
</details>