### PR TITLE
lib/salt.c: gensalt(): Default to SHA512 instead of DES

### DIFF
--- a/lib/obscure.c
+++ b/lib/obscure.c
@@ -215,19 +215,11 @@ obscure_get_range(int *minlen, int *maxlen)
 	}
 
 	method = getdef_str ("ENCRYPT_METHOD");
-	if (NULL != method) {
-		if (   streq(method, "MD5")
-		    || streq(method, "SHA256")
-		    || streq(method, "SHA512")
-#ifdef USE_BCRYPT
-		    || streq(method, "BCRYPT")
-#endif
-#ifdef USE_YESCRYPT
-		    || streq(method, "YESCRYPT")
-#endif
-		    ) {
-			return;
-		}
-	}
+	if (NULL == method)
+		return;
+
+	if (!streq(method, "DES"))
+		return;
+
 	*maxlen = getdef_num ("PASS_MAX_LEN", 8);
 }

--- a/lib/salt.c
+++ b/lib/salt.c
@@ -356,7 +356,7 @@ static /*@observer@*/const char *gensalt (size_t salt_size)
 
 	bzero(result, GENSALT_SETTING_SIZE);
 
-	method = meth ?: getdef_str("ENCRYPT_METHOD") ?: "DES";
+	method = meth ?: getdef_str("ENCRYPT_METHOD") ?: "SHA512";
 
 	if (streq(method, "MD5")) {
 		MAGNUM(result, '1');
@@ -382,6 +382,7 @@ static /*@observer@*/const char *gensalt (size_t salt_size)
 		rounds = SHA_get_salt_rounds (arg);
 		SHA_salt_rounds_to_buf (result, rounds);
 	} else if (streq(method, "SHA512")) {
+sha512:
 		MAGNUM(result, '6');
 		salt_len = SHA_CRYPT_SALT_SIZE;
 		rounds = SHA_get_salt_rounds (arg);
@@ -389,11 +390,9 @@ static /*@observer@*/const char *gensalt (size_t salt_size)
 	} else if (!streq(method, "DES")) {
 		fprintf (log_get_logfd(),
 			 _("Invalid ENCRYPT_METHOD value: '%s'.\n"
-			   "Defaulting to DES.\n"),
+			   "Defaulting to SHA512.\n"),
 			 method);
-		salt_len = MAX_SALT_SIZE;
-		rounds = 0;
-		bzero(result, GENSALT_SETTING_SIZE);
+		goto sha512;
 	}
 
 #if USE_XCRYPT_GENSALT

--- a/man/login.defs.d/ENCRYPT_METHOD.xml
+++ b/man/login.defs.d/ENCRYPT_METHOD.xml
@@ -12,10 +12,10 @@
     <para>
       It can take one of these values: <phrase condition="bcrypt">
       <replaceable>BCRYPT</replaceable>,</phrase>
-      <replaceable>DES</replaceable> (default),
+      <replaceable>DES</replaceable>,
       <replaceable>MD5</replaceable>,
       <replaceable>SHA256</replaceable>,
-      <replaceable>SHA512</replaceable>,
+      <replaceable>SHA512</replaceable> (default),
       <phrase condition="yescrypt">
       <replaceable>YESCRYPT</replaceable></phrase>.
       MD5 and DES should not be used for new hashes, see


### PR DESCRIPTION
DES is insecure; use it only if explicitly requested.
    
-  Closes: <https://github.com/shadow-maint/shadow/issues/1278>
-  Reported-by:@andreboscatto
-  Cc: @ikerexxe 

---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git rd 
1:  f4dd13ccb108 < -:  ------------ */: Remove support for MD5_CRYPT_ENAB
2:  85771ad90a6c < -:  ------------ lib/salt.c: Compact conditionals
3:  fdc32380c44a < -:  ------------ */: chpasswd(8): -m,--md5: Remove option
4:  43b5bef9f464 < -:  ------------ */: chgpasswd(8): -m,--md5: Remove option
5:  5bb41add8c8a = 1:  0c12025560a2 lib/salt.c: gensalt(): Default to SHA512 instead of DES
```
</details>

<details>
<summary>v1c</summary>

-  Rebase

```
$ git rd 
1:  0c120255 = 1:  887f62eb lib/salt.c: gensalt(): Default to SHA512 instead of DES
```
</details>

<details>
<summary>v2</summary>

-  Update login.defs(5).  [@hallyn ]

```
$ git rd 
1:  887f62eb ! 1:  f7c5a949 lib/salt.c: gensalt(): Default to SHA512 instead of DES
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/salt.c: gensalt(): Default to SHA512 instead of DES
    +    lib/, man/: Default to SHA512 instead of DES
     
         DES is insecure; use it only if explicitly requested.
     
    @@ lib/salt.c: static /*@observer@*/const char *gensalt (size_t salt_size)
        }
      
      #if USE_XCRYPT_GENSALT
    +
    + ## man/login.defs.d/ENCRYPT_METHOD.xml ##
    +@@
    +     <para>
    +       It can take one of these values: <phrase condition="bcrypt">
    +       <replaceable>BCRYPT</replaceable>,</phrase>
    +-      <replaceable>DES</replaceable> (default),
    ++      <replaceable>DES</replaceable>,
    +       <replaceable>MD5</replaceable>,
    +       <replaceable>SHA256</replaceable>,
    +-      <replaceable>SHA512</replaceable>,
    ++      <replaceable>SHA512</replaceable> (default),
    +       <phrase condition="yescrypt">
    +       <replaceable>YESCRYPT</replaceable></phrase>.
    +       MD5 and DES should not be used for new hashes, see
```
</details>

<details>
<summary>v2b</summary>

-  Rebase

```
$ git rd
1:  f7c5a949 = 1:  571a06e6 lib/, man/: Default to SHA512 instead of DES
```
</details> 

<details>
<summary>v2c</summary>

-  Rebase

```
$ git rd 
1:  571a06e64f96 = 1:  48d4de9a8827 lib/, man/: Default to SHA512 instead of DES
```
</details>

<details>
<summary>v2d</summary>

-  Rebase

```
$ git rd 
1:  48d4de9a8827 = 1:  a9cd6347d71a lib/, man/: Default to SHA512 instead of DES
```
</details>