### PR TITLE
usermod: Update passwd entry when shadowing entry

### DIFF
--- a/src/usermod.c
+++ b/src/usermod.c
@@ -1807,7 +1807,7 @@ static void usr_update(const struct option_flags *flags)
 	}
 
 	if (lflg || uflg || gflg || cflg || dflg || sflg || pflg
-	    || Lflg || Uflg) {
+	    || Lflg || Uflg || spwd == &spent) {
 		if (pw_update (&pwent) == 0) {
 			fprintf (stderr,
 			         _("%s: failed to prepare the new %s entry '%s'\n"),


### PR DESCRIPTION
If a new shadow entry is created, the passwd entry's password hash is moved and replaced with an `x`. If this happens, update the passwd file as well, otherwise the `x` is not written to disk.

Resolves: https://github.com/shadow-maint/shadow/issues/1580

Proof of Concept (run as root):
1. Create a temporary directory
```
BASE=$(mktemp -d)
mkdir -p $BASE/etc
```
2. Create a new user
```
useradd -P $BASE user
```
3. Create an empty shadow file
```
touch $BASE/etc/shadow
```
4. Disable the user account
```
usermod -P $BASE -e 0 user
```
5. Check content of passwd file
```
cat $BASE/etc/passwd
```
```
user:!:1000:1000::/home/user:/bin/bash
```

It should be `x` instead of `!`, since a new shadow file was created:
```
cat $BASE/etc/shadow
```
```
user:!:20527:::::0:
```