### PR TITLE
src/chgpasswd.c: fix handling of files without trailing newlines

### DIFF
--- a/src/chgpasswd.c
+++ b/src/chgpasswd.c
@@ -479,10 +479,12 @@ int main (int argc, char **argv)
 	while (fgets(buf, sizeof(buf), stdin) != NULL) {
 		line++;
 		if (stpsep(buf, "\n") == NULL) {
-			fprintf (stderr, _("%s: line %jd: line too long\n"),
-			         Prog, line);
-			errors = true;
-			continue;
+			if (feof(stdin) == 0) {
+				fprintf (stderr, _("%s: line %jd: line too long\n"),
+				         Prog, line);
+				errors = true;
+				continue;
+			}
 		}
 
 		/*


### PR DESCRIPTION
The chgpasswd command was incorrectly reporting "missing new password" when processing files with a trailing newline. This happened because the code was missing an EOF check.

Reproduction steps:
$ groupadd tgroup1
$ groupadd tgroup2
$ cat /tmp/test_chgpasswd.txt
tgroup1:Secret123
tgroup2:Secret456

$ #The file contains a trailing newline
$ chgpasswd < /tmp/test_chgpasswd.txt
chgpasswd: line 3: missing new password
chgpasswd: error detected, changes ignored