### PR TITLE
lib/commonio.c: Call utime for correct target

### DIFF
--- a/lib/commonio.c
+++ b/lib/commonio.c
@@ -318,7 +318,7 @@ static int create_backup (const char *name, FILE * fp)
 
 	ub.actime = sb.st_atime;
 	ub.modtime = sb.st_mtime;
-	(void) utime(tmpf, &ub);
+	(void) utime(target, &ub);
 	return 0;
 }
 


### PR DESCRIPTION
Since tmpf has been already renamed to target at this point, call utime with target instead of tmpf.

Fixes: f8732b17dd1d (2026-01-11; "lib/commonio.c: Use unpredictable temporary names")
Reported-by: Alejandro Colomar <alx@kernel.org>