### PR TITLE
Tests: Add a new user with a specified non-existing gid

### DIFF
--- a/tests/system/tests/test_useradd.py
+++ b/tests/system/tests/test_useradd.py
@@ -328,3 +328,35 @@ def test_useradd__add_user_with_existing_uid(shadow: Shadow):
         shadow.useradd("test2 -u 4242")
 
     assert exc_info.value.rc == 4, f"Expected return code 4 (UID already in use), got {exc_info.value.rc}"
+
+
+@pytest.mark.topology(KnownTopology.Shadow)
+def test_useradd__invalid_numeric_primary_group(shadow: Shadow):
+    """
+    :title: Add a new user with a specified non-existing gid
+    :steps:
+        1. Attempt to create user with -g 4242 option
+        2. Verify command fails with appropriate error code and message
+        3. Check passwd and group entries
+        4. Check home directory
+    :expectedresults:
+        1. Useradd command fails
+        2. Return code is 6 (specified group doesn't exist) and error message indicates group doesn't exist
+        3. No entries are added to passwd and group
+        4. No home directory is created
+    :customerscenario: False
+    """
+    with pytest.raises(ProcessError) as exc_info:
+        shadow.useradd("test1 -g 4242")
+
+    actual_rc = getattr(exc_info.value, "rc", getattr(exc_info.value, "returncode", None))
+    assert actual_rc == 6, f"Expected return code 6 (specified group doesn't exist), got {actual_rc}"
+
+    error_output = exc_info.value.stderr.lower() if exc_info.value.stderr else ""
+    assert (
+        "group" in error_output and "does not exist" in error_output
+    ), f"Error message should indicate group doesn't exist. Got: {error_output}"
+
+    assert shadow.tools.getent.passwd("test1") is None, "User test1 should not be found in passwd"
+    assert shadow.tools.getent.group("test1") is None, "Group test1 should not be found"
+    assert not shadow.fs.exists("/home/test1"), "Home directory should not be created"


### PR DESCRIPTION
This is the transformation to Python of the test located in `tests/usertools/01/05_useradd_invalid_numeric_primary_group.test`, which checks that `useradd` fails to create a new user with non-existing group