### PR TITLE
useradd: Correctly set subuid/subgid when using -F

### DIFF
--- a/src/useradd.c
+++ b/src/useradd.c
@@ -2511,12 +2511,10 @@ int main (int argc, char **argv)
 	subgid_count = getdef_ulong ("SUB_GID_COUNT", 65536);
 	is_sub_uid = want_subuid_file () &&
 	    subuid_count > 0 && sub_uid_file_present () &&
-	    (!rflg || Fflg) &&
-	    (!user_id || (user_id <= uid_max && user_id >= uid_min));
+	    (!rflg && (!user_id || (user_id <= uid_max && user_id >= uid_min))) || Fflg;
 	is_sub_gid = want_subgid_file() &&
 	    subgid_count > 0 && sub_gid_file_present() &&
-	    (!rflg || Fflg) &&
-	    (!user_id || (user_id <= uid_max && user_id >= uid_min));
+	    (!rflg && (!user_id || (user_id <= uid_max && user_id >= uid_min))) || Fflg;
 #endif				/* ENABLE_SUBIDS */
 
 	if (run_parts ("/etc/shadow-maint/useradd-pre.d", user_name,


### PR DESCRIPTION
Fixes https://github.com/shadow-maint/shadow/issues/1255

I was not able to run the tests as described in doc/contributions/tests.md at the moment but I was able to build and test that `useradd -F` work as intended.