### PR TITLE
usermod: Add option to automatically find subordinate IDs

### DIFF
--- a/lib/find_new_sub_gids.c
+++ b/lib/find_new_sub_gids.c
@@ -25,11 +25,11 @@
  *
  * Return 0 on success, -1 if no unused GIDs are available.
  */
-int find_new_sub_gids (gid_t *range_start, unsigned long *range_count)
+int find_new_sub_gids (id_t *range_start, unsigned long *range_count)
 {
 	unsigned long min, max;
 	unsigned long count;
-	gid_t start;
+	id_t start;
 
 	assert (range_start != NULL);
 	assert (range_count != NULL);
@@ -47,7 +47,7 @@ int find_new_sub_gids (gid_t *range_start, unsigned long *range_count)
 	}
 
 	start = sub_gid_find_free_range(min, max, count);
-	if (start == (gid_t)-1) {
+	if (start == (id_t)-1) {
 		fprintf (log_get_logfd(),
 		         _("%s: Can't get unique subordinate GID range\n"),
 		         log_get_progname());

--- a/lib/find_new_sub_uids.c
+++ b/lib/find_new_sub_uids.c
@@ -25,11 +25,11 @@
  *
  * Return 0 on success, -1 if no unused UIDs are available.
  */
-int find_new_sub_uids (uid_t *range_start, unsigned long *range_count)
+int find_new_sub_uids (id_t *range_start, unsigned long *range_count)
 {
 	unsigned long min, max;
 	unsigned long count;
-	uid_t start;
+	id_t start;
 
 	assert (range_start != NULL);
 	assert (range_count != NULL);
@@ -47,7 +47,7 @@ int find_new_sub_uids (uid_t *range_start, unsigned long *range_count)
 	}
 
 	start = sub_uid_find_free_range(min, max, count);
-	if (start == (uid_t)-1) {
+	if (start == (id_t)-1) {
 		fprintf (log_get_logfd(),
 		         _("%s: Can't get unique subordinate UID range\n"),
 		         log_get_progname());

--- a/lib/prototypes.h
+++ b/lib/prototypes.h
@@ -133,10 +133,10 @@ extern int find_new_uid (bool sys_user,
 
 #ifdef ENABLE_SUBIDS
 /* find_new_sub_gids.c */
-extern int find_new_sub_gids (gid_t *range_start, unsigned long *range_count);
+extern int find_new_sub_gids (id_t *range_start, unsigned long *range_count);
 
 /* find_new_sub_uids.c */
-extern int find_new_sub_uids (uid_t *range_start, unsigned long *range_count);
+extern int find_new_sub_uids (id_t *range_start, unsigned long *range_count);
 #endif				/* ENABLE_SUBIDS */
 
 /* getgr_nam_gid.c */

--- a/man/usermod.8.xml
+++ b/man/usermod.8.xml
@@ -501,6 +501,19 @@
 	  </para>
 	</listitem>
       </varlistentry>
+      <varlistentry condition="subids">
+	<term>
+	  <option>-S</option>, <option>--add-subids</option>
+	</term>
+	<listitem>
+	  <para>
+	    Add subordinate uids and gids to the user's account.
+	  </para>
+	  <para>
+	     An appropriate uid and gid range is automatically selected from /etc/login.defs defaults.
+	  </para>
+	</listitem>
+      </varlistentry>
       <varlistentry>
 	<term>
 	  <option>-Z</option>, <option>--selinux-user</option>&nbsp;<replaceable>SEUSER</replaceable>


### PR DESCRIPTION
Tools such as useradd(8) automatically select subordinate UID and GID ranges based on settings in login.defs.
But when one wants to add subordinate IDs to an existing user, these ranges have to be specified manually using the -w and -v options of usermod(8).

Add a new -S / --add-subids option to usermod(8) which will, just like useradd(8), find a range based on the settings in login.defs.