### PR TITLE
Unconditionally use explicit_bzero(3)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -47,7 +47,7 @@ AC_CHECK_FUNCS([arc4random_buf \
 	updwtmpx innetgr \
 	getspnam_r \
 	rpmatch \
-	memset_explicit explicit_bzero stpecpy seprintf])
+	explicit_bzero stpecpy seprintf])
 AC_SYS_LARGEFILE
 
 dnl Checks for typedefs, structures, and compiler characteristics.

--- a/configure.ac
+++ b/configure.ac
@@ -47,7 +47,7 @@ AC_CHECK_FUNCS([arc4random_buf \
 	updwtmpx innetgr \
 	getspnam_r \
 	rpmatch \
-	explicit_bzero stpecpy seprintf])
+	stpecpy seprintf])
 AC_SYS_LARGEFILE
 
 dnl Checks for typedefs, structures, and compiler characteristics.

--- a/lib/string/memset/memzero.h
+++ b/lib/string/memset/memzero.h
@@ -28,9 +28,7 @@ inline char *strzero(char *s);
 inline void *
 memzero(void *ptr, size_t size)
 {
-#if defined(HAVE_MEMSET_EXPLICIT)
-	memset_explicit(ptr, 0, size);
-#elif defined(HAVE_EXPLICIT_BZERO)
+#if defined(HAVE_EXPLICIT_BZERO)
 	explicit_bzero(ptr, size);
 #else
 	bzero(ptr, size);

--- a/lib/string/memset/memzero.h
+++ b/lib/string/memset/memzero.h
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: 2022-2023, Christian Göttsche <cgzones@googlemail.com>
-// SPDX-FileCopyrightText: 2023-2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-FileCopyrightText: 2023-2026, Alejandro Colomar <alx@kernel.org>
 // SPDX-License-Identifier: BSD-3-Clause
 
 
@@ -11,7 +11,6 @@
 
 #include <stddef.h>
 #include <string.h>
-#include <strings.h>
 
 #include "sizeof.h"
 
@@ -28,12 +27,7 @@ inline char *strzero(char *s);
 inline void *
 memzero(void *ptr, size_t size)
 {
-#if defined(HAVE_EXPLICIT_BZERO)
 	explicit_bzero(ptr, size);
-#else
-	bzero(ptr, size);
-	__asm__ __volatile__ ("" : : "r"(ptr) : "memory");
-#endif
 	return ptr;
 }
 


### PR DESCRIPTION
All systems we care about have explicit_bzero(3), and most don't have memset_explicit() at all.

---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git rd 
1:  165359fd6ec2 ! 1:  2b26dd2b14a6 configure.ac, lib/: Don't use memset_explicit()
    @@ configure.ac: AC_CHECK_FUNCS([arc4random_buf \
        updwtmpx innetgr \
        getspnam_r \
        rpmatch \
    --  memset_explicit explicit_bzero stpecpy stpeprintf])
    -+  explicit_bzero stpecpy stpeprintf])
    +-  memset_explicit explicit_bzero stpecpy seprintf])
    ++  explicit_bzero stpecpy seprintf])
      AC_SYS_LARGEFILE
      
      dnl Checks for typedefs, structures, and compiler characteristics.
2:  e819ba044760 ! 2:  12807d5138ce configure.ac, lib/: Unconditionally use explicit_bzero(3)
    @@ configure.ac: AC_CHECK_FUNCS([arc4random_buf \
        updwtmpx innetgr \
        getspnam_r \
        rpmatch \
    --  explicit_bzero stpecpy stpeprintf])
    -+  stpecpy stpeprintf])
    +-  explicit_bzero stpecpy seprintf])
    ++  stpecpy seprintf])
      AC_SYS_LARGEFILE
      
      dnl Checks for typedefs, structures, and compiler characteristics.
```
</details>

<details>
<summary>v1c</summary>

-  Rebase

```
$ git rd 
1:  2b26dd2b14a6 ! 1:  a80ef751e509 configure.ac, lib/: Don't use memset_explicit()
    @@ configure.ac: AC_CHECK_FUNCS([arc4random_buf \
      
      dnl Checks for typedefs, structures, and compiler characteristics.
     
    - ## lib/string/memset/memzero.h ##
    -@@ lib/string/memset/memzero.h: inline char *strzero(char *s);
    + ## lib/memory/memset/memzero.h ##
    +@@ lib/memory/memset/memzero.h: inline void *memzero(void *ptr, size_t size);
      inline void *
      memzero(void *ptr, size_t size)
      {
2:  12807d5138ce ! 2:  b8e08a0fd308 configure.ac, lib/: Unconditionally use explicit_bzero(3)
    @@ configure.ac: AC_CHECK_FUNCS([arc4random_buf \
      
      dnl Checks for typedefs, structures, and compiler characteristics.
     
    - ## lib/string/memset/memzero.h ##
    -@@
    - // SPDX-FileCopyrightText: 2022-2023, Christian Göttsche <cgzones@googlemail.com>
    --// SPDX-FileCopyrightText: 2023-2024, Alejandro Colomar <alx@kernel.org>
    -+// SPDX-FileCopyrightText: 2023-2026, Alejandro Colomar <alx@kernel.org>
    - // SPDX-License-Identifier: BSD-3-Clause
    - 
    - 
    + ## lib/memory/memset/memzero.h ##
     @@
      
    + #include <memory.h>
      #include <stddef.h>
    - #include <string.h>
     -#include <strings.h>
      
      #include "sizeof.h"
      
    -@@ lib/string/memset/memzero.h: inline char *strzero(char *s);
    +@@ lib/memory/memset/memzero.h: inline void *memzero(void *ptr, size_t size);
      inline void *
      memzero(void *ptr, size_t size)
      {
```
</details>