### PR TITLE
vipw: Set correct pattern for fmkomstemp

### DIFF
--- a/src/vipw.c
+++ b/src/vipw.c
@@ -426,7 +426,7 @@ vipwedit (const char *file, int (*file_lock) (void), int (*file_unlock) (bool))
 		if (stat (file, &st1) != 0) {
 			vipwexit (_("failed to stat edited file"), errno, 1);
 		}
-		to_rename = aprintf("%s+", file);
+		to_rename = aprintf("%s,XXXXXX", file);
 		if (to_rename == NULL)
 			vipwexit (_("aprintf() failed"), errno, 1);
 


### PR DESCRIPTION
The fmkomstemp call requires a suffix of XXXXXX for correct operation. Do so in TCB case as well.

Note: If something fails and the file resides in this directory, it could be interpreted as a username. Use the ',' character as an illegal character to prevent shadow tools from erroneously accessing this file and assuming that the user actually exists.

Fixes: a5b3d56e2902 (2026-01-09; "vipw: Use fmkomstemp for temporary file")
Reported-by: Alejandro Colomar <alx@kernel.org>