### PR TITLE
configure.ac: remove redundant check for pam_fail_delay

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -548,13 +548,6 @@ if test "X$with_libpam" = "Xyes"; then
 	               [], [], [[#include <security/pam_appl.h>]])
 
 
-	save_libs=$LIBS
-	LIBS="$LIBS $LIBPAM"
-	# We do not use AC_CHECK_FUNCS to avoid duplicated definition with
-	# Linux PAM.
-	AC_CHECK_FUNC([pam_fail_delay], [AC_DEFINE([HAS_PAM_FAIL_DELAY], [1], [Define to 1 if you have the declaration of 'pam_fail_delay'])])
-	LIBS=$save_libs
-
 	AC_DEFINE([USE_PAM], [1], [Define to support Pluggable Authentication Modules])
 	AC_DEFINE_UNQUOTED([SHADOW_PAM_CONVERSATION], [$pam_conv_function],[PAM conversation to use])
 

--- a/src/login.c
+++ b/src/login.c
@@ -634,7 +634,7 @@ int main (int argc, char **argv)
 	PAM_FAIL_CHECK;
 	retcode = pam_set_item (pamh, PAM_TTY, tty);
 	PAM_FAIL_CHECK;
-#ifdef HAS_PAM_FAIL_DELAY
+#ifdef HAVE_PAM_FAIL_DELAY
 	retcode = pam_fail_delay (pamh, 1000000 * delay);
 	PAM_FAIL_CHECK;
 #endif
@@ -675,7 +675,7 @@ int main (int argc, char **argv)
 			bool failed = false;
 
 			failcount++;
-#ifdef HAS_PAM_FAIL_DELAY
+#ifdef HAVE_PAM_FAIL_DELAY
 			if (delay > 0) {
 				retcode = pam_fail_delay(pamh, 1000000*delay);
 				PAM_FAIL_CHECK;


### PR DESCRIPTION
This check was introduced in 276e406c (support for OpenPAM). OpenPAM has never declared pam_fail_delay.

linux-pam has defined HAVE_PAM_FAIL_DELAY in its headers for a very long time (before version history).