### PR TITLE
lib/list.c: realloc(3) and memmove(3) to prevent memory leaks

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -221,6 +221,8 @@ libshadow_la_SOURCES = \
 	string/strcmp/strneq.h \
 	string/strcmp/strprefix.c \
 	string/strcmp/strprefix.h \
+	string/strcpy/memmove.c \
+	string/strcpy/memmove.h \
 	string/strcpy/stpecpy.c \
 	string/strcpy/stpecpy.h \
 	string/strcpy/strncat.c \

--- a/lib/list.c
+++ b/lib/list.c
@@ -8,6 +8,9 @@
 
 #include "config.h"
 
+#include <stddef.h>
+#include <string.h>
+
 #include "alloc/malloc.h"
 #include "alloc/realloc.h"
 #include "prototypes.h"
@@ -51,59 +54,24 @@ add_list(/*@returned@*/ /*@only@*/char **list, const char *member)
 
 /*
  * del_list - delete a member from a list of group members
- *
- *	the array of member names is searched for the old member
- *	name, and if present it is deleted from a freshly allocated
- *	list of users.
  */
-
 /*@only@*/char **
 del_list(/*@returned@*/ /*@only@*/char **list, const char *member)
 {
-	int i, j;
-	char **tmp;
+	int  n, m;
 
 	assert (NULL != member);
 	assert (NULL != list);
 
-	/*
-	 * Scan the list for the old name.  Return the original list
-	 * pointer if it is not present.
-	 */
+	do {
+		for (n = 0; list[n] != NULL; n++)
+			continue;
+		for (m = 0; list[m] != NULL && !streq(list[m], member); m++)
+			continue;
+		memmove(&list[m], &list[m+1], (n-m) * sizeof(char *));
+	} while (m != n);
 
-	for (i = j = 0; list[i] != NULL; i++) {
-		if (!streq(list[i], member)) {
-			j++;
-		}
-	}
-
-	if (j == i) {
-		return list;
-	}
-
-	/*
-	 * Allocate a new list pointer large enough to hold all the
-	 * old entries.
-	 */
-
-	tmp = xmalloc_T(j + 1, char *);
-
-	/*
-	 * Copy the original list except the deleted members to the
-	 * new list, then NULL terminate the result.  This new list
-	 * is returned to the invoker.
-	 */
-
-	for (i = j = 0; list[i] != NULL; i++) {
-		if (!streq(list[i], member)) {
-			tmp[j] = list[i];
-			j++;
-		}
-	}
-
-	tmp[j] = NULL;
-
-	return tmp;
+	return xrealloc_T(list, n+1, char *);
 }
 
 /*

--- a/lib/list.c
+++ b/lib/list.c
@@ -17,6 +17,7 @@
 #include "defines.h"
 #include "string/strchr/strchrcnt.h"
 #include "string/strcmp/streq.h"
+#include "string/strcpy/memmove.h"
 #include "string/strdup/strdup.h"
 #include "string/strtok/strsep2ls.h"
 
@@ -68,7 +69,7 @@ del_list(/*@returned@*/ /*@only@*/char **list, const char *member)
 			continue;
 		for (m = 0; list[m] != NULL && !streq(list[m], member); m++)
 			continue;
-		memmove(&list[m], &list[m+1], (n-m) * sizeof(char *));
+		memmove_T(&list[m], &list[m+1], n-m, char *);
 	} while (m != n);
 
 	return xrealloc_T(list, n+1, char *);

--- a/lib/list.c
+++ b/lib/list.c
@@ -9,6 +9,7 @@
 #include "config.h"
 
 #include "alloc/malloc.h"
+#include "alloc/realloc.h"
 #include "prototypes.h"
 #include "defines.h"
 #include "string/strchr/strchrcnt.h"
@@ -22,16 +23,11 @@
 
 /*
  * add_list - add a member to a list of group members
- *
- *	the array of member names is searched for the new member
- *	name, and if not present it is added to a freshly allocated
- *	list of users.
  */
 /*@only@*/char **
 add_list(/*@returned@*/ /*@only@*/char **list, const char *member)
 {
 	int i;
-	char **tmp;
 
 	assert (NULL != member);
 	assert (NULL != list);
@@ -40,34 +36,17 @@ add_list(/*@returned@*/ /*@only@*/char **list, const char *member)
 	 * Scan the list for the new name.  Return the original list
 	 * pointer if it is present.
 	 */
-
 	for (i = 0; list[i] != NULL; i++) {
 		if (streq(list[i], member)) {
 			return list;
 		}
 	}
 
-	/*
-	 * Allocate a new list pointer large enough to hold all the
-	 * old entries, and the new entries as well.
-	 */
+	list = xrealloc_T(list, i + 2, char *);
+	list[i] = xstrdup(member);
+	list[i+1] = NULL;
 
-	tmp = xmalloc_T(i + 2, char *);
-
-	/*
-	 * Copy the original list to the new list, then append the
-	 * new member and NULL terminate the result.  This new list
-	 * is returned to the invoker.
-	 */
-
-	for (i = 0; list[i] != NULL; i++) {
-		tmp[i] = list[i];
-	}
-
-	tmp[i] = xstrdup (member);
-	tmp[i+1] = NULL;
-
-	return tmp;
+	return list;
 }
 
 /*

--- a/lib/string/README
+++ b/lib/string/README
@@ -213,6 +213,9 @@ strcpy/ - String copying
     MEMCPY()
 	Like memcpy(3), but takes two arrays.
 
+    memmove_T()
+	Like memmove(3), but type safe.
+
 sprintf/ - Formatted string creation
 
     aprintf(3)

--- a/lib/string/strcpy/memmove.c
+++ b/lib/string/strcpy/memmove.c
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#include "config.h"
+
+#include "string/strcpy/memmove.h"

--- a/lib/string/strcpy/memmove.h
+++ b/lib/string/strcpy/memmove.h
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#ifndef SHADOW_INCLUDE_LIB_STRING_STRCPY_MEMMOVE_H_
+#define SHADOW_INCLUDE_LIB_STRING_STRCPY_MEMMOVE_H_
+
+
+#include "config.h"
+
+#include <string.h>
+
+#include "sizeof.h"
+
+
+// memmove_T - memory move type-safe
+#define memmove_T(dst, src, n, T)   memmove_T_(dst, src, n, typeas(T))
+#define memmove_T_(dst, src, n, T)  do                                \
+{                                                                     \
+	_Generic(dst, T *: (void)0);                                  \
+	_Generic(src, T *: (void)0);                                  \
+	memmove(dst, src, (n) * sizeof(T));                           \
+} while (0)
+
+
+#endif  // include guard


### PR DESCRIPTION
Cc: @uecker 

---

Revisions:

<details>
<summary>v2</summary>

-  Improve commit message.
-  Also avoid memory leaks in del_list().

```
$ git rd 
1:  378deaa4b ! 1:  7ba6b1f82 lib/list.c: realloc(3) to prevent memory leaks
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/list.c: realloc(3) to prevent memory leaks
    +    lib/list.c: add_list(): realloc(3) to prevent memory leaks
     
         Each call to add_list() that resulted in adding a group to the list was
         leaking the old list.  There's no need to allocate a fresh list.
-:  --------- > 2:  55b3d70d9 lib/list.c: del_list(): Reimplement with memmove(3) and realloc(3) to avoid memory leaks
```
</details>

<details>
<summary>v2b</summary>

-  Clarify assumption.

```
$ git rd 
1:  7ba6b1f82 = 1:  7ba6b1f82 lib/list.c: add_list(): realloc(3) to prevent memory leaks
2:  55b3d70d9 ! 2:  c4c02cc30 lib/list.c: del_list(): Reimplement with memmove(3) and realloc(3) to avoid memory leaks
    @@ Commit message
         pointer.  We already return the original pointer in some cases, so this
         must be okay.
     
    +    This change assumes that list members are unique.  As far as I can see,
    +    they are.  add_list() makes sure this is true.  If a list was manually
    +    constructed without add_list(), and uniqueness wouldn't be preserved,
    +    that would be a problem.
    +
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/list.c ##
```
</details>

<details>
<summary>v3</summary>

-  del_list(): Return early, to avoid a no-op realloc(3) call.  It also reduces indentation.

```
$ git rd 
1:  7ba6b1f82 = 1:  7ba6b1f82 lib/list.c: add_list(): realloc(3) to prevent memory leaks
2:  c4c02cc30 ! 2:  ba4c3dcb8 lib/list.c: del_list(): Reimplement with memmove(3) and realloc(3) to avoid memory leaks
    @@ lib/list.c: add_list(/*@returned@*/ /*@only@*/char **list, const char *member)
     -          if (!streq(list[i], member)) {
     -                  j++;
     -          }
    -+  if (m != n) {
    -+          memmove(&list[m], &list[m+1], n-m-1);
    -+          list[n-1] = NULL;
    -   }
    - 
    --  if (j == i) {
    --          return list;
     -  }
     -
    +-  if (j == i) {
    ++  if (m == n)
    +           return list;
    +-  }
    + 
     -  /*
     -   * Allocate a new list pointer large enough to hold all the
     -   * old entries.
    @@ lib/list.c: add_list(/*@returned@*/ /*@only@*/char **list, const char *member)
     -  }
     -
     -  tmp[j] = NULL;
    ++  memmove(&list[m], &list[m+1], n-m-1);
    ++  list[n-1] = NULL;
     +  list = xrealloc_T(list, n, char *);
      
        return tmp;
```
</details>

<details>
<summary>v3b</summary>

-  Remove blank line.

<details>
<summary>interdiff</summary>

```diff
$ git diff gh/leakls 
diff --git c/lib/list.c w/lib/list.c
index 653ccbb80..fca00cf98 100644
--- c/lib/list.c
+++ w/lib/list.c
@@ -66,7 +66,6 @@ del_list(/*@returned@*/ /*@only@*/char **list, const char *member)
                continue;
        for (m = 0; list[m] != NULL && !streq(list[m], member); m++)
                continue;
-
        if (m == n)
                return list;
 
```
</details>
<details>
<summary>range-diff</summary>

```
$ git rd
1:  7ba6b1f82 = 1:  7ba6b1f82 lib/list.c: add_list(): realloc(3) to prevent memory leaks
2:  ba4c3dcb8 ! 2:  16e9556be lib/list.c: del_list(): Reimplement with memmove(3) and realloc(3) to avoid memory leaks
    @@ lib/list.c: add_list(/*@returned@*/ /*@only@*/char **list, const char *member)
     -   * Scan the list for the old name.  Return the original list
     -   * pointer if it is not present.
     -   */
    -+  for (n = 0; list[n] != NULL; n++)
    -+          continue;
    -+  for (m = 0; list[m] != NULL && !streq(list[m], member); m++)
    -+          continue;
    - 
    +-
     -  for (i = j = 0; list[i] != NULL; i++) {
     -          if (!streq(list[i], member)) {
     -                  j++;
    @@ lib/list.c: add_list(/*@returned@*/ /*@only@*/char **list, const char *member)
     -  }
     -
     -  if (j == i) {
    ++  for (n = 0; list[n] != NULL; n++)
    ++          continue;
    ++  for (m = 0; list[m] != NULL && !streq(list[m], member); m++)
    ++          continue;
     +  if (m == n)
                return list;
     -  }
```
</details>
</details>

<details>
<summary>v3c</summary>

-  Fix typo.

<details>
<summary>interdiff</summary>

```diff
$ git diff 16e9556be
diff --git c/lib/list.c w/lib/list.c
index fca00cf98..ff2a2509d 100644
--- c/lib/list.c
+++ w/lib/list.c
@@ -73,7 +73,7 @@ del_list(/*@returned@*/ /*@only@*/char **list, const char *member)
        list[n-1] = NULL;
        list = xrealloc_T(list, n, char *);
 
-       return tmp;
+       return list;
 }
 
 /*
```
</details>

<details>
<summary>range-diff</summary>

```
$ git rd 
1:  7ba6b1f82 = 1:  7ba6b1f82 lib/list.c: add_list(): realloc(3) to prevent memory leaks
2:  16e9556be ! 2:  bb1baf6b2 lib/list.c: del_list(): Reimplement with memmove(3) and realloc(3) to avoid memory leaks
    @@ lib/list.c: add_list(/*@returned@*/ /*@only@*/char **list, const char *member)
     -   * Allocate a new list pointer large enough to hold all the
     -   * old entries.
     -   */
    --
    ++  memmove(&list[m], &list[m+1], n-m-1);
    ++  list[n-1] = NULL;
    ++  list = xrealloc_T(list, n, char *);
    + 
     -  tmp = xmalloc_T(j + 1, char *);
     -
     -  /*
    @@ lib/list.c: add_list(/*@returned@*/ /*@only@*/char **list, const char *member)
     -  }
     -
     -  tmp[j] = NULL;
    -+  memmove(&list[m], &list[m+1], n-m-1);
    -+  list[n-1] = NULL;
    -+  list = xrealloc_T(list, n, char *);
    - 
    -   return tmp;
    +-
    +-  return tmp;
    ++  return list;
      }
    + 
    + /*
```
</details>
</details>

<details>
<summary>v3d</summary>

-  Compact return statement.

<details>
<summary>interdiff</summary>

```diff
$ git diff bb1baf6b2
diff --git c/lib/list.c w/lib/list.c
index ff2a2509d..334baa260 100644
--- c/lib/list.c
+++ w/lib/list.c
@@ -71,9 +71,7 @@ del_list(/*@returned@*/ /*@only@*/char **list, const char *member)
 
        memmove(&list[m], &list[m+1], n-m-1);
        list[n-1] = NULL;
-       list = xrealloc_T(list, n, char *);
-
-       return list;
+       return xrealloc_T(list, n, char *);
 }
 
 /*
```
</details>

<details>
<summary>range-diff</summary>

```
$ git rd 
1:  7ba6b1f82 = 1:  7ba6b1f82 lib/list.c: add_list(): realloc(3) to prevent memory leaks
2:  bb1baf6b2 ! 2:  1e0fdab10 lib/list.c: del_list(): Reimplement with memmove(3) and realloc(3) to avoid memory leaks
    @@ lib/list.c: add_list(/*@returned@*/ /*@only@*/char **list, const char *member)
     -   * Allocate a new list pointer large enough to hold all the
     -   * old entries.
     -   */
    -+  memmove(&list[m], &list[m+1], n-m-1);
    -+  list[n-1] = NULL;
    -+  list = xrealloc_T(list, n, char *);
    - 
    +-
     -  tmp = xmalloc_T(j + 1, char *);
     -
     -  /*
    @@ lib/list.c: add_list(/*@returned@*/ /*@only@*/char **list, const char *member)
     -  tmp[j] = NULL;
     -
     -  return tmp;
    -+  return list;
    ++  memmove(&list[m], &list[m+1], n-m-1);
    ++  list[n-1] = NULL;
    ++  return xrealloc_T(list, n, char *);
      }
      
      /*
```
</details>
</details>

<details>
<summary>v4</summary>

-  Copy the NULL delimiter with memmove(3).

```
$ git rd 
1:  7ba6b1f82 = 1:  7ba6b1f82 lib/list.c: add_list(): realloc(3) to prevent memory leaks
2:  1e0fdab10 ! 2:  64870eb95 lib/list.c: del_list(): Reimplement with memmove(3) and realloc(3) to avoid memory leaks
    @@ lib/list.c: add_list(/*@returned@*/ /*@only@*/char **list, const char *member)
     -  tmp[j] = NULL;
     -
     -  return tmp;
    -+  memmove(&list[m], &list[m+1], n-m-1);
    -+  list[n-1] = NULL;
    ++  memmove(&list[m], &list[m+1], n-m);
     +  return xrealloc_T(list, n, char *);
      }
      
```
</details>

<details>
<summary>v4b</summary>

-  Remove blank line.

```
$ git rd 
1:  7ba6b1f82 = 1:  7ba6b1f82 lib/list.c: add_list(): realloc(3) to prevent memory leaks
2:  64870eb95 ! 2:  6cbed79db lib/list.c: del_list(): Reimplement with memmove(3) and realloc(3) to avoid memory leaks
    @@ lib/list.c: add_list(/*@returned@*/ /*@only@*/char **list, const char *member)
     +  if (m == n)
                return list;
     -  }
    - 
    +-
     -  /*
     -   * Allocate a new list pointer large enough to hold all the
     -   * old entries.
```
</details>

<details>
<summary>v5</summary>

-  Iterate, to remove repeated entries.

<details>
<summary>interdiff</summary>

```diff
$ git diff gh/leakls 
diff --git c/lib/list.c w/lib/list.c
index ee56a7560..39a650567 100644
--- c/lib/list.c
+++ w/lib/list.c
@@ -62,13 +62,16 @@ del_list(/*@returned@*/ /*@only@*/char **list, const char *member)
        assert (NULL != member);
        assert (NULL != list);
 
-       for (n = 0; list[n] != NULL; n++)
-               continue;
-       for (m = 0; list[m] != NULL && !streq(list[m], member); m++)
-               continue;
-       if (m == n)
-               return list;
-       memmove(&list[m], &list[m+1], n-m);
+       do {
+               for (n = 0; list[n] != NULL; n++)
+                       continue;
+               for (m = 0; list[m] != NULL && !streq(list[m], member); m++)
+                       continue;
+               if (m == n)
+                       return list;
+               memmove(&list[m], &list[m+1], n-m);
+       } while (m != n);
+
        return xrealloc_T(list, n, char *);
 }
 
```
</details>

<details>
<summary>range-diff</summary>

```
$ git rd
1:  7ba6b1f82 = 1:  7ba6b1f82 lib/list.c: add_list(): realloc(3) to prevent memory leaks
2:  6cbed79db ! 2:  c6a7a19a8 lib/list.c: del_list(): Reimplement with memmove(3) and realloc(3) to avoid memory leaks
    @@ Commit message
         pointer.  We already return the original pointer in some cases, so this
         must be okay.
     
    -    This change assumes that list members are unique.  As far as I can see,
    -    they are.  add_list() makes sure this is true.  If a list was manually
    -    constructed without add_list(), and uniqueness wouldn't be preserved,
    -    that would be a problem.
    -
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/list.c ##
    @@ lib/list.c: add_list(/*@returned@*/ /*@only@*/char **list, const char *member)
     -   * Scan the list for the old name.  Return the original list
     -   * pointer if it is not present.
     -   */
    --
    ++  do {
    ++          for (n = 0; list[n] != NULL; n++)
    ++                  continue;
    ++          for (m = 0; list[m] != NULL && !streq(list[m], member); m++)
    ++                  continue;
    ++          if (m == n)
    ++                  return list;
    ++          memmove(&list[m], &list[m+1], n-m);
    ++  } while (m != n);
    + 
     -  for (i = j = 0; list[i] != NULL; i++) {
     -          if (!streq(list[i], member)) {
     -                  j++;
    @@ lib/list.c: add_list(/*@returned@*/ /*@only@*/char **list, const char *member)
     -  }
     -
     -  if (j == i) {
    -+  for (n = 0; list[n] != NULL; n++)
    -+          continue;
    -+  for (m = 0; list[m] != NULL && !streq(list[m], member); m++)
    -+          continue;
    -+  if (m == n)
    -           return list;
    +-          return list;
     -  }
     -
     -  /*
    @@ lib/list.c: add_list(/*@returned@*/ /*@only@*/char **list, const char *member)
     -  tmp[j] = NULL;
     -
     -  return tmp;
    -+  memmove(&list[m], &list[m+1], n-m);
     +  return xrealloc_T(list, n, char *);
      }
      
```
</details>
</details>

<details>
<summary>v6</summary>

-  del_list(): Don't shrink the allocation.  It's unnecessary, and this way we avoid an error condition.  It also simplifies the implementation.  The wasted memory shouldn't be important; after all, the memory isn't leaked.

```
$ git rd 
1:  7ba6b1f82 = 1:  7ba6b1f82 lib/list.c: add_list(): realloc(3) to prevent memory leaks
2:  c6a7a19a8 ! 2:  ee48f1a10 lib/list.c: del_list(): Reimplement with memmove(3) and realloc(3) to avoid memory leaks
    @@ lib/list.c: add_list(/*@returned@*/ /*@only@*/char **list, const char *member)
     +                  continue;
     +          for (m = 0; list[m] != NULL && !streq(list[m], member); m++)
     +                  continue;
    -+          if (m == n)
    -+                  return list;
     +          memmove(&list[m], &list[m+1], n-m);
     +  } while (m != n);
      
    @@ lib/list.c: add_list(/*@returned@*/ /*@only@*/char **list, const char *member)
     -  tmp[j] = NULL;
     -
     -  return tmp;
    -+  return xrealloc_T(list, n, char *);
    ++  return list;
      }
      
      /*
```
</details>

<details>
<summary>v7</summary>

-  Add missing sizeof() multiplication.

```
$ git rd 
1:  7ba6b1f82 = 1:  7ba6b1f82 lib/list.c: add_list(): realloc(3) to prevent memory leaks
2:  ee48f1a10 ! 2:  0d2aceb32 lib/list.c: del_list(): Reimplement with memmove(3) and realloc(3) to avoid memory leaks
    @@ lib/list.c: add_list(/*@returned@*/ /*@only@*/char **list, const char *member)
     +                  continue;
     +          for (m = 0; list[m] != NULL && !streq(list[m], member); m++)
     +                  continue;
    -+          memmove(&list[m], &list[m+1], n-m);
    ++          memmove(&list[m], &list[m+1], (n-m) * sizeof(char *));
     +  } while (m != n);
      
     -  for (i = j = 0; list[i] != NULL; i++) {
```
</details>

<details>
<summary>v8</summary>

-  Add memmove_T(), and use it instead of memmove(3).  This adds type safety.

```
$ git rd 
1:  7ba6b1f82 = 1:  7ba6b1f82 lib/list.c: add_list(): realloc(3) to prevent memory leaks
2:  0d2aceb32 = 2:  0d2aceb32 lib/list.c: del_list(): Reimplement with memmove(3) and realloc(3) to avoid memory leaks
-:  --------- > 3:  c529f833e lib/string/strcpy/: memmove_T(): Add API
-:  --------- > 4:  cdf9c9c71 lib/list.c: del_list(): Use memmove_T() instead of its pattern
```
</details>

<details>
<summary>v9</summary>

-  Clarify in the commit message why I didn't accept `const`-qualified input.
-  Convert the return value to the right type.

```
$ git rd 
1:  7ba6b1f82 = 1:  7ba6b1f82 lib/list.c: add_list(): realloc(3) to prevent memory leaks
2:  0d2aceb32 = 2:  0d2aceb32 lib/list.c: del_list(): Reimplement with memmove(3) and realloc(3) to avoid memory leaks
3:  c529f833e ! 3:  b814a74fc lib/string/strcpy/: memmove_T(): Add API
    @@ Metadata
      ## Commit message ##
         lib/string/strcpy/: memmove_T(): Add API
     
    +    An interesting detail is that we require the second argument to be
    +    non-const, while the memmove(3) function gets a const void*.  This is
    +    because the second argument should usually be just the same as the first
    +    one, plus some offset, and thus will have the same const qualification
    +    (that is, it will not be qualified).
    +
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/Makefile.am ##
    @@ lib/string/strcpy/memmove.h (new)
     +({                                                                    \
     +  _Generic(dst, T *: (void)0);                                  \
     +  _Generic(src, T *: (void)0);                                  \
    -+  memmove(dst, src, (n) * sizeof(T));                           \
    ++  (T *){memmove(dst, src, (n) * sizeof(T))};                    \
     +})
     +
     +
4:  cdf9c9c71 = 4:  79b7c3c53 lib/list.c: del_list(): Use memmove_T() instead of its pattern
```
</details>

<details>
<summary>v10</summary>

-  Reintroduce the realloc(3) call.  This is safer, as sanitizers or valgrind will more easily detect bounds violations.  BTW, after the loop, we must reallocate n+1, not n.

```
$ git rd 
1:  7ba6b1f82 = 1:  7ba6b1f82 lib/list.c: add_list(): realloc(3) to prevent memory leaks
2:  0d2aceb32 ! 2:  f9d14ed08 lib/list.c: del_list(): Reimplement with memmove(3) and realloc(3) to avoid memory leaks
    @@ lib/list.c: add_list(/*@returned@*/ /*@only@*/char **list, const char *member)
     -  tmp[j] = NULL;
     -
     -  return tmp;
    -+  return list;
    ++  return xrealloc_T(list, n+1, char *);
      }
      
      /*
3:  b814a74fc = 3:  3684af5f7 lib/string/strcpy/: memmove_T(): Add API
4:  79b7c3c53 ! 4:  c21af3c4d lib/list.c: del_list(): Use memmove_T() instead of its pattern
    @@ lib/list.c: del_list(/*@returned@*/ /*@only@*/char **list, const char *member)
     +          memmove_T(&list[m], &list[m+1], n-m, char *);
        } while (m != n);
      
    -   return list;
    +   return xrealloc_T(list, n+1, char *);
```
</details>

<details>
<summary>v10b</summary>

-  Document memmove_T() in lib/string/README.

```
$ git rd 
1:  7ba6b1f82 = 1:  7ba6b1f82 lib/list.c: add_list(): realloc(3) to prevent memory leaks
2:  f9d14ed08 = 2:  f9d14ed08 lib/list.c: del_list(): Reimplement with memmove(3) and realloc(3) to avoid memory leaks
3:  3684af5f7 ! 3:  65a37cc49 lib/string/strcpy/: memmove_T(): Add API
    @@ lib/Makefile.am: libshadow_la_SOURCES = \
        string/strcpy/stpecpy.h \
        string/strcpy/strncat.c \
     
    + ## lib/string/README ##
    +@@ lib/string/README: strcpy/ - String copying
    +     MEMCPY()
    +   Like memcpy(3), but takes two arrays.
    + 
    ++    memmove_T()
    ++  Like memmove(3), but type safe.
    ++
    + sprintf/ - Formatted string creation
    + 
    +     aprintf()
    +
      ## lib/string/strcpy/memmove.c (new) ##
     @@
     +// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
4:  c21af3c4d = 4:  8c95007b1 lib/list.c: del_list(): Use memmove_T() instead of its pattern
```
</details>

<details>
<summary>v10c</summary>

-  Rebase

```
$ git rd
1:  7ba6b1f82 = 1:  4258abf02 lib/list.c: add_list(): realloc(3) to prevent memory leaks
2:  f9d14ed08 = 2:  3818725e1 lib/list.c: del_list(): Reimplement with memmove(3) and realloc(3) to avoid memory leaks
3:  65a37cc49 = 3:  7639438e1 lib/string/strcpy/: memmove_T(): Add API
4:  8c95007b1 = 4:  5e4650e6b lib/list.c: del_list(): Use memmove_T() instead of its pattern
```
</details>

<details>
<summary>v10d</summary>

-  Rebase

```
$ git rd 
1:  4258abf02 = 1:  fcbd03d7e lib/list.c: add_list(): realloc(3) to prevent memory leaks
2:  3818725e1 = 2:  dc9dcb3f9 lib/list.c: del_list(): Reimplement with memmove(3) and realloc(3) to avoid memory leaks
3:  7639438e1 = 3:  acfbbd9dc lib/string/strcpy/: memmove_T(): Add API
4:  5e4650e6b = 4:  76373568d lib/list.c: del_list(): Use memmove_T() instead of its pattern
```
</details>

<details>
<summary>v10e</summary>

-  Rebase

```
$ git rd 
1:  fcbd03d7e95c = 1:  e521d385ef50 lib/list.c: add_list(): realloc(3) to prevent memory leaks
2:  dc9dcb3f945c = 2:  c4771bfe940e lib/list.c: del_list(): Reimplement with memmove(3) and realloc(3) to avoid memory leaks
3:  acfbbd9dca33 = 3:  8ff03b3ec30b lib/string/strcpy/: memmove_T(): Add API
4:  76373568d3c0 = 4:  d835be35c89c lib/list.c: del_list(): Use memmove_T() instead of its pattern
```
</details>

<details>
<summary>v11</summary>

-  Don't use a statement expression unnecessarily.

```
$ git rd 
1:  e521d385ef50 = 1:  e521d385ef50 lib/list.c: add_list(): realloc(3) to prevent memory leaks
2:  c4771bfe940e = 2:  c4771bfe940e lib/list.c: del_list(): Reimplement with memmove(3) and realloc(3) to avoid memory leaks
3:  8ff03b3ec30b ! 3:  ab80db0bba58 lib/string/strcpy/: memmove_T(): Add API
    @@ lib/string/strcpy/memmove.h (new)
     +// memmove_T - memory move type-safe
     +#define memmove_T(dst, src, n, T)   memmove_T_(dst, src, n, typeas(T))
     +#define memmove_T_(dst, src, n, T)                                    \
    -+({                                                                    \
    -+  _Generic(dst, T *: (void)0);                                  \
    -+  _Generic(src, T *: (void)0);                                  \
    -+  (T *){memmove(dst, src, (n) * sizeof(T))};                    \
    -+})
    ++(                                                                     \
    ++  _Generic(dst, T *: (void)0),                                  \
    ++  _Generic(src, T *: (void)0),                                  \
    ++  (T *){memmove(dst, src, (n) * sizeof(T))}                     \
    ++)
     +
     +
     +#endif  // include guard
4:  d835be35c89c = 4:  a0a653d13b60 lib/list.c: del_list(): Use memmove_T() instead of its pattern
```
</details>

<details>
<summary>v11b</summary>

-  Rebase

```
$ git rd 
1:  e521d385 = 1:  f90f47df lib/list.c: add_list(): realloc(3) to prevent memory leaks
2:  c4771bfe = 2:  96820d26 lib/list.c: del_list(): Reimplement with memmove(3) and realloc(3) to avoid memory leaks
3:  ab80db0b = 3:  f99911e6 lib/string/strcpy/: memmove_T(): Add API
4:  a0a653d1 = 4:  b4acf53b lib/list.c: del_list(): Use memmove_T() instead of its pattern
```
</details>

<details>
<summary>v11c</summary>

-  Rebase

```
$ git rd 
1:  f90f47df ! 1:  af9f4e64 lib/list.c: add_list(): realloc(3) to prevent memory leaks
    @@ Commit message
     
      ## lib/list.c ##
     @@
    - #include <assert.h>
    + #include "config.h"
      
      #include "alloc/malloc.h"
     +#include "alloc/realloc.h"
2:  96820d26 ! 2:  8d5bd6fa lib/list.c: del_list(): Reimplement with memmove(3) and realloc(3) to avoid memory leaks
    @@ lib/list.c
      
      #include "config.h"
      
    --#ident "$Id$"
     +#include <stddef.h>
     +#include <string.h>
    - 
    - #include <assert.h>
    - 
    ++
    + #include "alloc/malloc.h"
    + #include "alloc/realloc.h"
    + #include "prototypes.h"
     @@ lib/list.c: add_list(/*@returned@*/ /*@only@*/char **list, const char *member)
      
      /*
3:  f99911e6 ! 3:  1ecb3c63 lib/string/strcpy/: memmove_T(): Add API
    @@ lib/string/README: strcpy/ - String copying
     +
      sprintf/ - Formatted string creation
      
    -     aprintf()
    +     aprintf(3)
     
      ## lib/string/strcpy/memmove.c (new) ##
     @@
4:  b4acf53b = 4:  dbffce9d lib/list.c: del_list(): Use memmove_T() instead of its pattern
```
</details>

<details>
<summary>v12</summary>

-  Prevent -Wunused-value error by using a cast instead of a compound literal.

```
$ git rd 
1:  af9f4e64 = 1:  af9f4e64 lib/list.c: add_list(): realloc(3) to prevent memory leaks
2:  8d5bd6fa = 2:  8d5bd6fa lib/list.c: del_list(): Reimplement with memmove(3) and realloc(3) to avoid memory leaks
3:  1ecb3c63 ! 3:  ceba2131 lib/string/strcpy/: memmove_T(): Add API
    @@ Commit message
         one, plus some offset, and thus will have the same const qualification
         (that is, it will not be qualified).
     
    +    Use a cast instead of a compound literal, to prevent a -Wunused-value
    +    diagnostic.
    +
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/Makefile.am ##
    @@ lib/string/strcpy/memmove.h (new)
     +(                                                                     \
     +  _Generic(dst, T *: (void)0),                                  \
     +  _Generic(src, T *: (void)0),                                  \
    -+  (T *){memmove(dst, src, (n) * sizeof(T))}                     \
    ++  (T *) memmove(dst, src, (n) * sizeof(T))                      \
     +)
     +
     +
4:  dbffce9d = 4:  077ef336 lib/list.c: del_list(): Use memmove_T() instead of its pattern
```
</details>

<details>
<summary>v13</summary>

-  Better yet, return void.

```
$ git rd 
1:  af9f4e64 = 1:  af9f4e64 lib/list.c: add_list(): realloc(3) to prevent memory leaks
2:  8d5bd6fa = 2:  8d5bd6fa lib/list.c: del_list(): Reimplement with memmove(3) and realloc(3) to avoid memory leaks
3:  ceba2131 ! 3:  e87c60e6 lib/string/strcpy/: memmove_T(): Add API
    @@ Commit message
         one, plus some offset, and thus will have the same const qualification
         (that is, it will not be qualified).
     
    -    Use a cast instead of a compound literal, to prevent a -Wunused-value
    -    diagnostic.
    +    Don't return anything, as we're not using the return value.  That avoids
    +    having to use a cast (we can't use a compound literal because of
    +    -Werror=unused-value).
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    @@ lib/string/strcpy/memmove.h (new)
     +(                                                                     \
     +  _Generic(dst, T *: (void)0),                                  \
     +  _Generic(src, T *: (void)0),                                  \
    -+  (T *) memmove(dst, src, (n) * sizeof(T))                      \
    ++  memmove(dst, src, (n) * sizeof(T)),                           \
    ++  (void)0
     +)
     +
     +
4:  077ef336 = 4:  69e5f7ef lib/list.c: del_list(): Use memmove_T() instead of its pattern
```
</details>

<details>
<summary>v13b</summary>

-  Fix missing `\` from v13.

```
$ git rd 
1:  af9f4e64 = 1:  af9f4e64 lib/list.c: add_list(): realloc(3) to prevent memory leaks
2:  8d5bd6fa = 2:  8d5bd6fa lib/list.c: del_list(): Reimplement with memmove(3) and realloc(3) to avoid memory leaks
3:  e87c60e6 ! 3:  d4a6b1c2 lib/string/strcpy/: memmove_T(): Add API
    @@ lib/string/strcpy/memmove.h (new)
     +  _Generic(dst, T *: (void)0),                                  \
     +  _Generic(src, T *: (void)0),                                  \
     +  memmove(dst, src, (n) * sizeof(T)),                           \
    -+  (void)0
    ++  (void)0                                                       \
     +)
     +
     +
4:  69e5f7ef = 4:  7920b527 lib/list.c: del_list(): Use memmove_T() instead of its pattern
```
</details>

<details>
<summary>v13c</summary>

-  do{}while(0) is simpler for a function-like macro that doesn't return a value.

```
$ git rd 
1:  af9f4e64 = 1:  af9f4e64 lib/list.c: add_list(): realloc(3) to prevent memory leaks
2:  8d5bd6fa = 2:  8d5bd6fa lib/list.c: del_list(): Reimplement with memmove(3) and realloc(3) to avoid memory leaks
3:  d4a6b1c2 ! 3:  e79b2b80 lib/string/strcpy/: memmove_T(): Add API
    @@ lib/string/strcpy/memmove.h (new)
     +
     +// memmove_T - memory move type-safe
     +#define memmove_T(dst, src, n, T)   memmove_T_(dst, src, n, typeas(T))
    -+#define memmove_T_(dst, src, n, T)                                    \
    -+(                                                                     \
    -+  _Generic(dst, T *: (void)0),                                  \
    -+  _Generic(src, T *: (void)0),                                  \
    -+  memmove(dst, src, (n) * sizeof(T)),                           \
    -+  (void)0                                                       \
    -+)
    ++#define memmove_T_(dst, src, n, T)  do                                \
    ++{                                                                     \
    ++  _Generic(dst, T *: (void)0);                                  \
    ++  _Generic(src, T *: (void)0);                                  \
    ++  memmove(dst, src, (n) * sizeof(T));                           \
    ++} while (0)
     +
     +
     +#endif  // include guard
4:  7920b527 = 4:  1f0428ee lib/list.c: del_list(): Use memmove_T() instead of its pattern
```
</details>

<details>
<summary>v13d</summary>

-  Rebase

```
$ git rd 
1:  af9f4e6434f7 = 1:  58071d4dea03 lib/list.c: add_list(): realloc(3) to prevent memory leaks
2:  8d5bd6faff9f = 2:  62b66746c55f lib/list.c: del_list(): Reimplement with memmove(3) and realloc(3) to avoid memory leaks
3:  e79b2b8043f2 = 3:  ef7325b1b156 lib/string/strcpy/: memmove_T(): Add API
4:  1f0428ee769c = 4:  3eadbd1d3d14 lib/list.c: del_list(): Use memmove_T() instead of its pattern
```
</details>

<details>
<summary>v13e</summary>

-  tfix in commit message.

```
$ git rd 
1:  58071d4dea03 = 1:  58071d4dea03 lib/list.c: add_list(): realloc(3) to prevent memory leaks
2:  62b66746c55f ! 2:  0bb6a77cf61a lib/list.c: del_list(): Reimplement with memmove(3) and realloc(3) to avoid memory leaks
    @@ Metadata
      ## Commit message ##
         lib/list.c: del_list(): Reimplement with memmove(3) and realloc(3) to avoid memory leaks
     
    -    Like del_list(), each call to del_list() that wasn't a no-op, was
    +    Like add_list(), each call to del_list() that wasn't a no-op, was
         leaking the old list.  There's no need to allocate a fresh list; we can
         use memmove(3) to delete the old member, and return the original
         pointer.  We already return the original pointer in some cases, so this
3:  ef7325b1b156 = 3:  609da79c5f8c lib/string/strcpy/: memmove_T(): Add API
4:  3eadbd1d3d14 = 4:  d8cfb82e23d2 lib/list.c: del_list(): Use memmove_T() instead of its pattern
```
</details>

<details>
<summary>v13f</summary>

-  Rebase

```
$ git rd 
1:  58071d4dea03 = 1:  763a9948ee80 lib/list.c: add_list(): realloc(3) to prevent memory leaks
2:  0bb6a77cf61a = 2:  2de7217617ea lib/list.c: del_list(): Reimplement with memmove(3) and realloc(3) to avoid memory leaks
3:  609da79c5f8c = 3:  c1fc12a03053 lib/string/strcpy/: memmove_T(): Add API
4:  d8cfb82e23d2 = 4:  1e3cbc17ce69 lib/list.c: del_list(): Use memmove_T() instead of its pattern
```
</details>

<details>
<summary>v14</summary>

-  Rebase.  These leaks (and more, of which I didn't know about) have been fixed in master.  Now it's just for readability.

```
$ git rd 
1:  763a9948ee80 ! 1:  a6f2224ad80e lib/list.c: add_list(): realloc(3) to prevent memory leaks
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/list.c: add_list(): realloc(3) to prevent memory leaks
    -
    -    Each call to add_list() that resulted in adding a group to the list was
    -    leaking the old list.  There's no need to allocate a fresh list.
    -    Otherwise, it would be incorrect to return the original pointer in some
    -    cases, which we already did.
    +    lib/list.c: add_list(): Use realloc(3) instead of its pattern
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    @@ lib/list.c: add_list(/*@returned@*/ /*@only@*/char **list, const char *member)
     -  tmp[i] = xstrdup (member);
     -  tmp[i+1] = NULL;
     -
    +-  free (list);
    +-
     -  return tmp;
     +  return list;
      }
2:  2de7217617ea ! 2:  18eeb54f1064 lib/list.c: del_list(): Reimplement with memmove(3) and realloc(3) to avoid memory leaks
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/list.c: del_list(): Reimplement with memmove(3) and realloc(3) to avoid memory leaks
    -
    -    Like add_list(), each call to del_list() that wasn't a no-op, was
    -    leaking the old list.  There's no need to allocate a fresh list; we can
    -    use memmove(3) to delete the old member, and return the original
    -    pointer.  We already return the original pointer in some cases, so this
    -    must be okay.
    +    lib/list.c: del_list(): Use memmove(3) and realloc(3) to simplify
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    @@ lib/list.c: add_list(/*@returned@*/ /*@only@*/char **list, const char *member)
     +                  continue;
     +          for (m = 0; list[m] != NULL && !streq(list[m], member); m++)
     +                  continue;
    ++          free(list[m]);
     +          memmove(&list[m], &list[m+1], (n-m) * sizeof(char *));
     +  } while (m != n);
      
    @@ lib/list.c: add_list(/*@returned@*/ /*@only@*/char **list, const char *member)
     -          if (!streq(list[i], member)) {
     -                  tmp[j] = list[i];
     -                  j++;
    +-          } else {
    +-                  free (list[i]);
     -          }
     -  }
     -
     -  tmp[j] = NULL;
     -
    +-  free (list);
    +-
     -  return tmp;
     +  return xrealloc_T(list, n+1, char *);
      }
3:  c1fc12a03053 = 3:  ffee526bd16e lib/string/strcpy/: memmove_T(): Add API
4:  1e3cbc17ce69 ! 4:  756e6e19020a lib/list.c: del_list(): Use memmove_T() instead of its pattern
    @@ lib/list.c
      #include "string/strtok/strsep2ls.h"
      
     @@ lib/list.c: del_list(/*@returned@*/ /*@only@*/char **list, const char *member)
    -                   continue;
                for (m = 0; list[m] != NULL && !streq(list[m], member); m++)
                        continue;
    +           free(list[m]);
     -          memmove(&list[m], &list[m+1], (n-m) * sizeof(char *));
     +          memmove_T(&list[m], &list[m+1], n-m, char *);
        } while (m != n);
alx@devuan:~/src/shadow/shadow/master$ 
```
</details>

<details>
<summary>v15</summary>

-  Rebase after #1424 .

```
$ git range-diff master..gh/leakls strmove..leakls 
1:  a6f2224ad80e = 1:  c920283b7e79 lib/list.c: add_list(): Use realloc(3) instead of its pattern
2:  18eeb54f1064 = 2:  3d92f3afb0be lib/list.c: del_list(): Use memmove(3) and realloc(3) to simplify
3:  ffee526bd16e < -:  ------------ lib/string/strcpy/: memmove_T(): Add API
4:  756e6e19020a = 3:  2d3cad578682 lib/list.c: del_list(): Use memmove_T() instead of its pattern
```
</details>

<details>
<summary>v15b</summary>

-  Rebase

```
$ git range-diff gh/strmove..gh/leakls strmove..leakls 
1:  c920283b7e79 = 1:  b7c4823ac956 lib/list.c: add_list(): Use realloc(3) instead of its pattern
2:  3d92f3afb0be = 2:  3684c22b2ae7 lib/list.c: del_list(): Use memmove(3) and realloc(3) to simplify
3:  2d3cad578682 ! 3:  5517d97cde03 lib/list.c: del_list(): Use memmove_T() instead of its pattern
    @@ Commit message
     
      ## lib/list.c ##
     @@
    + 
    + #include "alloc/malloc.h"
    + #include "alloc/realloc.h"
    +-#include "prototypes.h"
      #include "defines.h"
    ++#include "memmory/memcpy/memmove.h"
    ++#include "prototypes.h"
      #include "string/strchr/strchrcnt.h"
      #include "string/strcmp/streq.h"
    -+#include "string/strcpy/memmove.h"
      #include "string/strdup/strdup.h"
    - #include "string/strtok/strsep2ls.h"
    - 
     @@ lib/list.c: del_list(/*@returned@*/ /*@only@*/char **list, const char *member)
                for (m = 0; list[m] != NULL && !streq(list[m], member); m++)
                        continue;
```
</details>

<details>
<summary>v15c</summary>

-  Fix include.

```
$ git range-diff gh/strmove gh/leakls leakls 
1:  b7c4823ac956 = 1:  b7c4823ac956 lib/list.c: add_list(): Use realloc(3) instead of its pattern
2:  3684c22b2ae7 = 2:  3684c22b2ae7 lib/list.c: del_list(): Use memmove(3) and realloc(3) to simplify
3:  5517d97cde03 ! 3:  44e4752965b8 lib/list.c: del_list(): Use memmove_T() instead of its pattern
    @@ lib/list.c
      #include "alloc/realloc.h"
     -#include "prototypes.h"
      #include "defines.h"
    -+#include "memmory/memcpy/memmove.h"
    ++#include "memory/memcpy/memmove.h"
     +#include "prototypes.h"
      #include "string/strchr/strchrcnt.h"
      #include "string/strcmp/streq.h"
```
</details>

<details>
<summary>v15d</summary>

-  Rebase

```
$ git range-diff gh/strmove..gh/leakls strmove..leakls 
1:  b7c4823ac956 = 1:  b4b043be8add lib/list.c: add_list(): Use realloc(3) instead of its pattern
2:  3684c22b2ae7 = 2:  20814c1a98e3 lib/list.c: del_list(): Use memmove(3) and realloc(3) to simplify
3:  44e4752965b8 = 3:  60cf6427e4b4 lib/list.c: del_list(): Use memmove_T() instead of its pattern
```
</details>

<details>
<summary>v16</summary>

-  Rebase before #1424, and move the commit adding memmove_T() to this PR (from that PR at v5b).

```
$ git range-diff gh/strmove..gh/leakls master..leakls 
-:  ------------ > 1:  ed367fca819f lib/memory/memcpy/: memmove_T(): Add API
1:  b4b043be8add = 2:  dd5a8bee19d7 lib/list.c: add_list(): Use realloc(3) instead of its pattern
2:  20814c1a98e3 = 3:  910bb66dbcd1 lib/list.c: del_list(): Use memmove(3) and realloc(3) to simplify
3:  60cf6427e4b4 = 4:  dc3472c4e968 lib/list.c: del_list(): Use memmove_T() instead of its pattern
```
</details>

<details>
<summary>v16b</summary>

-  Rebase

```
$ git rd 
1:  ed367fca819f = 1:  a77fe7ab584c lib/memory/memcpy/: memmove_T(): Add API
2:  dd5a8bee19d7 = 2:  00eaab595487 lib/list.c: add_list(): Use realloc(3) instead of its pattern
3:  910bb66dbcd1 = 3:  e7ca35fa67ab lib/list.c: del_list(): Use memmove(3) and realloc(3) to simplify
4:  dc3472c4e968 = 4:  272383f111db lib/list.c: del_list(): Use memmove_T() instead of its pattern
```
</details>

<details>
<summary>v17</summary>

-  Rebase

```
$ git rd 
1:  a77fe7ab584c ! 1:  83b4e36cb142 lib/memory/memcpy/: memmove_T(): Add API
    @@ Commit message
     
      ## lib/Makefile.am ##
     @@ lib/Makefile.am: libshadow_la_SOURCES = \
    -   lockpw.c \
    -   loginprompt.c \
    -   mail.c \
    +   memory/memcmp/memeq.h \
    +   memory/memcmp/strneq.c \
    +   memory/memcmp/strneq.h \
     +  memory/memcpy/memmove.c \
     +  memory/memcpy/memmove.h \
    -   memory/memcpy/strncpytail.c \
    -   memory/memcpy/strncpytail.h \
    -   motd.c \
    +   memory/memcpy/strncat.c \
    +   memory/memcpy/strncat.h \
    +   memory/memcpy/strncpy.c \
     
      ## lib/memory/memcpy/memmove.c (new) ##
     @@
    @@ lib/memory/memcpy/memmove.h (new)
     +#endif  // include guard
     
      ## lib/string/README ##
    -@@ lib/string/README: strcpy/ - String copying
    -     MEMCPY()
    +@@ lib/string/README: memory/ - memory operations
    +     memcpy_a()
        Like memcpy(3), but takes two arrays.
      
     +    memmove_T()
     +  Like memmove(3), but type safe.
     +
    - sprintf/ - Formatted string creation
    + string/ - string operations
    +   ctype/ - Character classification and conversion functions
      
    -     aprintf(3)
2:  00eaab595487 = 2:  9a5a933f3c94 lib/list.c: add_list(): Use realloc(3) instead of its pattern
3:  e7ca35fa67ab = 3:  bc0a8234db19 lib/list.c: del_list(): Use memmove(3) and realloc(3) to simplify
4:  272383f111db = 4:  e5e830a1f8c2 lib/list.c: del_list(): Use memmove_T() instead of its pattern
```
</details>

<details>
<summary>v17b</summary>

-  Rebase

```
$ git rd 
1:  83b4e36c = 1:  13c63d4b lib/memory/memcpy/: memmove_T(): Add API
2:  9a5a933f = 2:  bd03cb70 lib/list.c: add_list(): Use realloc(3) instead of its pattern
3:  bc0a8234 = 3:  b42a3d00 lib/list.c: del_list(): Use memmove(3) and realloc(3) to simplify
4:  e5e830a1 = 4:  bc8702d5 lib/list.c: del_list(): Use memmove_T() instead of its pattern
```
</details>

<details>
<summary>v18</summary>

-  Check `m < n` instead of checking again for `NULL`.  [@hallyn ]
-  Add `lslen()`.  [@hallyn ]
-  Document in the commit message why memmove(3) is fine to be called unconditionally.  [@hallyn ]

```
$ git rd 
1:  13c63d4b = 1:  13c63d4b lib/memory/memcpy/: memmove_T(): Add API
2:  bd03cb70 = 2:  bd03cb70 lib/list.c: add_list(): Use realloc(3) instead of its pattern
3:  b42a3d00 ! 3:  5ab24cf9 lib/list.c: del_list(): Use memmove(3) and realloc(3) to simplify
    @@ Metadata
      ## Commit message ##
         lib/list.c: del_list(): Use memmove(3) and realloc(3) to simplify
     
    +    When the second loop doesn't find anything --that is, when n==m--, the
    +    memmove(3) call is a no-op, since the length, specified by 'n-m', is 0.
    +
    +    Cc: Serge Hallyn <serge@hallyn.com>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/list.c ##
    @@ lib/list.c: add_list(/*@returned@*/ /*@only@*/char **list, const char *member)
     +  do {
     +          for (n = 0; list[n] != NULL; n++)
     +                  continue;
    -+          for (m = 0; list[m] != NULL && !streq(list[m], member); m++)
    ++          for (m = 0; m < n && !streq(list[m], member); m++)
     +                  continue;
     +          free(list[m]);
     +          memmove(&list[m], &list[m+1], (n-m) * sizeof(char *));
4:  bc8702d5 ! 4:  5dc9a262 lib/list.c: del_list(): Use memmove_T() instead of its pattern
    @@ lib/list.c
      #include "string/strcmp/streq.h"
      #include "string/strdup/strdup.h"
     @@ lib/list.c: del_list(/*@returned@*/ /*@only@*/char **list, const char *member)
    -           for (m = 0; list[m] != NULL && !streq(list[m], member); m++)
    +           for (m = 0; m < n && !streq(list[m], member); m++)
                        continue;
                free(list[m]);
     -          memmove(&list[m], &list[m+1], (n-m) * sizeof(char *));
-:  -------- > 5:  b02eba40 lib/list.c: lslen(): Add function
-:  -------- > 6:  7e39f01b lib/list.c: Use lslen() instead of its pattern
```
</details>

<details>
<summary>v18b</summary>

-  Fix const issues (C's qualifier rules are a bit bad).

```
$ git rd 
1:  13c63d4b = 1:  13c63d4b lib/memory/memcpy/: memmove_T(): Add API
2:  bd03cb70 = 2:  bd03cb70 lib/list.c: add_list(): Use realloc(3) instead of its pattern
3:  5ab24cf9 = 3:  5ab24cf9 lib/list.c: del_list(): Use memmove(3) and realloc(3) to simplify
4:  5dc9a262 = 4:  5dc9a262 lib/list.c: del_list(): Use memmove_T() instead of its pattern
5:  b02eba40 ! 5:  94df402a lib/list.c: lslen(): Add function
    @@ Commit message
         The difference is that this takes a list of pointers instead of a list
         of characters.
     
    +    The parameter is 'char*const[]' instead of 'const char*const[]', because
    +    two levels of const are problematic in C.  I have a proposal for
    +    importing C++'s qualifier rules --which are more benevolent-- into
    +    ISO C, but that'll take years to be usable.
    +
    +    Link: <https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3749.txt>
         Suggested-by: Serge Hallyn <serge@hallyn.com>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    @@ lib/list.c
      #include <assert.h>
      
      
    -+static size_t lslen(const char *const ls[]);
    ++static size_t lslen(char *const ls[]);
     +
     +
      /*
    @@ lib/list.c: comma_to_list(const char *comma)
      
     +
     +static size_t
    -+lslen(const char *const ls[])
    ++lslen(char *const ls[])
     +{
     +  size_t  i;
     +
6:  7e39f01b = 6:  e8fdf1b1 lib/list.c: Use lslen() instead of its pattern
```
</details>

<details>
<summary>v19</summary>

-  Break early from the loop, to make it explicit that memory is moved only if `n!=m`.  [@hallyn ]

```
$ git rd 
1:  13c63d4b = 1:  13c63d4b lib/memory/memcpy/: memmove_T(): Add API
2:  bd03cb70 = 2:  bd03cb70 lib/list.c: add_list(): Use realloc(3) instead of its pattern
3:  5ab24cf9 ! 3:  0128d2b2 lib/list.c: del_list(): Use memmove(3) and realloc(3) to simplify
    @@ Metadata
      ## Commit message ##
         lib/list.c: del_list(): Use memmove(3) and realloc(3) to simplify
     
    -    When the second loop doesn't find anything --that is, when n==m--, the
    -    memmove(3) call is a no-op, since the length, specified by 'n-m', is 0.
    -
         Cc: Serge Hallyn <serge@hallyn.com>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    @@ lib/list.c: add_list(/*@returned@*/ /*@only@*/char **list, const char *member)
     -   * Scan the list for the old name.  Return the original list
     -   * pointer if it is not present.
     -   */
    -+  do {
    -+          for (n = 0; list[n] != NULL; n++)
    -+                  continue;
    -+          for (m = 0; m < n && !streq(list[m], member); m++)
    -+                  continue;
    -+          free(list[m]);
    -+          memmove(&list[m], &list[m+1], (n-m) * sizeof(char *));
    -+  } while (m != n);
    - 
    +-
     -  for (i = j = 0; list[i] != NULL; i++) {
     -          if (!streq(list[i], member)) {
     -                  j++;
     -          }
    --  }
    --
    ++  for (;;) {
    ++          for (n = 0; list[n] != NULL; n++)
    ++                  continue;
    ++          for (m = 0; m < n && !streq(list[m], member); m++)
    ++                  continue;
    ++          if (m == n)
    ++                  break;
    ++          free(list[m]);
    ++          memmove(&list[m], &list[m+1], (n-m) * sizeof(char *));
    +   }
    + 
     -  if (j == i) {
     -          return list;
     -  }
4:  5dc9a262 ! 4:  67bf63c8 lib/list.c: del_list(): Use memmove_T() instead of its pattern
    @@ lib/list.c
      #include "string/strcmp/streq.h"
      #include "string/strdup/strdup.h"
     @@ lib/list.c: del_list(/*@returned@*/ /*@only@*/char **list, const char *member)
    -           for (m = 0; m < n && !streq(list[m], member); m++)
    -                   continue;
    +           if (m == n)
    +                   break;
                free(list[m]);
     -          memmove(&list[m], &list[m+1], (n-m) * sizeof(char *));
     +          memmove_T(&list[m], &list[m+1], n-m, char *);
    -   } while (m != n);
    +   }
      
        return xrealloc_T(list, n+1, char *);
5:  94df402a = 5:  36d62e7c lib/list.c: lslen(): Add function
6:  e8fdf1b1 ! 6:  b9d7bcf2 lib/list.c: Use lslen() instead of its pattern
    @@ lib/list.c: add_list(/*@returned@*/ /*@only@*/char **list, const char *member)
        assert (NULL != member);
        assert (NULL != list);
      
    -   do {
    +   for (;;) {
     -          for (n = 0; list[n] != NULL; n++)
     -                  continue;
     +          n = lslen(list);
                for (m = 0; m < n && !streq(list[m], member); m++)
                        continue;
    -           free(list[m]);
    +           if (m == n)
```
</details>