### PR TITLE
lib/chkhash.c: is_valid_hash(): Accept '!' as the hash

### DIFF
--- a/lib/chkhash.c
+++ b/lib/chkhash.c
@@ -40,6 +40,9 @@ match_regex(const char *pattern, const char *string)
 bool 
 is_valid_hash(const char *hash) 
 {
+	if (streq(hash, "!"))
+		return true;
+
 	hash = strprefix(hash, "!") ?: hash;
 
 	if (streq(hash, "*"))


### PR DESCRIPTION
Following ddc2549, also allow a bare '!' as the hash. anaconda, the installer used by Red Hat, Fedora and related distributions, has used this as the default hash for the root password (if the user does not explicitly set a root password during the install process) for a long time (at least since 2015). It has the same effect as a bare '*': it'll make the account inaccessible.