### PR TITLE
Debbug 1124835: lib/chkhash.c: Fix support for `!` and `*` in hashes

### DIFF
--- a/lib/chkhash.c
+++ b/lib/chkhash.c
@@ -7,6 +7,7 @@
 #include <stddef.h>
 #include <string.h>
 
+#include "string/strcmp/streq.h"
 #include "string/strcmp/strprefix.h"
 
 
@@ -40,6 +41,9 @@ bool
 is_valid_hash(const char *hash) 
 {
 	hash = strprefix(hash, "!") ?: hash;
+
+	if (streq(hash, "*"))
+		return true;
 
 	// Minimum hash length
 	if (strlen(hash) < 13)


### PR DESCRIPTION
```
    lib/chkhash.c: is_valid_hash(): Accept '*' as the hash
    
    This is widely accepted as an invalid hash, to remove password access
    for an account (that is, no passwords will match the "hash").

    lib/chkhash.c: is_valid_hash(): Accept a leading '!'
    
    A leading '!' means that the account is locked.
```
    
Fixes: c44f1e096a19 (2025-07-20; "chpasswd: Check hash before write when using -e")
Link: <https://github.com/shadow-maint/shadow/issues/1483>
Reported-by: @zeha
Cc: @mmpx12

---

Revisions:

<details>
<summary>v2</summary>

-  Add missing includes.

```
$ git rd 
1:  23ed96cec ! 1:  eeee36619 lib/chkhash.c: is_valid_hash(): Accept a leading '!'
    @@ Commit message
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/chkhash.c ##
    +@@
    + #include <stddef.h>
    + #include <string.h>
    + 
    ++#include "string/strcmp/strprefix.h"
    ++
    + 
    + /*
    +  * match_regex - return true if match, false if not
     @@ lib/chkhash.c: match_regex(const char *pattern, const char *string)
      bool 
      is_valid_hash(const char *hash) 
2:  7ab8a90a7 ! 2:  7f65f5097 lib/chkhash.c: is_valid_hash(): Accept '*' as the hash
    @@ Commit message
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/chkhash.c ##
    +@@
    + #include <stddef.h>
    + #include <string.h>
    + 
    ++#include "string/strcmp/streq.h"
    + #include "string/strcmp/strprefix.h"
    + 
    + 
     @@ lib/chkhash.c: is_valid_hash(const char *hash)
      
        hash = strprefix(hash, "!") ?: hash;
```
</details>

<details>
<summary>v2b</summary>

-  Remove unused local variable.

```
$ git rd 
1:  eeee36619 ! 1:  0f9352281 lib/chkhash.c: is_valid_hash(): Accept a leading '!'
    @@ lib/chkhash.c: match_regex(const char *pattern, const char *string)
      bool 
      is_valid_hash(const char *hash) 
      {
    -+  const char  *p;
    -+
     +  hash = strprefix(hash, "!") ?: hash;
     +
        // Minimum hash length
2:  7f65f5097 ! 2:  cd664a13a lib/chkhash.c: is_valid_hash(): Accept '*' as the hash
    @@ lib/chkhash.c
      
      
     @@ lib/chkhash.c: is_valid_hash(const char *hash)
    - 
    + {
        hash = strprefix(hash, "!") ?: hash;
      
     +  if (streq(hash, "*"))
```
</details>

<details>
<summary>v2c</summary>

-  Reviewed-by: @zeha 

```
$ git rd 
1:  0f9352281 ! 1:  57eacac15 lib/chkhash.c: is_valid_hash(): Accept a leading '!'
    @@ Commit message
         Link: <https://github.com/shadow-maint/shadow/issues/1483>
         Link: <https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1124835>
         Reported-by: Chris Hofstaedtler <zeha@debian.org>
    +    Reviewed-by: Chris Hofstaedtler <zeha@debian.org>
         Cc: vinz <mmpx09@protonmail.com>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
2:  cd664a13a ! 2:  d3d63b3c3 lib/chkhash.c: is_valid_hash(): Accept '*' as the hash
    @@ Commit message
         Closes: <https://github.com/shadow-maint/shadow/issues/1483>
         Closes: <https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1124835>
         Reported-by: Chris Hofstaedtler <zeha@debian.org>
    +    Reviewed-by: Chris Hofstaedtler <zeha@debian.org>
         Cc: vinz <mmpx09@protonmail.com>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
```
</details>