### PR TITLE
lib/: Use the comma operator to perform lvalue conversion

### DIFF
--- a/lib/alloc/calloc.h
+++ b/lib/alloc/calloc.h
@@ -17,9 +17,10 @@
 // calloc_T - calloc type-safe
 #define calloc_T(n, T)   calloc_T_(n, typeas(T))
 #define calloc_T_(n, T)                                               \
-({                                                                    \
-	(T *){calloc(n, sizeof(T))};                                  \
-})
+(                                                                     \
+	(void)0,                                                      \
+	(T *){calloc(n, sizeof(T))}                                   \
+)
 
 
 // xcalloc_T - exit-on-error calloc type-safe

--- a/lib/alloc/calloc.h
+++ b/lib/alloc/calloc.h
@@ -12,12 +12,10 @@
 
 #include "cast.h"
 #include "exit_if_null.h"
-#include "sizeof.h"
 
 
 // calloc_T - calloc type-safe
-#define calloc_T(n, T)   calloc_T_(n, typeas(T))
-#define calloc_T_(n, T)  rvalue((T *){calloc(n, sizeof(T))})
+#define calloc_T(n, T)   ptr_cast(T, calloc(n, sizeof(T)))
 
 
 // xcalloc_T - exit-on-error calloc type-safe

--- a/lib/alloc/calloc.h
+++ b/lib/alloc/calloc.h
@@ -10,17 +10,14 @@
 
 #include <stdlib.h>
 
+#include "cast.h"
 #include "exit_if_null.h"
 #include "sizeof.h"
 
 
 // calloc_T - calloc type-safe
 #define calloc_T(n, T)   calloc_T_(n, typeas(T))
-#define calloc_T_(n, T)                                               \
-(                                                                     \
-	(void)0,                                                      \
-	(T *){calloc(n, sizeof(T))}                                   \
-)
+#define calloc_T_(n, T)  rvalue((T *){calloc(n, sizeof(T))})
 
 
 // xcalloc_T - exit-on-error calloc type-safe

--- a/lib/alloc/malloc.c
+++ b/lib/alloc/malloc.c
@@ -1,16 +1,7 @@
-// SPDX-FileCopyrightText: 1990-1994, Julianne Frances Haugh
-// SPDX-FileCopyrightText: 1996-1998, Marek Michałkiewicz
-// SPDX-FileCopyrightText: 2003-2006, Tomasz Kłoczko
-// SPDX-FileCopyrightText: 2008     , Nicolas François
-// SPDX-FileCopyrightText: 2023-2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-FileCopyrightText: 2023-2026, Alejandro Colomar <alx@kernel.org>
 // SPDX-License-Identifier: BSD-3-Clause
 
 
 #include "config.h"
 
 #include "alloc/malloc.h"
-
-#include <stddef.h>
-
-
-extern inline void *mallocarray(size_t nmemb, size_t size);

--- a/lib/alloc/malloc.h
+++ b/lib/alloc/malloc.h
@@ -18,9 +18,10 @@
 // malloc_T - malloc type-safe
 #define malloc_T(n, T)   malloc_T_(n, typeas(T))
 #define malloc_T_(n, T)                                               \
-({                                                                    \
-	(T *){mallocarray(n, sizeof(T))};                             \
-})
+(                                                                     \
+	(void)0,                                                      \
+	(T *){mallocarray(n, sizeof(T))}                              \
+)
 
 
 // xmalloc_T - exit-on-error malloc type-safe

--- a/lib/alloc/malloc.h
+++ b/lib/alloc/malloc.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023-2025, Alejandro Colomar <alx@kernel.org>
+// SPDX-FileCopyrightText: 2023-2026, Alejandro Colomar <alx@kernel.org>
 // SPDX-License-Identifier: BSD-3-Clause
 
 
@@ -10,7 +10,6 @@
 
 #include <stdlib.h>
 
-#include "attr.h"
 #include "cast.h"
 #include "exit_if_null.h"
 #include "sizeof.h"
@@ -26,16 +25,7 @@
 
 
 // mallocarray - malloc array
-ATTR_ALLOC_SIZE(1, 2)
-ATTR_MALLOC(free)
-inline void *mallocarray(size_t nmemb, size_t size);
-
-
-inline void *
-mallocarray(size_t nmemb, size_t size)
-{
-	return reallocarray(NULL, nmemb, size);
-}
+#define mallocarray(...)  reallocarray(NULL, __VA_ARGS__)
 
 
 #endif  // include guard

--- a/lib/alloc/malloc.h
+++ b/lib/alloc/malloc.h
@@ -12,12 +12,10 @@
 
 #include "cast.h"
 #include "exit_if_null.h"
-#include "sizeof.h"
 
 
 // malloc_T - malloc type-safe
-#define malloc_T(n, T)   malloc_T_(n, typeas(T))
-#define malloc_T_(n, T)  rvalue((T *){mallocarray(n, sizeof(T))})
+#define malloc_T(n, T)   ptr_cast(T, mallocarray(n, sizeof(T)))
 
 
 // xmalloc_T - exit-on-error malloc type-safe

--- a/lib/alloc/malloc.h
+++ b/lib/alloc/malloc.h
@@ -11,17 +11,14 @@
 #include <stdlib.h>
 
 #include "attr.h"
+#include "cast.h"
 #include "exit_if_null.h"
 #include "sizeof.h"
 
 
 // malloc_T - malloc type-safe
 #define malloc_T(n, T)   malloc_T_(n, typeas(T))
-#define malloc_T_(n, T)                                               \
-(                                                                     \
-	(void)0,                                                      \
-	(T *){mallocarray(n, sizeof(T))}                              \
-)
+#define malloc_T_(n, T)  rvalue((T *){mallocarray(n, sizeof(T))})
 
 
 // xmalloc_T - exit-on-error malloc type-safe

--- a/lib/alloc/realloc.h
+++ b/lib/alloc/realloc.h
@@ -17,10 +17,10 @@
 // realloc_T - realloc type-safe
 #define realloc_T(p, n, T)   realloc_T_(p, n, typeas(T))
 #define realloc_T_(p, n, T)                                           \
-({                                                                    \
-	_Generic(p, T *: (void)0);                                    \
-	(T *){reallocarray_(p, n, sizeof(T))};                        \
-})
+(                                                                     \
+	_Generic(p, T *: (void)0),                                    \
+	(T *){reallocarray_(p, n, sizeof(T))}                         \
+)
 
 #define reallocarray_(p, n, size)  reallocarray(p, (n) ?: 1, (size) ?: 1)
 

--- a/lib/alloc/realloc.h
+++ b/lib/alloc/realloc.h
@@ -20,7 +20,7 @@
 #define realloc_T_(p, n, T)                                           \
 (                                                                     \
 	_Generic(p, T *: (void)0),                                    \
-	rvalue((T *){reallocarray_(p, n, sizeof(T))})                 \
+	ptr_cast(T, reallocarray_(p, n, sizeof(T)))                   \
 )
 
 #define reallocarray_(p, n, size)  reallocarray(p, (n) ?: 1, (size) ?: 1)

--- a/lib/alloc/realloc.h
+++ b/lib/alloc/realloc.h
@@ -10,6 +10,7 @@
 
 #include <stdlib.h>
 
+#include "cast.h"
 #include "exit_if_null.h"
 #include "sizeof.h"
 
@@ -19,7 +20,7 @@
 #define realloc_T_(p, n, T)                                           \
 (                                                                     \
 	_Generic(p, T *: (void)0),                                    \
-	(T *){reallocarray_(p, n, sizeof(T))}                         \
+	rvalue((T *){reallocarray_(p, n, sizeof(T))})                 \
 )
 
 #define reallocarray_(p, n, size)  reallocarray(p, (n) ?: 1, (size) ?: 1)

--- a/lib/alloc/reallocf.h
+++ b/lib/alloc/reallocf.h
@@ -18,10 +18,10 @@
 // reallocf_T - realloc free-on-error type-safe
 #define reallocf_T(p, n, T)   reallocf_T_(p, n, typeas(T))
 #define reallocf_T_(p, n, T)                                          \
-({                                                                    \
-	_Generic(p, T *: (void)0);                                    \
-	(T *){reallocarrayf_(p, n, sizeof(T))};                       \
-})
+(                                                                     \
+	_Generic(p, T *: (void)0),                                    \
+	(T *){reallocarrayf_(p, n, sizeof(T))}                        \
+)
 
 #define reallocarrayf_(p, n, size)  reallocarrayf(p, (n) ?: 1, (size) ?: 1)
 

--- a/lib/alloc/reallocf.h
+++ b/lib/alloc/reallocf.h
@@ -12,6 +12,7 @@
 #include <stdlib.h>
 
 #include "attr.h"
+#include "cast.h"
 #include "sizeof.h"
 
 
@@ -20,7 +21,7 @@
 #define reallocf_T_(p, n, T)                                          \
 (                                                                     \
 	_Generic(p, T *: (void)0),                                    \
-	(T *){reallocarrayf_(p, n, sizeof(T))}                        \
+	rvalue((T *){reallocarrayf_(p, n, sizeof(T))})                \
 )
 
 #define reallocarrayf_(p, n, size)  reallocarrayf(p, (n) ?: 1, (size) ?: 1)

--- a/lib/alloc/reallocf.h
+++ b/lib/alloc/reallocf.h
@@ -21,7 +21,7 @@
 #define reallocf_T_(p, n, T)                                          \
 (                                                                     \
 	_Generic(p, T *: (void)0),                                    \
-	rvalue((T *){reallocarrayf_(p, n, sizeof(T))})                \
+	ptr_cast(T, reallocarrayf_(p, n, sizeof(T)))                  \
 )
 
 #define reallocarrayf_(p, n, size)  reallocarrayf(p, (n) ?: 1, (size) ?: 1)

--- a/lib/cast.h
+++ b/lib/cast.h
@@ -8,8 +8,11 @@
 
 #include "config.h"
 
+#include "sizeof.h"
+
 
 #define const_cast(T, p)  _Generic(p, const T:  (T) (p))
+#define ptr_cast(T, p)    rvalue((typeas(T) *){(p)})
 
 #define rvalue(lv)        ((void)0, (lv))
 

--- a/lib/cast.h
+++ b/lib/cast.h
@@ -11,5 +11,7 @@
 
 #define const_cast(T, p)  _Generic(p, const T:  (T) (p))
 
+#define rvalue(lv)        ((void)0, (lv))
+
 
 #endif  // include guard

--- a/lib/search/l/lfind.h
+++ b/lib/search/l/lfind.h
@@ -18,11 +18,11 @@
 // lfind_T - linear find type-safe
 #define lfind_T(T, ...)            lfind_T_(typeas(T), __VA_ARGS__)
 #define lfind_T_(T, k, a, n, cmp)                                     \
-({                                                                    \
-	_Generic(k, T *: (void)0, const T *: (void)0);                \
-	_Generic(a, T *: (void)0, const T *: (void)0);                \
-	(T *){lfind_(k, a, n, sizeof(T), cmp)};                       \
-})
+(                                                                     \
+	_Generic(k, T *: (void)0, const T *: (void)0),                \
+	_Generic(a, T *: (void)0, const T *: (void)0),                \
+	(T *){lfind_(k, a, n, sizeof(T), cmp)}                        \
+)
 
 #define LFIND(T, ...)  lfind_T(T, __VA_ARGS__, CMP(T))
 

--- a/lib/search/l/lfind.h
+++ b/lib/search/l/lfind.h
@@ -22,7 +22,7 @@
 (                                                                     \
 	_Generic(k, T *: (void)0, const T *: (void)0),                \
 	_Generic(a, T *: (void)0, const T *: (void)0),                \
-	rvalue((T *){lfind_(k, a, n, sizeof(T), cmp)})                \
+	ptr_cast(T, lfind_(k, a, n, sizeof(T), cmp))                  \
 )
 
 #define LFIND(T, ...)  lfind_T(T, __VA_ARGS__, CMP(T))

--- a/lib/search/l/lfind.h
+++ b/lib/search/l/lfind.h
@@ -11,6 +11,7 @@
 #include <search.h>
 #include <stddef.h>
 
+#include "cast.h"
 #include "search/cmp/cmp.h"
 #include "sizeof.h"
 
@@ -21,7 +22,7 @@
 (                                                                     \
 	_Generic(k, T *: (void)0, const T *: (void)0),                \
 	_Generic(a, T *: (void)0, const T *: (void)0),                \
-	(T *){lfind_(k, a, n, sizeof(T), cmp)}                        \
+	rvalue((T *){lfind_(k, a, n, sizeof(T), cmp)})                \
 )
 
 #define LFIND(T, ...)  lfind_T(T, __VA_ARGS__, CMP(T))

--- a/lib/sizeof.h
+++ b/lib/sizeof.h
@@ -17,7 +17,7 @@
 
 #define typeas(T)            typeof((T){0})
 
-#define ssizeof(x)           ({(ssize_t){sizeof(x)};})
+#define ssizeof(x)           ((void)0, (ssize_t){sizeof(x)})
 #define memberof(T, member)  ((T){}.member)
 #define WIDTHOF(x)           (sizeof(x) * CHAR_BIT)
 

--- a/lib/sizeof.h
+++ b/lib/sizeof.h
@@ -14,10 +14,12 @@
 #endif
 #include <sys/types.h>
 
+#include "cast.h"
+
 
 #define typeas(T)            typeof((T){0})
 
-#define ssizeof(x)           ((void)0, (ssize_t){sizeof(x)})
+#define ssizeof(x)           rvalue((ssize_t){sizeof(x)})
 #define memberof(T, member)  ((T){}.member)
 #define WIDTHOF(x)           (sizeof(x) * CHAR_BIT)
 


### PR DESCRIPTION
-  Queued after <https://github.com/shadow-maint/shadow/pull/1717>.

---

Compound literals are lvalues, and thus somewhat dangerous.  Their address can be taken, and they can be assigned to.

We were using statement expressions to perform lvalue conversion on compound literals, transforming them to rvalues, and thus removing their dangers.  However, statement expressions are non-standard, and quite complex within the compiler, so it would be interesting to use simpler compiler features to achieve the same.

The comma operator also performs lvalue conversion, and we can use a dummy (void)0 expression to introduce it.  This is significantly simpler, and is more portable than the statement expression (it is valid all the way back to ANSI C89).

By using a simpler feature, we have a smaller risk of running into a compiler bug.

Suggested-by: @uecker
Cc: @chrisbazley
Cc: @kees
Cc: @flatcap

---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git rd 
1:  9558736a5b42 = 1:  5732c14f453e lib/: Use the comma operator to perform lvalue conversion
```
</details>

<details>
<summary>v1c</summary>

-  Rebase

```
$ git rd 
1:  5732c14f = 1:  8956e27a lib/: Use the comma operator to perform lvalue conversion
```
</details>

<details>
<summary>v1d</summary>

-  Rebase

```
$ git rd 
1:  8956e27a = 1:  5a03c618 lib/: Use the comma operator to perform lvalue conversion
```
</details>

<details>
<summary>v1e</summary>

-  Clarify portability.

```
$ git rd
1:  5a03c618 ! 1:  b7ab3f97 lib/: Use the comma operator to perform lvalue conversion
    @@ Commit message
     
         The comma operator also performs lvalue conversion, and we can use
         a dummy (void)0 expression to introduce it.  This is significantly
    -    simpler, and is more portable than the statement expression (it is valid
    -    all the way back to ANSI C89).
    +    simpler, and is more portable than the statement expression: it is valid
    +    all the way back to C99 (the comma operator and the (void)0 expression
    +    are portable to C89, but the compound literal is from C99).
     
         By using a simpler feature, we have a smaller risk of running into
         a compiler bug.
```
</details>

<details>
<summary>v1f</summary>

-  Rebase

```
$ git rd 
1:  b7ab3f97a0c8 = 1:  617ded6a961c lib/: Use the comma operator to perform lvalue conversion
```
</details>

<details>
<summary>v2</summary>

-  Add rvalue() and ptr_cast(), to encapsulate these operations.

```
$ git rd 
1:  617ded6a961c = 1:  617ded6a961c lib/: Use the comma operator to perform lvalue conversion
-:  ------------ > 2:  b2f581e3a2de lib/cast.h: rvalue(): Add macro for performing lvalue conversion
-:  ------------ > 3:  ad5d5b419079 lib/: Use rvalue() instead of its pattern
-:  ------------ > 4:  f2878fbaf173 lib/cast.h: ptr_cast(): Add macro
-:  ------------ > 5:  cbd1a16c7541 lib/: Use ptr_cast() instead of its pattern
```
</details>

<details>
<summary>v2b</summary>

-  Rebase

```
$ git rd -U0
1:  617ded6a961c ! 1:  512aba26e5a2 lib/: Use the comma operator to perform lvalue conversion
    @@ lib/sizeof.h
    -
    - ## lib/string/strerrno.h ##
    -@@
    - 
    - 
    - // strerrno - string errno
    --#define strerrno()  ({(const char *){strerror(errno)};})
    -+#define strerrno()  ((void)0, (const char *){strerror(errno)})
    - 
    - 
    - #endif  // include guard
2:  b2f581e3a2de = 2:  5bc74aa0449d lib/cast.h: rvalue(): Add macro for performing lvalue conversion
3:  ad5d5b419079 ! 3:  ed9069c3cde6 lib/: Use rvalue() instead of its pattern
    @@ lib/sizeof.h
    -
    - ## lib/string/strerrno.h ##
    -@@
    - 
    - 
    - // strerrno - string errno
    --#define strerrno()  ((void)0, (const char *){strerror(errno)})
    -+#define strerrno()  rvalue((const char *){strerror(errno)})
    - 
    - 
    - #endif  // include guard
4:  f2878fbaf173 = 4:  f787e34499fa lib/cast.h: ptr_cast(): Add macro
5:  cbd1a16c7541 ! 5:  04855d90a948 lib/: Use ptr_cast() instead of its pattern
    @@ lib/search/l/lfind.h
    -
    - ## lib/string/strerrno.h ##
    -@@
    - 
    - 
    - // strerrno - string errno
    --#define strerrno()  rvalue((const char *){strerror(errno)})
    -+#define strerrno()  ptr_cast(const char, strerror(errno))
    - 
    - 
```
</details>

<details>
<summary>v2c</summary>

-  Rebase

```
$ git rd 
1:  512aba26e5a2 = 1:  473f4bfe7f23 lib/: Use the comma operator to perform lvalue conversion
2:  5bc74aa0449d = 2:  1d1201430ee1 lib/cast.h: rvalue(): Add macro for performing lvalue conversion
3:  ed9069c3cde6 = 3:  ffd6f93a1b1d lib/: Use rvalue() instead of its pattern
4:  f787e34499fa = 4:  7a5c6c94ff63 lib/cast.h: ptr_cast(): Add macro
5:  04855d90a948 = 5:  0fec8a9bd8c2 lib/: Use ptr_cast() instead of its pattern
```
</details>

<details>
<summary>v2d</summary>

-  Update includes.

```
$ git rd -U0
1:  473f4bfe7f23 = 1:  473f4bfe7f23 lib/: Use the comma operator to perform lvalue conversion
2:  1d1201430ee1 = 2:  1d1201430ee1 lib/cast.h: rvalue(): Add macro for performing lvalue conversion
3:  ffd6f93a1b1d ! 3:  f9c915931851 lib/: Use rvalue() instead of its pattern
    @@ lib/alloc/calloc.h
    + #include <stdlib.h>
    + 
    ++#include "cast.h"
    + #include "exit_if_null.h"
    + #include "sizeof.h"
    + 
    + 
    @@ lib/alloc/malloc.h
    + #include <stdlib.h>
    + 
    + #include "attr.h"
    ++#include "cast.h"
    + #include "exit_if_null.h"
    + #include "sizeof.h"
    + 
    @@ lib/sizeof.h
    + #endif
    + #include <sys/types.h>
    + 
    ++#include "cast.h"
    ++
4:  7a5c6c94ff63 = 4:  611f249602be lib/cast.h: ptr_cast(): Add macro
5:  0fec8a9bd8c2 ! 5:  81f34a70a7f9 lib/: Use ptr_cast() instead of its pattern
    @@ lib/alloc/calloc.h
    + #include "cast.h"
    + #include "exit_if_null.h"
    +-#include "sizeof.h"
    + 
    @@ lib/alloc/malloc.h
    + #include <stdlib.h>
    + 
    + #include "attr.h"
    +-#include "cast.h"
    + #include "exit_if_null.h"
    + #include "sizeof.h"
```
</details>

<details>
<summary>v2e</summary>

-  Fix includes

```
$ git rd 
1:  473f4bfe7f23 = 1:  473f4bfe7f23 lib/: Use the comma operator to perform lvalue conversion
2:  1d1201430ee1 = 2:  1d1201430ee1 lib/cast.h: rvalue(): Add macro for performing lvalue conversion
3:  f9c915931851 = 3:  f9c915931851 lib/: Use rvalue() instead of its pattern
4:  611f249602be = 4:  611f249602be lib/cast.h: ptr_cast(): Add macro
5:  81f34a70a7f9 ! 5:  22efc5885028 lib/: Use ptr_cast() instead of its pattern
    @@ lib/alloc/calloc.h
     
      ## lib/alloc/malloc.h ##
     @@
    - #include <stdlib.h>
    - 
      #include "attr.h"
    --#include "cast.h"
    + #include "cast.h"
      #include "exit_if_null.h"
    - #include "sizeof.h"
    +-#include "sizeof.h"
      
      
      // malloc_T - malloc type-safe
    @@ lib/alloc/malloc.h
      // xmalloc_T - exit-on-error malloc type-safe
     
      ## lib/alloc/realloc.h ##
    +@@
    + 
    + #include <stdlib.h>
    + 
    ++#include "cast.h"
    + #include "exit_if_null.h"
    + #include "sizeof.h"
    + 
     @@
      #define realloc_T_(p, n, T)                                           \
      (                                                                     \
    @@ lib/alloc/realloc.h
      #define reallocarray_(p, n, size)  reallocarray(p, (n) ?: 1, (size) ?: 1)
     
      ## lib/alloc/reallocf.h ##
    +@@
    + #include <stdlib.h>
    + 
    + #include "attr.h"
    ++#include "cast.h"
    + #include "sizeof.h"
    + 
    + 
     @@
      #define reallocf_T_(p, n, T)                                          \
      (                                                                     \
    @@ lib/alloc/reallocf.h
      #define reallocarrayf_(p, n, size)  reallocarrayf(p, (n) ?: 1, (size) ?: 1)
     
      ## lib/search/l/lfind.h ##
    +@@
    + #include <search.h>
    + #include <stddef.h>
    + 
    ++#include "cast.h"
    + #include "search/cmp/cmp.h"
    + #include "sizeof.h"
    + 
     @@
      (                                                                     \
        _Generic(k, T *: (void)0, const T *: (void)0),                \
```
</details>

<details>
<summary>v2f</summary>

-  Fix includes

```
$ git rd 
1:  473f4bfe7f23 = 1:  473f4bfe7f23 lib/: Use the comma operator to perform lvalue conversion
2:  1d1201430ee1 = 2:  1d1201430ee1 lib/cast.h: rvalue(): Add macro for performing lvalue conversion
3:  f9c915931851 = 3:  f9c915931851 lib/: Use rvalue() instead of its pattern
4:  611f249602be ! 4:  07123301d82e lib/cast.h: ptr_cast(): Add macro
    @@ Commit message
      ## lib/cast.h ##
     @@
      
    + #include "config.h"
    + 
    ++#include "sizeof.h"
    ++
      
      #define const_cast(T, p)  _Generic(p, const T:  (T) (p))
     +#define ptr_cast(T, p)    rvalue((typeas(T) *){(p)})
5:  22efc5885028 = 5:  49ab21971acf lib/: Use ptr_cast() instead of its pattern
```
</details>

<details>
<summary>v2g</summary>

-  Rebase

```
$ git rd 
1:  473f4bfe7f23 = 1:  a5953e443b47 lib/: Use the comma operator to perform lvalue conversion
2:  1d1201430ee1 = 2:  bdd2c4a56780 lib/cast.h: rvalue(): Add macro for performing lvalue conversion
3:  f9c915931851 = 3:  2c4aa3d199d3 lib/: Use rvalue() instead of its pattern
4:  07123301d82e = 4:  804757333484 lib/cast.h: ptr_cast(): Add macro
5:  49ab21971acf = 5:  d94bdd1406fd lib/: Use ptr_cast() instead of its pattern
```
</details>

<details>
<summary>v3</summary>

-  Rebase after #1708.

```
$ git range-diff a5953e443b47^..gh/void0 mallocarray..void0 
1:  a5953e443b47 < -:  ------------ lib/: Use the comma operator to perform lvalue conversion
2:  bdd2c4a56780 < -:  ------------ lib/cast.h: rvalue(): Add macro for performing lvalue conversion
3:  2c4aa3d199d3 < -:  ------------ lib/: Use rvalue() instead of its pattern
4:  804757333484 = 1:  58f9486eb31e lib/cast.h: ptr_cast(): Add macro
5:  d94bdd1406fd ! 2:  66588b42d73b lib/: Use ptr_cast() instead of its pattern
    @@ lib/alloc/calloc.h
     
      ## lib/alloc/malloc.h ##
     @@
    - #include "attr.h"
    + 
      #include "cast.h"
      #include "exit_if_null.h"
     -#include "sizeof.h"
    @@ lib/alloc/malloc.h
      // xmalloc_T - exit-on-error malloc type-safe
     
      ## lib/alloc/realloc.h ##
    -@@
    - 
    - #include <stdlib.h>
    - 
    -+#include "cast.h"
    - #include "exit_if_null.h"
    - #include "sizeof.h"
    - 
     @@
      #define realloc_T_(p, n, T)                                           \
      (                                                                     \
        _Generic(p, T *: (void)0),                                    \
    --  (T *){reallocarray_(p, n, sizeof(T))}                         \
    +-  rvalue((T *){reallocarray_(p, n, sizeof(T))})                 \
     +  ptr_cast(T, reallocarray_(p, n, sizeof(T)))                   \
      )
      
      #define reallocarray_(p, n, size)  reallocarray(p, (n) ?: 1, (size) ?: 1)
     
      ## lib/alloc/reallocf.h ##
    -@@
    - #include <stdlib.h>
    - 
    - #include "attr.h"
    -+#include "cast.h"
    - #include "sizeof.h"
    - 
    - 
     @@
      #define reallocf_T_(p, n, T)                                          \
      (                                                                     \
        _Generic(p, T *: (void)0),                                    \
    --  (T *){reallocarrayf_(p, n, sizeof(T))}                        \
    +-  rvalue((T *){reallocarrayf_(p, n, sizeof(T))})                \
     +  ptr_cast(T, reallocarrayf_(p, n, sizeof(T)))                  \
      )
      
      #define reallocarrayf_(p, n, size)  reallocarrayf(p, (n) ?: 1, (size) ?: 1)
     
      ## lib/search/l/lfind.h ##
    -@@
    - #include <search.h>
    - #include <stddef.h>
    - 
    -+#include "cast.h"
    - #include "search/cmp/cmp.h"
    - #include "sizeof.h"
    - 
     @@
      (                                                                     \
        _Generic(k, T *: (void)0, const T *: (void)0),                \
        _Generic(a, T *: (void)0, const T *: (void)0),                \
    --  (T *){lfind_(k, a, n, sizeof(T), cmp)}                        \
    +-  rvalue((T *){lfind_(k, a, n, sizeof(T), cmp)})                \
     +  ptr_cast(T, lfind_(k, a, n, sizeof(T), cmp))                  \
      )
      
```
</details>