### PR TITLE
lib/xgetXXbyYY.c: include stdint.h for SIZE_MAX

### DIFF
--- a/lib/xgetXXbyYY.c
+++ b/lib/xgetXXbyYY.c
@@ -29,6 +29,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdint.h>
 #include <errno.h>
 
 #include "alloc/malloc.h"


### PR DESCRIPTION
Fixes build failure:
```
In file included from xgetgrnam.c:40:
xgetXXbyYY.c: In function ‘xgetgrnam’:
xgetXXbyYY.c:83:31: error: ‘SIZE_MAX’ undeclared (first use in this function)
   83 |                 if (length == SIZE_MAX) {
      |                               ^~~~~~~~
```