### PR TITLE
su: Simplify SIGALRM signal handling

### DIFF
--- a/src/su.c
+++ b/src/su.c
@@ -172,7 +172,7 @@ kill_child(pid_t pid_child)
 {
 	kill(-pid_child, SIGKILL);
 	fputs(_(" ...killed.\n"), stderr);
-	_exit (255);
+	exit (255);
 }
 
 static void
@@ -402,7 +402,7 @@ static void prepare_pam_close_session (void)
 		if (sigprocmask (SIG_BLOCK, &ourset, NULL) != 0) {
 			fprintf (stderr, _("%s: signal masking malfunction\n"), Prog);
 			kill_child(pid_child);
-			/* Never reached (_exit called). */
+			/* Never reached (exit called). */
 		}
 
 		/* Send SIGKILL to the child if it doesn't
@@ -418,7 +418,7 @@ static void prepare_pam_close_session (void)
 			sigsuspend (&ourset);
 			if (timeout) {
 				kill_child(pid_child);
-				/* Never reached (_exit called). */
+				/* Never reached (exit called). */
 			}
 		}
 		pid_child = 0;


### PR DESCRIPTION
The SIGALRM signal handling performs quite some actions and reads shared variables on heap.

To avoid any form of analysis if these specific actions are safe or not, fall back to a signal handler which just sets a flag, which is eventually read.

See https://github.com/shadow-maint/shadow/pull/423 for a good way to test this. Especially to avoid regressions.

CC @lrh2000 for review request due to awesome analysis back in 2021. :)