### PR TITLE
lib/limits.c: setup_limits(): Simplify, calling stpspn() instead of strprefix()

### DIFF
--- a/lib/limits.c
+++ b/lib/limits.c
@@ -468,7 +468,7 @@ void setup_limits (const struct passwd *info)
 		for (cp = info->pw_gecos; cp != NULL; cp = strchr (cp, ',')) {
 			char  *val;
 
-			cp = strprefix(cp, ",") ?: cp;
+			cp = stpspn(cp, ",");
 
 			val = strprefix(cp, "pri=");
 			if (val != NULL) {


### PR DESCRIPTION
p=stpspn(p,",") jumps over any amount of leading commas, which we were doing anyway in the loop.

Cc: @kees, @uecker 

---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git rd 
1:  07d932c1 = 1:  4f30a796 lib/limits.c: setup_limits(): Simplify, calling stpspn() instead of strprefix()
```
</details>

<details>
<summary>v1c</summary>

-  Rebase

```
$ git rd 
1:  4f30a7967739 = 1:  4d88ca2f6be3 lib/limits.c: setup_limits(): Simplify, calling stpspn() instead of strprefix()
```
</details>

<details>
<summary>v1d</summary>

-  Rebase

```
$ git rd 
1:  4d88ca2f6be3 = 1:  46e17601269b lib/limits.c: setup_limits(): Simplify, calling stpspn() instead of strprefix()
```
</details>

<details>
<summary>v1e</summary>

-  Rebase

```
$ git rd 
1:  46e17601269b = 1:  a4e88b431a96 lib/limits.c: setup_limits(): Simplify, calling stpspn() instead of strprefix()
```
</details>