### PR TITLE
configure.ac: fix detection of secure_getenv

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -68,9 +68,7 @@ AC_REPLACE_FUNCS([putgrent putpwent putspent])
 AC_REPLACE_FUNCS([sgetgrent sgetpwent sgetspent])
 
 AC_CHECK_FUNC([setpgrp])
-AC_CHECK_FUNC([secure_getenv],
-	[AC_DEFINE([HAS_SECURE_GETENV],[1],[Defined to 1 if you have the declaration of 'secure_getenv'])]
-)
+AC_CHECK_DECLS([secure_getenv])
 
 AC_CACHE_CHECK([location of shared mail directory], [shadow_cv_maildir],
 [for shadow_cv_maildir in /var/mail /var/spool/mail /usr/spool/mail /usr/mail none; do

--- a/lib/defines.h
+++ b/lib/defines.h
@@ -174,7 +174,7 @@
 /* Maximum length of passwd entry */
 #define PASSWD_ENTRY_MAX_LENGTH 32768
 
-#ifdef HAVE_SECURE_GETENV
+#if HAVE_DECL_SECURE_GETENV
 #  define shadow_getenv(name) secure_getenv(name)
 # else
 #  define shadow_getenv(name) getenv(name)


### PR DESCRIPTION
lib/defines.h was looking for HAVE_SECURE_GETENV instead of of HAS_SECURE_GETENV as defined in configure. This resulted in shadow_getenv always being defined to getenv.

AC_CHECK_FUNC is linker test; it does not check for declarations. Replace this with AC_CHECK_DECLS/HAVE_DECL_SECURE_GETENV.