### PR TITLE
fcopy(): Add function, and use it instead of its pattern

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -83,6 +83,8 @@ libshadow_la_SOURCES = \
 	find_new_uid.c \
 	find_new_sub_gids.c \
 	find_new_sub_uids.c \
+	fs/copy/fcopy.c \
+	fs/copy/fcopy.h \
 	fs/mkstemp/fmkomstemp.c \
 	fs/mkstemp/fmkomstemp.h \
 	fs/mkstemp/mkomstemp.c \

--- a/lib/commonio.c
+++ b/lib/commonio.c
@@ -24,6 +24,7 @@
 #include "atoi/getnum.h"
 #include "commonio.h"
 #include "defines.h"
+#include "fs/copy/fcopy.h"
 #include "fs/mkstemp/fmkomstemp.h"
 #include "nscd.h"
 #ifdef WITH_TCB
@@ -247,7 +248,6 @@ static int create_backup (const char *name, FILE * fp)
 	struct stat sb;
 	struct utimbuf ub;
 	FILE *bkfp;
-	int c;
 
 	stprintf_a(tmpf, "%s.cioXXXXXX", name);
 	if (fstat (fileno (fp), &sb) != 0) {
@@ -259,16 +259,7 @@ static int create_backup (const char *name, FILE * fp)
 		return -1;
 	}
 
-	/* TODO: faster copy, not one-char-at-a-time.  --marekm */
-	c = 0;
-	if (fseek (fp, 0, SEEK_SET) == 0) {
-		while ((c = getc (fp)) != EOF) {
-			if (putc (c, bkfp) == EOF) {
-				break;
-			}
-		}
-	}
-	if ((c != EOF) || (ferror (fp) != 0) || (fflush (bkfp) != 0)) {
+	if (fcopy(bkfp, fp) == -1) {
 		(void) fclose (bkfp);
 		unlink(tmpf);
 		return -1;

--- a/lib/fs/copy/fcopy.c
+++ b/lib/fs/copy/fcopy.c
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2026, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#include "config.h"
+
+#include "fs/copy/fcopy.h"
+
+#include <stdio.h>
+
+
+extern inline int fcopy(FILE *dst, FILE *src);

--- a/lib/fs/copy/fcopy.h
+++ b/lib/fs/copy/fcopy.h
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2026, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#ifndef SHADOW_INCLUDE_LIB_FS_COPY_FCOPY_H_
+#define SHADOW_INCLUDE_LIB_FS_COPY_FCOPY_H_
+
+
+#include "config.h"
+
+#include <stdio.h>
+
+
+inline int fcopy(FILE *dst, FILE *src);
+
+
+// fcopy - FILE copy
+inline int
+fcopy(FILE *dst, FILE *src)
+{
+	int  c;
+
+	if (ftello(dst) != 0)
+		return -1;
+	if (fseek(src, 0, SEEK_SET) == -1)
+		return -1;
+
+	while (EOF != (c = fgetc(src))) {
+		if (fputc(c, dst) == EOF)
+			return -1;
+	}
+	if (ferror(src))
+		return -1;
+	if (fflush(dst) == -1)
+		return -1;
+	return 0;
+}
+
+
+#endif  // include guard

--- a/src/vipw.c
+++ b/src/vipw.c
@@ -130,7 +130,7 @@ static int create_backup_file (FILE * fp, char *backup, struct stat *sb)
 	ub.modtime = sb->st_mtime;
 	if (   (utime (backup, &ub) != 0)
 	    || (fchown(fileno(bkfp), sb->st_uid, sb->st_gid) != 0)
-	    || (fchmod(fileno(bkfp), sb->st_mode) != 0)) {
+	    || (fchmod(fileno(bkfp), sb->st_mode & 0664) != 0)) {
 		fclose(bkfp);
 		unlink (backup);
 		return -1;

--- a/src/vipw.c
+++ b/src/vipw.c
@@ -43,6 +43,7 @@
 #endif				/* WITH_TCB */
 #include "shadowlog.h"
 #include "sssd.h"
+#include "fs/copy/fcopy.h"
 #include "fs/mkstemp/fmkomstemp.h"
 #include "string/sprintf/aprintf.h"
 #include "string/sprintf/stprintf.h"
@@ -108,21 +109,13 @@ static int create_backup_file (FILE * fp, char *backup, struct stat *sb)
 {
 	struct utimbuf ub;
 	FILE *bkfp;
-	int c;
 
 	bkfp = fmkomstemp(backup, 0, 0600);
 	if (NULL == bkfp) {
 		return -1;
 	}
 
-	c = 0;
-	if (fseeko (fp, 0, SEEK_SET) == 0)
-		while ((c = getc (fp)) != EOF) {
-			if (putc (c, bkfp) == EOF) {
-				break;
-			}
-		}
-	if ((EOF != c) || (ferror (fp) != 0) || (fflush (bkfp) != 0)) {
+	if (fcopy(bkfp, fp) == -1) {
 		fclose (bkfp);
 		unlink (backup);
 		return -1;


### PR DESCRIPTION
Cc: @stoeckmann 

---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git rd 
1:  b80a2811e = 1:  64af7e26e lib/fs/copy/: fcopy(): Add function to copy the contents of a file into another
2:  9ce666a3d = 2:  ff6f6933b lib/, src/: Use fcopy() instead of its pattern
```
</details>

<details>
<summary>v2</summary>

-  Add mask for mode_t in vipw(8) surrounding code.  [@stoeckmann ]

```
$ git rd 
1:  64af7e26e = 1:  64af7e26e lib/fs/copy/: fcopy(): Add function to copy the contents of a file into another
2:  ff6f6933b = 2:  ff6f6933b lib/, src/: Use fcopy() instead of its pattern
-:  --------- > 3:  3bdea8b75 src/vipw.c: create_backup_file(): Use mask for mode_t
```
</details>

<details>
<summary>v2b</summary>

-  Fix copyright year.

```
$ git rd 
1:  64af7e26e ! 1:  81ba76135 lib/fs/copy/: fcopy(): Add function to copy the contents of a file into another
    @@ lib/Makefile.am: libshadow_la_SOURCES = \
     
      ## lib/fs/copy/fcopy.c (new) ##
     @@
    -+// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
    ++// SPDX-FileCopyrightText: 2026, Alejandro Colomar <alx@kernel.org>
     +// SPDX-License-Identifier: BSD-3-Clause
     +
     +
    @@ lib/fs/copy/fcopy.c (new)
     
      ## lib/fs/copy/fcopy.h (new) ##
     @@
    -+// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
    ++// SPDX-FileCopyrightText: 2026, Alejandro Colomar <alx@kernel.org>
     +// SPDX-License-Identifier: BSD-3-Clause
     +
     +
2:  ff6f6933b = 2:  b37bbc39a lib/, src/: Use fcopy() instead of its pattern
3:  3bdea8b75 = 3:  27d38068a src/vipw.c: create_backup_file(): Use mask for mode_t
```
</details>

<details>
<summary>v2c</summary>

-  Rebase

```
$ git rd 
1:  81ba76135 = 1:  0decb1cf3 lib/fs/copy/: fcopy(): Add function to copy the contents of a file into another
2:  b37bbc39a = 2:  27a3472c6 lib/, src/: Use fcopy() instead of its pattern
3:  27d38068a = 3:  8f22b1d3b src/vipw.c: create_backup_file(): Use mask for mode_t
```
</details>

<details>
<summary>v2d</summary>

-  Rebase

```
$ git rd 
1:  0decb1cf3de4 = 1:  aa35b48a13e4 lib/fs/copy/: fcopy(): Add function to copy the contents of a file into another
2:  27a3472c6bbd = 2:  b0d9421e493c lib/, src/: Use fcopy() instead of its pattern
3:  8f22b1d3bfab = 3:  4049e3953483 src/vipw.c: create_backup_file(): Use mask for mode_t
```
</details>

<details>
<summary>v2e</summary>

-  Rebase

```
$ git rd 
1:  aa35b48a = 1:  feaa5378 lib/fs/copy/: fcopy(): Add function to copy the contents of a file into another
2:  b0d9421e = 2:  95867af2 lib/, src/: Use fcopy() instead of its pattern
3:  4049e395 = 3:  26114cb9 src/vipw.c: create_backup_file(): Use mask for mode_t
```
</details>

<details>
<summary>v2f</summary>

-  Rebase

```
$ git rd 
1:  feaa53781e31 = 1:  389b9e5d9605 lib/fs/copy/: fcopy(): Add function to copy the contents of a file into another
2:  95867af2115e ! 2:  2ab5fb1903c9 lib/, src/: Use fcopy() instead of its pattern
    @@ src/vipw.c
     +#include "fs/copy/fcopy.h"
      #include "fs/mkstemp/fmkomstemp.h"
      #include "string/sprintf/aprintf.h"
    - #include "string/sprintf/snprintf.h"
    + #include "string/sprintf/stprintf.h"
     @@ src/vipw.c: static int create_backup_file (FILE * fp, char *backup, struct stat *sb)
      {
        struct utimbuf ub;
3:  26114cb922cd = 3:  4d24b2971228 src/vipw.c: create_backup_file(): Use mask for mode_t
```
</details>