### PR TITLE
src/useradd.c: create_home(): Fix benign off-by-one bug

### DIFF
--- a/src/useradd.c
+++ b/src/useradd.c
@@ -2216,7 +2216,7 @@ usr_update (unsigned long subuid_count, unsigned long subgid_count,
  */
 static void create_home(const struct option_flags *flags)
 {
-	char    path[strlen(prefix_user_home) + 2];
+	char    path[strlen(prefix_user_home) + 1];
 	char    *bhome, *cp;
 	mode_t  mode;
 	bool    process_selinux;

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -2183,7 +2183,7 @@ want_btrfs_subvolume(const char *path)
  */
 static void create_home(const struct option_flags *flags)
 {
-	char    path[strlen(prefix_user_home) + 2];
+	char    path[strlen(prefix_user_home) + 1];
 	char    *bhome, *cp;
 	mode_t  mode;
 	bool    process_selinux;


### PR DESCRIPTION
    'path' will only copy contents from 'bhome', which itself is a dup of
    'prefix_user_home'.  Thus it only needs to be able to hold the contents
    of that string (thus, strlen(3) + 1 for the NUL).
    
    We don't add any characters that were not present in the original
    string (but we do collapse adjacent slashes), and thus the 'path' string
    may be shorter or as long as 'bhome', but certainly not longer.
    
    This seems to have been an off-by-one calculation, as this code has
    never needed space for an extra byte, AFAICS.
    
- Fixes: b3b6d9d7 (2018-05-15; "Create parent dirs for useradd -m")
- Link: <https://github.com/shadow-maint/shadow/pull/112>
- Link: <https://github.com/shadow-maint/shadow/pull/2>
- Cc: @jubalh , @thorstenb,  @thkukuk, @hallyn , @seiferteric, @ikerexxe

---

Revisions:

<details>
<summary>v2</summary>

-  Rebase

```
$ git rd 
1:  6e1ab018 < -:  -------- src/useradd.c: create_home(): Move the first copy to 'path' closer to its use
2:  a4182b11 < -:  -------- src/useradd.c: create_home(): Handle first slash separately
3:  c925eb4d < -:  -------- src/useradd.c: Use strsep(3) instead of strtok(3)
4:  617fcf02 < -:  -------- lib/, src/: Move lib/string/{strtok => strsep}/
5:  a3c4055b < -:  -------- lib/string/README: Add strtok(3) to the sanctions list
6:  a2c3365d ! 1:  c6d21e11 src/useradd.c: create_home(): Fix benign off-by-one bug
    @@ src/useradd.c: usr_update (unsigned long subuid_count, unsigned long subgid_coun
      {
     -  char    path[strlen(prefix_user_home) + 2];
     +  char    path[strlen(prefix_user_home) + 1];
    -   char    *bhome, *cp, *p;
    +   char    *bhome, *cp;
        mode_t  mode;
        bool    process_selinux;
```
</details>

<details>
<summary>v2b</summary>

-  Rebase

```
$ git rd 
1:  c6d21e11 = 1:  de7a9d6f src/useradd.c: create_home(): Fix benign off-by-one bug
```
</details>

<details>
<summary>v2c</summary>

-  Rebase

```
$ git rd 
1:  de7a9d6f90c1 = 1:  05799cbab76d src/useradd.c: create_home(): Fix benign off-by-one bug
```
</details>

<details>
<summary>v2d</summary>

-  Rebase

```
$ git rd -U0
1:  05799cbab76d ! 1:  e16c96b1692e src/useradd.c: create_home(): Fix benign off-by-one bug
    @@ src/useradd.c
    -@@ src/useradd.c: usr_update (unsigned long subuid_count, unsigned long subgid_count,
    +@@ src/useradd.c: want_btrfs_subvolume(const char *path)
```
</details>