### PR TITLE
vipw: Prefer file based functions over path functions in correct order

### DIFF
--- a/src/vipw.c
+++ b/src/vipw.c
@@ -136,8 +136,8 @@ static int create_backup_file (FILE * fp, char *backup, struct stat *sb)
 	ub.actime = sb->st_atime;
 	ub.modtime = sb->st_mtime;
 	if (   (utime (backup, &ub) != 0)
-	    || (fchmod(fileno(bkfp), sb->st_mode) != 0)
-	    || (fchown(fileno(bkfp), sb->st_uid, sb->st_gid) != 0)) {
+	    || (fchown(fileno(bkfp), sb->st_uid, sb->st_gid) != 0)
+	    || (fchmod(fileno(bkfp), sb->st_mode) != 0)) {
 		fclose(bkfp);
 		unlink (backup);
 		return -1;


### PR DESCRIPTION
Avoid symlink dereferences and other race conditions. Also, set ownership and then modes to handle more edge cases.

Purely defensive measures, since vipw operates within /etc which should have proper permissions to avoid these issues to begin with.

Helps https://github.com/shadow-maint/shadow/issues/1500