### PR TITLE
usermod: Create shadow entry with -e 0 or -f 0

### DIFF
--- a/src/usermod.c
+++ b/src/usermod.c
@@ -97,6 +97,9 @@
 
 #define VALID(s)  (!strpbrk(s, ":\n"))
 
+/* invalid shadow time indicating missing entry */
+#define MISSING_TIME	-2
+
 /*
  * Structures
  */
@@ -127,10 +130,10 @@ static const char *user_selinux = "";
 static const char *user_selinux_range = NULL;
 #endif				/* WITH_SELINUX */
 static char *user_newshell;
-static long user_expire;
-static long user_newexpire;
-static long user_inactive;
-static long user_newinactive;
+static long user_expire = MISSING_TIME;
+static long user_newexpire = MISSING_TIME;
+static long user_inactive = MISSING_TIME;
+static long user_newinactive = MISSING_TIME;
 static long sys_ngroups;
 static char **user_groups;	/* NULL-terminated list */
 


### PR DESCRIPTION
If -e 0 or -f 0 are supplied but no shadow entry exists, these flags are silently ignored. Internally, the supplied values (0) are compared with static long values which are initially 0 as well. If they are identical, usermod drops the flags.

This does not match usermod's manual page, which states that a missing shadow entry is created. This is also true for any other valid command line values, e.g. -e 1 or -f 1.

Proof of Concept (run as root):
1. Create a temporary directory
```
BASE=$(mktemp -d)
mkdir -p $BASE/etc
```
2. Create a new user
```
useradd -P $BASE user
```
3. Create an empty shadow file
```
touch $BASE/etc/shadow
```
4. Try to disable the user account
```
usermod -P $BASE -e 0 user
```
```
usermod: no changes
```

With this PR applied, a shadow entry is created. You will notice though that the passwd file is not updated, i.e. no `x` password entry is created, which effectively duplicates the hash. But that's a topic for another PR ...