### PR TITLE
wtmp

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -270,6 +270,8 @@ libshadow_la_SOURCES = \
 	typetraits.h \
 	tz.c \
 	ulimit.c \
+	utmp/wtmp.c \
+	utmp/wtmp.h \
 	user_busy.c \
 	valid.c \
 	write_full.c \

--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -358,8 +358,6 @@ setutmp(struct utmpx *ut)
 {
 	int err = 0;
 
-	assert (NULL != ut);
-
 	setutxent();
 	if (pututxline(ut) == NULL) {
 		err = 1;
@@ -382,6 +380,7 @@ update_utmp(const char *user, const char *tty, const char *host,
 
 	utent = get_current_utmp(main_pid);
 	ut = prepare_utmp(user, tty, host, utent, main_pid);
+	assert (NULL != ut);
 
 	(void) setutmp  (ut);	/* make entry in the utmp & wtmp files */
 

--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -348,23 +348,15 @@ prepare_utmp(const char *name, const char *line, const char *host,
 }
 
 
-/*
- * setutmp - Update utmp(5)
- *
- *	Return 1 on failure and 0 on success.
- */
-static int
+// setutmp - Update utmp(5)
+static struct utmpx *
 setutmp(struct utmpx *ut)
 {
-	int err = 0;
-
 	setutxent();
-	if (pututxline(ut) == NULL) {
-		err = 1;
-	}
+	ut = pututxline(ut);
 	endutxent();
 
-	return err;
+	return ut;
 }
 
 

--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -367,8 +367,7 @@ setutmp(struct utmpx *ut)
 	endutxent();
 
 #if !defined(USE_PAM)
-	/* This is done by pam_lastlog */
-	updwtmpx(_PATH_WTMP, ut);
+	updwtmpx(_PATH_WTMP, ut);  // wtmp(5) is PAM's responsibility
 #endif
 
 	return err;

--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -349,7 +349,7 @@ prepare_utmp(const char *name, const char *line, const char *host,
 
 
 /*
- * setutmp - Update an entry in utmp and log an entry in wtmp
+ * setutmp - Update utmp(5)
  *
  *	Return 1 on failure and 0 on success.
  */
@@ -363,10 +363,6 @@ setutmp(struct utmpx *ut)
 		err = 1;
 	}
 	endutxent();
-
-#if !defined(USE_PAM)
-	updwtmpx(_PATH_WTMP, ut);  // wtmp(5) is PAM's responsibility
-#endif
 
 	return err;
 }
@@ -382,7 +378,10 @@ update_utmp(const char *user, const char *tty, const char *host,
 	ut = prepare_utmp(user, tty, host, utent, main_pid);
 	assert (NULL != ut);
 
-	(void) setutmp  (ut);	/* make entry in the utmp & wtmp files */
+#if !defined(USE_PAM)
+	updwtmpx(_PATH_WTMP, ut);  // wtmp(5) is PAM's responsibility
+#endif
+	(void) setutmp(ut);
 
 	free(utent);
 	free(ut);

--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -348,9 +348,9 @@ prepare_utmp(const char *name, const char *line, const char *host,
 }
 
 
-// setutmp - Update utmp(5)
+// updutmpx - Update utmp(5) struct-utmpx
 static struct utmpx *
-setutmp(struct utmpx *ut)
+updutmpx(struct utmpx *ut)
 {
 	setutxent();
 	ut = pututxline(ut);
@@ -373,7 +373,7 @@ update_utmp(const char *user, const char *tty, const char *host,
 #if !defined(USE_PAM)
 	updwtmpx(_PATH_WTMP, ut);  // wtmp(5) is PAM's responsibility
 #endif
-	(void) setutmp(ut);
+	updutmpx(ut);
 
 	free(utent);
 	free(ut);

--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -1,12 +1,11 @@
-/*
- * SPDX-FileCopyrightText: 1989 - 1994, Julianne Frances Haugh
- * SPDX-FileCopyrightText: 1996 - 1999, Marek Michałkiewicz
- * SPDX-FileCopyrightText: 2001 - 2005, Tomasz Kłoczko
- * SPDX-FileCopyrightText: 2008 - 2009, Nicolas François
- * SPDX-FileCopyrightText: 2025, Evgeny Grin (Karlson2k)
- *
- * SPDX-License-Identifier: BSD-3-Clause
- */
+// SPDX-FileCopyrightText: 1989 - 1994, Julianne Frances Haugh
+// SPDX-FileCopyrightText: 1996 - 1999, Marek Michałkiewicz
+// SPDX-FileCopyrightText: 2001 - 2005, Tomasz Kłoczko
+// SPDX-FileCopyrightText: 2008 - 2009, Nicolas François
+// SPDX-FileCopyrightText: 2025, Evgeny Grin (Karlson2k)
+// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
 
 #include "config.h"
 
@@ -39,6 +38,7 @@
 #include "string/strdup/memdup.h"
 #include "string/strdup/strdup.h"
 #include "string/strdup/strndup.h"
+#include "utmp/wtmp.h"
 
 #undef NDEBUG
 #include <assert.h>
@@ -217,25 +217,6 @@ get_session_host(char **out, pid_t main_pid)
 
 	return ret;
 }
-
-
-#if !defined(USE_PAM) && !defined(HAVE_UPDWTMPX)
-/*
- * Some systems already have updwtmpx().  Others
- * don't, so we re-implement these functions if necessary.
- */
-static void
-updwtmpx(const char *filename, const struct utmpx *ut)
-{
-	int fd;
-
-	fd = open (filename, O_APPEND | O_WRONLY, 0);
-	if (fd >= 0) {
-		write_full(fd, ut, sizeof(*ut));
-		close (fd);
-	}
-}
-#endif
 
 
 /*

--- a/lib/utmp/wtmp.c
+++ b/lib/utmp/wtmp.c
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#include "config.h"
+
+#include "utmp/wtmp.h"
+
+#include <utmpx.h>
+
+
+#if !defined(HAVE_UPDWTMPX)
+extern inline void updwtmpx(const char *filename, const struct utmpx *ut);
+#endif

--- a/lib/utmp/wtmp.c
+++ b/lib/utmp/wtmp.c
@@ -10,5 +10,5 @@
 
 
 #if !defined(HAVE_UPDWTMPX)
-extern inline void updwtmpx(const char *filename, const struct utmpx *ut);
+extern inline void updwtmpx(const char *path, const struct utmpx *ut);
 #endif

--- a/lib/utmp/wtmp.h
+++ b/lib/utmp/wtmp.h
@@ -15,20 +15,21 @@
 #include "prototypes.h"
 
 
-inline void updwtmpx(const char *filename, const struct utmpx *ut);
+inline void updwtmpx(const char *path, const struct utmpx *ut);
 
 
 #if !defined(HAVE_UPDWTMPX)
 // updwtmpx(3) - update wtmp(5) struct-utmpx
 inline void
-updwtmpx(const char *filename, const struct utmpx *ut)
+updwtmpx(const char *path, const struct utmpx *ut)
 {
-	int fd;
+	int  fd;
 
-	fd = open (filename, O_APPEND | O_WRONLY, 0);
-	if (fd >= 0) {
-		write_full(fd, ut, sizeof(*ut));
-		close (fd);
-	}
+	fd = open(path, O_APPEND | O_WRONLY, 0);
+	if (fd == -1)
+		return;
+
+	write_full(fd, ut, sizeof(*ut));
+	close(fd);
 }
 #endif

--- a/lib/utmp/wtmp.h
+++ b/lib/utmp/wtmp.h
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 1989-1994, Julianne Frances Haugh
+// SPDX-FileCopyrightText: 1996-1999, Marek Michałkiewicz
+// SPDX-FileCopyrightText: 2001-2005, Tomasz Kłoczko
+// SPDX-FileCopyrightText: 2008-2009, Nicolas François
+// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#include "config.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <utmpx.h>
+
+#include "prototypes.h"
+
+
+inline void updwtmpx(const char *filename, const struct utmpx *ut);
+
+
+#if !defined(HAVE_UPDWTMPX)
+// updwtmpx(3) - update wtmp(5) struct-utmpx
+inline void
+updwtmpx(const char *filename, const struct utmpx *ut)
+{
+	int fd;
+
+	fd = open (filename, O_APPEND | O_WRONLY, 0);
+	if (fd >= 0) {
+		write_full(fd, ut, sizeof(*ut));
+		close (fd);
+	}
+}
+#endif


### PR DESCRIPTION
Some readability improvements around wtmp(5).

Closes: <https://github.com/shadow-maint/shadow/issues/1415>

---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git rd 
1:  b01e53f0e = 1:  f65be2147 lib/utmp.c: Reword comment
2:  6e1602679 = 2:  1b5294fd2 lib/utmp.c: Move assertion out of setutmp()
3:  8f797ecf7 = 3:  4374ff4b1 lib/utmp.c: Move updwtmpx(3) call out of setutmp()
4:  aec39c45b = 4:  3c2627d63 lib/utmp.c: setutmp(): Simplify error handling
5:  7775c9753 = 5:  53c221c1d lib/utmp.c: Rename setutmp() => updutmpx()
6:  7c1543e10 = 6:  d67a08960 lib/utmp*: Move wtmp(5) APIs to "utmp/wtmp.h"
7:  be6b6a984 = 7:  1753b65fc lib/utmp/wtmp.*: updwtmpx(): Cosmetic
```
</details>

<details>
<summary>v1c</summary>

-  Rebase

```
$ git rd 
1:  f65be2147 = 1:  f6d6f97a1 lib/utmp.c: Reword comment
2:  1b5294fd2 = 2:  5c41f4b47 lib/utmp.c: Move assertion out of setutmp()
3:  4374ff4b1 = 3:  5e58315b6 lib/utmp.c: Move updwtmpx(3) call out of setutmp()
4:  3c2627d63 = 4:  87ba0c851 lib/utmp.c: setutmp(): Simplify error handling
5:  53c221c1d = 5:  fab57f3a7 lib/utmp.c: Rename setutmp() => updutmpx()
6:  d67a08960 = 6:  b0f777b17 lib/utmp*: Move wtmp(5) APIs to "utmp/wtmp.h"
7:  1753b65fc = 7:  b92c8c4e4 lib/utmp/wtmp.*: updwtmpx(): Cosmetic
```
</details>

<details>
<summary>v1d</summary>

-  Rebase

```
$ git rd 
1:  f6d6f97a16d5 = 1:  e481fa20d9bb lib/utmp.c: Reword comment
2:  5c41f4b47082 = 2:  34f24cd77fc1 lib/utmp.c: Move assertion out of setutmp()
3:  5e58315b6347 = 3:  bf216f6ae48c lib/utmp.c: Move updwtmpx(3) call out of setutmp()
4:  87ba0c851516 = 4:  0340828a4173 lib/utmp.c: setutmp(): Simplify error handling
5:  fab57f3a7ab3 = 5:  a28345ca7151 lib/utmp.c: Rename setutmp() => updutmpx()
6:  b0f777b172da ! 6:  ca7d34ffd0c9 lib/utmp*: Move wtmp(5) APIs to "utmp/wtmp.h"
    @@ lib/utmp.c
      #include "config.h"
      
     @@
    - #include "string/strcpy/strncpy.h"
    + #include "string/strdup/memdup.h"
      #include "string/strdup/strdup.h"
      #include "string/strdup/strndup.h"
     -
7:  b92c8c4e4a84 = 7:  adfcedbfef41 lib/utmp/wtmp.*: updwtmpx(): Cosmetic
```
</details>

<details>
<summary>v1e</summary>

-  Rebase

```
$ git rd 
1:  e481fa20 = 1:  ff241916 lib/utmp.c: Reword comment
2:  34f24cd7 = 2:  26fb0d00 lib/utmp.c: Move assertion out of setutmp()
3:  bf216f6a = 3:  81230f15 lib/utmp.c: Move updwtmpx(3) call out of setutmp()
4:  0340828a = 4:  40681e22 lib/utmp.c: setutmp(): Simplify error handling
5:  a28345ca = 5:  d087832e lib/utmp.c: Rename setutmp() => updutmpx()
6:  ca7d34ff = 6:  b7490cf0 lib/utmp*: Move wtmp(5) APIs to "utmp/wtmp.h"
7:  adfcedbf = 7:  3af52d1c lib/utmp/wtmp.*: updwtmpx(): Cosmetic
```
</details>

<details>
<summary>v1f</summary>

-  Rebase

```
$ git rd 
1:  ff241916 = 1:  2ac02f42 lib/utmp.c: Reword comment
2:  26fb0d00 = 2:  48114631 lib/utmp.c: Move assertion out of setutmp()
3:  81230f15 = 3:  967e5a14 lib/utmp.c: Move updwtmpx(3) call out of setutmp()
4:  40681e22 = 4:  c2e492c9 lib/utmp.c: setutmp(): Simplify error handling
5:  d087832e = 5:  c9e5f2e5 lib/utmp.c: Rename setutmp() => updutmpx()
6:  b7490cf0 ! 6:  32fcbf84 lib/utmp*: Move wtmp(5) APIs to "utmp/wtmp.h"
    @@ lib/utmp.c
      #include "string/strdup/memdup.h"
      #include "string/strdup/strdup.h"
      #include "string/strdup/strndup.h"
    --
    --#ident "$Id$"
     +#include "utmp/wtmp.h"
      
    - 
    - #define UTX_LINESIZE  countof(memberof(struct utmpx, ut_line))
    + #undef NDEBUG
    + #include <assert.h>
     @@ lib/utmp.c: get_session_host(char **out, pid_t main_pid)
      }
      
7:  3af52d1c = 7:  84c746d5 lib/utmp/wtmp.*: updwtmpx(): Cosmetic
```
</details>

<details>
<summary>v1g</summary>

-  Rebase

```
$ git rd 
1:  2ac02f42e77a = 1:  604ee10f8472 lib/utmp.c: Reword comment
2:  4811463123ae = 2:  d0ec2197629d lib/utmp.c: Move assertion out of setutmp()
3:  967e5a14154e = 3:  d42e26b12ded lib/utmp.c: Move updwtmpx(3) call out of setutmp()
4:  c2e492c92f55 = 4:  0d62d130fac8 lib/utmp.c: setutmp(): Simplify error handling
5:  c9e5f2e565f2 = 5:  513ddeb59f68 lib/utmp.c: Rename setutmp() => updutmpx()
6:  32fcbf84fab2 = 6:  8e91fabc0c16 lib/utmp*: Move wtmp(5) APIs to "utmp/wtmp.h"
7:  84c746d50fa1 = 7:  c4b06e81c5a8 lib/utmp/wtmp.*: updwtmpx(): Cosmetic
```
</details>

<details>
<summary>v1h</summary>

-  Rebase

```
$ git rd 
1:  604ee10f8472 = 1:  b232c4c74c45 lib/utmp.c: Reword comment
2:  d0ec2197629d = 2:  bd429f480c60 lib/utmp.c: Move assertion out of setutmp()
3:  d42e26b12ded = 3:  4161c5cb3e22 lib/utmp.c: Move updwtmpx(3) call out of setutmp()
4:  0d62d130fac8 = 4:  daf00d16ee34 lib/utmp.c: setutmp(): Simplify error handling
5:  513ddeb59f68 = 5:  dacd289ba032 lib/utmp.c: Rename setutmp() => updutmpx()
6:  8e91fabc0c16 ! 6:  dbff225f207c lib/utmp*: Move wtmp(5) APIs to "utmp/wtmp.h"
    @@ lib/utmp.c
      #include "config.h"
      
     @@
    - #include "string/strdup/memdup.h"
    + #include "string/strcmp/streq.h"
    + #include "string/strcmp/strprefix.h"
      #include "string/strdup/strdup.h"
    - #include "string/strdup/strndup.h"
     +#include "utmp/wtmp.h"
      
      #undef NDEBUG
7:  c4b06e81c5a8 = 7:  ec326113bd29 lib/utmp/wtmp.*: updwtmpx(): Cosmetic
```
</details>

<details>
<summary>v1i</summary>

-  Rebase

```
$ git rd 
1:  b232c4c7 = 1:  87b37790 lib/utmp.c: Reword comment
2:  bd429f48 = 2:  955f31d7 lib/utmp.c: Move assertion out of setutmp()
3:  4161c5cb = 3:  0ebb0a4e lib/utmp.c: Move updwtmpx(3) call out of setutmp()
4:  daf00d16 = 4:  76d921cb lib/utmp.c: setutmp(): Simplify error handling
5:  dacd289b = 5:  284b801b lib/utmp.c: Rename setutmp() => updutmpx()
6:  dbff225f = 6:  ecd66646 lib/utmp*: Move wtmp(5) APIs to "utmp/wtmp.h"
7:  ec326113 = 7:  e9e4dab4 lib/utmp/wtmp.*: updwtmpx(): Cosmetic
```
</details>