### PR TITLE
sg: Fix usage and manual page

### DIFF
--- a/man/sg.1.xml
+++ b/man/sg.1.xml
@@ -45,13 +45,15 @@
   <refsynopsisdiv id='synopsis'>
     <cmdsynopsis>
       <command>sg</command>
-      <arg choice='opt'>- </arg>
+      <arg choice='opt'>
+        <replaceable>-</replaceable>
+      </arg>
       <arg choice='plain'>
         <replaceable>group</replaceable>
       </arg>
       <arg choice='opt'>
-	<arg choice='opt'>-c </arg>
-	command
+        <arg choice='opt'><replaceable>-c</replaceable></arg>
+        <replaceable>command</replaceable>
       </arg>
     </cmdsynopsis>
   </refsynopsisdiv>
@@ -71,6 +73,37 @@
       <command>sg</command> command you are returned to your previous group
       ID.
     </para>
+  </refsect1>
+
+  <refsect1 id='options'>
+    <title>OPTIONS</title>
+    <para>
+      The options which apply to the <command>sg</command> command are:
+    </para>
+    <variablelist remap='IP'>
+      <varlistentry>
+	<term><option>-</option>, <option>-l</option></term>
+	<listitem>
+	  <para>
+	    Start the shell as a login shell.
+	  </para>
+	</listitem>
+      </varlistentry>
+      <varlistentry>
+	<term>
+	  <option>-c</option>
+	</term>
+	<listitem>
+	  <para>
+	    Specify a command that will be invoked by the shell using its
+	    <option>-c</option>.
+	  </para>
+	  <para>
+	    This is the default; for backward compatibility.
+	  </para>
+	</listitem>
+      </varlistentry>
+    </variablelist>
   </refsect1>
 
   <refsect1 id='configuration'>

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -72,7 +72,7 @@ static void usage (void)
 	if (is_newgrp) {
 		(void) fputs (_("Usage: newgrp [-] [group]\n"), stderr);
 	} else {
-		(void) fputs (_("Usage: sg group [[-c] command]\n"), stderr);
+		(void) fputs (_("Usage: sg [-] group [[-c] command]\n"), stderr);
 	}
 }
 
@@ -465,8 +465,8 @@ int main (int argc, char **argv)
 	 * The valid syntax are
 	 *      newgrp [-] [groupid]
 	 *      newgrp [-l] [groupid]
-	 *      sg [-]
-	 *      sg [-] groupid [[-c command]
+	 *      sg [-] groupid [[-c] command]
+	 *      sg [-l] groupid [[-c] command]
 	 */
 	if (   (argc > 0)
 	    && (   streq(argv[0], "-")
@@ -499,8 +499,7 @@ int main (int argc, char **argv)
 
 			/*
 			 * Skip -c if specified so both forms work:
-			 * "sg group -c command" (as in the man page) or
-			 * "sg group command" (as in the usage message).
+			 * "sg group -c command" or "sg group command".
 			 */
 			if ((argc > 1) && streq(argv[0], "-c")) {
 				command = argv[1];


### PR DESCRIPTION
The usage message of `sg` and its manual page contain different information. Synchronize both and document what `sg`'s options do.