### PR TITLE
passwd: Clarify password strength check comment

### DIFF
--- a/src/passwd.c
+++ b/src/passwd.c
@@ -241,9 +241,9 @@ static int new_password (const struct passwd *pw)
 
 	/*
 	 * Get the new password. The user is prompted for the new password
-	 * and has five tries to get it right. The password will be tested
-	 * for strength, unless it is the root user. This provides an escape
-	 * for initial login passwords.
+	 * and has PASS_CHANGE_TRIES tries to get it right. The password will
+	 * be optionally tested for strength. The root user can circumvent
+	 * tests. This provides an escape for initial login passwords.
 	 */
 	method = getdef_str ("ENCRYPT_METHOD");
 	if (NULL == method) {


### PR DESCRIPTION
- The total number of password change tries can be configured
- Except min length, password strength checks can be disabled
- Even the root user can have password strength checks...
- ... except in some cases (stdin, command line arguments)

In general, this code does not run for PAM, except root directory is modified through command line arguments by root user.

Helps https://github.com/shadow-maint/shadow/issues/886