### PR TITLE
Use countof() where appropriate, and do it implicitly where possible

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -197,6 +197,8 @@ libshadow_la_SOURCES = \
 	string/ctype/isascii.h \
 	string/ctype/toascii.c \
 	string/ctype/toascii.h \
+	string/memset/bzero.c \
+	string/memset/bzero.h \
 	string/memset/memzero.c \
 	string/memset/memzero.h \
 	string/sprintf/aprintf.c \

--- a/lib/audit_help.c
+++ b/lib/audit_help.c
@@ -25,7 +25,9 @@
 #include "attr.h"
 #include "prototypes.h"
 #include "shadowlog.h"
+#include "sizeof.h"
 #include "string/sprintf/stprintf.h"
+
 
 int audit_fd;
 
@@ -102,7 +104,7 @@ audit_logger_with_group(int type, const char *op, const char *name,
 	if (audit_fd < 0)
 		return;
 
-	len = strnlen(grp, sizeof(enc_group)/2);
+	len = strnlen(grp, countof(enc_group)/2);
 	if (audit_value_needs_encoding(grp, len)) {
 		stprintf_a(buf, "%s %s=%s", op, grp_type,
 			audit_encode_value(enc_group, grp, len));

--- a/lib/commonio.c
+++ b/lib/commonio.c
@@ -32,6 +32,7 @@
 #endif				/* WITH_TCB */
 #include "prototypes.h"
 #include "shadowlog.h"
+#include "sizeof.h"
 #include "sssd.h"
 #include "string/memset/memzero.h"
 #include "string/sprintf/aprintf.h"
@@ -147,7 +148,7 @@ static int do_lock_file (const char *file, const char *lock, bool log)
 		errno = EINVAL;
 		return 0;
 	}
-	len = read(fd, buf, sizeof(buf) - 1);
+	len = read(fd, buf, sizeof_a(buf) - 1);
 	close (fd);
 	if (len <= 0) {
 		if (log) {

--- a/lib/copydir.c
+++ b/lib/copydir.c
@@ -31,6 +31,7 @@
 #include <acl/libacl.h>
 #endif				/* WITH_ACL */
 #include "shadowlog.h"
+#include "sizeof.h"
 #include "string/sprintf/aprintf.h"
 #include "string/strcmp/streq.h"
 #include "string/strcmp/strprefix.h"
@@ -681,7 +682,7 @@ static int copy_file (const struct path_info *src, const struct path_info *dst,
 		char buf[8192];
 		ssize_t cnt;
 
-		cnt = read(ifd, buf, sizeof(buf));
+		cnt = read(ifd, buf, sizeof_a(buf));
 		if (cnt < 0) {
 			if (errno == EINTR) {
 				continue;

--- a/lib/env.c
+++ b/lib/env.c
@@ -18,6 +18,7 @@
 #include "prototypes.h"
 #include "defines.h"
 #include "shadowlog.h"
+#include "sizeof.h"
 #include "string/sprintf/aprintf.h"
 #include "string/sprintf/stprintf.h"
 #include "string/strcmp/strprefix.h"
@@ -163,7 +164,7 @@ void set_env (int argc, char *const *argv)
 	char  *cp;
 
 	for (; argc > 0; argc--, argv++) {
-		if (strlen(*argv) >= sizeof(variable)) {
+		if (strlen(*argv) >= countof(variable)) {
 			continue;	/* ignore long entries */
 		}
 

--- a/lib/fields.c
+++ b/lib/fields.c
@@ -59,10 +59,10 @@ valid_field_(const char *field, const char *illegal)
  * current value.
  */
 void
-change_field(char *buf, size_t maxsize, const char *prompt)
+change_field(char *buf, size_t n, const char *prompt)
 {
 	char *cp;
-	char  newf[MIN(200, maxsize)];
+	char  newf[MIN(200, n)];
 
 	printf ("\t%s [%s]: ", prompt, buf);
 	(void) fflush (stdout);

--- a/lib/fields.h
+++ b/lib/fields.h
@@ -11,10 +11,11 @@
 
 
 #define valid_field(field, illegal)  valid_field_(field, "" illegal "")
+#define change_field_a(buf, prompt)  change_field(buf, countof(buf), prompt)
 
 
 int valid_field_(const char *field, const char *illegal);
-void change_field(char *buf, size_t maxsize, const char *prompt);
+void change_field(char *buf, size_t n, const char *prompt);
 
 
 #endif  // include guard

--- a/lib/idmapping.c
+++ b/lib/idmapping.c
@@ -161,7 +161,7 @@ void write_mapping(int proc_dir_fd, int ranges, const struct map_range *mappings
 	}
 
 	/* Lockdown new{g,u}idmap by dropping all unneeded capabilities. */
-	bzero(data, sizeof(data));
+	bzero(data, sizeof_a(data));
 	data[0].effective = CAP_TO_MASK(cap);
 	/*
 	 * When uid 0 from the ancestor userns is supposed to be mapped into

--- a/lib/idmapping.c
+++ b/lib/idmapping.c
@@ -28,6 +28,7 @@
 #include "prototypes.h"
 #include "shadowlog.h"
 #include "sizeof.h"
+#include "string/memset/bzero.h"
 #include "string/sprintf/seprintf.h"
 #include "string/strcmp/streq.h"
 
@@ -161,7 +162,7 @@ void write_mapping(int proc_dir_fd, int ranges, const struct map_range *mappings
 	}
 
 	/* Lockdown new{g,u}idmap by dropping all unneeded capabilities. */
-	bzero(data, sizeof_a(data));
+	bzero_a(data);
 	data[0].effective = CAP_TO_MASK(cap);
 	/*
 	 * When uid 0 from the ancestor userns is supposed to be mapped into

--- a/lib/loginprompt.c
+++ b/lib/loginprompt.c
@@ -18,6 +18,7 @@
 #include "getdef.h"
 #include "io/fgets/fgets.h"
 #include "prototypes.h"
+#include "sizeof.h"
 #include "string/memset/memzero.h"
 #include "string/strcpy/strtcpy.h"
 #include "string/strspn/stpspn.h"
@@ -73,7 +74,7 @@ login_prompt(char *name, int namesize)
 			(void) fclose (fp);
 		}
 	}
-	(void) gethostname(buf, sizeof(buf));
+	(void) gethostname(buf, countof(buf));
 	printf (_("\n%s login: "), buf);
 	(void) fflush (stdout);
 

--- a/lib/pwauth.c
+++ b/lib/pwauth.c
@@ -21,9 +21,10 @@
 
 #include "agetpass.h"
 #include "defines.h"
+#include "getdef.h"
 #include "prototypes.h"
 #include "pwauth.h"
-#include "getdef.h"
+#include "sizeof.h"
 #include "string/memset/memzero.h"
 #include "string/sprintf/stprintf.h"
 #include "string/strcmp/streq.h"
@@ -89,7 +90,7 @@ pw_auth(const char *cipher, const char *user)
 	 * Some BSD updates to the S/KEY API adds a fourth parameter; the
 	 * sizeof of the challenge info buffer.
 	 */
-#  define skeychallenge(s,u,c) skeychallenge(s,u,c,sizeof(c))
+#  define skeychallenge(s,u,c) skeychallenge(s,u,c,countof(c))
 # endif
 
 	if (skeychallenge (&skey, user, challenge_info) == 0) {

--- a/lib/salt.c
+++ b/lib/salt.c
@@ -351,7 +351,7 @@ static /*@observer@*/const char *gensalt (size_t salt_size)
 	const char *method;
 	unsigned long rounds = 0;
 
-	bzero(result, GENSALT_SETTING_SIZE);
+	bzero(result, countof(result));
 
 	method = meth ?: getdef_str("ENCRYPT_METHOD") ?: "SHA512";
 

--- a/lib/salt.c
+++ b/lib/salt.c
@@ -23,6 +23,7 @@
 #include "getdef.h"
 #include "prototypes.h"
 #include "shadowlog.h"
+#include "string/memset/bzero.h"
 #include "string/sprintf/stprintf.h"
 #include "string/strcmp/streq.h"
 
@@ -316,7 +317,7 @@ static /*@observer@*/const char *gensalt (size_t salt_size)
 {
 	static char salt[MAX_SALT_SIZE + 6];
 
-	bzero(salt, MAX_SALT_SIZE + 6);
+	bzero_a(salt);
 
 	assert (salt_size >= MIN_SALT_SIZE &&
 	        salt_size <= MAX_SALT_SIZE);
@@ -351,7 +352,7 @@ static /*@observer@*/const char *gensalt (size_t salt_size)
 	const char *method;
 	unsigned long rounds = 0;
 
-	bzero(result, countof(result));
+	bzero_a(result);
 
 	method = meth ?: getdef_str("ENCRYPT_METHOD") ?: "SHA512";
 

--- a/lib/shadow/passwd/sgetpwent.c
+++ b/lib/shadow/passwd/sgetpwent.c
@@ -19,6 +19,7 @@
 #include "atoi/getnum.h"
 #include "defines.h"
 #include "prototypes.h"
+#include "sizeof.h"
 #include "string/strcmp/streq.h"
 #include "string/strtok/stpsep.h"
 #include "string/strtok/strsep2arr.h"

--- a/lib/sizeof.h
+++ b/lib/sizeof.h
@@ -27,6 +27,7 @@
 
 // sizeof_a - sizeof array
 #define sizeof_a(a)          (countof(a) * sizeof((a)[0]))
+#define endof(a)             (&(a)[countof(a)])
 #define STRLEN(s)            (countof("" s "") - 1)
 
 

--- a/lib/string/README
+++ b/lib/string/README
@@ -94,6 +94,9 @@ ctype/ - Character classification and conversion functions
 
 memset/ - Memory zeroing
 
+    bzero_a()
+	Like bzero(3), but takes an array.
+
     memzero()
 	Synonym of explicit_bzero(3).
     memzero_a()

--- a/lib/string/memset/bzero.c
+++ b/lib/string/memset/bzero.c
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#include "config.h"
+
+#include "string/memset/bzero.h"

--- a/lib/string/memset/bzero.h
+++ b/lib/string/memset/bzero.h
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
+
+#ifndef SHADOW_INCLUDE_LIB_STRING_MEMSET_BZERO_H_
+#define SHADOW_INCLUDE_LIB_STRING_MEMSET_BZERO_H_
+
+
+#include "config.h"
+
+#include <strings.h>
+
+#include "sizeof.h"
+
+
+// bzero_a - byte zero array
+#define bzero_a(a)  bzero(a, sizeof_a(a))
+
+
+#endif  // include guard

--- a/lib/subordinateio.c
+++ b/lib/subordinateio.c
@@ -26,6 +26,7 @@
 #include "atoi/a2i.h"
 #include "atoi/getnum.h"
 #include "shadow/passwd/getpw.h"
+#include "sizeof.h"
 #include "string/ctype/isascii.h"
 #include "string/sprintf/stprintf.h"
 #include "string/strcmp/streq.h"
@@ -100,7 +101,7 @@ subordinate_parse(const char *line)
 	 * Copy the string to a temporary buffer so the substrings can
 	 * be modified to be NULL terminated.
 	 */
-	if (strlen(line) >= sizeof(rangebuf))
+	if (strlen(line) >= countof(rangebuf))
 		return NULL;	/* fail if too long */
 	strcpy (rangebuf, line);
 

--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -302,7 +302,7 @@ prepare_utmp(const char *name, const char *line, const char *host,
 #endif
 #if defined(HAVE_STRUCT_UTMPX_UT_SYSLEN)
 		utent->ut_syslen = MIN(strlen(hostname),
-		                       sizeof(utent->ut_host));
+		                       countof(utent->ut_host));
 #endif
 #if defined(HAVE_STRUCT_UTMPX_UT_ADDR) || defined(HAVE_STRUCT_UTMPX_UT_ADDR_V6)
 		if (getaddrinfo (hostname, NULL, NULL, &info) == 0) {

--- a/src/chage.c
+++ b/src/chage.c
@@ -29,6 +29,7 @@
 #include "pwio.h"
 #include "shadowio.h"
 #include "shadowlog.h"
+#include "sizeof.h"
 #include "string/memset/memzero.h"
 #include "string/sprintf/stprintf.h"
 #include "string/strcmp/streq.h"
@@ -167,7 +168,7 @@ static int new_fields (void)
 	(void) puts ("");
 
 	stprintf_a(buf, "%ld", maxdays);
-	change_field(buf, sizeof(buf), _("Maximum Password Age"));
+	change_field(buf, countof(buf), _("Maximum Password Age"));
 	if (a2sl(&maxdays, buf, NULL, 0, -1, LONG_MAX) == -1)
 		return 0;
 
@@ -176,7 +177,7 @@ static int new_fields (void)
 	else
 		day_to_str_a(buf, lstchgdate);
 
-	change_field(buf, sizeof(buf), _("Last Password Change (YYYY-MM-DD)"));
+	change_field(buf, countof(buf), _("Last Password Change (YYYY-MM-DD)"));
 
 	if (streq(buf, "-1")) {
 		lstchgdate = -1;
@@ -188,12 +189,12 @@ static int new_fields (void)
 	}
 
 	stprintf_a(buf, "%ld", warndays);
-	change_field(buf, sizeof(buf), _("Password Expiration Warning"));
+	change_field(buf, countof(buf), _("Password Expiration Warning"));
 	if (a2sl(&warndays, buf, NULL, 0, -1, LONG_MAX) == -1)
 		return 0;
 
 	stprintf_a(buf, "%ld", inactdays);
-	change_field(buf, sizeof(buf), _("Password Inactive"));
+	change_field(buf, countof(buf), _("Password Inactive"));
 	if (a2sl(&inactdays, buf, NULL, 0, -1, LONG_MAX) == -1)
 		return 0;
 
@@ -202,7 +203,7 @@ static int new_fields (void)
 	else
 		day_to_str_a(buf, expdate);
 
-	change_field(buf, sizeof(buf),
+	change_field(buf, countof(buf),
 	              _("Account Expiration Date (YYYY-MM-DD)"));
 
 	if (streq(buf, "-1")) {

--- a/src/chage.c
+++ b/src/chage.c
@@ -168,7 +168,7 @@ static int new_fields (void)
 	(void) puts ("");
 
 	stprintf_a(buf, "%ld", maxdays);
-	change_field(buf, countof(buf), _("Maximum Password Age"));
+	change_field_a(buf, _("Maximum Password Age"));
 	if (a2sl(&maxdays, buf, NULL, 0, -1, LONG_MAX) == -1)
 		return 0;
 
@@ -177,7 +177,7 @@ static int new_fields (void)
 	else
 		day_to_str_a(buf, lstchgdate);
 
-	change_field(buf, countof(buf), _("Last Password Change (YYYY-MM-DD)"));
+	change_field_a(buf, _("Last Password Change (YYYY-MM-DD)"));
 
 	if (streq(buf, "-1")) {
 		lstchgdate = -1;
@@ -189,12 +189,12 @@ static int new_fields (void)
 	}
 
 	stprintf_a(buf, "%ld", warndays);
-	change_field(buf, countof(buf), _("Password Expiration Warning"));
+	change_field_a(buf, _("Password Expiration Warning"));
 	if (a2sl(&warndays, buf, NULL, 0, -1, LONG_MAX) == -1)
 		return 0;
 
 	stprintf_a(buf, "%ld", inactdays);
-	change_field(buf, countof(buf), _("Password Inactive"));
+	change_field_a(buf, _("Password Inactive"));
 	if (a2sl(&inactdays, buf, NULL, 0, -1, LONG_MAX) == -1)
 		return 0;
 
@@ -203,8 +203,7 @@ static int new_fields (void)
 	else
 		day_to_str_a(buf, expdate);
 
-	change_field(buf, countof(buf),
-	              _("Account Expiration Date (YYYY-MM-DD)"));
+	change_field_a(buf, _("Account Expiration Date (YYYY-MM-DD)"));
 
 	if (streq(buf, "-1")) {
 		expdate = -1;

--- a/src/chfn.c
+++ b/src/chfn.c
@@ -181,32 +181,31 @@ static void new_fields (void)
 	puts (_("Enter the new value, or press ENTER for the default"));
 
 	if (may_change_field ('f')) {
-		change_field(fullnm, countof(fullnm), _("Full Name"));
+		change_field_a(fullnm, _("Full Name"));
 	} else {
 		printf (_("\t%s: %s\n"), _("Full Name"), fullnm);
 	}
 
 	if (may_change_field ('r')) {
-		change_field(roomno, countof(roomno), _("Room Number"));
+		change_field_a(roomno, _("Room Number"));
 	} else {
 		printf (_("\t%s: %s\n"), _("Room Number"), roomno);
 	}
 
 	if (may_change_field ('w')) {
-		change_field(workph, countof(workph), _("Work Phone"));
+		change_field_a(workph, _("Work Phone"));
 	} else {
 		printf (_("\t%s: %s\n"), _("Work Phone"), workph);
 	}
 
 	if (may_change_field ('h')) {
-		change_field(homeph, countof(homeph), _("Home Phone"));
+		change_field_a(homeph, _("Home Phone"));
 	} else {
 		printf (_("\t%s: %s\n"), _("Home Phone"), homeph);
 	}
 
-	if (amroot) {
-		change_field(slop, countof(slop), _("Other"));
-	}
+	if (amroot)
+		change_field_a(slop, _("Other"));
 }
 
 /*

--- a/src/chfn.c
+++ b/src/chfn.c
@@ -181,31 +181,31 @@ static void new_fields (void)
 	puts (_("Enter the new value, or press ENTER for the default"));
 
 	if (may_change_field ('f')) {
-		change_field(fullnm, sizeof(fullnm), _("Full Name"));
+		change_field(fullnm, countof(fullnm), _("Full Name"));
 	} else {
 		printf (_("\t%s: %s\n"), _("Full Name"), fullnm);
 	}
 
 	if (may_change_field ('r')) {
-		change_field(roomno, sizeof(roomno), _("Room Number"));
+		change_field(roomno, countof(roomno), _("Room Number"));
 	} else {
 		printf (_("\t%s: %s\n"), _("Room Number"), roomno);
 	}
 
 	if (may_change_field ('w')) {
-		change_field(workph, sizeof(workph), _("Work Phone"));
+		change_field(workph, countof(workph), _("Work Phone"));
 	} else {
 		printf (_("\t%s: %s\n"), _("Work Phone"), workph);
 	}
 
 	if (may_change_field ('h')) {
-		change_field(homeph, sizeof(homeph), _("Home Phone"));
+		change_field(homeph, countof(homeph), _("Home Phone"));
 	} else {
 		printf (_("\t%s: %s\n"), _("Home Phone"), homeph);
 	}
 
 	if (amroot) {
-		change_field(slop, sizeof(slop), _("Other"));
+		change_field(slop, countof(slop), _("Other"));
 	}
 }
 

--- a/src/chsh.c
+++ b/src/chsh.c
@@ -125,7 +125,7 @@ usage (int status)
 static void new_fields (void)
 {
 	puts (_("Enter the new value, or press ENTER for the default"));
-	change_field(loginsh, countof(loginsh), _("Login Shell"));
+	change_field_a(loginsh, _("Login Shell"));
 }
 
 /*

--- a/src/chsh.c
+++ b/src/chsh.c
@@ -32,6 +32,7 @@
 #include "pam_defs.h"
 #endif
 #include "shadowlog.h"
+#include "sizeof.h"
 #include "sssd.h"
 #include "string/strcmp/streq.h"
 #include "string/strcpy/strtcpy.h"
@@ -124,7 +125,7 @@ usage (int status)
 static void new_fields (void)
 {
 	puts (_("Enter the new value, or press ENTER for the default"));
-	change_field(loginsh, sizeof(loginsh), _("Login Shell"));
+	change_field(loginsh, countof(loginsh), _("Login Shell"));
 }
 
 /*

--- a/src/login.c
+++ b/src/login.c
@@ -40,6 +40,7 @@
 #include "pwauth.h"
 #include "shadow/gshadow/endsgent.h"
 #include "shadowlog.h"
+#include "sizeof.h"
 #include "string/memset/memzero.h"
 #include "string/sprintf/stprintf.h"
 #include "string/strcmp/streq.h"
@@ -645,7 +646,7 @@ int main (int argc, char **argv)
 		unsigned int  failcount = 0;
 
 		/* Make the login prompt look like we want it */
-		if (gethostname(hostn, sizeof(hostn)) == 0) {
+		if (gethostname(hostn, countof(hostn)) == 0) {
 			stprintf_a(loginprompt, _("%s login: "), hostn);
 		} else {
 			strtcpy_a(loginprompt, _("login: "));

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -183,7 +183,7 @@ static char *myhostname (void)
 	static char name[MAXHOSTNAMELEN + 1] = "";
 
 	if (streq(name, "")) {
-		gethostname(name, sizeof(name));
+		gethostname(name, countof(name));
 		stpcpy(&name[MAXHOSTNAMELEN], "");
 	}
 	return (name);

--- a/src/newgidmap.c
+++ b/src/newgidmap.c
@@ -20,6 +20,7 @@
 #include "io/fprintf.h"
 #include "prototypes.h"
 #include "shadowlog.h"
+#include "sizeof.h"
 #include "string/strcmp/strprefix.h"
 #include "subordinateio.h"
 
@@ -112,7 +113,7 @@ static void write_setgroups(int proc_dir_fd, bool allow_setgroups)
 	 * is write-once, so attempting to write after it's already written to will
 	 * fail.
 	 */
-	if (read(setgroups_fd, policy_buffer, sizeof(policy_buffer)) < 0) {
+	if (read(setgroups_fd, policy_buffer, sizeof_a(policy_buffer)) < 0) {
 		eprinte(_("%s: failed to read setgroups"), Prog);
 		exit(EXIT_FAILURE);
 	}


### PR DESCRIPTION
This improves bounds safety by using countof(3) where appropriate, and doing it implicitly where possible.

Cc: @kees, @uecker 

---

Revisions:

<details>
<summary>v1b</summary>

-  Update lib/string/README.

```
$ git rd 
1:  91814a70 = 1:  91814a70 lib/, src/, tests/: Use countof() or sizeof_a() where appropriate
2:  35962749 = 2:  35962749 lib/salt.c: crypt_make_salt(): Use countof() instead of a hardcoded value
3:  b53f7325 = 3:  b53f7325 lib/sizeof.h: endof(): Add macro
4:  f355a1b4 = 4:  f355a1b4 lib/fields.[ch]: change_field_a(): Add macro
5:  cd6d3c42 = 5:  cd6d3c42 src/: Use change_field_a() instead of its pattern
6:  39e963ed ! 6:  b5e41a06 lib/string/memset/: bzero_a(): Add macro
    @@ lib/Makefile.am: libshadow_la_SOURCES = \
        string/memset/memzero.h \
        string/sprintf/aprintf.c \
     
    + ## lib/string/README ##
    +@@ lib/string/README: ctype/ - Character classification and conversion functions
    + 
    + memset/ - Memory zeroing
    + 
    ++    bzero_a()
    ++  Like bzero(3), but takes an array.
    ++
    +     memzero()
    +   Synonym of explicit_bzero(3).
    +     memzero_a()
    +
      ## lib/string/memset/bzero.c (new) ##
     @@
     +// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
7:  b02d91a9 = 7:  210f91ef lib/: Use bzero_a() instead of its pattern
8:  077542bd = 8:  dd2262a8 lib/audit_help.c: Use countof() instead of sizeof()
```
</details>

<details>
<summary>v2</summary>

-  Consistently use sizeof_a() with read(2).

```
$ git rd 
1:  91814a70 ! 1:  580ccf69 lib/, src/, tests/: Use countof() or sizeof_a() where appropriate
    @@ src/newgidmap.c: static void write_setgroups(int proc_dir_fd, bool allow_setgrou
         * fail.
         */
     -  if (read(setgroups_fd, policy_buffer, sizeof(policy_buffer)) < 0) {
    -+  if (read(setgroups_fd, policy_buffer, countof(policy_buffer)) < 0) {
    ++  if (read(setgroups_fd, policy_buffer, sizeof_a(policy_buffer)) < 0) {
                fprintf(stderr, _("%s: failed to read setgroups: %s\n"),
                        Prog, strerrno());
                exit(EXIT_FAILURE);
2:  35962749 = 2:  3805154d lib/salt.c: crypt_make_salt(): Use countof() instead of a hardcoded value
3:  b53f7325 = 3:  aa6a3dcd lib/sizeof.h: endof(): Add macro
4:  f355a1b4 = 4:  d29e1cac lib/fields.[ch]: change_field_a(): Add macro
5:  cd6d3c42 = 5:  524beee5 src/: Use change_field_a() instead of its pattern
6:  b5e41a06 = 6:  2d4f61d4 lib/string/memset/: bzero_a(): Add macro
7:  210f91ef = 7:  68da424c lib/: Use bzero_a() instead of its pattern
8:  dd2262a8 = 8:  8ae2c113 lib/audit_help.c: Use countof() instead of sizeof()
```
</details>

<details>
<summary>v2b</summary>

-  Rebase


```
$ git rd 
1:  580ccf69 ! 1:  5b876d74 lib/, src/, tests/: Use countof() or sizeof_a() where appropriate
    @@ lib/shadow/passwd/sgetpwent.c
     
      ## lib/subordinateio.c ##
     @@
    - #include "alloc/malloc.h"
    - #include "alloc/reallocf.h"
      #include "atoi/a2i.h"
    + #include "atoi/getnum.h"
    + #include "shadow/passwd/getpw.h"
     +#include "sizeof.h"
      #include "string/ctype/strisascii/strisdigit.h"
      #include "string/sprintf/snprintf.h"
2:  3805154d = 2:  47998f8e lib/salt.c: crypt_make_salt(): Use countof() instead of a hardcoded value
3:  aa6a3dcd = 3:  7403f8a7 lib/sizeof.h: endof(): Add macro
4:  d29e1cac = 4:  ddc4c557 lib/fields.[ch]: change_field_a(): Add macro
5:  524beee5 = 5:  2d445619 src/: Use change_field_a() instead of its pattern
6:  2d4f61d4 = 6:  d41e8f8b lib/string/memset/: bzero_a(): Add macro
7:  68da424c = 7:  f7fcf073 lib/: Use bzero_a() instead of its pattern
8:  8ae2c113 = 8:  d401c9c7 lib/audit_help.c: Use countof() instead of sizeof()
```
</details>

<details>
<summary>v2c</summary>

-  Rebase

```
$ git rd 
1:  5b876d74 ! 1:  a55ef44c lib/, src/, tests/: Use countof() or sizeof_a() where appropriate
    @@ lib/env.c
      #include "shadowlog.h"
     +#include "sizeof.h"
      #include "string/sprintf/aprintf.h"
    - #include "string/sprintf/snprintf.h"
    - #include "string/sprintf/aprintf.h"
    + #include "string/sprintf/stprintf.h"
    + #include "string/strcmp/strprefix.h"
     @@ lib/env.c: void set_env (int argc, char *const *argv)
        char  *cp;
      
    @@ lib/pwauth.c
     -#include "getdef.h"
     +#include "sizeof.h"
      #include "string/memset/memzero.h"
    - #include "string/sprintf/snprintf.h"
    + #include "string/sprintf/stprintf.h"
      #include "string/strcmp/streq.h"
     @@ lib/pwauth.c: pw_auth(const char *cipher, const char *user)
         * Some BSD updates to the S/KEY API adds a fourth parameter; the
    @@ lib/subordinateio.c
      #include "shadow/passwd/getpw.h"
     +#include "sizeof.h"
      #include "string/ctype/strisascii/strisdigit.h"
    - #include "string/sprintf/snprintf.h"
    + #include "string/sprintf/stprintf.h"
      #include "string/strcmp/streq.h"
     @@ lib/subordinateio.c: subordinate_parse(const char *line)
         * Copy the string to a temporary buffer so the substrings can
    @@ src/chage.c
      #include "shadowlog.h"
     +#include "sizeof.h"
      #include "string/memset/memzero.h"
    - #include "string/sprintf/snprintf.h"
    + #include "string/sprintf/stprintf.h"
      #include "string/strcmp/streq.h"
     @@ src/chage.c: static int new_fields (void)
        (void) puts ("");
    @@ src/login.c
      #include "shadowlog.h"
     +#include "sizeof.h"
      #include "string/memset/memzero.h"
    - #include "string/sprintf/snprintf.h"
    + #include "string/sprintf/stprintf.h"
      #include "string/strcmp/streq.h"
     @@ src/login.c: int main (int argc, char **argv)
                unsigned int  failcount = 0;
2:  47998f8e = 2:  8dcccac7 lib/salt.c: crypt_make_salt(): Use countof() instead of a hardcoded value
3:  7403f8a7 = 3:  59b70f98 lib/sizeof.h: endof(): Add macro
4:  ddc4c557 = 4:  e5e22386 lib/fields.[ch]: change_field_a(): Add macro
5:  2d445619 = 5:  cde6ecb1 src/: Use change_field_a() instead of its pattern
6:  d41e8f8b = 6:  e592ba7e lib/string/memset/: bzero_a(): Add macro
7:  f7fcf073 ! 7:  11f603e9 lib/: Use bzero_a() instead of its pattern
    @@ lib/idmapping.c
      #include "shadowlog.h"
      #include "sizeof.h"
     +#include "string/memset/bzero.h"
    - #include "string/sprintf/stpeprintf.h"
    + #include "string/sprintf/seprintf.h"
      #include "string/strcmp/streq.h"
      #include "string/strerrno.h"
     @@ lib/idmapping.c: void write_mapping(int proc_dir_fd, int ranges, const struct map_range *mappings
    @@ lib/salt.c
      #include "prototypes.h"
      #include "shadowlog.h"
     +#include "string/memset/bzero.h"
    + #include "string/sprintf/stprintf.h"
      #include "string/strcmp/streq.h"
      
    - #undef NDEBUG
     @@ lib/salt.c: static /*@observer@*/const char *gensalt (size_t salt_size)
      {
        static char salt[MAX_SALT_SIZE + 6];
8:  d401c9c7 ! 8:  53e44dca lib/audit_help.c: Use countof() instead of sizeof()
    @@ lib/audit_help.c
      #include "prototypes.h"
      #include "shadowlog.h"
     +#include "sizeof.h"
    - #include "string/sprintf/snprintf.h"
    + #include "string/sprintf/stprintf.h"
      
     +
      int audit_fd;
```
</details>

<details>
<summary>v2d</summary>

-  Rebase

```
$ git rd 
1:  a55ef44cb6e2 ! 1:  9e8caa0adaf5 lib/, src/, tests/: Use countof() or sizeof_a() where appropriate
    @@ lib/subordinateio.c
      #include "atoi/getnum.h"
      #include "shadow/passwd/getpw.h"
     +#include "sizeof.h"
    - #include "string/ctype/strisascii/strisdigit.h"
    + #include "string/ctype/isascii.h"
      #include "string/sprintf/stprintf.h"
      #include "string/strcmp/streq.h"
     @@ lib/subordinateio.c: subordinate_parse(const char *line)
2:  8dcccac740d6 = 2:  f560d8ed42ee lib/salt.c: crypt_make_salt(): Use countof() instead of a hardcoded value
3:  59b70f984792 = 3:  cca19b96d01f lib/sizeof.h: endof(): Add macro
4:  e5e223861df7 = 4:  d7577cefb075 lib/fields.[ch]: change_field_a(): Add macro
5:  cde6ecb1d6f1 = 5:  3af5e4ed0ca3 src/: Use change_field_a() instead of its pattern
6:  e592ba7e6239 ! 6:  c0bbc5d8a7a6 lib/string/memset/: bzero_a(): Add macro
    @@ Commit message
     
      ## lib/Makefile.am ##
     @@ lib/Makefile.am: libshadow_la_SOURCES = \
    -   string/ctype/strisascii/strisprint.h \
    -   string/ctype/strtoascii/strtolower.c \
    -   string/ctype/strtoascii/strtolower.h \
    +   string/ctype/isascii.h \
    +   string/ctype/toascii.c \
    +   string/ctype/toascii.h \
     +  string/memset/bzero.c \
     +  string/memset/bzero.h \
        string/memset/memzero.c \
7:  11f603e92042 = 7:  ac53f2eae876 lib/: Use bzero_a() instead of its pattern
8:  53e44dcaa61d = 8:  a62246f17276 lib/audit_help.c: Use countof() instead of sizeof()
```
</details>

<details>
<summary>v3</summary>

-  Rebase

```
$ git rd -U0 --creation-factor=99
1:  9e8caa0adaf5 ! 1:  601137b847db lib/, src/, tests/: Use countof() or sizeof_a() where appropriate
    @@ src/chage.c: static int new_fields (void)
    -   stprintf_a(buf, "%ld", mindays);
    --  change_field(buf, sizeof(buf), _("Minimum Password Age"));
    -+  change_field(buf, countof(buf), _("Minimum Password Age"));
    -   if (a2sl(&mindays, buf, NULL, 0, -1, LONG_MAX) == -1)
    -           return 0;
    - 
    @@ src/newgidmap.c
    - #include "idmapping.h"
    + #include "io/fprintf.h"
    @@ src/newgidmap.c
    - #include "string/strerrno.h"
    @@ src/newgidmap.c
    + 
    @@ src/newgidmap.c: static void write_setgroups(int proc_dir_fd, bool allow_setgrou
    -           fprintf(stderr, _("%s: failed to read setgroups: %s\n"),
    -                   Prog, strerrno());
    +           eprinte(_("%s: failed to read setgroups"), Prog);
    @@ src/newgidmap.c: static void write_setgroups(int proc_dir_fd, bool allow_setgrou
    -
    - ## tests/unit/test_strncpy.c ##
    -@@
    - 
    - #include "config.h"
    - 
    -+#include <stddef.h>
    - #include <string.h>
    - 
    - #include <stdarg.h>  // Required by <cmocka.h>
    -@@ tests/unit/test_strncpy.c: test_strncpy_a_trunc(MAYBE_UNUSED void ** _1)
    - 
    -   char  src1[4] = {'f', 'o', 'o', 'o'};
    -   char  res1[3] = {'f', 'o', 'o'};
    --  assert_true(memcmp(res1, strncpy_a(buf, src1), sizeof(buf)) == 0);
    -+  assert_true(memcmp(res1, strncpy_a(buf, src1), countof(buf)) == 0);
    - 
    -   char  src2[5] = "barb";
    -   char  res2[3] = {'b', 'a', 'r'};
    --  assert_true(memcmp(res2, strncpy_a(buf, src2), sizeof(buf)) == 0);
    -+  assert_true(memcmp(res2, strncpy_a(buf, src2), countof(buf)) == 0);
    - }
    - 
    - 
    -@@ tests/unit/test_strncpy.c: test_strncpy_a_fit(MAYBE_UNUSED void ** _1)
    - 
    -   char  src1[3] = {'b', 'a', 'z'};
    -   char  res1[3] = {'b', 'a', 'z'};
    --  assert_true(memcmp(res1, strncpy_a(buf, src1), sizeof(buf)) == 0);
    -+  assert_true(memcmp(res1, strncpy_a(buf, src1), countof(buf)) == 0);
    - 
    -   char  src2[4] = "qwe";
    -   char  res2[3] = {'q', 'w', 'e'};
    --  assert_true(memcmp(res2, strncpy_a(buf, src2), sizeof(buf)) == 0);
    -+  assert_true(memcmp(res2, strncpy_a(buf, src2), countof(buf)) == 0);
    - }
    - 
    - 
    -@@ tests/unit/test_strncpy.c: test_strncpy_a_pad(MAYBE_UNUSED void ** _1)
    - 
    -   char  src1[3] = "as";
    -   char  res1[3] = {'a', 's', 0};
    --  assert_true(memcmp(res1, strncpy_a(buf, src1), sizeof(buf)) == 0);
    -+  assert_true(memcmp(res1, strncpy_a(buf, src1), countof(buf)) == 0);
    - 
    -   char  src2[3] = "";
    -   char  res2[3] = {0, 0, 0};
    --  assert_true(memcmp(res2, strncpy_a(buf, src2), sizeof(buf)) == 0);
    -+  assert_true(memcmp(res2, strncpy_a(buf, src2), countof(buf)) == 0);
    - 
    -   char  src3[3] = {'a', 0, 'b'};
    -   char  res3[3] = {'a', 0, 0};
    --  assert_true(memcmp(res3, strncpy_a(buf, src3), sizeof(buf)) == 0);
    -+  assert_true(memcmp(res3, strncpy_a(buf, src3), countof(buf)) == 0);
    - }
    +   }
2:  f560d8ed42ee ! 2:  caeb38b63bf9 lib/salt.c: crypt_make_salt(): Use countof() instead of a hardcoded value
    @@ lib/salt.c: static /*@observer@*/const char *gensalt (size_t salt_size)
    -   method = meth ?: getdef_str("ENCRYPT_METHOD") ?: "DES";
    +   method = meth ?: getdef_str("ENCRYPT_METHOD") ?: "SHA512";
    @@ lib/salt.c: static /*@observer@*/const char *gensalt (size_t salt_size)
    -@@ lib/salt.c: static /*@observer@*/const char *gensalt (size_t salt_size)
    -                    method);
    -           salt_len = MAX_SALT_SIZE;
    -           rounds = 0;
    --          bzero(result, GENSALT_SETTING_SIZE);
    -+          bzero(result, countof(result));
    -   }
    - 
    - #if USE_XCRYPT_GENSALT
    -@@ lib/salt.c: static /*@observer@*/const char *gensalt (size_t salt_size)
    -    */
    -   if (streq(result, "")) {
    -           /* Avoid -Wunused-but-set-variable. */
    --          salt_len = GENSALT_SETTING_SIZE - 1;
    -+          salt_len = countof(result) - 1;
    -           rounds = 0;
    -           memset(result, '.', salt_len);
    -           stpcpy(&result[salt_len], "");
3:  cca19b96d01f = 3:  4ceae54d8d16 lib/sizeof.h: endof(): Add macro
4:  d7577cefb075 = 4:  c30c40037d82 lib/fields.[ch]: change_field_a(): Add macro
5:  3af5e4ed0ca3 ! 5:  a4ed1e5c4a64 src/: Use change_field_a() instead of its pattern
    @@ src/chage.c: static int new_fields (void)
    -   stprintf_a(buf, "%ld", mindays);
    --  change_field(buf, countof(buf), _("Minimum Password Age"));
    -+  change_field_a(buf, _("Minimum Password Age"));
    -   if (a2sl(&mindays, buf, NULL, 0, -1, LONG_MAX) == -1)
    -           return 0;
    - 
6:  c0bbc5d8a7a6 = 6:  8653089c35bf lib/string/memset/: bzero_a(): Add macro
7:  ac53f2eae876 ! 7:  5e9694c0ad56 lib/: Use bzero_a() instead of its pattern
    @@ lib/idmapping.c
    - #include "string/strerrno.h"
    + 
    @@ lib/salt.c: static /*@observer@*/const char *gensalt (size_t salt_size)
    -   method = meth ?: getdef_str("ENCRYPT_METHOD") ?: "DES";
    +   method = meth ?: getdef_str("ENCRYPT_METHOD") ?: "SHA512";
    @@ lib/salt.c: static /*@observer@*/const char *gensalt (size_t salt_size)
    -@@ lib/salt.c: static /*@observer@*/const char *gensalt (size_t salt_size)
    -                    method);
    -           salt_len = MAX_SALT_SIZE;
    -           rounds = 0;
    --          bzero(result, countof(result));
    -+          bzero_a(result);
    -   }
    - 
    - #if USE_XCRYPT_GENSALT
8:  a62246f17276 = 8:  2c0e76efa624 lib/audit_help.c: Use countof() instead of sizeof()
```
</details>

<details>
<summary>v4</summary>

-  Rebase

```
$ git rd --creation-factor=99 -U0
1:  601137b847db ! 1:  9cb8aab7e043 lib/, src/, tests/: Use countof() or sizeof_a() where appropriate
    @@ lib/commonio.c
    - #include "string/memset/memzero.h"
    @@ lib/commonio.c
    + #include "string/sprintf/stprintf.h"
    @@ lib/loginprompt.c
    - #include "getdef.h"
    @@ lib/loginprompt.c
    + #include "memory/memset/memzero.h"
    @@ lib/loginprompt.c
    - #include "string/memset/memzero.h"
    @@ lib/loginprompt.c
    + #include "string/strtok/stpsep.h"
    @@ lib/pwauth.c
    +-#include "string/sprintf/stprintf.h"
    @@ lib/pwauth.c
    - #include "string/memset/memzero.h"
    - #include "string/sprintf/stprintf.h"
    @@ lib/pwauth.c
    + 
    + #ifdef SKEY
    @@ lib/subordinateio.c
    - #include "atoi/a2i.h"
    @@ lib/subordinateio.c
    + #include "memory/memdup/memdup.h"
    @@ src/chage.c
    - #include "string/memset/memzero.h"
    @@ src/chage.c
    + #include "string/strcpy/strtcpy.h"
    @@ src/login.c
    - #include "string/memset/memzero.h"
    @@ src/login.c
    + #include "string/strcmp/strprefix.h"
2:  caeb38b63bf9 = 2:  fd0ff38dc15e lib/salt.c: crypt_make_salt(): Use countof() instead of a hardcoded value
3:  4ceae54d8d16 = 3:  7406a2ced079 lib/sizeof.h: endof(): Add macro
4:  c30c40037d82 = 4:  5cf1c768f81a lib/fields.[ch]: change_field_a(): Add macro
5:  a4ed1e5c4a64 = 5:  1d333d8f700f src/: Use change_field_a() instead of its pattern
6:  8653089c35bf ! 6:  76c26b0c53ad lib/string/memset/: bzero_a(): Add macro
    @@ Commit message
    -    lib/string/memset/: bzero_a(): Add macro
    +    lib/memory/memset/: bzero_a(): Add macro
    @@ Commit message
    - ## lib/Makefile.am ##
    -@@ lib/Makefile.am: libshadow_la_SOURCES = \
    -   string/ctype/isascii.h \
    -   string/ctype/toascii.c \
    -   string/ctype/toascii.h \
    -+  string/memset/bzero.c \
    -+  string/memset/bzero.h \
    -   string/memset/memzero.c \
    -   string/memset/memzero.h \
    -   string/sprintf/aprintf.c \
    + ## lib/memory/memset/memzero.h ##
    +@@
    + #include "sizeof.h"
    + 
    + 
    ++// bzero_a - byte zero array
    ++#define bzero_a(a)  bzero(a, sizeof_a(a))
    ++
    + // memzero_a - memory zero (explicit) array
    + #define memzero_a(arr)  memzero(arr, sizeof_a(arr))
    + 
    @@ lib/string/README
    -@@ lib/string/README: ctype/ - Character classification and conversion functions
    - 
    - memset/ - Memory zeroing
    +@@ lib/string/README: Specific guidelines:
    + memory/ - memory operations
    +   memset/ - Memory setting
    @@ lib/string/README: ctype/ - Character classification and conversion functions
    -
    - ## lib/string/memset/bzero.c (new) ##
    -@@
    -+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
    -+// SPDX-License-Identifier: BSD-3-Clause
    -+
    -+
    -+#include "config.h"
    -+
    -+#include "string/memset/bzero.h"
    -
    - ## lib/string/memset/bzero.h (new) ##
    -@@
    -+// SPDX-FileCopyrightText: 2024, Alejandro Colomar <alx@kernel.org>
    -+// SPDX-License-Identifier: BSD-3-Clause
    -+
    -+
    -+#ifndef SHADOW_INCLUDE_LIB_STRING_MEMSET_BZERO_H_
    -+#define SHADOW_INCLUDE_LIB_STRING_MEMSET_BZERO_H_
    -+
    -+
    -+#include "config.h"
    -+
    -+#include <strings.h>
    -+
    -+#include "sizeof.h"
    -+
    -+
    -+// bzero_a - byte zero array
    -+#define bzero_a(a)  bzero(a, sizeof_a(a))
    -+
    -+
    -+#endif  // include guard
7:  5e9694c0ad56 ! 7:  d60ed06109b3 lib/: Use bzero_a() instead of its pattern
    @@ lib/idmapping.c
    + #include "attr.h"
    + #include "idmapping.h"
    + #include "io/fprintf.h"
    ++#include "memory/memset/memzero.h"
    @@ lib/idmapping.c
    -+#include "string/memset/bzero.h"
    - #include "string/sprintf/seprintf.h"
    - #include "string/strcmp/streq.h"
    - 
    @@ lib/salt.c
    + 
    + #include "defines.h"
    @@ lib/salt.c
    ++#include "memory/memset/memzero.h"
    @@ lib/salt.c
    -+#include "string/memset/bzero.h"
    @@ lib/salt.c
    - #include "string/strcmp/streq.h"
    - 
8:  2c0e76efa624 = 8:  a159d8a4d184 lib/audit_help.c: Use countof() instead of sizeof()
```
</details>