### PR TITLE
src/: Properly set up libsubid tools

### DIFF
--- a/src/free_subid_range.c
+++ b/src/free_subid_range.c
@@ -5,10 +5,9 @@
 #include <unistd.h>
 
 #include "atoi/a2i.h"
+#include "string/strerrno.h"
 #include "subid.h"
 #include "stdlib.h"
-#include "prototypes.h"
-#include "shadowlog.h"
 
 
 /* Test program for the subid freeing routine */
@@ -29,8 +28,8 @@ int main(int argc, char *argv[])
 	struct subordinate_range range;
 	bool group = false;   // get subuids by default
 
-	log_set_progname(Prog);
-	log_set_logfd(stderr);
+	if (!subid_init(Prog, stderr))
+		fprintf(stderr, "subid_init: %s\n", strerrno());
 	while ((c = getopt(argc, argv, "g")) != EOF) {
 		switch(c) {
 		case 'g': group = true; break;

--- a/src/get_subid_owners.c
+++ b/src/get_subid_owners.c
@@ -6,9 +6,9 @@
 #include "atoi/getnum.h"
 #include "attr.h"
 #include "prototypes.h"
-#include "shadowlog.h"
 #include "stdlib.h"
 #include "string/strcmp/streq.h"
+#include "string/strerrno.h"
 #include "subid.h"
 
 
@@ -24,8 +24,8 @@ int main(int argc, char *argv[])
 	uid_t  u;
 	uid_t  *uids;
 
-	log_set_progname(Prog);
-	log_set_logfd(stderr);
+	if (!subid_init(Prog, stderr))
+		fprintf(stderr, "subid_init: %s\n", strerrno());
 	if (argc < 2) {
 		usage();
 	}

--- a/src/getsubids.c
+++ b/src/getsubids.c
@@ -6,8 +6,8 @@
 
 #include "attr.h"
 #include "prototypes.h"
-#include "shadowlog.h"
 #include "string/strcmp/streq.h"
+#include "string/strerrno.h"
 #include "subid.h"
 
 static const char Prog[] = "getsubids";
@@ -22,8 +22,8 @@ int main(int argc, char *argv[])
 	struct subid_range *ranges;
 	const char *owner;
 
-	log_set_progname(Prog);
-	log_set_logfd(stderr);
+	if (!subid_init(Prog, stderr))
+		fprintf(stderr, "subid_init: %s\n", strerrno());
 	if (argc < 2)
 		usage();
 	owner = argv[1];

--- a/src/new_subid_range.c
+++ b/src/new_subid_range.c
@@ -4,10 +4,9 @@
 #include <unistd.h>
 
 #include "atoi/a2i.h"
+#include "string/strerrno.h"
 #include "subid.h"
 #include "stdlib.h"
-#include "prototypes.h"
-#include "shadowlog.h"
 
 
 /* Test program for the subid creation routine */
@@ -31,8 +30,8 @@ int main(int argc, char *argv[])
 	bool group = false;   // get subuids by default
 	bool ok;
 
-	log_set_progname(Prog);
-	log_set_logfd(stderr);
+	if (!subid_init(Prog, stderr))
+		fprintf(stderr, "subid_init: %s\n", strerrno());
 	while ((c = getopt(argc, argv, "gn")) != EOF) {
 		switch(c) {
 		case 'n': makenew = true; break;


### PR DESCRIPTION
Do not call any shadowlog functions directly from program source files which are also linked with libsubid.

Both, the program and the library, will have their own version of the static variables within shadowlog.c and thus would have different logging mechanisms.

Use `subid_init` instead.

Proof of Concept:

Call `new_subid_range`, the not installed program, as regular user
```
./src/new_subid_range 0 1
```
```
Segmentation fault         (core dumped) ./src/new_subid_range 0 1
```

A poor man's approach of showing the issue:
```
$ for i in src/.libs/*; do objdump -x $i | grep '\.c'; done
 25 .comment      0000001b  0000000000000000  0000000000000000  00003068  2**0
0000000000000000 l    df *ABS*  0000000000000000              free_subid_range.c
0000000000000000 l    df *ABS*  0000000000000000              strtou_noneg.c
0000000000000000 l    df *ABS*  0000000000000000              shadowlog.c
0000000000000000 l    df *ABS*  0000000000000000              strtoi.c
0000000000000000 l    df *ABS*  0000000000000000              strtou.c
 25 .comment      0000001b  0000000000000000  0000000000000000  00003078  2**0
0000000000000000 l    df *ABS*  0000000000000000              get_subid_owners.c
0000000000000000 l    df *ABS*  0000000000000000              getnum.c
0000000000000000 l    df *ABS*  0000000000000000              strtoi.c
0000000000000000 l    df *ABS*  0000000000000000              strtou_noneg.c
0000000000000000 l    df *ABS*  0000000000000000              shadowlog.c
0000000000000000 l    df *ABS*  0000000000000000              streq.c
0000000000000000 l    df *ABS*  0000000000000000              strtou.c
 25 .comment      0000001b  0000000000000000  0000000000000000  00003060  2**0
0000000000000000 l    df *ABS*  0000000000000000              getsubids.c
0000000000000000 l    df *ABS*  0000000000000000              shadowlog.c
0000000000000000 l    df *ABS*  0000000000000000              streq.c
 25 .comment      0000001b  0000000000000000  0000000000000000  00003070  2**0
0000000000000000 l    df *ABS*  0000000000000000              new_subid_range.c
0000000000000000 l    df *ABS*  0000000000000000              strtou_noneg.c
0000000000000000 l    df *ABS*  0000000000000000              shadowlog.c
0000000000000000 l    df *ABS*  0000000000000000              strtoi.c
0000000000000000 l    df *ABS*  0000000000000000              strtou.c
```

These are the source files which are linked into the binary. The `shadowlog.c` ones are the main issue here. With these in place, a different `shadow_logfd` is set than expected by the library code, which has its own.

With the PR applied, the output changes:

```
 25 .comment      0000001b  0000000000000000  0000000000000000  00003068  2**0
0000000000000000 l    df *ABS*  0000000000000000              free_subid_range.c
0000000000000000 l    df *ABS*  0000000000000000              strtou_noneg.c
0000000000000000 l    df *ABS*  0000000000000000              strtoi.c
0000000000000000 l    df *ABS*  0000000000000000              strtou.c
 25 .comment      0000001b  0000000000000000  0000000000000000  00003078  2**0
0000000000000000 l    df *ABS*  0000000000000000              get_subid_owners.c
0000000000000000 l    df *ABS*  0000000000000000              getnum.c
0000000000000000 l    df *ABS*  0000000000000000              strtoi.c
0000000000000000 l    df *ABS*  0000000000000000              strtou_noneg.c
0000000000000000 l    df *ABS*  0000000000000000              streq.c
0000000000000000 l    df *ABS*  0000000000000000              strtou.c
 25 .comment      0000001b  0000000000000000  0000000000000000  00003060  2**0
0000000000000000 l    df *ABS*  0000000000000000              getsubids.c
0000000000000000 l    df *ABS*  0000000000000000              streq.c
 25 .comment      0000001b  0000000000000000  0000000000000000  00003070  2**0
0000000000000000 l    df *ABS*  0000000000000000              new_subid_range.c
0000000000000000 l    df *ABS*  0000000000000000              strtou_noneg.c
0000000000000000 l    df *ABS*  0000000000000000              strtoi.c
0000000000000000 l    df *ABS*  0000000000000000              strtou.c
```

Due to this, the correct functions are called, and thus the correct variables are set.