### PR TITLE
Clarify documentation regarding creation of homedir

### DIFF
--- a/man/useradd.8.xml
+++ b/man/useradd.8.xml
@@ -184,13 +184,30 @@
 	    user's login directory. The default is to append the
 	    <replaceable>LOGIN</replaceable> name to
 	    <replaceable>BASE_DIR</replaceable> and use that as the
-	    login directory name.  
+	    login directory name.
 	    The directory <replaceable>HOME_DIR</replaceable> is not created by
-	    default.  However it will be created for non-system users if either the
-	    <option>-m</option> flag is specified or
-	    <replaceable>CREATE_HOME</replaceable> in
-	    <filename>login.defs</filename> is set to true.  However, it will never
-	    be created if the <option>-M</option> flag is specified.
+	    default.
+		Whether it gets created
+		depends on the user type and command-line options.
+	  </para>
+	  <para>
+	    For regular users,
+		the home directory is created
+		if either the <option>-m</option> flag is specified
+		or <replaceable>CREATE_HOME</replaceable>
+		in <citerefentry><refentrytitle>login.defs</refentrytitle><manvolnum>5</manvolnum></citerefentry>.
+		is set to true.
+	  </para>
+	  <para>
+	    For system users,
+		the home directory is created
+		only if the <option>-m</option> flag is explicitly specified,
+	    regardless of the <replaceable>CREATE_HOME</replaceable> setting.
+	  </para>
+	  <para>
+	    The <option>-M</option> flag
+		prevents home directory creation in all cases,
+		overriding any other settings.
 	  </para>
 	</listitem>
       </varlistentry>
@@ -399,7 +416,7 @@
 	</term>
 	<listitem>
 	  <para>
-	    Create the user's home directory if it does not exist. 
+	    Create the user's home directory if it does not exist.
 	    The files and directories contained in the skeleton directory
 	    (which can be defined with the <option>-k</option> option)
 	    will be copied to the home directory.
@@ -489,7 +506,7 @@
             password himself.
 	  </para>
 	  <para>
-	    <emphasis role="bold">Note:</emphasis>Avoid this option on the command  
+	    <emphasis role="bold">Note:</emphasis>Avoid this option on the command
 	     line because the password (or encrypted password) will
 	    be visible by users listing the processes.
 	  </para>


### PR DESCRIPTION
The "for non-system users" only applies to the CREATE_HOME config and is does not matter when using the `-m` flag.

Fixes #1522.

```
podman run --rm -it fedora:44
[root@cae89bd5de3c /]# ls -l /home/
total 0
[root@cae89bd5de3c /]# grep CREATE_HOME /etc/login.defs
CREATE_HOME     yes
[root@cae89bd5de3c /]# useradd --system foo
[root@cae89bd5de3c /]# useradd --system --create-home bar
[root@cae89bd5de3c /]# ls -l /home/
total 0
drwx------. 1 bar bar 64 Jan 30 01:39 bar
```