### PR TITLE
lib/prefix_flag.c: Remove 't' flag from fopen(3)

### DIFF
--- a/lib/prefix_flag.c
+++ b/lib/prefix_flag.c
@@ -154,7 +154,7 @@ extern struct group *prefix_getgrnam(const char *name)
 		FILE* fg;
 		struct group * grp = NULL;
 
-		fg = fopen(group_db_file, "rt");
+		fg = fopen(group_db_file, "r");
 		if (!fg)
 			return NULL;
 		while (NULL != (grp = fgetgrent(fg))) {
@@ -174,7 +174,7 @@ extern struct group *prefix_getgrgid(gid_t gid)
 		FILE* fg;
 		struct group * grp = NULL;
 
-		fg = fopen(group_db_file, "rt");
+		fg = fopen(group_db_file, "r");
 		if (!fg)
 			return NULL;
 		while (NULL != (grp = fgetgrent(fg))) {
@@ -194,7 +194,7 @@ extern struct passwd *prefix_getpwuid(uid_t uid)
 		FILE* fg;
 		struct passwd *pwd = NULL;
 
-		fg = fopen(passwd_db_file, "rt");
+		fg = fopen(passwd_db_file, "r");
 		if (!fg)
 			return NULL;
 		while (NULL != (pwd = fgetpwent(fg))) {
@@ -214,7 +214,7 @@ extern struct passwd *prefix_getpwnam(const char* name)
 		FILE* fg;
 		struct passwd *pwd = NULL;
 
-		fg = fopen(passwd_db_file, "rt");
+		fg = fopen(passwd_db_file, "r");
 		if (!fg)
 			return NULL;
 		while (NULL != (pwd = fgetpwent(fg))) {
@@ -236,7 +236,7 @@ extern int prefix_getpwnam_r(const char* name, struct passwd* pwd,
 		FILE* fg;
 		int ret = 0;
 
-		fg = fopen(passwd_db_file, "rt");
+		fg = fopen(passwd_db_file, "r");
 		if (!fg)
 			return errno;
 		while ((ret = fgetpwent_r(fg, pwd, buf, buflen, result)) == 0) {
@@ -257,7 +257,7 @@ extern struct spwd *prefix_getspnam(const char* name)
 		FILE* fg;
 		struct spwd *sp = NULL;
 
-		fg = fopen(spw_db_file, "rt");
+		fg = fopen(spw_db_file, "r");
 		if (!fg)
 			return NULL;
 		while (NULL != (sp = fgetspent(fg))) {
@@ -281,7 +281,7 @@ extern void prefix_setpwent(void)
 	if (fp_pwent)
 		fclose (fp_pwent);
 
-	fp_pwent = fopen(passwd_db_file, "rt");
+	fp_pwent = fopen(passwd_db_file, "r");
 	if (!fp_pwent)
 		return;
 }
@@ -315,7 +315,7 @@ extern void prefix_setgrent(void)
 	if (fp_grent)
 		fclose (fp_grent);
 
-	fp_grent = fopen(group_db_file, "rt");
+	fp_grent = fopen(group_db_file, "r");
 	if (!fp_grent)
 		return;
 }


### PR DESCRIPTION
It is a Windows extension ignored by musl and glibc.  It is not in POSIX nor ISO C.

Since most of our calls to fopen(3) don't use it, let's be consistent and not use it anywhere.

Closes: <https://github.com/shadow-maint/shadow/issues/1541>

Cc: @vapier , @fariouche 

---

Revisions:

<details>
<summary>v1b</summary>

-  Acked-by: @vapier 

```
$ git rd 
1:  282d72233b5b ! 1:  02f70a5523e8 lib/prefix_flag.c: Remove 't' flag from fopen(3)
    @@ Commit message
         and not use it anywhere.
     
         Closes: <https://github.com/shadow-maint/shadow/issues/1541>
    +    Acked-by: Mike Frysinger <vapier@gentoo.org>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/prefix_flag.c ##
```
</details>