### PR TITLE
lib/nss.c: Verify that lines are complete

### DIFF
--- a/lib/nss.c
+++ b/lib/nss.c
@@ -79,23 +79,23 @@ nss_init(const char *nsswitch_path) {
 	}
 	p = NULL;
 	while (getline(&line, &len, nssfp) != -1) {
+		if (stpsep(line, "\n") == NULL) {
+			fprintf(log_get_logfd(), "%s: Non-text file.\n", nsswitch_path);
+			goto null_subid;
+		}
 		if (strprefix(line, "#"))
 			continue;
-		if (strlen(line) < 8)
+		if (strlen(line) < 7)
 			continue;
 		if (!strcaseprefix(line, "subid:"))
 			continue;
 		p = &line[6];
-		p = stpspn(p, " \t\n");
+		p = stpspn(p, " \t");
 		if (!streq(p, ""))
 			break;
 		p = NULL;
 	}
 	if (p == NULL) {
-		goto null_subid;
-	}
-	if (stpsep(p, "\n") == NULL) {
-		fprintf(log_get_logfd(), "%s: Non-text file.\n", nsswitch_path);
 		goto null_subid;
 	}
 	stpsep(p, " \t");

--- a/lib/nss.c
+++ b/lib/nss.c
@@ -94,11 +94,12 @@ nss_init(const char *nsswitch_path) {
 	if (p == NULL) {
 		goto null_subid;
 	}
-	if (stpsep(p, " \t\n") == NULL) {
+	if (stpsep(p, "\n") == NULL) {
 		fprintf(log_get_logfd(), "No usable subid NSS module found, using files\n");
 		// subid_nss has to be null here, but to ease reviews:
 		goto null_subid;
 	}
+	stpsep(p, " \t");
 	if (streq(p, "files")) {
 		goto null_subid;
 	}

--- a/lib/nss.c
+++ b/lib/nss.c
@@ -95,11 +95,15 @@ nss_init(const char *nsswitch_path) {
 		goto null_subid;
 	}
 	if (stpsep(p, "\n") == NULL) {
+		fprintf(log_get_logfd(), "%s: Non-text file.\n", nsswitch_path);
+		goto null_subid;
+	}
+	stpsep(p, " \t");
+	if (streq(p, "")) {
 		fprintf(log_get_logfd(), "No usable subid NSS module found, using files\n");
 		// subid_nss has to be null here, but to ease reviews:
 		goto null_subid;
 	}
-	stpsep(p, " \t");
 	if (streq(p, "files")) {
 		goto null_subid;
 	}


### PR DESCRIPTION
If a line doesn't have a '\n', this is a problem, and the line should be rejected (ideally, the complete file should be rejected, since the next line would be in fact just part of the current one, but that'll be for another day --or year--).

Also, remove the '\n' during the check (with stpsep()), because we don't want it there when handling the string.

Link: <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap03.html#tag_03_387>

Cc: @YiPrograms

---

Revisions:

<details>
<summary>v2</summary>

-  This was a can of worms.

```
$ git rd 
-:  -------- > 1:  910ec720 lib/nss.c: Fix incorrect handling of white space
1:  1345dc52 ! 2:  5cb096f4 lib/nss.c: Verify that lines are complete
    @@ Commit message
         Also, remove the '\n' during the check (with stpsep()), because we don't
         want it there when handling the string.
     
    +    That stpsep() call had an error message, which I'm not sure what it
    +    really meant.  I've removed it, because I don't know what better to do
    +    with it.
    +
         Link: <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap03.html#tag_03_387>
    +    Cc: Serge Hallyn <serge@hallyn.com>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/nss.c ##
    @@ lib/nss.c: nss_init(const char *nsswitch_path) {
        if (p == NULL) {
                goto null_subid;
        }
    --  if (stpsep(p, " \t\n") == NULL) {
    -+  if (stpsep(p, " \t") == NULL) {
    -           fprintf(log_get_logfd(), "No usable subid NSS module found, using files\n");
    -           // subid_nss has to be null here, but to ease reviews:
    +-  if (stpsep(p, "\n") == NULL) {
    +-          fprintf(log_get_logfd(), "No usable subid NSS module found, using files\n");
    +-          // subid_nss has to be null here, but to ease reviews:
    +-          goto null_subid;
    +-  }
    +   stpsep(p, " \t");
    +   if (streq(p, "files")) {
                goto null_subid;
```
</details>

<details>
<summary>v3</summary>

-  Follow the rabbit.

```
$ git rd 
1:  910ec720 = 1:  910ec720 lib/nss.c: Fix incorrect handling of white space
-:  -------- > 2:  bad7f61b lib/nss.c: Fix error handling
2:  5cb096f4 ! 3:  d075e8b8 lib/nss.c: Verify that lines are complete
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/nss.c: Verify that lines are complete
    +    lib/nss.c: Move '\n' check earlier
     
         If a line doesn't have a '\n', this is a problem, and the line should be
    -    rejected.
    +    rejected, immediately.
     
         Also, remove the '\n' during the check (with stpsep()), because we don't
         want it there when handling the string.
     
    -    That stpsep() call had an error message, which I'm not sure what it
    -    really meant.  I've removed it, because I don't know what better to do
    -    with it.
    -
         Link: <https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap03.html#tag_03_387>
         Cc: Serge Hallyn <serge@hallyn.com>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
    @@ lib/nss.c: nss_init(const char *nsswitch_path) {
        if (p == NULL) {
                goto null_subid;
        }
    --  if (stpsep(p, "\n") == NULL) {
    --          fprintf(log_get_logfd(), "No usable subid NSS module found, using files\n");
    --          // subid_nss has to be null here, but to ease reviews:
    +-  if (stpsep(p, "\n") == NULL)
     -          goto null_subid;
    --  }
        stpsep(p, " \t");
    -   if (streq(p, "files")) {
    -           goto null_subid;
    +   if (streq(p, "")) {
    +           fprintf(log_get_logfd(), "No usable subid NSS module found, using files\n");
```
</details>

<details>
<summary>v4</summary>

-  Report a diagnostic if the file isn't a text file [@lslebodn ]
-  and abort any parsing of the remaining file contents.

```
$ git rd 
1:  910ec720 = 1:  910ec720 lib/nss.c: Fix incorrect handling of white space
2:  bad7f61b ! 2:  1a88265a lib/nss.c: Fix error handling
    @@ Commit message
     
         Rewrite it in the following way:
     
    -    -  If there's not a '\n', the entire line is bogus.  Fail (but without
    -       diagnostic).
    +    -  If there's not a '\n', the entire line is bogus.  Fail, and report an
    +       appropriate diagnostic.
     
         -  Then, break the string at the first white space, as we were doing
            before.  No error handling is appropriate here.
    @@ Commit message
     
      ## lib/nss.c ##
     @@ lib/nss.c: nss_init(const char *nsswitch_path) {
    -   if (p == NULL) {
                goto null_subid;
        }
    --  if (stpsep(p, "\n") == NULL) {
    -+  if (stpsep(p, "\n") == NULL)
    +   if (stpsep(p, "\n") == NULL) {
    ++          fprintf(log_get_logfd(), "%s: Non-text file.\n", nsswitch_path);
     +          goto null_subid;
    ++  }
     +  stpsep(p, " \t");
     +  if (streq(p, "")) {
                fprintf(log_get_logfd(), "No usable subid NSS module found, using files\n");
3:  d075e8b8 ! 3:  79964e8b lib/nss.c: Move '\n' check earlier
    @@ lib/nss.c: nss_init(const char *nsswitch_path) {
        }
        p = NULL;
        while (getline(&line, &len, nssfp) != -1) {
    -+          if (stpsep(line, "\n") == NULL)
    -+                  continue;
    ++          if (stpsep(line, "\n") == NULL) {
    ++                  fprintf(log_get_logfd(), "%s: Non-text file.\n", nsswitch_path);
    ++                  goto null_subid;
    ++          }
                if (strprefix(line, "#"))
                        continue;
     -          if (strlen(line) < 8)
    @@ lib/nss.c: nss_init(const char *nsswitch_path) {
        if (p == NULL) {
                goto null_subid;
        }
    --  if (stpsep(p, "\n") == NULL)
    +-  if (stpsep(p, "\n") == NULL) {
    +-          fprintf(log_get_logfd(), "%s: Non-text file.\n", nsswitch_path);
     -          goto null_subid;
    +-  }
        stpsep(p, " \t");
        if (streq(p, "")) {
                fprintf(log_get_logfd(), "No usable subid NSS module found, using files\n");
```
</details>

<details>
<summary>v4b</summary>

-  Rebase

```
$ git rd 
1:  910ec720 = 1:  1e6087ae lib/nss.c: Fix incorrect handling of white space
2:  1a88265a = 2:  0528c3c2 lib/nss.c: Fix error handling
3:  79964e8b = 3:  81cb1e74 lib/nss.c: Move '\n' check earlier
```
</details>