### PR TITLE
strchriscntrl: reject C1 control bytes (0x80-0x9F)

### DIFF
--- a/lib/string/ctype/strchrisascii/strchriscntrl.h
+++ b/lib/string/ctype/strchrisascii/strchriscntrl.h
@@ -18,7 +18,10 @@ inline bool strchriscntrl(const char *s);
 
 
 // string character is [:cntrl:]
-// Return true if any iscntrl(3) character is found in the string.
+// Return true if any control character is found in the string.
+// Check both C0 (0x00-0x1F, 0x7F) via iscntrl(3) and C1 (0x80-0x9F)
+// explicitly, since glibc's iscntrl() does not classify C1 bytes as
+// control characters in any locale.
 inline bool
 strchriscntrl(const char *s)
 {
@@ -26,6 +29,8 @@ strchriscntrl(const char *s)
 		unsigned char  c = *s;
 
 		if (iscntrl(c))
+			return true;
+		if (c >= 0x80 && c <= 0x9F)
 			return true;
 	}
 


### PR DESCRIPTION
Shadow's chfn allows C1 control bytes (0x80-0x9F) to be written into GECOS fields in /etc/passwd. The input validation in valid_field() uses iscntrl() via strchriscntrl() to reject control characters, but glibc's iscntrl() does not classify the C1 range as control characters in any locale. The iscntrl() check was added as part of the fix for CVE-2023-29383, which blocked C0 control characters like carriage return, but C1 control bytes were never considered. The C0 range (0x00-0x1F) is correctly rejected, but the C1 range passes through.

The byte 0x9B is the C1 encoding of CSI (Control Sequence Introducer), equivalent to ESC [. On terminals that interpret C1 codes (VTE-based terminals -- GNOME Terminal, Tilix, Terminator, XFCE Terminal, etc.), an attacker can inject cursor movement and SGR sequences into a GECOS field via "chfn -r". This allows visual spoofing of /etc/passwd output -- for example, making a user's UID appear as 0 when viewed with cat. The chfn.c code also contributes to the issue, as it only warns (but does not reject) non-ASCII characters in the name and room fields, so valid_field() returning 1 for non-ASCII does not prevent the write.

This patch adds an explicit check for the 0x80-0x9F range in strchriscntrl(), so that valid_field() returns -1 (rejected) instead of 1 (non-ASCII warning) for these bytes. This causes check_fields() in chfn.c to reject the input and exit, rather than printing a warning and proceeding with the write.

Tested on Shadow 4.17.4-2ubuntu2 (Ubuntu 25.10, passwd package, aarch64) with /usr/bin/chfn as the SUID binary. Before the patch, running "chfn -r" with a payload containing 0x9B bytes exits 0 and writes the C1 bytes into /etc/passwd. After the patch, chfn prints "invalid room number" and exits 1, leaving /etc/passwd unchanged. Legitimate ASCII room numbers are still accepted normally.