### PR TITLE
passwd: Fix TOCTOU race condition (no PAM)

### DIFF
--- a/src/passwd.c
+++ b/src/passwd.c
@@ -649,6 +649,7 @@ static void update_noshadow(bool process_selinux)
 		                Prog, name, pw_dbname ());
 		fail_exit (E_NOPERM, process_selinux);
 	}
+	check_password(pw, pwd_to_spwd(pw), process_selinux);
 	npw = __pw_dup (pw);
 	if (NULL == npw) {
 		oom (process_selinux);
@@ -664,6 +665,7 @@ static void update_noshadow(bool process_selinux)
 
 static void update_shadow(bool process_selinux)
 {
+	const struct passwd pw = { .pw_passwd = SHADOW_PASSWD_STRING };
 	const struct spwd *sp;
 	struct spwd *nsp;
 
@@ -673,6 +675,7 @@ static void update_shadow(bool process_selinux)
 		update_noshadow (process_selinux);
 		return;
 	}
+	check_password(&pw, sp, process_selinux);
 	nsp = __spw_dup (sp);
 	if (NULL == nsp) {
 		oom (process_selinux);


### PR DESCRIPTION
The `passwd` tool checks if the password of a user may be changed before locking the passwd/shadow files. This leaves a time window to perform the same action twice (e.g. circumventing PASS_MIN_DAYS limit) or to circumvent a locked password by an administrator.

Perform the check after the lock again. This keeps the behavior as it is today for a user and also prevents the race condition.

Again, since this is `passwd`, a very close review is appreciated!

How to reproduce:

Scenario 1, PASS_MIN_DAYS:

1. Set minimum password change time of a user to 1 day
```
# chage -m 1 user
```
2. As user, start password changing in terminal 1 and 2
```
t1 $ passwd
Changing password for user
Old password: <enter old password here>
Enter the new password (minimum of 5 characters)
Please use a combination of upper and lower case letters and numbers.
New password: <stop typing here, no enter!>
```

```
t2 $ passwd
Changing password for user
Old password: <enter old password here>
Enter the new password (minimum of 5 characters)
Please use a combination of upper and lower case letters and numbers.
New password: <stop typing here, no enter!>
```

3. Finish password changing in terminal 1
4. Finish password changing in terminal 2

Both commands succeed, but one should be blocked.

Scenario 2, Prevent Account Locking:

1. Let user start changing the password
```
$ passwd
Changing password for user
Old password: <enter old password here>
Enter the new password (minimum of 5 characters)
Please use a combination of upper and lower case letters and numbers.
New password: <stop typing here, no enter!>
```
2. Lock user account as root
```
# passwd -l user
```
3. Finish password changing as user

The account is unlocked again.