### PR TITLE
man/: Fix SELinux note formatting

### DIFF
--- a/man/chfn.1.xml
+++ b/man/chfn.1.xml
@@ -138,7 +138,7 @@
 	    Apply changes in the <replaceable>CHROOT_DIR</replaceable>
 	    directory and use the configuration files from the
 	    <replaceable>CHROOT_DIR</replaceable> directory.
-      No SELINUX support.
+	    No SELINUX support.
 	  </para>
 	</listitem>
       </varlistentry>

--- a/man/chgpasswd.8.xml
+++ b/man/chgpasswd.8.xml
@@ -134,7 +134,7 @@
 	    directory and use the configuration files from the
 	    <replaceable>CHROOT_DIR</replaceable> directory.
 	    Only absolute paths are supported.
-      No SELINUX support.
+	    No SELINUX support.
 	  </para>
 	</listitem>
       </varlistentry>

--- a/man/chpasswd.8.xml
+++ b/man/chpasswd.8.xml
@@ -176,7 +176,7 @@
 	    directory and use the configuration files from the
 	    <replaceable>CHROOT_DIR</replaceable> directory.
 	    Only absolute paths are supported.
-      No SELINUX support.
+	    No SELINUX support.
 	  </para>
 	</listitem>
       </varlistentry>

--- a/man/chsh.1.xml
+++ b/man/chsh.1.xml
@@ -89,7 +89,7 @@
 	    directory and use the configuration files from the
 	    <replaceable>CHROOT_DIR</replaceable> directory.
 	    Only absolute paths are supported.
-      No SELINUX support.
+	    No SELINUX support.
 	  </para>
 	</listitem>
       </varlistentry>

--- a/man/gpasswd.1.xml
+++ b/man/gpasswd.1.xml
@@ -165,7 +165,7 @@
 	    directory and use the configuration files from the
 	    <replaceable>CHROOT_DIR</replaceable> directory.
 	    Only absolute paths are supported.
-      No SELINUX support.
+	    No SELINUX support.
 	  </para>
 	</listitem>
       </varlistentry>

--- a/man/groupdel.8.xml
+++ b/man/groupdel.8.xml
@@ -94,7 +94,7 @@
 	    directory and use the configuration files from the
 	    <replaceable>CHROOT_DIR</replaceable> directory.
 	    Only absolute paths are supported.
-      No SELINUX support.
+	    No SELINUX support.
 	  </para>
 	</listitem>
       </varlistentry>

--- a/man/groupmems.8.xml
+++ b/man/groupmems.8.xml
@@ -147,7 +147,7 @@
 	    directory and use the configuration files from the
 	    <replaceable>CHROOT_DIR</replaceable> directory.
 	    Only absolute paths are supported.
-      No SELINUX support.
+	    No SELINUX support.
 	  </para>
 	</listitem>
       </varlistentry>

--- a/man/grpck.8.xml
+++ b/man/grpck.8.xml
@@ -154,7 +154,7 @@
 	    directory and use the configuration files from the
 	    <replaceable>CHROOT_DIR</replaceable> directory.
 	    Only absolute paths are supported.
-      No SELINUX support.
+	    No SELINUX support.
 	  </para>
 	</listitem>
       </varlistentry>

--- a/man/lastlog.8.xml
+++ b/man/lastlog.8.xml
@@ -109,7 +109,7 @@
 	    directory and use the configuration files from the
 	    <replaceable>CHROOT_DIR</replaceable> directory.
 	    Only absolute paths are supported.
-      No SELINUX support.
+	    No SELINUX support.
 	  </para>
 	</listitem>
       </varlistentry>

--- a/man/pwck.8.xml
+++ b/man/pwck.8.xml
@@ -202,7 +202,7 @@
 	    directory and use the configuration files from the
 	    <replaceable>CHROOT_DIR</replaceable> directory.
 	    Only absolute paths are supported.
-      No SELINUX support.
+	    No SELINUX support.
 	  </para>
 	</listitem>
       </varlistentry>

--- a/man/pwconv.8.xml
+++ b/man/pwconv.8.xml
@@ -183,7 +183,7 @@
 	    directory and use the configuration files from the
 	    <replaceable>CHROOT_DIR</replaceable> directory.
 	    Only absolute paths are supported.
-      No SELINUX support.
+	    No SELINUX support.
 	  </para>
 	</listitem>
       </varlistentry>

--- a/man/userdel.8.xml
+++ b/man/userdel.8.xml
@@ -120,7 +120,7 @@
 	    directory and use the configuration files from the
 	    <replaceable>CHROOT_DIR</replaceable> directory.
 	    Only absolute paths are supported.
-      No SELINUX support.
+	    No SELINUX support.
 	  </para>
 	</listitem>
       </varlistentry>

--- a/man/vipw.8.xml
+++ b/man/vipw.8.xml
@@ -120,7 +120,7 @@
 	    directory and use the configuration files from the
 	    <replaceable>CHROOT_DIR</replaceable> directory.
 	    Only absolute paths are supported.
-      No SELINUX support.
+	    No SELINUX support.
 	  </para>
 	</listitem>
       </varlistentry>


### PR DESCRIPTION
Use tab instead of spaces to comply with rest of files.

Fixes: 923aeac250d0 (2025-07-04; "man/: update `--root` flag with no SELinux support")