### PR TITLE
src/newgrp.c: sg(1): Various source code improvements and bug fixes

### DIFF
--- a/lib/prototypes.h
+++ b/lib/prototypes.h
@@ -168,7 +168,8 @@ extern void audit_help_open (void);
 #define AUDIT_NO_ID	((unsigned int) -1)
 typedef enum {
 	SHADOW_AUDIT_FAILURE = 0,
-	SHADOW_AUDIT_SUCCESS = 1} shadow_audit_result;
+	SHADOW_AUDIT_SUCCESS = 1
+} shadow_audit_result;
 extern void audit_logger (int type, const char *op,
                           const char *name, unsigned int id,
                           shadow_audit_result result);

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -296,7 +296,7 @@ static void syslog_sg (const char *name, const char *group)
 		if ((pid_t)-1 == child) {
 			/* error in fork() */
 			fprintf (stderr, _("%s: failure forking: %s\n"),
-				is_newgrp ? "newgrp" : "sg", strerrno());
+			         Prog, strerrno());
 #ifdef WITH_AUDIT
 			if (group) {
 				audit_logger_with_group(AUDIT_CHGRP_ID, "changing", NULL,

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -488,17 +488,6 @@ main(int, char *argv[])
 			closelog ();
 			exit (EXIT_FAILURE);
 		}
-		if (argv[0] != NULL && streq(argv[0], "-c")) {
-			argv++;
-			if (argv[0] == NULL) {
-				fprintf(stderr, _("%s: -c: missing argument.\n"), Prog);
-				goto failure;
-			}
-		}
-		if (argv[0] != NULL) {
-			command = argv[0];
-			cflag = true;
-		}
 	} else {
 		if (argv[0] != NULL) {
 			if (!is_valid_group_name (argv[0])) {
@@ -508,6 +497,7 @@ main(int, char *argv[])
 				goto failure;
 			}
 			group = argv[0];
+			argv++;
 		} else {
 			/*
 			 * get the group file entry for her login group id.
@@ -526,6 +516,19 @@ main(int, char *argv[])
 				goto failure;
 			}
 			group = grp->gr_name;
+		}
+	}
+	if (!is_newgrp) {
+		if (argv[0] != NULL && streq(argv[0], "-c")) {
+			argv++;
+			if (argv[0] == NULL) {
+				fprintf(stderr, _("%s: -c: missing argument.\n"), Prog);
+				goto failure;
+			}
+		}
+		if (argv[0] != NULL) {
+			command = argv[0];
+			cflag = true;
 		}
 	}
 

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -465,9 +465,7 @@ main(int, char *argv[])
 	 *      newgrp [-l|-] [groupid]
 	 *      sg [-l|-] groupid [[-c] command]
 	 */
-	if (   argv[0] != NULL
-	    && (   streq(argv[0], "-")
-	        || streq(argv[0], "-l"))) {
+	if (argv[0] != NULL && (streq(argv[0], "-l") || streq(argv[0], "-"))) {
 		argv++;
 		initflag = true;
 	}

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -454,10 +454,6 @@ main(int, char *argv[])
 		argv++;
 		initflag = true;
 	}
-	if (*argv != NULL && strspn(*argv, "-")) {
-		usage();
-		goto failure;
-	}
 	if (*argv != NULL) {
 		if (!is_valid_group_name(*argv)) {
 			fprintf(stderr, _("%s: provided group is not a valid group name\n"),

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -473,7 +473,7 @@ main(int, char *argv[])
 		usage();
 		goto failure;
 	}
-	if (!is_newgrp) {
+	{
 		if (argv[0] != NULL) {
 			if (!is_valid_group_name (argv[0])) {
 				fprintf (
@@ -483,21 +483,10 @@ main(int, char *argv[])
 			}
 			group = argv[0];
 			argv++;
-		} else {
+		} else if (!is_newgrp) {
 			usage ();
 			closelog ();
 			exit (EXIT_FAILURE);
-		}
-	} else {
-		if (argv[0] != NULL) {
-			if (!is_valid_group_name (argv[0])) {
-				fprintf (
-					stderr, _("%s: provided group is not a valid group name\n"),
-					Prog);
-				goto failure;
-			}
-			group = argv[0];
-			argv++;
 		} else {
 			/*
 			 * get the group file entry for her login group id.

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -71,9 +71,9 @@ static void syslog_sg (const char *name, const char *group);
 static void usage (void)
 {
 	if (is_newgrp) {
-		(void) fputs (_("Usage: newgrp [-] [group]\n"), stderr);
+		(void) fputs (_("Usage: newgrp [-l|-] [group]\n"), stderr);
 	} else {
-		(void) fputs (_("Usage: sg [-] group [[-c] command]\n"), stderr);
+		(void) fputs (_("Usage: sg [-l|-] group [[-c] command]\n"), stderr);
 	}
 }
 
@@ -452,7 +452,7 @@ int main (int argc, char **argv)
 
 	/*
 	 * Parse the command line. There are two accepted flags. The first
-	 * is "-", which for newgrp means to re-create the entire
+	 * is "-l" or "-", which for newgrp means to re-create the entire
 	 * environment as though a login had been performed, and "-c", which
 	 * for sg causes a command string to be executed.
 	 *
@@ -462,10 +462,8 @@ int main (int argc, char **argv)
 	 * the login group ID of the current user.
 	 *
 	 * The valid syntax are
-	 *      newgrp [-] [groupid]
-	 *      newgrp [-l] [groupid]
-	 *      sg [-] groupid [[-c] command]
-	 *      sg [-l] groupid [[-c] command]
+	 *      newgrp [-l|-] [groupid]
+	 *      sg [-l|-] groupid [[-c] command]
 	 */
 	if (   (argc > 0)
 	    && (   streq(argv[0], "-")

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -775,11 +775,11 @@ main(int, char *argv[])
 #ifdef WITH_AUDIT
 	if (NULL != group) {
 		audit_logger_with_group(AUDIT_CHGRP_ID, "changing", NULL,
-					getuid(), "new_group", group,
+		                        getuid(), "new_group", group,
 					SHADOW_AUDIT_FAILURE);
 	} else {
-		audit_logger (AUDIT_CHGRP_ID,
-		              "changing", NULL, getuid (), 0);
+		audit_logger(AUDIT_CHGRP_ID, "changing", NULL,
+		             getuid(), SHADOW_AUDIT_FAILURE);
 	}
 #endif
 	exit (EXIT_FAILURE);

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -499,10 +499,10 @@ int main (int argc, char **argv)
 			 * "sg group -c command" or "sg group command".
 			 */
 			if ((argc > 1) && streq(argv[0], "-c")) {
-				command = argv[1];
-			} else {
-				command = argv[0];
+				argc--;
+				argv++;
 			}
+			command = argv[0];
 			cflag = true;
 		}
 	} else {

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -473,39 +473,28 @@ main(int, char *argv[])
 		usage();
 		goto failure;
 	}
-	{
-		if (argv[0] != NULL) {
-			if (!is_valid_group_name (argv[0])) {
-				fprintf (
-					stderr, _("%s: provided group is not a valid group name\n"),
-					Prog);
-				goto failure;
-			}
-			group = argv[0];
-			argv++;
-		} else if (!is_newgrp) {
-			usage ();
-			closelog ();
-			exit (EXIT_FAILURE);
-		} else {
-			/*
-			 * get the group file entry for her login group id.
-			 * the entry must exist, simply to be annoying.
-			 *
-			 * Perhaps in the past, but the default behavior now depends on the
-			 * group entry, so it had better exist.  -- JWP
-			 */
-			grp = xgetgrgid (pwd->pw_gid);
-			if (NULL == grp) {
-				fprintf (stderr,
-				         _("%s: GID '%lu' does not exist\n"),
-				         Prog, (unsigned long) pwd->pw_gid);
-				SYSLOG(LOG_CRIT, "GID '%lu' does not exist",
-				       (unsigned long) pwd->pw_gid);
-				goto failure;
-			}
-			group = grp->gr_name;
+	if (argv[0] != NULL) {
+		if (!is_valid_group_name(argv[0])) {
+			fprintf(stderr, _("%s: provided group is not a valid group name\n"),
+			        Prog);
+			goto failure;
 		}
+		group = argv[0];
+		argv++;
+	} else if (!is_newgrp) {
+		usage();
+		closelog();
+		exit(EXIT_FAILURE);
+	} else {
+		grp = xgetgrgid(pwd->pw_gid);
+		if (NULL == grp) {
+			fprintf(stderr, _("%s: GID '%lu' does not exist\n"),
+			        Prog, (unsigned long) pwd->pw_gid);
+			SYSLOG(LOG_CRIT, "GID '%lu' does not exist",
+			       (unsigned long) pwd->pw_gid);
+			goto failure;
+		}
+		group = grp->gr_name;
 	}
 	if (!is_newgrp) {
 		if (argv[0] != NULL && streq(argv[0], "-c")) {

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -498,9 +498,13 @@ int main (int argc, char **argv)
 			 * Skip -c if specified so both forms work:
 			 * "sg group -c command" or "sg group command".
 			 */
-			if ((argc > 1) && streq(argv[0], "-c")) {
+			if (streq(argv[0], "-c")) {
 				argc--;
 				argv++;
+				if (argc == 0) {
+					fprintf(stderr, _("%s: -c: missing argument.\n"), Prog);
+					goto failure;
+				}
 			}
 			command = argv[0];
 			cflag = true;

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -65,16 +65,14 @@ static void check_perms (const struct group *grp,
                          const char *groupname);
 static void syslog_sg (const char *name, const char *group);
 
-/*
- * usage - print command usage message
- */
-static void usage (void)
+
+static void
+usage(void)
 {
-	if (is_newgrp) {
-		(void) fputs (_("Usage: newgrp [-l|-] [group]\n"), stderr);
-	} else {
-		(void) fputs (_("Usage: sg [-l|-] group [[-c] command]\n"), stderr);
-	}
+	if (is_newgrp)
+		fputs(_("Usage: newgrp [-l|-] [group]\n"), stderr);
+	else
+		fputs(_("Usage: sg [-l|-] group [[-c] command]\n"), stderr);
 }
 
 static bool ingroup(const char *name, struct group *gr)
@@ -448,11 +446,6 @@ main(int, char *argv[])
 	}
 	name = pwd->pw_name;
 
-	/*
-	 * Synopsis
-	 *      newgrp [-l|-] [groupid]
-	 *      sg [-l|-] groupid [[-c] command]
-	 */
 	if (*argv != NULL && (streq(*argv, "-l") || streq(*argv, "-"))) {
 		argv++;
 		initflag = true;

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -451,17 +451,7 @@ main(int, char *argv[])
 	name = pwd->pw_name;
 
 	/*
-	 * Parse the command line. There are two accepted flags. The first
-	 * is "-l" or "-", which for newgrp means to re-create the entire
-	 * environment as though a login had been performed, and "-c", which
-	 * for sg causes a command string to be executed.
-	 *
-	 * The next argument, if present, must be the new group name. Any
-	 * remaining arguments will be used to execute a command
-	 * as the named group. If the group name isn't present, I just use
-	 * the login group ID of the current user.
-	 *
-	 * The valid syntax are
+	 * Synopsis
 	 *      newgrp [-l|-] [groupid]
 	 *      sg [-l|-] groupid [[-c] command]
 	 */

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -473,8 +473,7 @@ main(int, char *argv[])
 		argv++;
 	} else if (!is_newgrp) {
 		usage();
-		closelog();
-		exit(EXIT_FAILURE);
+		goto failure;
 	} else {
 		grp = xgetgrgid(pwd->pw_gid);
 		if (NULL == grp) {

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -507,7 +507,8 @@ main(int, char *argv[])
 		if (argv[0] != NULL && strprefix(argv[0], "-")) {
 			usage ();
 			goto failure;
-		} else if (argv[0] != NULL) {
+		}
+		if (argv[0] != NULL) {
 			if (!is_valid_group_name (argv[0])) {
 				fprintf (
 					stderr, _("%s: provided group is not a valid group name\n"),
@@ -531,9 +532,8 @@ main(int, char *argv[])
 				SYSLOG(LOG_CRIT, "GID '%lu' does not exist",
 				       (unsigned long) pwd->pw_gid);
 				goto failure;
-			} else {
-				group = grp->gr_name;
 			}
+			group = grp->gr_name;
 		}
 	}
 

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -469,12 +469,12 @@ main(int, char *argv[])
 		argv++;
 		initflag = true;
 	}
+	if (argv[0] != NULL && strspn(argv[0], "-")) {
+		usage();
+		goto failure;
+	}
 	if (!is_newgrp) {
-		/*
-		 * Do the command line for everything that is
-		 * not "newgrp".
-		 */
-		if (argv[0] != NULL && argv[0][0] != '-') {
+		if (argv[0] != NULL) {
 			if (!is_valid_group_name (argv[0])) {
 				fprintf (
 					stderr, _("%s: provided group is not a valid group name\n"),
@@ -500,14 +500,6 @@ main(int, char *argv[])
 			cflag = true;
 		}
 	} else {
-		/*
-		 * Do the command line for "newgrp". It's just making sure
-		 * there aren't any flags and getting the new group name.
-		 */
-		if (argv[0] != NULL && strprefix(argv[0], "-")) {
-			usage ();
-			goto failure;
-		}
 		if (argv[0] != NULL) {
 			if (!is_valid_group_name (argv[0])) {
 				fprintf (

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -70,9 +70,9 @@ static void
 usage(void)
 {
 	if (is_newgrp)
-		fputs(_("Usage: newgrp [-l|-] [group]\n"), stderr);
+		fputs(_("Usage: newgrp [-l] [-] [group]\n"), stderr);
 	else
-		fputs(_("Usage: sg [-l|-] group [[-c] command]\n"), stderr);
+		fputs(_("Usage: sg [-l] [-] group [[-c] command]\n"), stderr);
 }
 
 static bool ingroup(const char *name, struct group *gr)
@@ -446,7 +446,11 @@ main(int, char *argv[])
 	}
 	name = pwd->pw_name;
 
-	if (*argv != NULL && (streq(*argv, "-l") || streq(*argv, "-"))) {
+	if (*argv != NULL && streq(*argv, "-l")) {
+		argv++;
+		initflag = true;
+	}
+	if (*argv != NULL && streq(*argv, "-")) {
 		argv++;
 		initflag = true;
 	}

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -366,7 +366,8 @@ static void syslog_sg (const char *name, const char *group)
 /*
  * newgrp - change the invokers current real and effective group id
  */
-int main (int argc, char **argv)
+int
+main(int, char *argv[])
 {
 	bool initflag = false;
 	bool is_member = false;
@@ -430,7 +431,6 @@ int main (int argc, char **argv)
 #ifdef WITH_AUDIT
 	audit_help_open ();
 #endif
-	argc--;
 	argv++;
 
 	initenv ();
@@ -465,10 +465,9 @@ int main (int argc, char **argv)
 	 *      newgrp [-l|-] [groupid]
 	 *      sg [-l|-] groupid [[-c] command]
 	 */
-	if (   (argc > 0)
+	if (   argv[0] != NULL
 	    && (   streq(argv[0], "-")
 	        || streq(argv[0], "-l"))) {
-		argc--;
 		argv++;
 		initflag = true;
 	}
@@ -477,7 +476,7 @@ int main (int argc, char **argv)
 		 * Do the command line for everything that is
 		 * not "newgrp".
 		 */
-		if ((argc > 0) && (argv[0][0] != '-')) {
+		if (argv[0] != NULL && argv[0][0] != '-') {
 			if (!is_valid_group_name (argv[0])) {
 				fprintf (
 					stderr, _("%s: provided group is not a valid group name\n"),
@@ -485,22 +484,20 @@ int main (int argc, char **argv)
 				goto failure;
 			}
 			group = argv[0];
-			argc--;
 			argv++;
 		} else {
 			usage ();
 			closelog ();
 			exit (EXIT_FAILURE);
 		}
-		if (argc > 0 && streq(argv[0], "-c")) {
-			argc--;
+		if (argv[0] != NULL && streq(argv[0], "-c")) {
 			argv++;
-			if (argc == 0) {
+			if (argv[0] == NULL) {
 				fprintf(stderr, _("%s: -c: missing argument.\n"), Prog);
 				goto failure;
 			}
 		}
-		if (argc > 0) {
+		if (argv[0] != NULL) {
 			command = argv[0];
 			cflag = true;
 		}
@@ -509,7 +506,7 @@ int main (int argc, char **argv)
 		 * Do the command line for "newgrp". It's just making sure
 		 * there aren't any flags and getting the new group name.
 		 */
-		if ((argc > 0) && strprefix(argv[0], "-")) {
+		if (argv[0] != NULL && strprefix(argv[0], "-")) {
 			usage ();
 			goto failure;
 		} else if (argv[0] != NULL) {

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -504,25 +504,10 @@ main(int, char *argv[])
 		goto failure;
 	}
 
-	/*
-	 * get the current user's groupset. The new group will be added to
-	 * the concurrent groupset if there is room, otherwise you get a
-	 * nasty message but at least your real and effective group ids are
-	 * set.
-	 */
 	gids = agetgroups(&ngroups);
 	if (gids == NULL) {
 		perror("agetgroups");
-#ifdef WITH_AUDIT
-		if (group) {
-			audit_logger_with_group(AUDIT_CHGRP_ID, "changing", NULL, getuid(),
-						"new_group", group, SHADOW_AUDIT_FAILURE);
-		} else {
-			audit_logger(AUDIT_CHGRP_ID,
-				     "changing", NULL, getuid(), SHADOW_AUDIT_FAILURE);
-		}
-#endif
-		exit(EXIT_FAILURE);
+		goto failure;
 	}
 
 	/*

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -506,8 +506,13 @@ main(int, char *argv[])
 		}
 		if (argv[0] != NULL) {
 			command = argv[0];
+			argv++;
 			cflag = true;
 		}
+	}
+	if (argv[0] != NULL) {
+		usage();
+		goto failure;
 	}
 
 	/*

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -492,20 +492,15 @@ int main (int argc, char **argv)
 			closelog ();
 			exit (EXIT_FAILURE);
 		}
-		if (argc > 0) {
-
-			/*
-			 * Skip -c if specified so both forms work:
-			 * "sg group -c command" or "sg group command".
-			 */
-			if (streq(argv[0], "-c")) {
-				argc--;
-				argv++;
-				if (argc == 0) {
-					fprintf(stderr, _("%s: -c: missing argument.\n"), Prog);
-					goto failure;
-				}
+		if (argc > 0 && streq(argv[0], "-c")) {
+			argc--;
+			argv++;
+			if (argc == 0) {
+				fprintf(stderr, _("%s: -c: missing argument.\n"), Prog);
+				goto failure;
 			}
+		}
+		if (argc > 0) {
 			command = argv[0];
 			cflag = true;
 		}

--- a/src/newgrp.c
+++ b/src/newgrp.c
@@ -422,7 +422,7 @@ main(int, char *argv[])
 	 * injecting arbitrary strings into our stderr/stdout, as this can
 	 * be an exploit vector.
 	 */
-	is_newgrp = streq(Basename (argv[0]), "newgrp");
+	is_newgrp = streq(Basename(*argv++), "newgrp");
 	Prog = is_newgrp ? "newgrp" : "sg";
 
 	log_set_progname(Prog);
@@ -431,8 +431,6 @@ main(int, char *argv[])
 #ifdef WITH_AUDIT
 	audit_help_open ();
 #endif
-	argv++;
-
 	initenv ();
 
 	pwd = get_my_pwent ();
@@ -455,22 +453,21 @@ main(int, char *argv[])
 	 *      newgrp [-l|-] [groupid]
 	 *      sg [-l|-] groupid [[-c] command]
 	 */
-	if (argv[0] != NULL && (streq(argv[0], "-l") || streq(argv[0], "-"))) {
+	if (*argv != NULL && (streq(*argv, "-l") || streq(*argv, "-"))) {
 		argv++;
 		initflag = true;
 	}
-	if (argv[0] != NULL && strspn(argv[0], "-")) {
+	if (*argv != NULL && strspn(*argv, "-")) {
 		usage();
 		goto failure;
 	}
-	if (argv[0] != NULL) {
-		if (!is_valid_group_name(argv[0])) {
+	if (*argv != NULL) {
+		if (!is_valid_group_name(*argv)) {
 			fprintf(stderr, _("%s: provided group is not a valid group name\n"),
 			        Prog);
 			goto failure;
 		}
-		group = argv[0];
-		argv++;
+		group = *argv++;
 	} else if (!is_newgrp) {
 		usage();
 		goto failure;
@@ -486,20 +483,19 @@ main(int, char *argv[])
 		group = grp->gr_name;
 	}
 	if (!is_newgrp) {
-		if (argv[0] != NULL && streq(argv[0], "-c")) {
+		if (*argv != NULL && streq(*argv, "-c")) {
 			argv++;
-			if (argv[0] == NULL) {
+			if (*argv == NULL) {
 				fprintf(stderr, _("%s: -c: missing argument.\n"), Prog);
 				goto failure;
 			}
 		}
-		if (argv[0] != NULL) {
-			command = argv[0];
-			argv++;
+		if (*argv != NULL) {
+			command = *argv++;
 			cflag = true;
 		}
 	}
-	if (argv[0] != NULL) {
+	if (*argv != NULL) {
 		usage();
 		goto failure;
 	}


### PR DESCRIPTION
Cc: @stoeckmann , @ikerexxe 

---

Revisions:

<details>
<summary>v2</summary>

-  Unname `argc`.

```
$ git rd -U0
 1:  ef0420019 =  1:  ef0420019 src/newgrp.c: Document '-l'
 2:  b6d4f9b7a =  2:  b6d4f9b7a src/newgrp.c: sg(1): Refactor, to remove 'else' branch
 3:  56166b669 =  3:  56166b669 src/newgrp.c: sg(1): -c: Fail if the option is used without an argument
 4:  2b8316a3f =  4:  2b8316a3f src/newgrp.c: Split conditional block
 5:  8046815f8 !  5:  6843c19b3 src/newgrp.c: Use argv instead of argc to check an argument
    @@ Commit message
    +    Unname 'argc' to avoid diagnostics about the unused argument.
    +
    @@ src/newgrp.c: static void syslog_sg (const char *name, const char *group)
    -+main(int argc, char *argv[argc + 1])
    ++main(int, char *argv[])
 6:  17c01e5f4 !  6:  028e5c748 src/newgrp.c: Check '-l' and '-' in the documented order
    @@ src/newgrp.c
    -@@ src/newgrp.c: main(int argc, char *argv[argc + 1])
    +@@ src/newgrp.c: main(int, char *argv[])
 7:  82c563b90 !  7:  3a0892de5 src/newgrp.c: newgrp(1): Remove 'else's after 'goto'
    @@ src/newgrp.c
    -@@ src/newgrp.c: main(int argc, char *argv[argc + 1])
    +@@ src/newgrp.c: main(int, char *argv[])
    @@ src/newgrp.c: main(int argc, char *argv[argc + 1])
    -@@ src/newgrp.c: main(int argc, char *argv[argc + 1])
    +@@ src/newgrp.c: main(int, char *argv[])
 8:  e7ee9d344 !  8:  4246adf9a src/newgrp.c: De-duplicate check
    @@ src/newgrp.c
    -@@ src/newgrp.c: main(int argc, char *argv[argc + 1])
    +@@ src/newgrp.c: main(int, char *argv[])
    @@ src/newgrp.c: main(int argc, char *argv[argc + 1])
    -@@ src/newgrp.c: main(int argc, char *argv[argc + 1])
    +@@ src/newgrp.c: main(int, char *argv[])
 9:  f58234eb3 !  9:  1f62687b7 src/newgrp.c: Separate code handling group name and code handling command
    @@ src/newgrp.c
    -@@ src/newgrp.c: main(int argc, char *argv[argc + 1])
    +@@ src/newgrp.c: main(int, char *argv[])
    @@ src/newgrp.c: main(int argc, char *argv[argc + 1])
    -@@ src/newgrp.c: main(int argc, char *argv[argc + 1])
    +@@ src/newgrp.c: main(int, char *argv[])
    @@ src/newgrp.c: main(int argc, char *argv[argc + 1])
    -@@ src/newgrp.c: main(int argc, char *argv[argc + 1])
    +@@ src/newgrp.c: main(int, char *argv[])
10:  03bb4b4ef ! 10:  67834ed31 src/newgrp.c: Refactor conditionals to de-duplicate code
    @@ src/newgrp.c
    -@@ src/newgrp.c: main(int argc, char *argv[argc + 1])
    +@@ src/newgrp.c: main(int, char *argv[])
    @@ src/newgrp.c: main(int argc, char *argv[argc + 1])
    -@@ src/newgrp.c: main(int argc, char *argv[argc + 1])
    +@@ src/newgrp.c: main(int, char *argv[])
11:  5ae74951d ! 11:  f11890b4f src/newgrp.c: Fix indentation
    @@ src/newgrp.c
    -@@ src/newgrp.c: main(int argc, char *argv[argc + 1])
    +@@ src/newgrp.c: main(int, char *argv[])
12:  de4cc76cc ! 12:  85706b5ec src/newgrp.c: Fail if there are trailing (unexpected) arguments
    @@ src/newgrp.c
    -@@ src/newgrp.c: main(int argc, char *argv[argc + 1])
    +@@ src/newgrp.c: main(int, char *argv[])
13:  33dfdafe9 ! 13:  499eadeb2 src/newgrp.c: Remove incorrect comment
    @@ src/newgrp.c
    -@@ src/newgrp.c: main(int argc, char *argv[argc + 1])
    +@@ src/newgrp.c: main(int, char *argv[])
14:  a9af91f67 ! 14:  3573e24a6 src/newgrp.c: sg(1): Use 'goto failure;' to fail
    @@ src/newgrp.c
    -@@ src/newgrp.c: main(int argc, char *argv[argc + 1])
    +@@ src/newgrp.c: main(int, char *argv[])
15:  6b652d160 = 15:  d78ede7e7 lib/prototypes.h: Fix indentation
16:  99c712e35 ! 16:  89c89007c src/newgrp.c: Report SHADOW_AUDIT_FAILURE on failure
    @@ src/newgrp.c
    -@@ src/newgrp.c: main(int argc, char *argv[argc + 1])
    +@@ src/newgrp.c: main(int, char *argv[])
17:  41fa8b9e8 ! 17:  657823c6f src/newgrp.c: Fix error handling
    @@ src/newgrp.c
    -@@ src/newgrp.c: main(int argc, char *argv[argc + 1])
    +@@ src/newgrp.c: main(int, char *argv[])
18:  fc5e5462b = 18:  919b2c77d src/newgrp.c: syslog_sg(): Use Prog instead of its pattern
19:  23acca2c6 ! 19:  28aae3568 src/newgrp.c: Use idiomatic pointer arithmetic notation
    @@ src/newgrp.c
    -@@ src/newgrp.c: main(int argc, char *argv[argc + 1])
    +@@ src/newgrp.c: main(int, char *argv[])
    @@ src/newgrp.c: main(int argc, char *argv[argc + 1])
    -@@ src/newgrp.c: main(int argc, char *argv[argc + 1])
    +@@ src/newgrp.c: main(int, char *argv[])
    @@ src/newgrp.c: main(int argc, char *argv[argc + 1])
    -@@ src/newgrp.c: main(int argc, char *argv[argc + 1])
    +@@ src/newgrp.c: main(int, char *argv[])
    @@ src/newgrp.c: main(int argc, char *argv[argc + 1])
    -@@ src/newgrp.c: main(int argc, char *argv[argc + 1])
    +@@ src/newgrp.c: main(int, char *argv[])
20:  0e4f97b2a ! 20:  e4266db15 src/newgrp.c: Remove redundant comment
    @@ src/newgrp.c: static void check_perms (const struct group *grp,
    -@@ src/newgrp.c: main(int argc, char *argv[argc + 1])
    +@@ src/newgrp.c: main(int, char *argv[])
```
</details>

<details>
<summary>v3</summary>

-  Accept both `-l` and `-` in the same command, for consistency with su(1).  [@stoeckmann ]
-  Remove redundant input validation.  [@stoeckmann ]

```
$ git rd 
 1:  ef0420019 =  1:  ef0420019 src/newgrp.c: Document '-l'
 2:  b6d4f9b7a =  2:  b6d4f9b7a src/newgrp.c: sg(1): Refactor, to remove 'else' branch
 3:  56166b669 =  3:  56166b669 src/newgrp.c: sg(1): -c: Fail if the option is used without an argument
 4:  2b8316a3f =  4:  2b8316a3f src/newgrp.c: Split conditional block
 5:  6843c19b3 =  5:  6843c19b3 src/newgrp.c: Use argv instead of argc to check an argument
 6:  028e5c748 =  6:  028e5c748 src/newgrp.c: Check '-l' and '-' in the documented order
 7:  3a0892de5 =  7:  3a0892de5 src/newgrp.c: newgrp(1): Remove 'else's after 'goto'
 8:  4246adf9a =  8:  4246adf9a src/newgrp.c: De-duplicate check
 9:  1f62687b7 =  9:  1f62687b7 src/newgrp.c: Separate code handling group name and code handling command
10:  67834ed31 = 10:  67834ed31 src/newgrp.c: Refactor conditionals to de-duplicate code
11:  f11890b4f = 11:  f11890b4f src/newgrp.c: Fix indentation
12:  85706b5ec = 12:  85706b5ec src/newgrp.c: Fail if there are trailing (unexpected) arguments
13:  499eadeb2 = 13:  499eadeb2 src/newgrp.c: Remove incorrect comment
14:  3573e24a6 = 14:  3573e24a6 src/newgrp.c: sg(1): Use 'goto failure;' to fail
15:  d78ede7e7 = 15:  d78ede7e7 lib/prototypes.h: Fix indentation
16:  89c89007c = 16:  89c89007c src/newgrp.c: Report SHADOW_AUDIT_FAILURE on failure
17:  657823c6f = 17:  657823c6f src/newgrp.c: Fix error handling
18:  919b2c77d = 18:  919b2c77d src/newgrp.c: syslog_sg(): Use Prog instead of its pattern
19:  28aae3568 = 19:  28aae3568 src/newgrp.c: Use idiomatic pointer arithmetic notation
20:  e4266db15 = 20:  e4266db15 src/newgrp.c: Remove redundant comment
 -:  --------- > 21:  29c24fed6 src/newgrp.c: Accept both -l and - in the same command
 -:  --------- > 22:  df3bb4cbe src/newgrp.c: Remove redundant input validation
```
</details>

<details>
<summary>v3b</summary>

-  Rebase

```
$ git rd 
 1:  ef04200199d2 =  1:  5bc5e6157526 src/newgrp.c: Document '-l'
 2:  b6d4f9b7a5c8 =  2:  bf9e61c0ef7e src/newgrp.c: sg(1): Refactor, to remove 'else' branch
 3:  56166b6697a6 =  3:  fefe02ecb687 src/newgrp.c: sg(1): -c: Fail if the option is used without an argument
 4:  2b8316a3f78d =  4:  3635176e2822 src/newgrp.c: Split conditional block
 5:  6843c19b360d =  5:  3aa5a64e3a31 src/newgrp.c: Use argv instead of argc to check an argument
 6:  028e5c748b33 =  6:  4bf4e30960e3 src/newgrp.c: Check '-l' and '-' in the documented order
 7:  3a0892de52b6 =  7:  8b29b89fee14 src/newgrp.c: newgrp(1): Remove 'else's after 'goto'
 8:  4246adf9a5f4 =  8:  e007fbcb1eaa src/newgrp.c: De-duplicate check
 9:  1f62687b7ff4 =  9:  36f9a127dfae src/newgrp.c: Separate code handling group name and code handling command
10:  67834ed31be1 = 10:  c74525577028 src/newgrp.c: Refactor conditionals to de-duplicate code
11:  f11890b4f79a = 11:  e23d52c64070 src/newgrp.c: Fix indentation
12:  85706b5ec1be = 12:  4e0209d0d6af src/newgrp.c: Fail if there are trailing (unexpected) arguments
13:  499eadeb203d = 13:  deda72428f86 src/newgrp.c: Remove incorrect comment
14:  3573e24a6f39 = 14:  f9d2fadd0bf4 src/newgrp.c: sg(1): Use 'goto failure;' to fail
15:  d78ede7e76cd = 15:  b91bed51b80c lib/prototypes.h: Fix indentation
16:  89c89007c03c = 16:  7ceadd0af331 src/newgrp.c: Report SHADOW_AUDIT_FAILURE on failure
17:  657823c6f1ca = 17:  d34e55368aac src/newgrp.c: Fix error handling
18:  919b2c77d4ba = 18:  b526d9097b61 src/newgrp.c: syslog_sg(): Use Prog instead of its pattern
19:  28aae35684c0 = 19:  29a64c5b7339 src/newgrp.c: Use idiomatic pointer arithmetic notation
20:  e4266db158a6 = 20:  22ad719bfcbd src/newgrp.c: Remove redundant comment
21:  29c24fed60a0 = 21:  d08282fce523 src/newgrp.c: Accept both -l and - in the same command
22:  df3bb4cbea44 = 22:  9faab479f973 src/newgrp.c: Remove redundant input validation
```
</details>

<details>
<summary>v3c</summary>

-  Rebase

```
$ git rd 
 1:  5bc5e615 =  1:  59265b45 src/newgrp.c: Document '-l'
 2:  bf9e61c0 =  2:  f6f71954 src/newgrp.c: sg(1): Refactor, to remove 'else' branch
 3:  fefe02ec =  3:  de6ea3a7 src/newgrp.c: sg(1): -c: Fail if the option is used without an argument
 4:  3635176e =  4:  6ac361bd src/newgrp.c: Split conditional block
 5:  3aa5a64e =  5:  721a3d65 src/newgrp.c: Use argv instead of argc to check an argument
 6:  4bf4e309 =  6:  33a370f9 src/newgrp.c: Check '-l' and '-' in the documented order
 7:  8b29b89f !  7:  07747cce src/newgrp.c: newgrp(1): Remove 'else's after 'goto'
    @@ src/newgrp.c: main(int, char *argv[])
                                fprintf (
                                        stderr, _("%s: provided group is not a valid group name\n"),
     @@ src/newgrp.c: main(int, char *argv[])
    -                           SYSLOG ((LOG_CRIT, "GID '%lu' does not exist",
    -                                   (unsigned long) pwd->pw_gid));
    +                           SYSLOG(LOG_CRIT, "GID '%lu' does not exist",
    +                                  (unsigned long) pwd->pw_gid);
                                goto failure;
     -                  } else {
     -                          group = grp->gr_name;
 8:  e007fbcb =  8:  aa6e589f src/newgrp.c: De-duplicate check
 9:  36f9a127 =  9:  4a9d2c27 src/newgrp.c: Separate code handling group name and code handling command
10:  c7452557 = 10:  6cfa7edf src/newgrp.c: Refactor conditionals to de-duplicate code
11:  e23d52c6 ! 11:  0aa744cd src/newgrp.c: Fix indentation
    @@ src/newgrp.c: main(int, char *argv[])
     -                          fprintf (stderr,
     -                                   _("%s: GID '%lu' does not exist\n"),
     -                                   Prog, (unsigned long) pwd->pw_gid);
    --                          SYSLOG ((LOG_CRIT, "GID '%lu' does not exist",
    --                                  (unsigned long) pwd->pw_gid));
    +-                          SYSLOG(LOG_CRIT, "GID '%lu' does not exist",
    +-                                 (unsigned long) pwd->pw_gid);
     -                          goto failure;
     -                  }
     -                  group = grp->gr_name;
    @@ src/newgrp.c: main(int, char *argv[])
     +          if (NULL == grp) {
     +                  fprintf(stderr, _("%s: GID '%lu' does not exist\n"),
     +                          Prog, (unsigned long) pwd->pw_gid);
    -+                  SYSLOG((LOG_CRIT, "GID '%lu' does not exist",
    -+                         (unsigned long) pwd->pw_gid));
    ++                  SYSLOG(LOG_CRIT, "GID '%lu' does not exist",
    ++                         (unsigned long) pwd->pw_gid);
     +                  goto failure;
     +          }
     +          group = grp->gr_name;
12:  4e0209d0 = 12:  0e4f56bd src/newgrp.c: Fail if there are trailing (unexpected) arguments
13:  deda7242 = 13:  737b4246 src/newgrp.c: Remove incorrect comment
14:  f9d2fadd = 14:  0476fb9b src/newgrp.c: sg(1): Use 'goto failure;' to fail
15:  b91bed51 = 15:  0de44ac5 lib/prototypes.h: Fix indentation
16:  7ceadd0a = 16:  4d82e688 src/newgrp.c: Report SHADOW_AUDIT_FAILURE on failure
17:  d34e5536 = 17:  711ad17f src/newgrp.c: Fix error handling
18:  b526d909 = 18:  61867cb6 src/newgrp.c: syslog_sg(): Use Prog instead of its pattern
19:  29a64c5b = 19:  b2dfc346 src/newgrp.c: Use idiomatic pointer arithmetic notation
20:  22ad719b = 20:  9505b7b0 src/newgrp.c: Remove redundant comment
21:  d08282fc = 21:  5463f229 src/newgrp.c: Accept both -l and - in the same command
22:  9faab479 = 22:  aff2bd8b src/newgrp.c: Remove redundant input validation
```
</details>

<details>
<summary>v3d</summary>

-  Rebase

```
$ git rd 
 1:  59265b45 =  1:  461e4a09 src/newgrp.c: Document '-l'
 2:  f6f71954 =  2:  ff803096 src/newgrp.c: sg(1): Refactor, to remove 'else' branch
 3:  de6ea3a7 =  3:  ae4974a5 src/newgrp.c: sg(1): -c: Fail if the option is used without an argument
 4:  6ac361bd =  4:  b55d73b4 src/newgrp.c: Split conditional block
 5:  721a3d65 =  5:  acb6da11 src/newgrp.c: Use argv instead of argc to check an argument
 6:  33a370f9 =  6:  e07b06db src/newgrp.c: Check '-l' and '-' in the documented order
 7:  07747cce =  7:  f76e18f3 src/newgrp.c: newgrp(1): Remove 'else's after 'goto'
 8:  aa6e589f =  8:  b2142554 src/newgrp.c: De-duplicate check
 9:  4a9d2c27 =  9:  eb01dbc5 src/newgrp.c: Separate code handling group name and code handling command
10:  6cfa7edf = 10:  1df97c87 src/newgrp.c: Refactor conditionals to de-duplicate code
11:  0aa744cd = 11:  fc4443aa src/newgrp.c: Fix indentation
12:  0e4f56bd = 12:  3d964c57 src/newgrp.c: Fail if there are trailing (unexpected) arguments
13:  737b4246 = 13:  e7f6ca99 src/newgrp.c: Remove incorrect comment
14:  0476fb9b = 14:  ea162c9f src/newgrp.c: sg(1): Use 'goto failure;' to fail
15:  0de44ac5 = 15:  63805d1a lib/prototypes.h: Fix indentation
16:  4d82e688 = 16:  2aae9238 src/newgrp.c: Report SHADOW_AUDIT_FAILURE on failure
17:  711ad17f = 17:  1076a30c src/newgrp.c: Fix error handling
18:  61867cb6 = 18:  acccf15c src/newgrp.c: syslog_sg(): Use Prog instead of its pattern
19:  b2dfc346 = 19:  8ee07de8 src/newgrp.c: Use idiomatic pointer arithmetic notation
20:  9505b7b0 = 20:  68031eb3 src/newgrp.c: Remove redundant comment
21:  5463f229 = 21:  e170755c src/newgrp.c: Accept both -l and - in the same command
22:  aff2bd8b = 22:  f3559537 src/newgrp.c: Remove redundant input validation
```
</details>

<details>
<summary>v3e</summary>

-  Rebase

```
$ git rd 
 1:  461e4a098890 =  1:  08012a68b4d6 src/newgrp.c: Document '-l'
 2:  ff8030962706 =  2:  de307e311fb7 src/newgrp.c: sg(1): Refactor, to remove 'else' branch
 3:  ae4974a5578a =  3:  d65c8397d076 src/newgrp.c: sg(1): -c: Fail if the option is used without an argument
 4:  b55d73b4c09a =  4:  4b8b87b50b98 src/newgrp.c: Split conditional block
 5:  acb6da112132 =  5:  a8a865abda9c src/newgrp.c: Use argv instead of argc to check an argument
 6:  e07b06db83e3 =  6:  3e5706342fbe src/newgrp.c: Check '-l' and '-' in the documented order
 7:  f76e18f3698c =  7:  4088994dd0d5 src/newgrp.c: newgrp(1): Remove 'else's after 'goto'
 8:  b21425547c8e =  8:  c89ed108df7d src/newgrp.c: De-duplicate check
 9:  eb01dbc58edf =  9:  bea61ad4a0b2 src/newgrp.c: Separate code handling group name and code handling command
10:  1df97c87644e = 10:  1656c7a41426 src/newgrp.c: Refactor conditionals to de-duplicate code
11:  fc4443aa0169 = 11:  3a9bdee0e3bf src/newgrp.c: Fix indentation
12:  3d964c5758f5 = 12:  6472b1cac7ed src/newgrp.c: Fail if there are trailing (unexpected) arguments
13:  e7f6ca998151 = 13:  8381db795e98 src/newgrp.c: Remove incorrect comment
14:  ea162c9fee83 = 14:  0a975191f8ca src/newgrp.c: sg(1): Use 'goto failure;' to fail
15:  63805d1a2f48 = 15:  7ba423811286 lib/prototypes.h: Fix indentation
16:  2aae9238f3b1 = 16:  9a2be39d7175 src/newgrp.c: Report SHADOW_AUDIT_FAILURE on failure
17:  1076a30c0a14 = 17:  32bdced784c7 src/newgrp.c: Fix error handling
18:  acccf15ca5d1 = 18:  ca9e281e9cdd src/newgrp.c: syslog_sg(): Use Prog instead of its pattern
19:  8ee07de87ae7 = 19:  df675fc9faaf src/newgrp.c: Use idiomatic pointer arithmetic notation
20:  68031eb36c41 = 20:  703ff72f6f0f src/newgrp.c: Remove redundant comment
21:  e170755cd2f3 = 21:  9529daa92cac src/newgrp.c: Accept both -l and - in the same command
22:  f35595370cd8 = 22:  1fca9d93738f src/newgrp.c: Remove redundant input validation
```
</details>