### PR TITLE
useradd, usermod: Gracefully handle sysconf -1 return value

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -262,6 +262,8 @@ libshadow_la_SOURCES = \
 	subordinateio.h \
 	subordinateio.c \
 	sulog.c \
+	sysconf.c \
+	sysconf.h \
 	time/day_to_str.c \
 	time/day_to_str.h \
 	ttytype.c \

--- a/lib/chkname.c
+++ b/lib/chkname.c
@@ -37,27 +37,10 @@
 #include "string/ctype/strisascii/strisdigit.h"
 #include "string/strcmp/streq.h"
 #include "string/strcmp/strcaseeq.h"
-
-
-#ifndef  LOGIN_NAME_MAX
-# define LOGIN_NAME_MAX  256
-#endif
+#include "sysconf.h"
 
 
 int allow_bad_names = false;
-
-
-size_t
-login_name_max_size(void)
-{
-	long  conf;
-
-	conf = sysconf(_SC_LOGIN_NAME_MAX);
-	if (conf == -1)
-		return LOGIN_NAME_MAX;
-
-	return conf;
-}
 
 
 static bool

--- a/lib/chkname.h
+++ b/lib/chkname.h
@@ -24,10 +24,8 @@
 #include "config.h"
 
 #include <stdbool.h>
-#include <stddef.h>
 
 
-extern size_t login_name_max_size(void);
 extern bool is_valid_user_name (const char *name);
 extern bool is_valid_group_name (const char *name);
 

--- a/lib/sysconf.c
+++ b/lib/sysconf.c
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
+// SPDX-FileCopyrightText: 2026, Tobias Stoeckmann <tobias@stoeckmann.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#include "config.h"
+
+#include <limits.h>
+#include <unistd.h>
+
+
+#ifndef  LOGIN_NAME_MAX
+# define LOGIN_NAME_MAX  256
+#endif
+
+#ifndef  NGROUPS_MAX
+# define NGROUPS_MAX  65536
+#endif
+
+
+size_t
+login_name_max_size(void)
+{
+	long  conf;
+
+	conf = sysconf(_SC_LOGIN_NAME_MAX);
+	if (conf == -1)
+		return LOGIN_NAME_MAX;
+
+	return conf;
+}
+
+size_t
+ngroups_max_size(void)
+{
+	long  conf;
+
+	conf = sysconf(_SC_NGROUPS_MAX);
+	if (conf == -1)
+		conf = NGROUPS_MAX;
+
+	return conf;
+}

--- a/lib/sysconf.h
+++ b/lib/sysconf.h
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
+// SPDX-FileCopyrightText: 2026, Tobias Stoeckmann <tobias@stoeckmann.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#ifndef _SYSCONF_H_
+#define _SYSCONF_H_
+
+
+#include "config.h"
+
+#include <stddef.h>
+
+
+extern size_t login_name_max_size(void);
+extern size_t ngroups_max_size(void);
+
+#endif  // include guard

--- a/src/login.c
+++ b/src/login.c
@@ -48,6 +48,7 @@
 #include "string/strdup/strdup.h"
 #include "string/strerrno.h"
 #include "string/strftime.h"
+#include "sysconf.h"
 
 
 #ifdef USE_PAM

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -72,6 +72,7 @@
 #include "string/strdup/strdup.h"
 #include "string/strerrno.h"
 #include "string/strtok/stpsep.h"
+#include "sysconf.h"
 
 
 #ifndef SKEL_DIR
@@ -153,7 +154,7 @@ static bool pw_locked = false;
 static bool gr_locked = false;
 static bool spw_locked = false;
 static char **user_groups;	/* NULL-terminated list */
-static long sys_ngroups;
+static size_t sys_ngroups;
 static bool do_grp_update = false;	/* group files need to be updated */
 
 extern int allow_bad_names;
@@ -220,10 +221,6 @@ static bool home_added = false;
 #define DCREATE_MAIL_SPOOL	"CREATE_MAIL_SPOOL"
 #define DBTRFS_SUBVOLUME_HOME	"BTRFS_SUBVOLUME_HOME"
 #define DLOG_INIT		"LOG_INIT"
-
-#ifndef NGROUPS_MAX
-#define NGROUPS_MAX		65536
-#endif
 
 /* local function prototypes */
 NORETURN static void fail_exit (int, bool);
@@ -764,7 +761,7 @@ static int get_groups(char *list, const struct option_flags *flags)
 {
 	struct group *grp;
 	bool errors = false;
-	int ngroups = 0;
+	size_t ngroups = 0;
 	bool process_selinux;
 
 	process_selinux = !flags->chroot && !flags->prefix;
@@ -825,7 +822,7 @@ static int get_groups(char *list, const struct option_flags *flags)
 
 		if (ngroups == sys_ngroups) {
 			fprintf (stderr,
-			         _("%s: too many groups specified (max %d).\n"),
+			         _("%s: too many groups specified (max %zu).\n"),
 			         Prog, ngroups);
 			gr_free(grp);
 			break;
@@ -2532,9 +2529,7 @@ int main (int argc, char **argv)
 	audit_help_open ();
 #endif
 
-	sys_ngroups = sysconf (_SC_NGROUPS_MAX);
-	if (sys_ngroups == -1)
-		sys_ngroups = NGROUPS_MAX;
+	sys_ngroups = ngroups_max_size();
 	user_groups = xmalloc_T(1 + sys_ngroups, char *);
 	/*
 	 * Initialize the list to be empty

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -66,6 +66,7 @@
 #include "string/strdup/strdup.h"
 #include "string/strerrno.h"
 #include "string/strspn/stprspn.h"
+#include "sysconf.h"
 #include "time/day_to_str.h"
 #include "typetraits.h"
 
@@ -99,10 +100,6 @@
 
 /* invalid shadow time indicating missing entry */
 #define MISSING_TIME	-2
-
-#ifndef NGROUPS_MAX
-#define NGROUPS_MAX		65536
-#endif
 
 /*
  * Structures
@@ -138,7 +135,7 @@ static long user_expire = MISSING_TIME;
 static long user_newexpire = MISSING_TIME;
 static long user_inactive = MISSING_TIME;
 static long user_newinactive = MISSING_TIME;
-static long sys_ngroups;
+static size_t sys_ngroups;
 static char **user_groups;	/* NULL-terminated list */
 
 static const char* prefix = "";
@@ -238,7 +235,7 @@ static int get_groups (char *list)
 {
 	struct group *grp;
 	bool errors = false;
-	int ngroups = 0;
+	size_t ngroups = 0;
 
 	/*
 	 * Initialize the list to be empty
@@ -288,7 +285,7 @@ static int get_groups (char *list)
 
 		if (ngroups == sys_ngroups) {
 			fprintf (stderr,
-			         _("%s: too many groups specified (max %d).\n"),
+			         _("%s: too many groups specified (max %zu).\n"),
 			         Prog, ngroups);
 			gr_free (grp);
 			break;
@@ -2206,9 +2203,7 @@ int main (int argc, char **argv)
 	audit_help_open ();
 #endif
 
-	sys_ngroups = sysconf (_SC_NGROUPS_MAX);
-	if (sys_ngroups == -1)
-		sys_ngroups = NGROUPS_MAX;
+	sys_ngroups = ngroups_max_size();
 	user_groups = xmalloc_T(sys_ngroups + 1, char *);
 	user_groups[0] = NULL;
 

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -65,6 +65,7 @@ test_chkhash_LDADD = \
 
 test_chkname_SOURCES = \
     ../../lib/chkname.c \
+    ../../lib/sysconf.c \
     test_chkname.c \
     $(NULL)
 test_chkname_CFLAGS = \


### PR DESCRIPTION
If sysconf returns -1, use predefined upper limit from `linux/limits.h`. If it's not defined, use a sane default value.

This avoids potenial out of boundary writes into a 0 byte allocated buffer.