### PR TITLE
man/groupmems: Fix grammar

### DIFF
--- a/man/groupmems.8.xml
+++ b/man/groupmems.8.xml
@@ -84,7 +84,7 @@
 	<listitem>
 	  <para>Add a user to the group membership list.</para>
 	  <para condition="gshadow">
-	    If the <filename>/etc/gshadow</filename> file exist, and the
+	    If the <filename>/etc/gshadow</filename> file exists, and the
 	    group has no entry in the <filename>/etc/gshadow</filename>
 	    file, a new entry will be created.
 	  </para>
@@ -95,12 +95,12 @@
 	<listitem>
 	  <para>Delete a user from the group membership list.</para>
 	  <para condition="gshadow">
-	    If the <filename>/etc/gshadow</filename> file exist, the user
+	    If the <filename>/etc/gshadow</filename> file exists, the user
 	    will be removed from the list of members and administrators of
 	    the group.
 	  </para>
 	  <para condition="gshadow">
-	    If the <filename>/etc/gshadow</filename> file exist, and the
+	    If the <filename>/etc/gshadow</filename> file exists, and the
 	    group has no entry in the <filename>/etc/gshadow</filename>
 	    file, a new entry will be created.
 	  </para>
@@ -131,7 +131,7 @@
 	<listitem>
 	  <para>Purge all users from the group membership list.</para>
 	  <para condition="gshadow">
-	    If the <filename>/etc/gshadow</filename> file exist, and the
+	    If the <filename>/etc/gshadow</filename> file exists, and the
 	    group has no entry in the <filename>/etc/gshadow</filename>
 	    file, a new entry will be created.
 	  </para>


### PR DESCRIPTION
The groupmems utility is deprecated by now, but let's keep existing documentation properly maintained until it's gone.