### PR TITLE
src/useradd.c: Refactor unreadable conditionals.

### DIFF
--- a/src/useradd.c
+++ b/src/useradd.c
@@ -2449,18 +2449,27 @@ static void check_uid_range(int rflg, uid_t user_id)
 static bool
 should_assign_subuid(void)
 {
-	uid_t uid_min;
-	uid_t uid_max;
-	unsigned long subuid_count;
+	uid_t          uid_min;
+	uid_t          uid_max;
+	unsigned long  subuid_count;
 
 	uid_min = getdef_ulong ("UID_MIN", 1000UL);
 	uid_max = getdef_ulong ("UID_MAX", 60000UL);
 	subuid_count = getdef_ulong ("SUB_UID_COUNT", 65536);
 
-	return want_subuid_file () &&
-	    subuid_count > 0 && sub_uid_file_present () &&
-	    (!rflg || Fflg) &&
-	    (!user_id || (user_id <= uid_max && user_id >= uid_min));
+	if (!want_subuid_file())
+		return false;
+	if (subuid_count == 0)
+		return false;
+	if (!sub_uid_file_present())
+		return false;
+	if (rflg && !Fflg)
+		return false;
+	if (user_id == 0)
+		return false;
+	if (user_id > uid_max || user_id < uid_min)
+		return false;
+	return true;
 }
 #endif
 
@@ -2468,18 +2477,27 @@ should_assign_subuid(void)
 static bool
 should_assign_subgid(void)
 {
-	uid_t uid_min;
-	uid_t uid_max;
-	unsigned long subgid_count;
+	uid_t          uid_min;
+	uid_t          uid_max;
+	unsigned long  subgid_count;
 
 	uid_min = getdef_ulong ("UID_MIN", 1000UL);
 	uid_max = getdef_ulong ("UID_MAX", 60000UL);
 	subgid_count = getdef_ulong ("SUB_GID_COUNT", 65536);
 
-	return want_subgid_file() &&
-	    subgid_count > 0 && sub_gid_file_present() &&
-	    (!rflg || Fflg) &&
-	    (!user_id || (user_id <= uid_max && user_id >= uid_min));
+	if (!want_subgid_file())
+		return false;
+	if (subgid_count == 0)
+		return false;
+	if (!sub_gid_file_present())
+		return false;
+	if (rflg && !Fflg)
+		return false;
+	if (user_id == 0)
+		return false;
+	if (user_id > uid_max || user_id < uid_min)
+		return false;
+	return true;
 }
 #endif
 


### PR DESCRIPTION
Co-authored-by: @hallyn 
Cc: @acdn-ndostert

---

Revisions:

<details>
<summary>v2</summary>

-  Signed-off-by: @hallyn 
-  tfix [@hallyn ]

```
$ git rd 
1:  1427d2df087b ! 1:  4fa43ef9f01e src/useradd.c: Factor out logic to helper functions
    @@ Commit message
         src/useradd.c: Factor out logic to helper functions
     
         Co-authored-by: Serge Hallyn <serge@hallyn.com>
    +    Signed-off-by: Serge Hallyn <serge@hallyn.com>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## src/useradd.c ##
    @@ src/useradd.c: int main (int argc, char **argv)
     -      (!rflg || Fflg) &&
     -      (!user_id || (user_id <= uid_max && user_id >= uid_min));
     +  is_sub_uid = should_assign_subuid();
    -+  is_sub_gid = should_assign_subuid();
    ++  is_sub_gid = should_assign_subgid();
      #endif                            /* ENABLE_SUBIDS */
      
        if (run_parts ("/etc/shadow-maint/useradd-pre.d", user_name,
2:  9d6b44cf0029 ! 2:  1a1cabf8a463 src/useradd.c: Refactor long expression into many simple conditionals
    @@ Commit message
         src/useradd.c: Refactor long expression into many simple conditionals
     
         Co-authored-by: Serge Hallyn <serge@hallyn.com>
    +    Signed-off-by: Serge Hallyn <serge@hallyn.com>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## src/useradd.c ##
```
</details>