### PR TITLE
lib/motd.c: Use motd only for non-PAM builds

### DIFF
--- a/lib/motd.c
+++ b/lib/motd.c
@@ -9,6 +9,8 @@
 
 #include "config.h"
 
+#ifndef USE_PAM
+
 #ident "$Id$"
 
 #include <stdio.h>
@@ -59,3 +61,7 @@ motd(void)
 	free (motdlist);
 	return 0;
 }
+
+#else				/* !USE_PAM */
+extern int ISO_C_forbids_an_empty_translation_unit;
+#endif				/* !USE_PAM */

--- a/lib/prototypes.h
+++ b/lib/prototypes.h
@@ -218,7 +218,9 @@ extern void login_prompt (char *, int);
 extern void mailcheck (void);
 
 /* motd.c */
+#ifndef USE_PAM
 extern int motd(void);
+#endif
 
 /* myname.c */
 extern /*@null@*//*@only@*/struct passwd *get_my_pwent (void);


### PR DESCRIPTION
The motd functionality is only used in login if no PAM support was compiled in.