### PR TITLE
is_valid_hash: accept two more cases

### DIFF
--- a/lib/chkhash.c
+++ b/lib/chkhash.c
@@ -40,9 +40,13 @@ match_regex(const char *pattern, const char *string)
 bool 
 is_valid_hash(const char *hash) 
 {
-	hash = strprefix(hash, "!") ?: hash;
+	// If the hash starts with '!', it means just lock the password.
+	if (strprefix(hash, "!"))
+		return true;
 
-	if (streq(hash, "*"))
+	// If the hash starts with '*', this is an intentional way to prevent
+	// a user from logging in with password.
+	if (strprefix(hash, "*"))
 		return true;
 
 	// Minimum hash length


### PR DESCRIPTION
We currently allow ! followed by a valid hash but not ! followed by nothing, and * followed by nothing but not * followed by something.

Accept the other cases.


Cc: Marc 'Zugschlus' Haber <mh+githubvisible@zugschlus.de>
Cc: Alejandro Colomar <alx@kernel.org>
Cc: Chris Hofstaedtler <zeha@debian.org>