### PR TITLE
src/newusers.c: A user/group name with a leading digit is valid

### DIFF
--- a/src/newusers.c
+++ b/src/newusers.c
@@ -236,7 +236,7 @@ static int add_group (const char *name, const char *gid, gid_t *ngid, uid_t uid)
 		return 0;
 	}
 
-	if (isdigit_c(gid[0])) {
+	if (!streq(gid, "") && strisdigit_c(gid)) {
 		/*
 		 * The GID is a number, which means either this is a brand
 		 * new group, or an existing group.
@@ -280,7 +280,7 @@ static int add_group (const char *name, const char *gid, gid_t *ngid, uid_t uid)
 	/*
 	 * Now I have all of the fields required to create the new group.
 	 */
-	if (!streq(gid, "") && (!isdigit_c(gid[0]))) {
+	if (!streq(gid, "") && !strisdigit_c(gid)) {
 		grent.gr_name = xstrdup (gid);
 	} else {
 		grent.gr_name = xstrdup (name);
@@ -345,7 +345,7 @@ static int get_user_id (const char *uid, uid_t *nuid) {
 	 * The first guess for the UID is either the numerical UID that the
 	 * caller provided, or the next available UID.
 	 */
-	if (isdigit_c(uid[0])) {
+	if (!streq(uid, "") && strisdigit_c(uid)) {
 		if ((get_uid(uid, nuid) == -1) || (*nuid == (uid_t)-1)) {
 			fprintf (stderr,
 			         _("%s: invalid user ID '%s'\n"),


### PR DESCRIPTION
Only consider a string to be a UID/GID if it is all digits.
    
Closes: <https://github.com/shadow-maint/shadow/issues/1474>

---

Cc: @uecker 

---

Revisions:

<details>
<summary>v1b</summary>

-  Add reproducer to commit message.

```
$ git rd 
1:  f26af1fee ! 1:  497cbf1fe src/newusers.c: A user/group name with a leading digit is valid
    @@ Commit message
     
         Only consider a string to be a UID/GID if it is all digits.
     
    +    Here's a reproducer of the bug:
    +
    +            $ echo 'foo:p::1a::/tmp/nonexistent:/usr/bin/false' > x
    +            $ sudo newusers ./x
    +            newusers: invalid group ID '1a'
    +            newusers: line 1: can't create group
    +
    +    Where the expected behavior would be the same as for a group name that
    +    doesn't start with a digit:
    +
    +            $ echo 'foo:p::a1a::/tmp/nonexistent:/usr/bin/false' > x
    +            $ sudo newusers ./x
    +            $ tail -n1 /etc/group
    +            a1a:x:1004:
    +            $ tail -n1 /etc/passwd
    +            foo:x:1004:1004::/tmp/nonexistent:/usr/bin/false
    +
         Closes: <https://github.com/shadow-maint/shadow/issues/1474>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
```
</details>

<details>
<summary>v1c</summary>

-  Rebase

```
$ git rd 
1:  8d4aff7d = 1:  98677c4e src/newusers.c: A user/group name with a leading digit is valid
```
</details>

<details>
<summary>v1d</summary>

-  Rebase

```
$ git rd --creation-factor=99
1:  98677c4e39b2 ! 1:  8cbf06e0ebfb src/newusers.c: A user/group name with a leading digit is valid
    @@ Commit message
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## src/newusers.c ##
    -@@
    - #include "shadow/gshadow/sgrp.h"
    - #include "shadowlog.h"
    - #include "sssd.h"
    -+#include "string/ctype/strisascii/strisdigit.h"
    - #include "string/sprintf/snprintf.h"
    - #include "string/strcmp/streq.h"
    - #include "string/strdup/strdup.h"
     @@ src/newusers.c: static int add_group (const char *name, const char *gid, gid_t *ngid, uid_t uid)
                return 0;
        }
      
    --  if (isdigit (gid[0])) {
    -+  if (!streq(gid, "") && strisdigit(gid)) {
    +-  if (isdigit_c(gid[0])) {
    ++  if (!streq(gid, "") && strisdigit_c(gid)) {
                /*
                 * The GID is a number, which means either this is a brand
                 * new group, or an existing group.
    @@ src/newusers.c: static int add_group (const char *name, const char *gid, gid_t *
        /*
         * Now I have all of the fields required to create the new group.
         */
    --  if (!streq(gid, "") && (!isdigit(gid[0]))) {
    -+  if (!streq(gid, "") && !strisdigit(gid)) {
    +-  if (!streq(gid, "") && (!isdigit_c(gid[0]))) {
    ++  if (!streq(gid, "") && !strisdigit_c(gid)) {
                grent.gr_name = xstrdup (gid);
        } else {
                grent.gr_name = xstrdup (name);
    @@ src/newusers.c: static int get_user_id (const char *uid, uid_t *nuid) {
         * The first guess for the UID is either the numerical UID that the
         * caller provided, or the next available UID.
         */
    --  if (isdigit (uid[0])) {
    -+  if (!streq(uid, "") && strisdigit(uid)) {
    +-  if (isdigit_c(uid[0])) {
    ++  if (!streq(uid, "") && strisdigit_c(uid)) {
                if ((get_uid(uid, nuid) == -1) || (*nuid == (uid_t)-1)) {
                        fprintf (stderr,
                                 _("%s: invalid user ID '%s'\n"),
```
</details>