### PR TITLE
lib/: Use non-empty compound literals

### DIFF
--- a/lib/atoi/a2i.h
+++ b/lib/atoi/a2i.h
@@ -26,7 +26,7 @@
 	                                                              \
 	int  status;                                                  \
 	                                                              \
-	*n_ = _Generic((T){},                                         \
+	*n_ = _Generic((T){0},                                        \
 		short:              strtoi_,                          \
 		int:                strtoi_,                          \
 		long:               strtoi_,                          \

--- a/lib/search/cmp/cmp.h
+++ b/lib/search/cmp/cmp.h
@@ -11,7 +11,7 @@
 
 #define CMP(T)                                                        \
 (                                                                     \
-	_Generic((T){},                                               \
+	_Generic((T){0},                                              \
 		int:            cmp_int,                              \
 		long:           cmp_long,                             \
 		unsigned int:   cmp_uint,                             \

--- a/lib/sizeof.h
+++ b/lib/sizeof.h
@@ -15,7 +15,7 @@
 #include <sys/types.h>
 
 
-#define typeas(T)            typeof((T){})
+#define typeas(T)            typeof((T){0})
 
 #define ssizeof(x)           ({(ssize_t){sizeof(x)};})
 #define memberof(T, member)  ((T){}.member)

--- a/lib/typetraits.h
+++ b/lib/typetraits.h
@@ -57,10 +57,10 @@
 #define QChar_of(s)  typeof                                           \
 (                                                                     \
 	_Generic(s,                                                   \
-		const char *:  (const char){},                        \
-		const void *:  (const char){},                        \
-		char *:        (char){},                              \
-		void *:        (char){}                               \
+		const char *:  (const char){0},                       \
+		const void *:  (const char){0},                       \
+		char *:        (char){0},                             \
+		void *:        (char){0}                              \
 	)                                                             \
 )
 


### PR DESCRIPTION
While the empty one is more correct, {0} will also work, and will likely silence diagnostics in old compiler versions.

Reported-by: @hallyn 

Please test.  In my computer, both before and after the patch work fine.  I suspect this should silence your diagnostic, but am not 100% sure.

---

Revisions:

<details>
<summary>v2</summary>

-  Address another case.
-  Expand commit message.

```
$ git rd 
1:  1be3918be ! 1:  ce8345abc lib/: Use non-empty compound literals
    @@ Commit message
         While the empty one is more correct, {0} will also work, and will
         likely silence diagnostics in old compiler versions.
     
    +    Empty compound literals are only supported in GCC since commit
    +    gcc.git 14cfa01755a6 (2022-08-25; "c: Support C2x empty initializer braces")
    +
         Reported-by: Serge Hallyn <serge@hallyn.com>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    @@ lib/sizeof.h
      
      #define ssizeof(x)           ({(ssize_t){sizeof(x)};})
      #define memberof(T, member)  ((T){}.member)
    +
    + ## lib/typetraits.h ##
    +@@
    + #define QChar_of(s)  typeof                                           \
    + (                                                                     \
    +   _Generic(s,                                                   \
    +-          const char *:  (const char){},                        \
    +-          const void *:  (const char){},                        \
    +-          char *:        (char){},                              \
    +-          void *:        (char){}                               \
    ++          const char *:  (const char){0},                       \
    ++          const void *:  (const char){0},                       \
    ++          char *:        (char){0},                             \
    ++          void *:        (char){0}                              \
    +   )                                                             \
    + )
    + 
```
</details>