### PR TITLE
etc/login.defs: Remove defaults for password expiration

### DIFF
--- a/etc/login.defs
+++ b/etc/login.defs
@@ -207,13 +207,6 @@ UMASK		022
 #HOME_MODE	0700
 
 #
-# Password aging controls:
-#
-#	PASS_MIN_LEN	Minimum acceptable password length.
-#
-PASS_MIN_LEN	5
-
-#
 # If "yes", the user must be listed as a member of the first gid 0 group
 # in /etc/group (called "root" on most Linux systems) to be able to "su"
 # to uid 0 accounts.  If the group doesn't exist or is empty, no one
@@ -333,15 +326,15 @@ LOGIN_TIMEOUT		60
 PASS_CHANGE_TRIES	5
 
 #
+# Password strength controls:
+#
 # Warn about weak passwords (but still allow them) if you are root.
-#
 PASS_ALWAYS_WARN	yes
-
-#
+# Minimum acceptable password length.
+PASS_MIN_LEN	5
 # Number of significant characters in the password for crypt().
 # Default is 8, don't change unless your crypt() is better.
 # Only used for DES encryption algorithm.
-#
 #PASS_MAX_LEN		8
 
 #

--- a/etc/login.defs
+++ b/etc/login.defs
@@ -209,13 +209,9 @@ UMASK		022
 #
 # Password aging controls:
 #
-#	PASS_MAX_DAYS	Maximum number of days a password may be used.
 #	PASS_MIN_LEN	Minimum acceptable password length.
-#	PASS_WARN_AGE	Number of days warning given before a password expires.
 #
-PASS_MAX_DAYS	99999
 PASS_MIN_LEN	5
-PASS_WARN_AGE	7
 
 #
 # If "yes", the user must be listed as a member of the first gid 0 group


### PR DESCRIPTION
Expiring passwords has been determined to decrease safety. Let's default to not expiring passwords.

---

Revisions:

<details>
<summary>v2</summary>

-  Group password strength controls.  [@stoeckmann ]

```
$ git rd 
1:  2eae5ae18 = 1:  2eae5ae18 etc/login.defs: Remove defaults for password expiration
-:  --------- > 2:  b8db89e18 etc/login.defs: Group password strength controls
```
</details>

<details>
<summary>v2b</summary>

-  Rebase

```
$ git rd 
1:  2eae5ae18 = 1:  da0d41456 etc/login.defs: Remove defaults for password expiration
2:  b8db89e18 ! 2:  1f537129d etc/login.defs: Group password strength controls
    @@ etc/login.defs: LOGIN_TIMEOUT            60
     +PASS_MIN_LEN      5
      # Number of significant characters in the password for crypt().
      # Default is 8, don't change unless your crypt() is better.
    - # Ignored if MD5_CRYPT_ENAB set to "yes".
    + # Only used for DES encryption algorithm.
     -#
      #PASS_MAX_LEN             8
      
```
</details>

<details>
<summary>v2c</summary>

-  Rebase

```
$ git rd 
1:  da0d41456 = 1:  1d4fae278 etc/login.defs: Remove defaults for password expiration
2:  1f537129d = 2:  d2ea0c418 etc/login.defs: Group password strength controls
```
</details>

<details>
<summary>v2d</summary>

-  Rebase

```
$ git rd 
1:  1d4fae278 = 1:  0fb6e4e83 etc/login.defs: Remove defaults for password expiration
2:  d2ea0c418 = 2:  761661eeb etc/login.defs: Group password strength controls
```
</details>

<details>
<summary>v2e</summary>

-  Rebase

```
$ git rd 
1:  0fb6e4e836d9 = 1:  d4395d85f660 etc/login.defs: Remove defaults for password expiration
2:  761661eeb662 = 2:  ed1a033232f9 etc/login.defs: Group password strength controls
```
</details>

<details>
<summary>v2f</summary>

-  Rebase

```
$ git rd 
1:  d4395d85 = 1:  dcc7bf55 etc/login.defs: Remove defaults for password expiration
2:  ed1a0332 = 2:  05a5565a etc/login.defs: Group password strength controls
```
</details>

<details>
<summary>v2g</summary>

-  Rebase

```
$ git rd 
1:  dcc7bf55 = 1:  688a3b6e etc/login.defs: Remove defaults for password expiration
2:  05a5565a = 2:  b8e4ac45 etc/login.defs: Group password strength controls
```
</details>

<details>
<summary>v3</summary>

-  Rebase (PASS_MIN_DAYS doesn't exist anymore).

```
$ git rd 
1:  688a3b6e4723 ! 1:  a711c3efa308 etc/login.defs: Remove defaults for password expiration
    @@ etc/login.defs: UMASK            022
      # Password aging controls:
      #
     -# PASS_MAX_DAYS   Maximum number of days a password may be used.
    --# PASS_MIN_DAYS   Minimum number of days allowed between password changes.
      # PASS_MIN_LEN    Minimum acceptable password length.
     -# PASS_WARN_AGE   Number of days warning given before a password expires.
      #
     -PASS_MAX_DAYS     99999
    --PASS_MIN_DAYS     0
      PASS_MIN_LEN      5
     -PASS_WARN_AGE     7
      
2:  b8e4ac45f1e0 = 2:  48cebccc7956 etc/login.defs: Group password strength controls
```
</details>