### PR TITLE
lib/: Add ispfchar_c() and strisldh_rfc1035_c(), and use them instead of their pattern

### DIFF
--- a/lib/chkname.c
+++ b/lib/chkname.c
@@ -69,10 +69,7 @@ is_valid_name(const char *name, bool badnames)
 	 * sake of Samba 3.x "add machine script"
 	 */
 
-	if (!(isalnum_c(*name) ||
-	      *name == '_' ||
-	      *name == '.'))
-	{
+	if (!ispfchar_c(*name)) {
 		errno = EILSEQ;
 		return false;
 	}
@@ -81,12 +78,7 @@ is_valid_name(const char *name, bool badnames)
 		if (streq(name, "$"))  // Samba
 			return true;
 
-		if (!(isalnum_c(*name) ||
-		      *name == '_' ||
-		      *name == '.' ||
-		      *name == '-'
-		     ))
-		{
+		if (!ispfchar_c(*name)) {
 			errno = EILSEQ;
 			return false;
 		}

--- a/lib/chkname.c
+++ b/lib/chkname.c
@@ -130,7 +130,7 @@ is_valid_domain_label(const char *label)
 		errno = EINVAL;
 		return false;
 	}
-	if (!streq(stpspn(label, CTYPE_ALNUM_C "-"), "")) {
+	if (!strisldh_rfc1035_c(label)) {
 		errno = EINVAL;
 		return false;
 	}

--- a/lib/chkname.c
+++ b/lib/chkname.c
@@ -69,9 +69,7 @@ is_valid_name(const char *name, bool badnames)
 	 * sake of Samba 3.x "add machine script"
 	 */
 
-	if (!((*name >= 'a' && *name <= 'z') ||
-	      (*name >= 'A' && *name <= 'Z') ||
-	      (*name >= '0' && *name <= '9') ||
+	if (!(isalnum_c(*name) ||
 	      *name == '_' ||
 	      *name == '.'))
 	{
@@ -80,9 +78,7 @@ is_valid_name(const char *name, bool badnames)
 	}
 
 	while (!streq(++name, "")) {
-		if (!((*name >= 'a' && *name <= 'z') ||
-		      (*name >= 'A' && *name <= 'Z') ||
-		      (*name >= '0' && *name <= '9') ||
+		if (!(isalnum_c(*name) ||
 		      *name == '_' ||
 		      *name == '.' ||
 		      *name == '-' ||

--- a/lib/chkname.c
+++ b/lib/chkname.c
@@ -78,11 +78,13 @@ is_valid_name(const char *name, bool badnames)
 	}
 
 	while (!streq(++name, "")) {
+		if (streq(name, "$"))  // Samba
+			return true;
+
 		if (!(isalnum_c(*name) ||
 		      *name == '_' ||
 		      *name == '.' ||
-		      *name == '-' ||
-		      streq(name, "$")
+		      *name == '-'
 		     ))
 		{
 			errno = EILSEQ;

--- a/lib/string/ctype/isascii.h
+++ b/lib/string/ctype/isascii.h
@@ -30,6 +30,7 @@
 #define CTYPE_PRINT_C     CTYPE_GRAPH_C " "
 #define CTYPE_XDIGIT_C    CTYPE_DIGIT_C "abcdefABCDEF"
 #define CTYPE_ASCII_C     CTYPE_PRINT_C CTYPE_CNTRL_C /*NUL*/
+#define CTYPE_PFCHAR_C    CTYPE_ALNUM_C "._-"  // portable filename character set
 
 
 // isascii_c - is [:ascii:] C-locale
@@ -45,6 +46,7 @@
 #define isgraph_c(c)      (!streq(strchrnul(CTYPE_GRAPH_C, c), ""))
 #define isprint_c(c)      (!streq(strchrnul(CTYPE_PRINT_C, c), ""))
 #define isxdigit_c(c)     (!streq(strchrnul(CTYPE_XDIGIT_C, c), ""))
+#define ispfchar_c(c)     (!streq(strchrnul(CTYPE_PFCHAR_C, c), ""))
 
 
 // strisascii_c - string is [:ascii:] C-locale

--- a/lib/string/ctype/isascii.h
+++ b/lib/string/ctype/isascii.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2025, Alejandro Colomar <alx@kernel.org>
+// SPDX-FileCopyrightText: 2024-2026, Alejandro Colomar <alx@kernel.org>
 // SPDX-License-Identifier: BSD-3-Clause
 
 
@@ -31,6 +31,7 @@
 #define CTYPE_XDIGIT_C         CTYPE_DIGIT_C "abcdefABCDEF"
 #define CTYPE_ASCII_C          CTYPE_PRINT_C CTYPE_CNTRL_C /*NUL*/
 #define CTYPE_PFCHAR_C         CTYPE_ALNUM_C "._-"  // portable filename character set
+#define CTYPE_LDH_RFC1035_C    CTYPE_ALNUM_C "-"  // letter, digit, hyphen
 
 
 // isascii_c - is [:ascii:] C-locale
@@ -47,11 +48,13 @@
 #define isprint_c(c)           (!streq(strchrnul(CTYPE_PRINT_C, c), ""))
 #define isxdigit_c(c)          (!streq(strchrnul(CTYPE_XDIGIT_C, c), ""))
 #define ispfchar_c(c)          (!streq(strchrnul(CTYPE_PFCHAR_C, c), ""))
+#define isldh_rfc1035_c(c)     (!streq(strchrnul(CTYPE_LDH_RFC1035_C, c), ""))
 
 
 // strisascii_c - string is [:ascii:] C-locale
 #define strisdigit_c(s)        streq(stpspn(s, CTYPE_DIGIT_C), "")
 #define strisprint_c(s)        streq(stpspn(s, CTYPE_PRINT_C), "")
+#define strisldh_rfc1035_c(s)  streq(stpspn(s, CTYPE_LDH_RFC1035_C), "")
 
 
 // strchriscntrl_c - string character is [:cntrl:] C-locale

--- a/lib/string/ctype/isascii.h
+++ b/lib/string/ctype/isascii.h
@@ -19,43 +19,43 @@
 	"\x1F\x1E\x1D\x1C\x1B\x1A\x19\x18\x17\x16\x15\x14\x13\x12\x11\x10" \
 	"\x0F\x0E\x0D\x0C\x0B\x0A\x09\x08\x07\x06\x05\x04\x03\x02\x01" /*NUL*/
 
-#define CTYPE_LOWER_C     "abcdefghijklmnopqrstuvwxyz"
-#define CTYPE_UPPER_C     "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-#define CTYPE_DIGIT_C     "0123456789"
-#define CTYPE_PUNCT_C     "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
-#define CTYPE_SPACE_C     " \t\n\v\f\r"
-#define CTYPE_ALPHA_C     CTYPE_LOWER_C CTYPE_UPPER_C
-#define CTYPE_ALNUM_C     CTYPE_ALPHA_C CTYPE_DIGIT_C
-#define CTYPE_GRAPH_C     CTYPE_ALNUM_C CTYPE_PUNCT_C
-#define CTYPE_PRINT_C     CTYPE_GRAPH_C " "
-#define CTYPE_XDIGIT_C    CTYPE_DIGIT_C "abcdefABCDEF"
-#define CTYPE_ASCII_C     CTYPE_PRINT_C CTYPE_CNTRL_C /*NUL*/
-#define CTYPE_PFCHAR_C    CTYPE_ALNUM_C "._-"  // portable filename character set
+#define CTYPE_LOWER_C          "abcdefghijklmnopqrstuvwxyz"
+#define CTYPE_UPPER_C          "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+#define CTYPE_DIGIT_C          "0123456789"
+#define CTYPE_PUNCT_C          "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
+#define CTYPE_SPACE_C          " \t\n\v\f\r"
+#define CTYPE_ALPHA_C          CTYPE_LOWER_C CTYPE_UPPER_C
+#define CTYPE_ALNUM_C          CTYPE_ALPHA_C CTYPE_DIGIT_C
+#define CTYPE_GRAPH_C          CTYPE_ALNUM_C CTYPE_PUNCT_C
+#define CTYPE_PRINT_C          CTYPE_GRAPH_C " "
+#define CTYPE_XDIGIT_C         CTYPE_DIGIT_C "abcdefABCDEF"
+#define CTYPE_ASCII_C          CTYPE_PRINT_C CTYPE_CNTRL_C /*NUL*/
+#define CTYPE_PFCHAR_C         CTYPE_ALNUM_C "._-"  // portable filename character set
 
 
 // isascii_c - is [:ascii:] C-locale
-#define isascii_c(c)      (!!strchr(CTYPE_ASCII_C, c))
-#define iscntrl_c(c)      (!!strchr(CTYPE_CNTRL_C, c))
-#define islower_c(c)      (!streq(strchrnul(CTYPE_LOWER_C, c), ""))
-#define isupper_c(c)      (!streq(strchrnul(CTYPE_UPPER_C, c), ""))
-#define isdigit_c(c)      (!streq(strchrnul(CTYPE_DIGIT_C, c), ""))
-#define ispunct_c(c)      (!streq(strchrnul(CTYPE_PUNCT_C, c), ""))
-#define isspace_c(c)      (!streq(strchrnul(CTYPE_SPACE_C, c), ""))
-#define isalpha_c(c)      (!streq(strchrnul(CTYPE_ALPHA_C, c), ""))
-#define isalnum_c(c)      (!streq(strchrnul(CTYPE_ALNUM_C, c), ""))
-#define isgraph_c(c)      (!streq(strchrnul(CTYPE_GRAPH_C, c), ""))
-#define isprint_c(c)      (!streq(strchrnul(CTYPE_PRINT_C, c), ""))
-#define isxdigit_c(c)     (!streq(strchrnul(CTYPE_XDIGIT_C, c), ""))
-#define ispfchar_c(c)     (!streq(strchrnul(CTYPE_PFCHAR_C, c), ""))
+#define isascii_c(c)           (!!strchr(CTYPE_ASCII_C, c))
+#define iscntrl_c(c)           (!!strchr(CTYPE_CNTRL_C, c))
+#define islower_c(c)           (!streq(strchrnul(CTYPE_LOWER_C, c), ""))
+#define isupper_c(c)           (!streq(strchrnul(CTYPE_UPPER_C, c), ""))
+#define isdigit_c(c)           (!streq(strchrnul(CTYPE_DIGIT_C, c), ""))
+#define ispunct_c(c)           (!streq(strchrnul(CTYPE_PUNCT_C, c), ""))
+#define isspace_c(c)           (!streq(strchrnul(CTYPE_SPACE_C, c), ""))
+#define isalpha_c(c)           (!streq(strchrnul(CTYPE_ALPHA_C, c), ""))
+#define isalnum_c(c)           (!streq(strchrnul(CTYPE_ALNUM_C, c), ""))
+#define isgraph_c(c)           (!streq(strchrnul(CTYPE_GRAPH_C, c), ""))
+#define isprint_c(c)           (!streq(strchrnul(CTYPE_PRINT_C, c), ""))
+#define isxdigit_c(c)          (!streq(strchrnul(CTYPE_XDIGIT_C, c), ""))
+#define ispfchar_c(c)          (!streq(strchrnul(CTYPE_PFCHAR_C, c), ""))
 
 
 // strisascii_c - string is [:ascii:] C-locale
-#define strisdigit_c(s)   streq(stpspn(s, CTYPE_DIGIT_C), "")
-#define strisprint_c(s)   streq(stpspn(s, CTYPE_PRINT_C), "")
+#define strisdigit_c(s)        streq(stpspn(s, CTYPE_DIGIT_C), "")
+#define strisprint_c(s)        streq(stpspn(s, CTYPE_PRINT_C), "")
 
 
 // strchriscntrl_c - string character is [:cntrl:] C-locale
-#define strchriscntrl_c(s)  (!!strpbrk(s, CTYPE_CNTRL_C))
+#define strchriscntrl_c(s)     (!!strpbrk(s, CTYPE_CNTRL_C))
 
 
 #endif  // include guard


### PR DESCRIPTION
Cc: @uecker 

---

Revisions:

<details>
<summary>v2</summary>

-  Move ispfchar() under lib/string/.
-  Document it in lib/string/README.

```
$ git rd 
1:  247466ab6 ! 1:  85d3d8cb4 lib/ctype/: ispfchar(): Add function
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/ctype/: ispfchar(): Add function
    +    lib/string/ctype/isascii/: ispfchar(): Add function
     
         This function returns true if the input character is a character from
         the POSIX portable filename character set.
    @@ Commit message
     
      ## lib/Makefile.am ##
     @@ lib/Makefile.am: libshadow_la_SOURCES = \
    -   console.c \
    -   copydir.c \
    -   csrand.c \
    -+  ctype/ispfchar.c \
    -+  ctype/ispfchar.h \
    -   defines.h \
    -   encrypt.c \
    -   env.c \
    +   spawn.c \
    +   sssd.c \
    +   sssd.h \
    ++  string/ctype/isascii/ispfchar.c \
    ++  string/ctype/isascii/ispfchar.h \
    +   string/ctype/strchrisascii/strchriscntrl.c \
    +   string/ctype/strchrisascii/strchriscntrl.h \
    +   string/ctype/strisascii/strisdigit.c \
     
    - ## lib/ctype/ispfchar.c (new) ##
    + ## lib/string/README ##
    +@@ lib/string/README: Specific guidelines:
    + 
    + ctype/ - Character classification and conversion functions
    + 
    ++    isascii/
    ++  The functions defined under this directory
    ++  return true
    ++  is the character
    ++  belongs to the category specified in the function name.
    ++
    +     strchrisascii/
    +   The functions defined under this directory
    +   return true
    +
    + ## lib/string/ctype/isascii/ispfchar.c (new) ##
     @@
    -+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
    ++// SPDX-FileCopyrightText: 2024-2025, Alejandro Colomar <alx@kernel.org>
     +// SPDX-License-Identifier: BSD-3-Clause
     +
     +
     +#include <config.h>
     +
    -+#include "ctype/ispfchar.h"
    ++#include "string/ctype/isascii/ispfchar.h"
     +
     +#include <stdbool.h>
     +
     +
     +extern inline bool ispfchar(unsigned char c);
     
    - ## lib/ctype/ispfchar.h (new) ##
    + ## lib/string/ctype/isascii/ispfchar.h (new) ##
     @@
    -+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
    ++// SPDX-FileCopyrightText: 2024-2025, Alejandro Colomar <alx@kernel.org>
     +// SPDX-License-Identifier: BSD-3-Clause
     +
     +
    -+#ifndef SHADOW_INCLUDE_LIB_CTYPE_ISPFCHAR_H_
    -+#define SHADOW_INCLUDE_LIB_CTYPE_ISPFCHAR_H_
    ++#ifndef SHADOW_INCLUDE_LIB_STRING_CTYPE_ISASCII_ISPFCHAR_H_
    ++#define SHADOW_INCLUDE_LIB_STRING_CTYPE_ISASCII_ISPFCHAR_H_
     +
     +
     +#include <config.h>
2:  219955397 = 2:  1b917a73d lib/chkname.c: is_valid_name(): Use isalnum(3) instead of its pattern
3:  92332a203 = 3:  e2d77042a lib/chkname.c: is_valid_name(): Split Samba check
4:  1ead5c62f ! 4:  8fd9e48f6 lib/chkname.c: is_valid_name(): Use ispfchar() to simplify
    @@ lib/chkname.c
      
      #include "defines.h"
      #include "chkname.h"
    -+#include "ctype/ispfchar.h"
    ++#include "string/ctype/isascii/ispfchar.h"
      #include "string/ctype/strchrisascii/strchriscntrl.h"
      #include "string/ctype/strisascii/strisdigit.h"
      #include "string/strcmp/streq.h"
```
</details>

<details>
<summary>v2b</summary>

-  tfix

```
$ git rd 
1:  85d3d8cb4 ! 1:  d339ea77e lib/string/ctype/isascii/: ispfchar(): Add function
    @@ lib/string/README: Specific guidelines:
     +    isascii/
     +  The functions defined under this directory
     +  return true
    -+  is the character
    ++  if the character
     +  belongs to the category specified in the function name.
     +
          strchrisascii/
2:  1b917a73d = 2:  7f83c18fe lib/chkname.c: is_valid_name(): Use isalnum(3) instead of its pattern
3:  e2d77042a = 3:  4c7cee7bc lib/chkname.c: is_valid_name(): Split Samba check
4:  8fd9e48f6 = 4:  d39008cae lib/chkname.c: is_valid_name(): Use ispfchar() to simplify
```
</details>

<details>
<summary>v3</summary>

-  Rebase after #1471.

```
$ git range-diff master..gh/chkname gh/isascii_c..chkname 
1:  d339ea77e < -:  --------- lib/string/ctype/isascii/: ispfchar(): Add function
-:  --------- > 1:  02df1aa64 lib/string/ctype/isascii.h: ispfchar_c(): Add function
2:  7f83c18fe = 2:  4259b5bba lib/chkname.c: is_valid_name(): Use isalnum(3) instead of its pattern
3:  4c7cee7bc = 3:  69076fb30 lib/chkname.c: is_valid_name(): Split Samba check
4:  d39008cae ! 4:  1cabaf3f8 lib/chkname.c: is_valid_name(): Use ispfchar() to simplify
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/chkname.c: is_valid_name(): Use ispfchar() to simplify
    +    lib/chkname.c: is_valid_name(): Use ispfchar_c() to simplify
     
         In the first case, we can do the transformation because a few lines
         above, we explicitly reject a name starting with a '-'.
     
    -    In the second case, we're obviously using ispfchar() instead of its
    +    In the second case, we're obviously using ispfchar_c() instead of its
         pattern.
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
    @@ lib/chkname.c
      
      #include "defines.h"
      #include "chkname.h"
    -+#include "string/ctype/isascii/ispfchar.h"
    - #include "string/ctype/strchrisascii/strchriscntrl.h"
    - #include "string/ctype/strisascii/strisdigit.h"
    ++#include "string/ctype/isascii.h"
    + #include "string/ctype/strchrisascii.h"
    + #include "string/ctype/strisascii.h"
      #include "string/strcmp/streq.h"
     @@ lib/chkname.c: is_valid_name(const char *name)
         * sake of Samba 3.x "add machine script"
    @@ lib/chkname.c: is_valid_name(const char *name)
     -        *name == '_' ||
     -        *name == '.'))
     -  {
    -+  if (!ispfchar(*name)) {
    ++  if (!ispfchar_c(*name)) {
                errno = EILSEQ;
                return false;
        }
    @@ lib/chkname.c: is_valid_name(const char *name)
     -                *name == '-'
     -               ))
     -          {
    -+          if (!ispfchar(*name)) {
    ++          if (!ispfchar_c(*name)) {
                        errno = EILSEQ;
                        return false;
                }
```
</details>

<details>
<summary>v3b</summary>

-  Rebase

```
$ git range-diff 02df1aa649b7^..gh/chkname isascii_c..chkname 
1:  02df1aa64 = 1:  04d41a43c lib/string/ctype/isascii.h: ispfchar_c(): Add function
2:  4259b5bba = 2:  f15392da0 lib/chkname.c: is_valid_name(): Use isalnum(3) instead of its pattern
3:  69076fb30 = 3:  ecccb9861 lib/chkname.c: is_valid_name(): Split Samba check
4:  1cabaf3f8 = 4:  e371b465b lib/chkname.c: is_valid_name(): Use ispfchar_c() to simplify
```
</details>

<details>
<summary>v3c</summary>

-  Fix typo.

```
$ git range-diff gh/isascii_c gh/chkname chkname 
1:  04d41a43c ! 1:  d9c21d8e5 lib/string/ctype/isascii.h: ispfchar_c(): Add function
    @@ lib/string/ctype/isascii.h
      #define CTYPE_PRINT_C   CTYPE_GRAPH_C " "
      #define CTYPE_XDIGIT_C  CTYPE_DIGIT_C "abcdefABCDEF"
      #define CTYPE_ASCII_C   CTYPE_PRINT_C CTYPE_CNTRL_C /*NUL*/
    -+#define CTYPE_PFCHAR_C  CTYPE_ALNUM "._-"  // portable filename character set
    ++#define CTYPE_PFCHAR_C  CTYPE_ALNUM_C "._-"  // portable filename character set
      
      
      // isascii_c - is [:ascii:] C-locale
2:  f15392da0 = 2:  44af79d71 lib/chkname.c: is_valid_name(): Use isalnum(3) instead of its pattern
3:  ecccb9861 = 3:  ea9364860 lib/chkname.c: is_valid_name(): Split Samba check
4:  e371b465b = 4:  000c8c170 lib/chkname.c: is_valid_name(): Use ispfchar_c() to simplify
```
</details>

<details>
<summary>v3d</summary>

-  Rebase

```
$ git range-diff gh/isascii_c..gh/chkname isascii_c..chkname 
1:  d9c21d8e5e4c = 1:  31e007269215 lib/string/ctype/isascii.h: ispfchar_c(): Add function
2:  44af79d71b98 = 2:  f22a677577ec lib/chkname.c: is_valid_name(): Use isalnum(3) instead of its pattern
3:  ea9364860219 = 3:  5038f83258cb lib/chkname.c: is_valid_name(): Split Samba check
4:  000c8c170d17 = 4:  ed15a3cc0786 lib/chkname.c: is_valid_name(): Use ispfchar_c() to simplify
```
</details>

<details>
<summary>v3e</summary>

-  Rebase

```
$ git range-diff gh/isascii_c..gh/chkname isascii_c..chkname 
1:  31e00726 = 1:  52ecb2ee lib/string/ctype/isascii.h: ispfchar_c(): Add function
2:  f22a6775 = 2:  f8883e1b lib/chkname.c: is_valid_name(): Use isalnum(3) instead of its pattern
3:  5038f832 = 3:  8c2b031d lib/chkname.c: is_valid_name(): Split Samba check
4:  ed15a3cc = 4:  42b2e85b lib/chkname.c: is_valid_name(): Use ispfchar_c() to simplify
```
</details>

<details>
<summary>v3f</summary>

-  Rebase

```
$ git range-diff gh/isascii_c..gh/chkname isascii_c..chkname 
1:  52ecb2ee = 1:  e29f3481 lib/string/ctype/isascii.h: ispfchar_c(): Add function
2:  f8883e1b = 2:  4c8ed46a lib/chkname.c: is_valid_name(): Use isalnum(3) instead of its pattern
3:  8c2b031d = 3:  831be018 lib/chkname.c: is_valid_name(): Split Samba check
4:  42b2e85b = 4:  d3f1d69e lib/chkname.c: is_valid_name(): Use ispfchar_c() to simplify
```
</details>

<details>
<summary>v4</summary>

-  Rebase

```
$ git range-diff --creation-factor=99 gh/isascii_c..gh/chkname isascii_c..chkname 
1:  e29f3481 ! 1:  a78a389c lib/string/ctype/isascii.h: ispfchar_c(): Add function
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/string/ctype/isascii.h: ispfchar_c(): Add function
    +    lib/string/ctype/isascii.h: ispfchar_c(): Add macro
     
         This function returns true if the input character is a character from
         the POSIX portable filename character set.
    @@ Commit message
     
      ## lib/string/ctype/isascii.h ##
     @@
    - #define CTYPE_PRINT_C   CTYPE_GRAPH_C " "
    - #define CTYPE_XDIGIT_C  CTYPE_DIGIT_C "abcdefABCDEF"
    - #define CTYPE_ASCII_C   CTYPE_PRINT_C CTYPE_CNTRL_C /*NUL*/
    -+#define CTYPE_PFCHAR_C  CTYPE_ALNUM_C "._-"  // portable filename character set
    + #define CTYPE_PRINT_C     CTYPE_GRAPH_C " "
    + #define CTYPE_XDIGIT_C    CTYPE_DIGIT_C "abcdefABCDEF"
    + #define CTYPE_ASCII_C     CTYPE_PRINT_C CTYPE_CNTRL_C /*NUL*/
    ++#define CTYPE_PFCHAR_C    CTYPE_ALNUM_C "._-"  // portable filename character set
      
    - 
    - // isascii_c - is [:ascii:] C-locale
    + #define CTYPE_CNTRL_C0    CTYPE_CNTRL_C
    + #define CTYPE_CNTRL_C1                                                \
     @@
    - #define isgraph_c(c)   (!streq(strchrnul(CTYPE_GRAPH_C, c), ""))
    - #define isprint_c(c)   (!streq(strchrnul(CTYPE_PRINT_C, c), ""))
    - #define isxdigit_c(c)  (!streq(strchrnul(CTYPE_XDIGIT_C, c), ""))
    -+#define ispfchar_c(c)  (!streq(strchrnul(CTYPE_PFCHAR_C, c), ""))
    + #define isgraph_c(c)      (!streq(strchrnul(CTYPE_GRAPH_C, c), ""))
    + #define isprint_c(c)      (!streq(strchrnul(CTYPE_PRINT_C, c), ""))
    + #define isxdigit_c(c)     (!streq(strchrnul(CTYPE_XDIGIT_C, c), ""))
    ++#define ispfchar_c(c)     (!streq(strchrnul(CTYPE_PFCHAR_C, c), ""))
      
    - 
    - #endif  // include guard
    + // iscntrl_c0c1 - is control-character (C0 or C1)
    + #define iscntrl_c0c1(c)   (!!strchr(CTYPE_CNTRL_C0C1, c))
2:  4c8ed46a = 2:  08d72ce0 lib/chkname.c: is_valid_name(): Use isalnum(3) instead of its pattern
3:  831be018 = 3:  82202d26 lib/chkname.c: is_valid_name(): Split Samba check
4:  d3f1d69e ! 4:  4f120ee7 lib/chkname.c: is_valid_name(): Use ispfchar_c() to simplify
    @@ Commit message
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/chkname.c ##
    -@@
    - 
    - #include "defines.h"
    - #include "chkname.h"
    -+#include "string/ctype/isascii.h"
    - #include "string/ctype/strchrisascii.h"
    - #include "string/ctype/strisascii.h"
    - #include "string/strcmp/streq.h"
     @@ lib/chkname.c: is_valid_name(const char *name)
         * sake of Samba 3.x "add machine script"
         */
```
</details>

<details>
<summary>v5</summary>

 -  Rebase

```
$ git range-diff gh/isascii_c..gh/chkname isascii_c..chkname 
1:  a78a389c ! 1:  ff1fd936 lib/string/ctype/isascii.h: ispfchar_c(): Add macro
    @@ lib/string/ctype/isascii.h
      #define CTYPE_ASCII_C     CTYPE_PRINT_C CTYPE_CNTRL_C /*NUL*/
     +#define CTYPE_PFCHAR_C    CTYPE_ALNUM_C "._-"  // portable filename character set
      
    - #define CTYPE_CNTRL_C0    CTYPE_CNTRL_C
    - #define CTYPE_CNTRL_C1                                                \
    + 
    + // isascii_c - is [:ascii:] C-locale
     @@
      #define isgraph_c(c)      (!streq(strchrnul(CTYPE_GRAPH_C, c), ""))
      #define isprint_c(c)      (!streq(strchrnul(CTYPE_PRINT_C, c), ""))
      #define isxdigit_c(c)     (!streq(strchrnul(CTYPE_XDIGIT_C, c), ""))
     +#define ispfchar_c(c)     (!streq(strchrnul(CTYPE_PFCHAR_C, c), ""))
      
    - // iscntrl_c0c1 - is control-character (C0 or C1)
    - #define iscntrl_c0c1(c)   (!!strchr(CTYPE_CNTRL_C0C1, c))
    + 
    + // strisascii_c - string is [:ascii:] C-locale
2:  08d72ce0 = 2:  658309d8 lib/chkname.c: is_valid_name(): Use isalnum(3) instead of its pattern
3:  82202d26 = 3:  cc2eaf17 lib/chkname.c: is_valid_name(): Split Samba check
4:  4f120ee7 = 4:  15452a8f lib/chkname.c: is_valid_name(): Use ispfchar_c() to simplify
```
</details>

<details>
<summary>v5b</summary>

-  Rebase

```
$ git range-diff gh/isascii_c..gh/chkname isascii_c..chkname 
1:  ff1fd936 = 1:  42e056d4 lib/string/ctype/isascii.h: ispfchar_c(): Add macro
2:  658309d8 = 2:  277c74a4 lib/chkname.c: is_valid_name(): Use isalnum(3) instead of its pattern
3:  cc2eaf17 = 3:  ada55b69 lib/chkname.c: is_valid_name(): Split Samba check
4:  15452a8f = 4:  0d554596 lib/chkname.c: is_valid_name(): Use ispfchar_c() to simplify
```
</details>

<details>
<summary>v5c</summary>

-  Rebase

```
$ git range-diff gh/isascii_c..gh/chkname isascii_c..chkname 
1:  42e056d4 = 1:  9e750a07 lib/string/ctype/isascii.h: ispfchar_c(): Add macro
2:  277c74a4 = 2:  81c2ba62 lib/chkname.c: is_valid_name(): Use isalnum(3) instead of its pattern
3:  ada55b69 = 3:  87aa2cf5 lib/chkname.c: is_valid_name(): Split Samba check
4:  0d554596 = 4:  4d0acb92 lib/chkname.c: is_valid_name(): Use ispfchar_c() to simplify
```
</details>

<details>
<summary>v5d</summary>

-  Rebase

```
$ git range-diff 9e750a07c325^..gh/chkname isascii_c..chkname 
1:  9e750a07c325 = 1:  cd57500e79d8 lib/string/ctype/isascii.h: ispfchar_c(): Add macro
2:  81c2ba628fdc = 2:  6100dd972f4b lib/chkname.c: is_valid_name(): Use isalnum(3) instead of its pattern
3:  87aa2cf5cf8e = 3:  4dce9410ad58 lib/chkname.c: is_valid_name(): Split Samba check
4:  4d0acb92c588 = 4:  604fb99f8a2f lib/chkname.c: is_valid_name(): Use ispfchar_c() to simplify
```
</details>

<details>
<summary>v6</summary>

-  Rebase

```
$ git rd 
 1:  e28a0f4456c3 <  -:  ------------ lib/string/ctype/isascii.[ch]: is*_c(): Add APIs
 2:  b9c6a8e5c2a6 <  -:  ------------ lib/, src/: Use isascii_c() functions instead of isascii(3)
 3:  4d1f1e04feea <  -:  ------------ lib/: Merge directories "lib/string/ctype/*" into unified files
 4:  fcbf29261d17 <  -:  ------------ lib/string/ctype/strisascii.h: strisprint(): Simplify implementation
 5:  07546a3c18f7 <  -:  ------------ lib/string/ctype/strisascii.h: Compact definitions
 6:  891d6e726735 <  -:  ------------ lib/: stris*(): Rename C-locale APIs with a _c suffix
 7:  d01f482b737b <  -:  ------------ lib/string/ctype/strchrisascii.h: Use strpbrk(3) to simplify
 8:  822dbad4b220 <  -:  ------------ lib/fields.c: valid_field(): Check empty string before strisprint_c()
 9:  a5c2dd159645 <  -:  ------------ lib/string/ctype/strisascii.*: Don't special-case ""
10:  a39d16aaaa17 <  -:  ------------ lib/: Merge "lib/string/ctype/*" files even further
11:  cd57500e79d8 =  1:  470864e06510 lib/string/ctype/isascii.h: ispfchar_c(): Add macro
12:  6100dd972f4b =  2:  edb94eaff5be lib/chkname.c: is_valid_name(): Use isalnum(3) instead of its pattern
13:  4dce9410ad58 =  3:  029a114070bd lib/chkname.c: is_valid_name(): Split Samba check
14:  604fb99f8a2f =  4:  787abbfed42b lib/chkname.c: is_valid_name(): Use ispfchar_c() to simplify
```
</details>

<details>
<summary>v6b</summary>

-  Change intermediate commit to use isalnum_c() instead of isalnum(3).

<details>
<summary>range-diff</summary>

```
$ git rd 
1:  470864e06510 = 1:  470864e06510 lib/string/ctype/isascii.h: ispfchar_c(): Add macro
2:  edb94eaff5be ! 2:  cd6ff74b1163 lib/chkname.c: is_valid_name(): Use isalnum(3) instead of its pattern
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/chkname.c: is_valid_name(): Use isalnum(3) instead of its pattern
    +    lib/chkname.c: is_valid_name(): Use isalnum_c() instead of its pattern
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    @@ lib/chkname.c: is_valid_name(const char *name)
     -  if (!((*name >= 'a' && *name <= 'z') ||
     -        (*name >= 'A' && *name <= 'Z') ||
     -        (*name >= '0' && *name <= '9') ||
    -+  if (!(isalnum(*name) ||
    ++  if (!(isalnum_c(*name) ||
              *name == '_' ||
              *name == '.'))
        {
    @@ lib/chkname.c: is_valid_name(const char *name)
     -          if (!((*name >= 'a' && *name <= 'z') ||
     -                (*name >= 'A' && *name <= 'Z') ||
     -                (*name >= '0' && *name <= '9') ||
    -+          if (!(isalnum(*name) ||
    ++          if (!(isalnum_c(*name) ||
                      *name == '_' ||
                      *name == '.' ||
                      *name == '-' ||
3:  029a114070bd ! 3:  e81736c0a8cc lib/chkname.c: is_valid_name(): Split Samba check
    @@ lib/chkname.c: is_valid_name(const char *name)
     +          if (streq(name, "$"))  // Samba
     +                  return true;
     +
    -           if (!(isalnum(*name) ||
    +           if (!(isalnum_c(*name) ||
                      *name == '_' ||
                      *name == '.' ||
     -                *name == '-' ||
4:  787abbfed42b ! 4:  721567e137de lib/chkname.c: is_valid_name(): Use ispfchar_c() to simplify
    @@ lib/chkname.c: is_valid_name(const char *name)
         * sake of Samba 3.x "add machine script"
         */
      
    --  if (!(isalnum(*name) ||
    +-  if (!(isalnum_c(*name) ||
     -        *name == '_' ||
     -        *name == '.'))
     -  {
    @@ lib/chkname.c: is_valid_name(const char *name)
                if (streq(name, "$"))  // Samba
                        return true;
      
    --          if (!(isalnum(*name) ||
    +-          if (!(isalnum_c(*name) ||
     -                *name == '_' ||
     -                *name == '.' ||
     -                *name == '-'
```
</details>
<details>
<summary>interdiff</summary>

```sh
$ git diff gh/chkname..chkname 
$
```
</details>
</details>

<details>
<summary>v7</summary>

-  Add APIs for handling LDH from RFC1035.

```
$ git rd 
1:  470864e06510 = 1:  470864e06510 lib/string/ctype/isascii.h: ispfchar_c(): Add macro
2:  cd6ff74b1163 = 2:  cd6ff74b1163 lib/chkname.c: is_valid_name(): Use isalnum_c() instead of its pattern
3:  e81736c0a8cc = 3:  e81736c0a8cc lib/chkname.c: is_valid_name(): Split Samba check
4:  721567e137de = 4:  721567e137de lib/chkname.c: is_valid_name(): Use ispfchar_c() to simplify
-:  ------------ > 5:  97fd538ffe77 lib/string/ctype/isascii.h: Increase white-space alignment
-:  ------------ > 6:  a06e755548de lib/string/ctype/isascii.h: Add variants for handling LDH from RFC1035
-:  ------------ > 7:  188d2acc0830 lib/chkname.c: Use strisldh_rfc1035_c() instead of its pattern
```
</details>

<details>
<summary>v7b</summary>

-  Rebase

```
$ git rd -U0
1:  470864e06510 = 1:  db40bc974a5e lib/string/ctype/isascii.h: ispfchar_c(): Add macro
2:  cd6ff74b1163 ! 2:  c3997ce659c7 lib/chkname.c: is_valid_name(): Use isalnum_c() instead of its pattern
    @@ lib/chkname.c
    -@@ lib/chkname.c: is_valid_name(const char *name)
    +@@ lib/chkname.c: is_valid_name(const char *name, bool badnames)
    @@ lib/chkname.c: is_valid_name(const char *name)
    -@@ lib/chkname.c: is_valid_name(const char *name)
    +@@ lib/chkname.c: is_valid_name(const char *name, bool badnames)
3:  e81736c0a8cc ! 3:  92810eb121dd lib/chkname.c: is_valid_name(): Split Samba check
    @@ lib/chkname.c
    -@@ lib/chkname.c: is_valid_name(const char *name)
    +@@ lib/chkname.c: is_valid_name(const char *name, bool badnames)
4:  721567e137de ! 4:  c04185e4d8e7 lib/chkname.c: is_valid_name(): Use ispfchar_c() to simplify
    @@ lib/chkname.c
    -@@ lib/chkname.c: is_valid_name(const char *name)
    +@@ lib/chkname.c: is_valid_name(const char *name, bool badnames)
    @@ lib/chkname.c: is_valid_name(const char *name)
    -@@ lib/chkname.c: is_valid_name(const char *name)
    +@@ lib/chkname.c: is_valid_name(const char *name, bool badnames)
5:  97fd538ffe77 = 5:  de7adccfcd1e lib/string/ctype/isascii.h: Increase white-space alignment
6:  a06e755548de = 6:  f743dc690cf4 lib/string/ctype/isascii.h: Add variants for handling LDH from RFC1035
7:  188d2acc0830 = 7:  6284598da09c lib/chkname.c: Use strisldh_rfc1035_c() instead of its pattern
```
</details>