### PR TITLE
useradd: Cast terminating NULL in execl call

### DIFF
--- a/src/useradd.c
+++ b/src/useradd.c
@@ -2076,7 +2076,7 @@ static void tallylog_reset (const char *user_name)
 		break;
 	case 0: /* child */
 		pname = Basename(pam_tally2);
-		execl(pam_tally2, pname, "--user", user_name, "--reset", "--quiet", NULL);
+		execl(pam_tally2, pname, "--user", user_name, "--reset", "--quiet", (char *) NULL);
 		/* If we come here, something has gone terribly wrong */
 		perror(pam_tally2);
 		exit(42);       /* don't continue, we now have 2 processes running! */


### PR DESCRIPTION
The execl function takes variadic arguments, which should be cast to a pointer. Even though shadow targets POSIX systems, which require NULL to be (void *)0 instead of just 0, the latter would lead to just 32 bit written into stack with the upper 32 bit being potential junk.

Highly hypothetical defence, after all shadow is for Linux which is POSIX compatible, but stay compatible with execl(3) requirements and other execl calls throughout the tree.