### PR TITLE
Ignore IDE related directories and files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,11 @@ lib*.a
 *.la
 *.mo
 *.gmo
+.cache
 .deps
 .libs
 .dirstamp
+.vscode
 
 *.patch
 *.rej
@@ -21,6 +23,7 @@ test-driver
 /ABOUT-NLS
 /aclocal.m4
 /autom4te.cache
+/compile_commands.json
 /config.cache
 /config.h
 /config.h.in


### PR DESCRIPTION
Using clangd as language server with Code OSS adds three additional filesystem entries. Add them to the list if ignored files so that they will never be merged.

Having any form of IDE is helpful with these additional layers of code around bare library and system calls. The combination of clangd and (vs)code is a rather popular one, so this shouldn't be too specific to my use case. In fact, that's how I ended up with this quite useful combination.

In case somebody else wants to be able to jump directly to function definitions and get warnings from clangd (which should be fixed in other pull requests):

Instructions based on Arch Linux
```
$ pacman -S bear clang code # install https://github.com/rizsotto/Bear and llvm-clang which should contain clangd
<install Kyling Clangd extension in code>
$ cd shadow # stay in top level of source directory
$ CC=clang ./configure
$ bear -- make
```

The bear wrapper around make catches all relevant command line arguments passed to the compiler in `compile_commands.json` (due to clangd I chose to compile with clang as well) and stores temporary data in `.cache` for faster symbol lookups. Any further options or plugins which might be added for debugging or run options are stored in `.vscode` by Code OSS.

Teaser of what clangd with code will do for us:

<img width="1102" height="617" alt="code" src="https://github.com/user-attachments/assets/fb8fb0a6-47b5-4308-962c-ca3be329ac1c" />
