### PR TITLE
Tests: Add a new user with specified UID and GID

### DIFF
--- a/tests/system/tests/test_useradd.py
+++ b/tests/system/tests/test_useradd.py
@@ -262,3 +262,43 @@ def test_useradd__specified_uid(shadow: Shadow):
     assert group_entry is not None, "Group test1 should be found"
     assert group_entry.name == "test1", "Incorrect group name"
     assert group_entry.gid == 4242, f"Incorrect GID (expected 4242, got {group_entry.gid})"
+
+
+@pytest.mark.topology(KnownTopology.Shadow)
+def test_useradd__two_users_same_ids(shadow: Shadow):
+    """
+    :title: Add two users with same UID and GID
+    :setup:
+        1. Create first user with UID 4242
+        2. Create second user with same UID and GID using -o flag
+    :steps:
+        1. Check passwd entries for both users
+        2. Check group entries for both groups
+    :expectedresults:
+        1. Both users exist in passwd with UID 4242
+        2. First group should have entry with GID 4242, while second group shouldn't exist
+    :customerscenario: False
+    """
+    shadow.useradd("test1 -u 4242")
+
+    shadow.useradd("test2 -u 4242 -g 4242 -o")
+
+    passwd_entry1 = shadow.tools.getent.passwd("test1")
+    assert passwd_entry1 is not None, "User test1 should be found in passwd"
+    assert passwd_entry1.name == "test1", "Incorrect username for test1"
+    assert passwd_entry1.uid == 4242, "test1 should have UID 4242"
+    assert passwd_entry1.gid == 4242, "test1 should have GID 4242"
+
+    passwd_entry2 = shadow.tools.getent.passwd("test2")
+    assert passwd_entry2 is not None, "User test2 should be found in passwd"
+    assert passwd_entry2.name == "test2", "Incorrect username for test2"
+    assert passwd_entry2.uid == 4242, "test2 should have UID 4242"
+    assert passwd_entry2.gid == 4242, "test2 should have GID 4242"
+
+    group_entry1 = shadow.tools.getent.group("test1")
+    assert group_entry1 is not None, "Group test1 should be found"
+    assert group_entry1.name == "test1", "Incorrect group name for test1"
+    assert group_entry1.gid == 4242, "test1 group should have GID 4242"
+
+    group_entry2 = shadow.tools.getent.group("test2")
+    assert group_entry2 is None, "Group test2 should not be found"


### PR DESCRIPTION
This is the transformation to Python of the test located in `tests/usertools/01/04_useradd_specified_UID_and_GID.test`, which checks that `useradd` is able to create a new user with specified uid and gid