### PR TITLE
vipw: set SIGCHLD before fork

### DIFF
--- a/src/vipw.c
+++ b/src/vipw.c
@@ -291,6 +291,9 @@ vipwedit (const char *file, int (*file_lock) (void), int (*file_unlock) (bool))
 
 	orig_pgrp = tcgetpgrp(STDIN_FILENO);
 
+	/* set SIGCHLD to default for waitpid */
+	signal(SIGCHLD, SIG_DFL);
+
 	pid = fork ();
 	if (-1 == pid) {
 		vipwexit ("fork", 1, 1);
@@ -337,9 +340,6 @@ vipwedit (const char *file, int (*file_lock) (void), int (*file_unlock) (bool))
 		sigaddset(&mask, SIGTTOU);
 		sigprocmask(SIG_BLOCK, &mask, &omask);
 	}
-
-	/* set SIGCHLD to default for waitpid */
-	signal(SIGCHLD, SIG_DFL);
 
 	for (;;) {
 		pid = waitpid (pid, &status, WUNTRACED);


### PR DESCRIPTION
It could happen that, if SIGCHLD was set to SIG_IGN before calling vipw, the forked child is already gone before SIGCHLD is set to SIG_DFL after the fork.

Prevent this race condition and also properly set up SIGCHLD for child handling within the fork, even though system() should take care of that.

Follow up of https://github.com/shadow-maint/shadow/pull/440 (looks like older me is getting better at this ;) )