### PR TITLE
src/chgpasswd.c: match chpasswd behaviour for EOF handling

### DIFF
--- a/src/chgpasswd.c
+++ b/src/chgpasswd.c
@@ -479,10 +479,18 @@ int main (int argc, char **argv)
 	while (fgets(buf, sizeof(buf), stdin) != NULL) {
 		line++;
 		if (stpsep(buf, "\n") == NULL) {
-			fprintf (stderr, _("%s: line %jd: line too long\n"),
-			         Prog, line);
-			errors = true;
-			continue;
+			if (feof (stdin) == 0) {
+				// Drop all remaining characters on this line.
+				while (fgets(buf, sizeof(buf), stdin) != NULL) {
+					if (strchr(buf, '\n'))
+						break;
+				}
+
+				fprintf (stderr, _("%s: line %jd: line too long\n"),
+				         Prog, line);
+				errors = true;
+				continue;
+			}
 		}
 
 		/*


### PR DESCRIPTION
chgpasswd was incorrectly reporting "line too long" errors for the last line of input files that didn't end with a newline character. This differed from chpasswd, which gracefully handles missing trailing newlines when at EOF.

Updated chgpasswd.c to check feof(stdin) before reporting line length errors, consistent with chpasswd.c behavior.

The inconsistency was found while developing https://github.com/shadow-maint/shadow/pull/1357