### PR TITLE
useradd: Correctly set subuid/subgid when using -F

### DIFF
--- a/src/useradd.c
+++ b/src/useradd.c
@@ -2463,7 +2463,9 @@ should_assign_subuid(void)
 		return false;
 	if (!sub_uid_file_present())
 		return false;
-	if (rflg && !Fflg)
+	if (Fflg)
+		return true;
+	if (rflg)
 		return false;
 	if (user_id == 0)
 		return false;
@@ -2491,7 +2493,9 @@ should_assign_subgid(void)
 		return false;
 	if (!sub_gid_file_present())
 		return false;
-	if (rflg && !Fflg)
+	if (Fflg)
+		return true;
+	if (rflg)
 		return false;
 	if (user_id == 0)
 		return false;


### PR DESCRIPTION
The -F flag should bypass the -r flag and UID checks.

Closes: <shadow-maint#1255>

This is a followup of [#1511](https://github.com/shadow-maint/shadow/pull/1511) and https://github.com/shadow-maint/shadow/pull/1545

In the current implementation the case `useradd -r -F alice` was not working anymore, this is related to the change from `!user_id` to `if (user_id == 0)` while the user_id is not set at this moment.
As a side effect this PR restore the old behavior and `useradd -r -F alice` again add entries to `/etc/subuid` and `/etc/subgid`.

Cc: @alejandro-colomar 
Cc: @hallyn 