### PR TITLE
man/chage.1: Drop empty configuration section

### DIFF
--- a/man/chage.1.xml
+++ b/man/chage.1.xml
@@ -270,7 +270,7 @@
     </para>
   </refsect1>
 
-  <refsect1 id='configuration'>
+  <refsect1 id='configuration' condition="tcb">
     <title>CONFIGURATION</title>
     <para>
       The following configuration variables in


### PR DESCRIPTION
If TCB is not in use, the whole configuration section is a stub, containing no useful information. Make it conditional so it disappears if TCB is not in use.