### PR TITLE
strmove(): Add API, and use it instead of its pattern

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -219,6 +219,8 @@ libshadow_la_SOURCES = \
 	string/strcmp/strneq.h \
 	string/strcmp/strprefix.c \
 	string/strcmp/strprefix.h \
+	string/strcpy/memmove.c \
+	string/strcpy/memmove.h \
 	string/strcpy/stpecpy.c \
 	string/strcpy/stpecpy.h \
 	string/strcpy/strncat.c \

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -223,6 +223,8 @@ libshadow_la_SOURCES = \
 	string/strcpy/memmove.h \
 	string/strcpy/stpecpy.c \
 	string/strcpy/stpecpy.h \
+	string/strcpy/strmove.c \
+	string/strcpy/strmove.h \
 	string/strcpy/strncat.c \
 	string/strcpy/strncat.h \
 	string/strcpy/strncpy.c \

--- a/lib/string/README
+++ b/lib/string/README
@@ -191,6 +191,10 @@ strcpy/ - String copying
 	Do NOT use.  I'll remove it soon.
 
   s/
+    strmove()
+	Like memmove(3), for strings.  It takes the length of the string
+	internally with strlen(3).
+
     strtcpy()
 	Copy from a string into another string with truncation.
 	This is what the Linux kernel calls strscpy().

--- a/lib/string/README
+++ b/lib/string/README
@@ -213,6 +213,9 @@ strcpy/ - String copying
     MEMCPY()
 	Like memcpy(3), but takes two arrays.
 
+    memmove_T()
+	Like memmove(3), but type safe.
+
 sprintf/ - Formatted string creation
 
     aprintf(3)

--- a/lib/string/strcpy/memmove.c
+++ b/lib/string/strcpy/memmove.c
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#include "config.h"
+
+#include "string/strcpy/memmove.h"

--- a/lib/string/strcpy/memmove.h
+++ b/lib/string/strcpy/memmove.h
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#ifndef SHADOW_INCLUDE_LIB_STRING_STRCPY_MEMMOVE_H_
+#define SHADOW_INCLUDE_LIB_STRING_STRCPY_MEMMOVE_H_
+
+
+#include "config.h"
+
+#include <string.h>
+
+#include "sizeof.h"
+
+
+// memmove_T - memory move type-safe
+#define memmove_T(dst, src, n, T)   memmove_T_(dst, src, n, typeas(T))
+#define memmove_T_(dst, src, n, T)                                    \
+(                                                                     \
+	_Generic(dst, T *: (void)0),                                  \
+	_Generic(src, T *: (void)0),                                  \
+	(T *){memmove(dst, src, (n) * sizeof(T))}                     \
+)
+
+
+#endif  // include guard

--- a/lib/string/strcpy/strmove.c
+++ b/lib/string/strcpy/strmove.c
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#include "config.h"
+
+#include "string/strcpy/strmove.h"
+
+
+extern inline char *strmove(char *dst, char *src);

--- a/lib/string/strcpy/strmove.h
+++ b/lib/string/strcpy/strmove.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#ifndef SHADOW_INCLUDE_LIB_STRING_STRCPY_STRMOVE_H_
+#define SHADOW_INCLUDE_LIB_STRING_STRCPY_STRMOVE_H_
+
+
+#include "config.h"
+
+#include <string.h>
+
+#include "attr.h"
+#include "string/strcpy/memmove.h"
+
+
+ATTR_STRING(2)
+inline char *strmove(char *dst, char *src);
+
+
+// strmove - string move
+inline char *
+strmove(char *dst, char *src)
+{
+	return memmove_T(dst, src, strlen(src) + 1, char);
+}
+
+
+#endif  // include guard

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -63,6 +63,7 @@
 #include "string/sprintf/aprintf.h"
 #include "string/strcmp/streq.h"
 #include "string/strcmp/strprefix.h"
+#include "string/strcpy/strmove.h"
 #include "string/strdup/strdup.h"
 #include "string/strerrno.h"
 #include "string/strspn/stprspn.h"
@@ -493,7 +494,7 @@ new_pw_passwd(char *pw_pass, bool process_selinux)
 		              "updating-password", user_newname, user_newid, 1);
 #endif
 		SYSLOG(LOG_INFO, "unlock user '%s' password", user_newname);
-		memmove(pw_pass, pw_pass + 1, strlen(pw_pass));
+		strmove(pw_pass, pw_pass + 1);
 	} else if (pflg) {
 #ifdef WITH_AUDIT
 		audit_logger (AUDIT_USER_CHAUTHTOK,


### PR DESCRIPTION
Cc: @kees, @uecker 

---

-  Queued after #1423 .

---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git rd 
1:  cc0376415cbc = 1:  2969f95a3fdc lib/string/strcpy/: memmove_T(): Add API
2:  96c06d50e92c = 2:  fc6f018d2765 lib/string/strcpy/: strmove(): Add function
3:  28aeb9f6ae4d ! 3:  b1805c7f8806 src/usermod.c: new_pw_passwd(): Use strmove() instead of its pattern
    @@ src/usermod.c
      #include "string/strdup/strdup.h"
      #include "string/strerrno.h"
      #include "string/strspn/stprspn.h"
    -@@ src/usermod.c: static char *new_pw_passwd (char *pw_pass)
    +@@ src/usermod.c: new_pw_passwd(char *pw_pass, bool process_selinux)
                              "updating-password", user_newname, user_newid, 1);
      #endif
                SYSLOG ((LOG_INFO, "unlock user '%s' password", user_newname));
```
</details>

<details>
<summary>v2</summary>

-  Don't use a statement expression unnecessarily.

```
$ git rd 
1:  2969f95a3fdc ! 1:  d038ef9e46eb lib/string/strcpy/: memmove_T(): Add API
    @@ lib/string/strcpy/memmove.h (new)
     +// memmove_T - memory move type-safe
     +#define memmove_T(dst, src, n, T)   memmove_T_(dst, src, n, typeas(T))
     +#define memmove_T_(dst, src, n, T)                                    \
    -+({                                                                    \
    -+  _Generic(dst, T *: (void)0);                                  \
    -+  _Generic(src, T *: (void)0);                                  \
    -+  (T *){memmove(dst, src, (n) * sizeof(T))};                    \
    -+})
    ++(                                                                     \
    ++  _Generic(dst, T *: (void)0),                                  \
    ++  _Generic(src, T *: (void)0),                                  \
    ++  (T *){memmove(dst, src, (n) * sizeof(T))}                     \
    ++)
     +
     +
     +#endif  // include guard
2:  fc6f018d2765 = 2:  05f665578fbd lib/string/strcpy/: strmove(): Add function
3:  b1805c7f8806 = 3:  5708a7e9e1d3 src/usermod.c: new_pw_passwd(): Use strmove() instead of its pattern
```
</details>

<details>
<summary>v2b</summary>

-  Rebase

```
$ git rd 
1:  d038ef9e = 1:  64fda595 lib/string/strcpy/: memmove_T(): Add API
2:  05f66557 = 2:  c9830723 lib/string/strcpy/: strmove(): Add function
3:  5708a7e9 ! 3:  9bdb78a0 src/usermod.c: new_pw_passwd(): Use strmove() instead of its pattern
    @@ src/usermod.c
     @@ src/usermod.c: new_pw_passwd(char *pw_pass, bool process_selinux)
                              "updating-password", user_newname, user_newid, 1);
      #endif
    -           SYSLOG ((LOG_INFO, "unlock user '%s' password", user_newname));
    +           SYSLOG(LOG_INFO, "unlock user '%s' password", user_newname);
     -          memmove(pw_pass, pw_pass + 1, strlen(pw_pass));
     +          strmove(pw_pass, pw_pass + 1);
        } else if (pflg) {
```
</details>

<details>
<summary>v2c</summary>

-  Rebase

```
$ git rd 
1:  64fda595ad05 ! 1:  f262f2d2f274 lib/string/strcpy/: memmove_T(): Add API
    @@ lib/string/README: strcpy/ - String copying
     +
      sprintf/ - Formatted string creation
      
    -     aprintf()
    +     aprintf(3)
     
      ## lib/string/strcpy/memmove.c (new) ##
     @@
2:  c98307235f8b = 2:  0542843b7a34 lib/string/strcpy/: strmove(): Add function
3:  9bdb78a02518 = 3:  9b6c18ce75cf src/usermod.c: new_pw_passwd(): Use strmove() instead of its pattern
```
</details>

<details>
<summary>v2d</summary>

-  Rebase

```
$ git rd 
1:  f262f2d2f274 = 1:  cae69c557833 lib/string/strcpy/: memmove_T(): Add API
2:  0542843b7a34 = 2:  f4289243754c lib/string/strcpy/: strmove(): Add function
3:  9b6c18ce75cf ! 3:  e5c2238a5fa5 src/usermod.c: new_pw_passwd(): Use strmove() instead of its pattern
    @@ src/usermod.c
      #include "string/strcmp/strprefix.h"
     +#include "string/strcpy/strmove.h"
      #include "string/strdup/strdup.h"
    - #include "string/strerrno.h"
      #include "string/strspn/stprspn.h"
    + #include "sysconf.h"
     @@ src/usermod.c: new_pw_passwd(char *pw_pass, bool process_selinux)
                              "updating-password", user_newname, user_newid, 1);
      #endif
```
</details>

<details>
<summary>v2e</summary>

-  Rebase

```
$ git rd 
1:  cae69c557833 = 1:  deaaad707d90 lib/string/strcpy/: memmove_T(): Add API
2:  f4289243754c = 2:  402e9eeb86cc lib/string/strcpy/: strmove(): Add function
3:  e5c2238a5fa5 = 3:  ff09b98f9a6f src/usermod.c: new_pw_passwd(): Use strmove() instead of its pattern
```
</details>

<details>
<summary>v3</summary>

-  Use <memory.h> instead of <string.h>. Historically, and morally, it's more appropriate. It's quite portable, so it should be fine, even though it's non-standard. See memory.h(3head).

```
$ git rd 
1:  deaaad707d90 ! 1:  000b38d7d56e lib/string/strcpy/: memmove_T(): Add API
    @@ lib/string/strcpy/memmove.h (new)
     +
     +#include "config.h"
     +
    -+#include <string.h>
    ++#include <memory.h>
     +
     +#include "sizeof.h"
     +
2:  402e9eeb86cc = 2:  4b15b2b57c99 lib/string/strcpy/: strmove(): Add function
3:  ff09b98f9a6f = 3:  326a707b8eae src/usermod.c: new_pw_passwd(): Use strmove() instead of its pattern
```
</details>

<details>
<summary>v4</summary>

-  Don't return a value from memmove_T(), since we don't need it.

```
$ git rd 
1:  000b38d7d56e ! 1:  3433e9779eab lib/string/strcpy/: memmove_T(): Add API
    @@ Commit message
         one, plus some offset, and thus will have the same const qualification
         (that is, it will not be qualified).
     
    +    Don't return anything, as we're not using the return value.  That avoids
    +    having to use a cast (we can't use a compound literal because of
    +    -Werror=unused-value).
    +
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/Makefile.am ##
    @@ lib/string/strcpy/memmove.h (new)
     +
     +// memmove_T - memory move type-safe
     +#define memmove_T(dst, src, n, T)   memmove_T_(dst, src, n, typeas(T))
    -+#define memmove_T_(dst, src, n, T)                                    \
    -+(                                                                     \
    -+  _Generic(dst, T *: (void)0),                                  \
    -+  _Generic(src, T *: (void)0),                                  \
    -+  (T *){memmove(dst, src, (n) * sizeof(T))}                     \
    -+)
    ++#define memmove_T_(dst, src, n, T)  do                                \
    ++{                                                                     \
    ++  _Generic(dst, T *: (void)0);                                  \
    ++  _Generic(src, T *: (void)0);                                  \
    ++  memmove(dst, src, (n) * sizeof(T));                           \
    ++} while (0)
     +
     +
     +#endif  // include guard
2:  4b15b2b57c99 = 2:  cfbf55042e66 lib/string/strcpy/: strmove(): Add function
3:  326a707b8eae = 3:  970b7fd6d474 src/usermod.c: new_pw_passwd(): Use strmove() instead of its pattern
```
</details>

<details>
<summary>v4b</summary>

-  Don't return anything from strmove() either.

```
$ git rd -U0
1:  3433e9779eab = 1:  3433e9779eab lib/string/strcpy/: memmove_T(): Add API
2:  cfbf55042e66 ! 2:  839e3a4737bf lib/string/strcpy/: strmove(): Add function
    @@ lib/string/strcpy/strmove.c (new)
    -+// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
    ++// SPDX-FileCopyrightText: 2025-2026, Alejandro Colomar <alx@kernel.org>
    @@ lib/string/strcpy/strmove.c (new)
    -+extern inline char *strmove(char *dst, char *src);
    ++extern inline void strmove(char *dst, char *src);
    @@ lib/string/strcpy/strmove.h (new)
    -+// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
    ++// SPDX-FileCopyrightText: 2025-2026, Alejandro Colomar <alx@kernel.org>
    @@ lib/string/strcpy/strmove.h (new)
    -+inline char *strmove(char *dst, char *src);
    ++inline void strmove(char *dst, char *src);
    @@ lib/string/strcpy/strmove.h (new)
    -+inline char *
    ++inline void
    @@ lib/string/strcpy/strmove.h (new)
    -+  return memmove_T(dst, src, strlen(src) + 1, char);
    ++  memmove_T(dst, src, strlen(src) + 1, char);
3:  970b7fd6d474 = 3:  7888284b548f src/usermod.c: new_pw_passwd(): Use strmove() instead of its pattern
```
</details>

<details>
<summary>v5</summary>

-  Move memmove_T() to a new lib/memory/.  [@ikerexxe ]

```
$ git rd --creation-factor=99
1:  3433e9779eab ! 1:  ad9bf2a0d7e9 lib/string/strcpy/: memmove_T(): Add API
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/string/strcpy/: memmove_T(): Add API
    +    lib/memory/memcpy/: memmove_T(): Add API
     
         An interesting detail is that we require the second argument to be
         non-const, while the memmove(3) function gets a const void*.  This is
    @@ Commit message
     
      ## lib/Makefile.am ##
     @@ lib/Makefile.am: libshadow_la_SOURCES = \
    -   string/strcmp/strneq.h \
    -   string/strcmp/strprefix.c \
    -   string/strcmp/strprefix.h \
    -+  string/strcpy/memmove.c \
    -+  string/strcpy/memmove.h \
    -   string/strcpy/stpecpy.c \
    -   string/strcpy/stpecpy.h \
    -   string/strcpy/strncat.c \
    +   lockpw.c \
    +   loginprompt.c \
    +   mail.c \
    ++  memory/memcpy/memmove.c \
    ++  memory/memcpy/memmove.h \
    +   motd.c \
    +   myname.c \
    +   nss.c \
     
    - ## lib/string/README ##
    -@@ lib/string/README: strcpy/ - String copying
    -     MEMCPY()
    -   Like memcpy(3), but takes two arrays.
    - 
    -+    memmove_T()
    -+  Like memmove(3), but type safe.
    -+
    - sprintf/ - Formatted string creation
    - 
    -     aprintf(3)
    -
    - ## lib/string/strcpy/memmove.c (new) ##
    + ## lib/memory/memcpy/memmove.c (new) ##
     @@
    -+// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
    ++// SPDX-FileCopyrightText: 2025-2026, Alejandro Colomar <alx@kernel.org>
     +// SPDX-License-Identifier: BSD-3-Clause
     +
     +
     +#include "config.h"
     +
    -+#include "string/strcpy/memmove.h"
    ++#include "memory/memcpy/memmove.h"
     
    - ## lib/string/strcpy/memmove.h (new) ##
    + ## lib/memory/memcpy/memmove.h (new) ##
     @@
    -+// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
    ++// SPDX-FileCopyrightText: 2025-2026, Alejandro Colomar <alx@kernel.org>
     +// SPDX-License-Identifier: BSD-3-Clause
     +
     +
    -+#ifndef SHADOW_INCLUDE_LIB_STRING_STRCPY_MEMMOVE_H_
    -+#define SHADOW_INCLUDE_LIB_STRING_STRCPY_MEMMOVE_H_
    ++#ifndef SHADOW_INCLUDE_LIB_MEMORY_MEMCPY_MEMMOVE_H_
    ++#define SHADOW_INCLUDE_LIB_MEMORY_MEMCPY_MEMMOVE_H_
     +
     +
     +#include "config.h"
    @@ lib/string/strcpy/memmove.h (new)
     +
     +
     +#endif  // include guard
    +
    + ## lib/string/README ##
    +@@ lib/string/README: strcpy/ - String copying
    +     MEMCPY()
    +   Like memcpy(3), but takes two arrays.
    + 
    ++    memmove_T()
    ++  Like memmove(3), but type safe.
    ++
    + sprintf/ - Formatted string creation
    + 
    +     aprintf(3)
2:  839e3a4737bf ! 2:  7d370dcbf9eb lib/string/strcpy/: strmove(): Add function
    @@ Commit message
     
      ## lib/Makefile.am ##
     @@ lib/Makefile.am: libshadow_la_SOURCES = \
    -   string/strcpy/memmove.h \
    +   string/strcmp/strprefix.h \
        string/strcpy/stpecpy.c \
        string/strcpy/stpecpy.h \
     +  string/strcpy/strmove.c \
    @@ lib/string/strcpy/strmove.h (new)
     +#include <string.h>
     +
     +#include "attr.h"
    -+#include "string/strcpy/memmove.h"
    ++#include "memory/memcpy/memmove.h"
     +
     +
     +ATTR_STRING(2)
3:  7888284b548f = 3:  f32d45cd08e8 src/usermod.c: new_pw_passwd(): Use strmove() instead of its pattern
```
</details>

<details>
<summary>v5b</summary>

-  Rebase

```
$ git rd 
1:  ad9bf2a0d7e9 ! 1:  ed367fca819f lib/memory/memcpy/: memmove_T(): Add API
    @@ lib/Makefile.am: libshadow_la_SOURCES = \
        mail.c \
     +  memory/memcpy/memmove.c \
     +  memory/memcpy/memmove.h \
    +   memory/memcpy/strncpytail.c \
    +   memory/memcpy/strncpytail.h \
        motd.c \
    -   myname.c \
    -   nss.c \
     
      ## lib/memory/memcpy/memmove.c (new) ##
     @@
2:  7d370dcbf9eb = 2:  5f6ed585356a lib/string/strcpy/: strmove(): Add function
3:  f32d45cd08e8 = 3:  611a3349db81 src/usermod.c: new_pw_passwd(): Use strmove() instead of its pattern
```
</details>

<details>
<summary>v6</summary>

-  Rebase after #1423 .

```
$ git range-diff master..gh/strmove leakls..strmove 
1:  ed367fca819f < -:  ------------ lib/memory/memcpy/: memmove_T(): Add API
2:  5f6ed585356a = 1:  74623f4ba057 lib/string/strcpy/: strmove(): Add function
3:  611a3349db81 = 2:  2482ff043dea src/usermod.c: new_pw_passwd(): Use strmove() instead of its pattern
```
</details>

<details>
<summary>v7</summary>

-  Add mempmove_T(), and use it to implement strmove().
-  Copy the terminating null byte explicitly (without memmove(3)), to make strmove() thread-safe.

```
$ git range-diff leakls gh/strmove strmove 
-:  ------------ > 1:  5acba43116c2 lib/memory/memcpy/: mempmove(): Add function
-:  ------------ > 2:  4b61fb203066 lib/memory/memcpy/: mempmove_T(): Add macro
1:  74623f4ba057 = 3:  1ab13c42c15b lib/string/strcpy/: strmove(): Add function
2:  2482ff043dea = 4:  5e1587b867e2 src/usermod.c: new_pw_passwd(): Use strmove() instead of its pattern
-:  ------------ > 5:  58cc9627dac6 lib/string/strcpy/: strmove(): Copy the terminating null byte explicitly
```
</details>

<details>
<summary>v7b</summary>

-  Squash two commits (implement strmove() thread-safe directly).

```
$ git range-diff leakls gh/strmove strmove 
1:  5acba43116c2 = 1:  5acba43116c2 lib/memory/memcpy/: mempmove(): Add function
2:  4b61fb203066 = 2:  4b61fb203066 lib/memory/memcpy/: mempmove_T(): Add macro
3:  1ab13c42c15b ! 3:  4aef0aa42bd8 lib/string/strcpy/: strmove(): Add function
    @@ Metadata
      ## Commit message ##
         lib/string/strcpy/: strmove(): Add function
     
    +    While we could copy the terminating null byte as part of the memmove(3)
    +    call, by doing strlen(src)+1, let's copy the terminating null byte
    +    explicitly.
    +
    +    This needs using mempmove_T(), but it's more robust, since it makes this
    +    API thread-safe.  If the string changes between strlen(3) and
    +    memmove(3), we still write a terminating null byte, which makes sure
    +    this remains being a string, preventing serious vulnerabilities.
    +
    +    We don't need that, since our programs are single-threaded, but it
    +    doesn't hurt, and if some other project copies this API from us, it's
    +    better that they have it thread-safe, just in case.
    +
    +    Also, this removes the +1, which is slightly prone to off-by-one bugs.
    +
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/Makefile.am ##
    @@ lib/string/strcpy/strmove.h (new)
     +inline void
     +strmove(char *dst, char *src)
     +{
    -+  memmove_T(dst, src, strlen(src) + 1, char);
    ++  stpcpy(mempmove_T(dst, src, strlen(src), char), "");
     +}
     +
     +
4:  5e1587b867e2 = 4:  825baace7005 src/usermod.c: new_pw_passwd(): Use strmove() instead of its pattern
5:  58cc9627dac6 < -:  ------------ lib/string/strcpy/: strmove(): Copy the terminating null byte explicitly
```

```
$ git diff gh/strmove..strmove 
$
```
</details>

<details>
<summary>v7c</summary>

-  Rebase

```
$ git range-diff gh/leakls..gh/strmove leakls..strmove 
1:  5acba43116c2 = 1:  3e2c998bebce lib/memory/memcpy/: mempmove(): Add function
2:  4b61fb203066 = 2:  1360534d0348 lib/memory/memcpy/: mempmove_T(): Add macro
3:  4aef0aa42bd8 = 3:  bcb9bd4aac24 lib/string/strcpy/: strmove(): Add function
4:  825baace7005 = 4:  4145e366671a src/usermod.c: new_pw_passwd(): Use strmove() instead of its pattern
```
</details>

<details>
<summary>v8</summary>

-  Rebase

```
$ git range-diff gh/leakls..gh/strmove leakls..strmove 
1:  3e2c998bebce ! 1:  d0c2e3256afe lib/memory/memcpy/: mempmove(): Add function
    @@ lib/memory/memcpy/memmove.h
      #endif  // include guard
     
      ## lib/string/README ##
    -@@ lib/string/README: strcpy/ - String copying
    +@@ lib/string/README: memory/ - memory operations
          memmove_T()
        Like memmove(3), but type safe.
      
     +    mempmove()
     +  Like memmove(3), but return an offset pointer.
     +
    - sprintf/ - Formatted string creation
    + string/ - string operations
    +   ctype/ - Character classification and conversion functions
      
    -     aprintf(3)
2:  1360534d0348 ! 2:  e53fbf81c44f lib/memory/memcpy/: mempmove_T(): Add macro
    @@ lib/memory/memcpy/memmove.h
      
     
      ## lib/string/README ##
    -@@ lib/string/README: strcpy/ - String copying
    +@@ lib/string/README: memory/ - memory operations
      
          mempmove()
        Like memmove(3), but return an offset pointer.
     +    mempmove_T()
    -+  Like mempmove(3), but type safe.
    - 
    - sprintf/ - Formatted string creation
    ++  Like mempmove(), but type safe.
      
    + string/ - string operations
    +   ctype/ - Character classification and conversion functions
3:  bcb9bd4aac24 ! 3:  441fc7771e91 lib/string/strcpy/: strmove(): Add function
    @@ lib/Makefile.am: libshadow_la_SOURCES = \
        string/strcpy/stpecpy.h \
     +  string/strcpy/strmove.c \
     +  string/strcpy/strmove.h \
    -   string/strcpy/strncat.c \
    -   string/strcpy/strncat.h \
    -   string/strcpy/strncpy.c \
    +   string/strcpy/strtcat.c \
    +   string/strcpy/strtcat.h \
    +   string/strcpy/strtcpy.c \
     
      ## lib/string/README ##
    -@@ lib/string/README: strcpy/ - String copying
    -   Do NOT use.  I'll remove it soon.
    +@@ lib/string/README: string/ - string operations
    + 
    +   strcpy/ - String copying
      
    -   s/
     +    strmove()
     +  Like memmove(3), for strings.  It takes the length of the string
     +  internally with strlen(3).
4:  4145e366671a = 4:  83f66eec1117 src/usermod.c: new_pw_passwd(): Use strmove() instead of its pattern
```
</details>

<details>
<summary>v8b</summary>

-  Rebase

```
$ git range-diff d0c2e325^..gh/strmove gh/leakls..strmove 
1:  d0c2e325 = 1:  88d05d5b lib/memory/memcpy/: mempmove(): Add function
2:  e53fbf81 = 2:  6bc37a5e lib/memory/memcpy/: mempmove_T(): Add macro
3:  441fc777 = 3:  e425de6f lib/string/strcpy/: strmove(): Add function
4:  83f66eec = 4:  3684c06e src/usermod.c: new_pw_passwd(): Use strmove() instead of its pattern
```
</details>

<details>
<summary>v8c</summary>

-  Rebase

```
$ git range-diff gh/leakls..gh/strmove leakls..strmove 
1:  88d05d5b = 1:  b19caf83 lib/memory/memcpy/: mempmove(): Add function
2:  6bc37a5e = 2:  b8d4ac1a lib/memory/memcpy/: mempmove_T(): Add macro
3:  e425de6f = 3:  7e122f3a lib/string/strcpy/: strmove(): Add function
4:  3684c06e = 4:  32e71211 src/usermod.c: new_pw_passwd(): Use strmove() instead of its pattern
```
</details>

<details>
<summary>v8d</summary>

-  Rebase

```
$ git range-diff gh/leakls..gh/strmove leakls..strmove 
1:  b19caf83 = 1:  ca1ea451 lib/memory/memcpy/: mempmove(): Add function
2:  b8d4ac1a = 2:  d424a040 lib/memory/memcpy/: mempmove_T(): Add macro
3:  7e122f3a = 3:  67986ec6 lib/string/strcpy/: strmove(): Add function
4:  32e71211 = 4:  2d8280ab src/usermod.c: new_pw_passwd(): Use strmove() instead of its pattern
```
</details>