### PR TITLE
Re-design strr[c]spn(), to make it simpler and more useful

### DIFF
--- a/lib/string/README
+++ b/lib/string/README
@@ -235,7 +235,7 @@ sprintf/ - Formatted string creation
 strspn/ - String span searching
 
 	Naming conventions:
-	-  'r': reverse (search from the end).
+	-  'r': rear (search from the end).
 	-  'c': complement (negate the second argument).
 	-  'stp': return a pointer instead of a length.
 
@@ -243,20 +243,23 @@ strspn/ - String span searching
 	Like strspn(3), but return a pointer instead of an offset.
 	It is useful for skipping leading white space.
 
-    strrspn()
-	Use stprspn() instead.
-	Return the offset of a suffix segment consisting only of
+    strrspn_()
+	Return the length of a trailing span consisting only of
 	characters in 'accept'.
+	It is useful for determining if a string ends with characters
+	in "accept".
     stprspn()
-	Like strrspn(), but return a pointer instead of an offset.
+	Like strrspn(), but return a pointer instead of a length.
 	It is useful for removing trailing white space.
 
     strrcspn()
 	Use stprcspn() instead.
-	Return the offset of a suffix segment consisting only of
+	Return the length of a trailing span consisting only of
 	characters not in 'reject'.
+	It is useful for determining if a string ends with characters
+	not in "reject".
     stprcspn()
-	Like strrcspn(), but return a pointer instead of an offset.
+	Like strrcspn(), but return a pointer instead of a length.
 	This is rarely useful.  It was useful for implementing
 	basename().
 

--- a/lib/string/strspn/stprcspn.h
+++ b/lib/string/strspn/stprcspn.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-FileCopyrightText: 2024-2026, Alejandro Colomar <alx@kernel.org>
 // SPDX-License-Identifier: BSD-3-Clause
 
 
@@ -10,15 +10,16 @@
 
 #include <string.h>
 
+#include "string/strchr/strnul.h"
 #include "string/strspn/strrcspn.h"
 
 
-// string returns-pointer rear complement substring prefix length
-#define stprcspn(s, reject)                                                   \
-({                                                                            \
-	__auto_type  s_ = (s);                                                \
-	                                                                      \
-	s_ + strrcspn(s_, reject);                                            \
+// stprcspn - string returns-pointer rear complement span
+#define stprcspn(s, reject)                                           \
+({                                                                    \
+	__auto_type  s_ = (s);                                        \
+	                                                              \
+	strnul(s_) - strrcspn(s_, reject);                            \
 })
 
 

--- a/lib/string/strspn/stprspn.h
+++ b/lib/string/strspn/stprspn.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-FileCopyrightText: 2024-2026, Alejandro Colomar <alx@kernel.org>
 // SPDX-License-Identifier: BSD-3-Clause
 
 
@@ -10,17 +10,16 @@
 
 #include <string.h>
 
+#include "string/strchr/strnul.h"
 #include "string/strspn/strrspn.h"
 
 
-// string returns-pointer rear substring prefix length
-// Available in Oracle Solaris as strrspn(3GEN).
-// <https://docs.oracle.com/cd/E36784_01/html/E36877/strrspn-3gen.html>
-#define stprspn(s, accept)                                                    \
-({                                                                            \
-	__auto_type  s_ = (s);                                                \
-	                                                                      \
-	s_ + strrspn_(s_, accept);                                            \
+// stprspn - string returns-pointer rear span
+#define stprspn(s, accept)                                            \
+({                                                                    \
+	__auto_type  s_ = (s);                                        \
+	                                                              \
+	strnul(s_) - strrspn_(s_, accept);                            \
 })
 
 

--- a/lib/string/strspn/strrcspn.h
+++ b/lib/string/strspn/strrcspn.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-FileCopyrightText: 2024-2026, Alejandro Colomar <alx@kernel.org>
 // SPDX-License-Identifier: BSD-3-Clause
 
 
@@ -20,19 +20,20 @@ ATTR_STRING(2)
 inline size_t strrcspn(const char *s, const char *reject);
 
 
-// string rear complement substring prefix length
+// strrcspn - string rear complement span
 inline size_t
 strrcspn(const char *s, const char *reject)
 {
+	size_t      spn;
 	const char  *p;
 
 	p = strnul(s);
-	while (p > s) {
+	for (spn = 0; p > s; spn++) {
 		p--;
 		if (strchr(reject, *p) != NULL)
-			return p + 1 - s;
+			return spn;
 	}
-	return 0;
+	return spn;
 }
 
 

--- a/lib/string/strspn/strrspn.h
+++ b/lib/string/strspn/strrspn.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-FileCopyrightText: 2024-2026, Alejandro Colomar <alx@kernel.org>
 // SPDX-License-Identifier: BSD-3-Clause
 
 
@@ -20,19 +20,20 @@ ATTR_STRING(2)
 inline size_t strrspn_(const char *s, const char *accept);
 
 
-// string rear substring prefix length
+// strrspn_ - string rear span
 inline size_t
 strrspn_(const char *s, const char *accept)
 {
+	size_t      spn;
 	const char  *p;
 
 	p = strnul(s);
-	while (p > s) {
+	for (spn = 0; p > s; spn++) {
 		p--;
 		if (strchr(accept, *p) == NULL)
-			return p + 1 - s;
+			return spn;
 	}
-	return 0;
+	return spn;
 }
 
 

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -64,6 +64,7 @@
 #include "string/strcmp/strcaseeq.h"
 #include "string/strcmp/streq.h"
 #include "string/strcmp/strprefix.h"
+#include "string/strspn/strrspn.h"
 #include "string/strspn/stprspn.h"
 #include "string/strtok/stpsep.h"
 
@@ -316,7 +317,7 @@ static bool from_match (char *tok, const char *string)
 	} else if (strcaseeq(tok, "LOCAL")) {	/* LOCAL: no dots */
 		if (!strchr(string, '.'))
 			return true;
-	} else if (   (!streq(tok, "") && tok[strlen(tok) - 1] == '.') /* network */
+	} else if (   strrspn_(tok, ".")  /* network */
 		   && strprefix(resolve_hostname(string), tok)) {
 		return true;
 	}


### PR DESCRIPTION
Cc: @kees

---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git rd 
1:  a9b6d5b2 = 1:  8378517b lib/string/strspn/: strr[c]spn(): Return the length counting from the end
2:  f7aa9729 = 2:  adb25eda src/login_nopam.c: from_match(): Use strrspn_() instead of its pattern
```
</details>

<details>
<summary>v1c</summary>

-  Rebase

```
$ git rd 
1:  8378517b39bf = 1:  13befe5ae03a lib/string/strspn/: strr[c]spn(): Return the length counting from the end
2:  adb25eda7a2a = 2:  8f1850df8c38 src/login_nopam.c: from_match(): Use strrspn_() instead of its pattern
```
</details>

<details>
<summary>v1d</summary>

-  Rebase

```
$ git rd 
1:  13befe5ae03a = 1:  d318a743e56d lib/string/strspn/: strr[c]spn(): Return the length counting from the end
2:  8f1850df8c38 = 2:  dd2d8c59a6b7 src/login_nopam.c: from_match(): Use strrspn_() instead of its pattern
```
</details>

<details>
<summary>v2</summary>

-  Document the change in the lib/string/README.

```
$ git rd 
1:  d318a743e56d ! 1:  913a991b0185 lib/string/strspn/: strr[c]spn(): Return the length counting from the end
    @@ Commit message
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    + ## lib/string/README ##
    +@@ lib/string/README: sprintf/ - Formatted string creation
    + strspn/ - String span searching
    + 
    +   Naming conventions:
    +-  -  'r': reverse (search from the end).
    ++  -  'r': rear (search from the end).
    +   -  'c': complement (negate the second argument).
    +   -  'stp': return a pointer instead of a length.
    + 
    +@@ lib/string/README: strspn/ - String span searching
    +   Like strspn(3), but return a pointer instead of an offset.
    +   It is useful for skipping leading white space.
    + 
    +-    strrspn()
    +-  Use stprspn() instead.
    +-  Return the offset of a suffix segment consisting only of
    ++    strrspn_()
    ++  Return the length of a trailing span consisting only of
    +   characters in 'accept'.
    ++  It is useful for determining if a string ends with characters
    ++  in "accept".
    +     stprspn()
    +-  Like strrspn(), but return a pointer instead of an offset.
    ++  Like strrspn(), but return a pointer instead of a length.
    +   It is useful for removing trailing white space.
    + 
    +     strrcspn()
    +   Use stprcspn() instead.
    +-  Return the offset of a suffix segment consisting only of
    ++  Return the length of a trailing span consisting only of
    +   characters not in 'reject'.
    ++  It is useful for determining if a string ends with characters
    ++  not in "reject".
    +     stprcspn()
    +-  Like strrcspn(), but return a pointer instead of an offset.
    ++  Like strrcspn(), but return a pointer instead of a length.
    +   This is rarely useful.  It was useful for implementing
    +   basename().
    + 
    +
      ## lib/string/strspn/stprcspn.h ##
     @@
     -// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
2:  dd2d8c59a6b7 = 2:  658b3cc24f65 src/login_nopam.c: from_match(): Use strrspn_() instead of its pattern
```
</details>