### PR TITLE
man/po: copy over login.defs.d/*.xml

### DIFF
--- a/man/po/Makefile.in
+++ b/man/po/Makefile.in
@@ -90,6 +90,7 @@ $(DOMAIN).pot-update: $(XMLFILES) $(srcdir)/XMLFILES
 	@set -ex; tmpdir=`mktemp -d`; \
 	origdir=`pwd`; \
 	cd $(top_srcdir)/man; \
+	cp -r login.defs.d $$tmpdir/; \
 	cp *.xml $$tmpdir/; \
 	files=""; \
 	for file in $(notdir $(XMLFILES)); do \


### PR DESCRIPTION
When doing update-po, we copy man/*.xml into a tempdir, but some of those files reference login.defs.d/*.xml, so copy over those as well.