### PR TITLE
tests/unit: improve .gitignore to ignore all test executables

### DIFF
--- a/tests/unit/.gitignore
+++ b/tests/unit/.gitignore
@@ -2,5 +2,6 @@
 *.log
 *.trs
 
-# Specific files to be added each time a new file is included
-test_logind
+# All test executables
+test_*
+!test_*.c


### PR DESCRIPTION
Replace specific test file entries with pattern-based ignoring of all test_* executables while preserving test_*.c source files.