### PR TITLE
man/lastlog.8: Drop redundant closing brackets

### DIFF
--- a/man/lastlog.8.xml
+++ b/man/lastlog.8.xml
@@ -87,7 +87,7 @@
 	<listitem>
 	  <para>
 	    Clear lastlog record of a user. This option can be used only together
-	    with <option>-u</option> (<option>--user</option>)).
+	    with <option>-u</option> (<option>--user</option>).
 	  </para>
 	</listitem>
       </varlistentry>
@@ -120,7 +120,7 @@
 	<listitem>
 	  <para>
 	    Set lastlog record of a user to the current time. This option can be
-	    used only together with <option>-u</option> (<option>--user</option>)).
+	    used only together with <option>-u</option> (<option>--user</option>).
 	  </para>
 	</listitem>
       </varlistentry>


### PR DESCRIPTION
Only one opening bracket is used before two closing brackets are encountered for "(--user)".

Drop redundant ones within the file.