### PR TITLE
src/usermod.c: Some cleanups, improvements, fixes, and abstractions about open/close/lock/unlock on database files

### DIFF
--- a/src/usermod.c
+++ b/src/usermod.c
@@ -113,6 +113,20 @@ struct option_flags {
 	bool prefix;
 };
 
+struct lk_db_files {
+	bool  pw;
+	bool  spw;
+	bool  gr;
+#ifdef SHADOWGRP
+	bool  sgr;
+#endif
+#ifdef ENABLE_SUBIDS
+	bool  subuid;
+	bool  subgid;
+#endif
+};
+
+
 /*
  * Global variables
  */
@@ -186,16 +200,7 @@ static bool is_sub_uid = false;
 static bool is_sub_gid = false;
 #endif				/* ENABLE_SUBIDS */
 
-static bool pw_locked  = false;
-static bool spw_locked = false;
-static bool gr_locked  = false;
-#ifdef SHADOWGRP
-static bool sgr_locked = false;
-#endif
-#ifdef ENABLE_SUBIDS
-static bool sub_uid_locked = false;
-static bool sub_gid_locked = false;
-#endif				/* ENABLE_SUBIDS */
+static struct lk_db_files  lk = {};
 
 
 /* local function prototypes */
@@ -662,14 +667,14 @@ static void
 fail_exit(int code, bool process_selinux)
 {
 #ifdef ENABLE_SUBIDS
-	if (sub_gid_locked) {
+	if (lk.subgid) {
 		if (sub_gid_unlock(process_selinux) == 0) {
 			eprintf(_("%s: failed to unlock %s\n"), Prog, sub_gid_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sub_gid_dbname());
 			/* continue */
 		}
 	}
-	if (sub_uid_locked) {
+	if (lk.subuid) {
 		if (sub_uid_unlock(process_selinux) == 0) {
 			eprintf(_("%s: failed to unlock %s\n"), Prog, sub_uid_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sub_uid_dbname());
@@ -678,7 +683,7 @@ fail_exit(int code, bool process_selinux)
 	}
 #endif				/* ENABLE_SUBIDS */
 #ifdef	SHADOWGRP
-	if (sgr_locked) {
+	if (lk.sgr) {
 		if (sgr_unlock(process_selinux) == 0) {
 			eprintf(_("%s: failed to unlock %s\n"), Prog, sgr_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sgr_dbname());
@@ -686,21 +691,21 @@ fail_exit(int code, bool process_selinux)
 		}
 	}
 #endif
-	if (gr_locked) {
+	if (lk.gr) {
 		if (gr_unlock(process_selinux) == 0) {
 			eprintf(_("%s: failed to unlock %s\n"), Prog, gr_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", gr_dbname());
 			/* continue */
 		}
 	}
-	if (spw_locked) {
+	if (lk.spw) {
 		if (spw_unlock(process_selinux) == 0) {
 			eprintf(_("%s: failed to unlock %s\n"), Prog, spw_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", spw_dbname());
 			/* continue */
 		}
 	}
-	if (pw_locked) {
+	if (lk.pw) {
 		if (pw_unlock(process_selinux) == 0) {
 			eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", pw_dbname());
@@ -1472,7 +1477,7 @@ static void close_files(const struct option_flags *flags)
 	process_selinux = !flags->chroot && !flags->prefix;
 
 #ifdef ENABLE_SUBIDS
-	if (sub_gid_locked) {
+	if (lk.subgid) {
 		if (sub_gid_close(process_selinux) == 0) {
 			eprintf(_("%s: failure while writing changes to %s\n"), Prog, sub_gid_dbname());
 			SYSLOG(LOG_ERR, "failure while writing changes to %s", sub_gid_dbname());
@@ -1483,9 +1488,9 @@ static void close_files(const struct option_flags *flags)
 			SYSLOG(LOG_ERR, "failed to unlock %s", sub_gid_dbname());
 			/* continue */
 		}
-		sub_gid_locked = false;
+		lk.subgid = false;
 	}
-	if (sub_uid_locked) {
+	if (lk.subuid) {
 		if (sub_uid_close(process_selinux) == 0) {
 			eprintf(_("%s: failure while writing changes to %s\n"), Prog, sub_uid_dbname());
 			SYSLOG(LOG_ERR, "failure while writing changes to %s", sub_uid_dbname());
@@ -1496,12 +1501,12 @@ static void close_files(const struct option_flags *flags)
 			SYSLOG(LOG_ERR, "failed to unlock %s", sub_uid_dbname());
 			/* continue */
 		}
-		sub_uid_locked = false;
+		lk.subuid = false;
 	}
 #endif				/* ENABLE_SUBIDS */
 
 #ifdef SHADOWGRP
-	if (sgr_locked) {
+	if (lk.sgr) {
 		if (sgr_close(process_selinux) == 0) {
 			eprintf(_("%s: failure while writing changes to %s\n"), Prog, sgr_dbname());
 			SYSLOG(LOG_ERR, "failure while writing changes to %s", sgr_dbname());
@@ -1512,10 +1517,10 @@ static void close_files(const struct option_flags *flags)
 			SYSLOG(LOG_ERR, "failed to unlock %s", sgr_dbname());
 			/* continue */
 		}
-		sgr_locked = false;
+		lk.sgr = false;
 	}
 #endif
-	if (gr_locked) {
+	if (lk.gr) {
 		if (gr_close(process_selinux) == 0) {
 			eprintf(_("%s: failure while writing changes to %s\n"), Prog, gr_dbname());
 			SYSLOG(LOG_ERR, "failure while writing changes to %s", gr_dbname());
@@ -1526,9 +1531,9 @@ static void close_files(const struct option_flags *flags)
 			SYSLOG(LOG_ERR, "failed to unlock %s", gr_dbname());
 			/* continue */
 		}
-		gr_locked = false;
+		lk.gr = false;
 	}
-	if (spw_locked) {
+	if (lk.spw) {
 		if (spw_close(process_selinux) == 0) {
 			eprintf(_("%s: failure while writing changes to %s\n"), Prog, spw_dbname());
 			SYSLOG(LOG_ERR, "failure while writing changes to %s", spw_dbname());
@@ -1539,9 +1544,9 @@ static void close_files(const struct option_flags *flags)
 			SYSLOG(LOG_ERR, "failed to unlock %s", spw_dbname());
 			/* continue */
 		}
-		spw_locked = false;
+		lk.spw = false;
 	}
-	if (pw_locked) {
+	if (lk.pw) {
 		if (pw_close(process_selinux) == 0) {
 			eprintf(_("%s: failure while writing changes to %s\n"), Prog, pw_dbname());
 			SYSLOG(LOG_ERR, "failure while writing changes to %s", pw_dbname());
@@ -1552,7 +1557,7 @@ static void close_files(const struct option_flags *flags)
 			SYSLOG(LOG_ERR, "failed to unlock %s", pw_dbname());
 			/* continue */
 		}
-		pw_locked = false;
+		lk.pw = false;
 	}
 
 	/*
@@ -1578,7 +1583,7 @@ open_files(bool process_selinux)
 		eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, pw_dbname());
 		fail_exit(E_PW_UPDATE, process_selinux);
 	}
-	pw_locked = true;
+	lk.pw = true;
 	if (pw_open(O_CREAT | O_RDWR) == 0) {
 		eprintf(_("%s: cannot open %s\n"), Prog, pw_dbname());
 		fail_exit(E_PW_UPDATE, process_selinux);
@@ -1588,7 +1593,7 @@ open_files(bool process_selinux)
 			eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, spw_dbname());
 			fail_exit(E_PW_UPDATE, process_selinux);
 		}
-		spw_locked = true;
+		lk.spw = true;
 		if (spw_open(O_CREAT | O_RDWR) == 0) {
 			eprintf(_("%s: cannot open %s\n"), Prog, spw_dbname());
 			fail_exit(E_PW_UPDATE, process_selinux);
@@ -1604,7 +1609,7 @@ open_files(bool process_selinux)
 			eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, gr_dbname());
 			fail_exit(E_GRP_UPDATE, process_selinux);
 		}
-		gr_locked = true;
+		lk.gr = true;
 		if (gr_open(O_CREAT | O_RDWR) == 0) {
 			eprintf(_("%s: cannot open %s\n"), Prog, gr_dbname());
 			fail_exit(E_GRP_UPDATE, process_selinux);
@@ -1615,7 +1620,7 @@ open_files(bool process_selinux)
 				eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, sgr_dbname());
 				fail_exit(E_GRP_UPDATE, process_selinux);
 			}
-			sgr_locked = true;
+			lk.sgr = true;
 			if (sgr_open(O_CREAT | O_RDWR) == 0) {
 				eprintf(_("%s: cannot open %s\n"), Prog, sgr_dbname());
 				fail_exit(E_GRP_UPDATE, process_selinux);
@@ -1629,7 +1634,7 @@ open_files(bool process_selinux)
 			eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, sub_uid_dbname());
 			fail_exit(E_SUB_UID_UPDATE, process_selinux);
 		}
-		sub_uid_locked = true;
+		lk.subuid = true;
 		if (sub_uid_open(O_CREAT | O_RDWR) == 0) {
 			eprintf(_("%s: cannot open %s\n"), Prog, sub_uid_dbname());
 			fail_exit(E_SUB_UID_UPDATE, process_selinux);
@@ -1640,7 +1645,7 @@ open_files(bool process_selinux)
 			eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, sub_gid_dbname());
 			fail_exit(E_SUB_GID_UPDATE, process_selinux);
 		}
-		sub_gid_locked = true;
+		lk.subgid = true;
 		if (sub_gid_open(O_CREAT | O_RDWR) == 0) {
 			eprintf(_("%s: cannot open %s\n"), Prog, sub_gid_dbname());
 			fail_exit(E_SUB_GID_UPDATE, process_selinux);

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -1608,14 +1608,16 @@ open_files(bool process_selinux)
 			fail_exit(E_GRP_UPDATE, process_selinux);
 		}
 #ifdef SHADOWGRP
-		if (is_shadow_grp && (sgr_lock() == 0)) {
-			eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, sgr_dbname());
-			fail_exit(E_GRP_UPDATE, process_selinux);
-		}
-		sgr_locked = true;
-		if (is_shadow_grp && (sgr_open(O_CREAT | O_RDWR) == 0)) {
-			eprintf(_("%s: cannot open %s\n"), Prog, sgr_dbname());
-			fail_exit(E_GRP_UPDATE, process_selinux);
+		if (is_shadow_grp) {
+			if (sgr_lock() == 0) {
+				eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, sgr_dbname());
+				fail_exit(E_GRP_UPDATE, process_selinux);
+			}
+			sgr_locked = true;
+			if (sgr_open(O_CREAT | O_RDWR) == 0) {
+				eprintf(_("%s: cannot open %s\n"), Prog, sgr_dbname());
+				fail_exit(E_GRP_UPDATE, process_selinux);
+			}
 		}
 #endif
 	}

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -1587,7 +1587,7 @@ open_files(bool process_selinux)
 			fail_exit(E_PW_UPDATE, process_selinux);
 		}
 		spw_locked = true;
-		if (is_shadow_pwd && (spw_open(O_CREAT | O_RDWR) == 0)) {
+		if (spw_open(O_CREAT | O_RDWR) == 0) {
 			eprintf(_("%s: cannot open %s\n"), Prog, spw_dbname());
 			fail_exit(E_PW_UPDATE, process_selinux);
 		}

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -1479,29 +1479,24 @@ process_flags(int argc, char **argv, struct option_flags *flags)
 #endif				/* ENABLE_SUBIDS */
 }
 
-/*
- * close_files - close all of the files that were opened
- *
- *	close_files() closes all of the files that were opened for this new
- *	user. This causes any modified entries to be written out.
- */
-static void close_files(const struct option_flags *flags)
-{
-	bool process_selinux;
 
-	process_selinux = !flags->chroot && !flags->prefix;
+// close_db - close and unlock database files
+static int
+close_db(bool process_selinux)
+{
+	int  ret;
 
 #ifdef ENABLE_SUBIDS
 	if (lk.subgid) {
 		if (sub_gid_close(process_selinux) == 0) {
 			eprintf(_("%s: failure while writing changes to %s\n"), Prog, sub_gid_dbname());
 			SYSLOG(LOG_ERR, "failure while writing changes to %s", sub_gid_dbname());
-			fail_exit(E_SUB_GID_UPDATE, process_selinux);
+			ret = E_SUB_GID_UPDATE;
+			goto fail;
 		}
 		if (sub_gid_unlock(process_selinux) == 0) {
 			eprintf(_("%s: failed to unlock %s\n"), Prog, sub_gid_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sub_gid_dbname());
-			/* continue */
 		}
 		lk.subgid = false;
 	}
@@ -1509,28 +1504,27 @@ static void close_files(const struct option_flags *flags)
 		if (sub_uid_close(process_selinux) == 0) {
 			eprintf(_("%s: failure while writing changes to %s\n"), Prog, sub_uid_dbname());
 			SYSLOG(LOG_ERR, "failure while writing changes to %s", sub_uid_dbname());
-			fail_exit(E_SUB_UID_UPDATE, process_selinux);
+			ret = E_SUB_UID_UPDATE;
+			goto fail;
 		}
 		if (sub_uid_unlock(process_selinux) == 0) {
 			eprintf(_("%s: failed to unlock %s\n"), Prog, sub_uid_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sub_uid_dbname());
-			/* continue */
 		}
 		lk.subuid = false;
 	}
-#endif				/* ENABLE_SUBIDS */
-
+#endif
 #ifdef SHADOWGRP
 	if (lk.sgr) {
 		if (sgr_close(process_selinux) == 0) {
 			eprintf(_("%s: failure while writing changes to %s\n"), Prog, sgr_dbname());
 			SYSLOG(LOG_ERR, "failure while writing changes to %s", sgr_dbname());
-			fail_exit(E_GRP_UPDATE, process_selinux);
+			ret = E_GRP_UPDATE;
+			goto fail;
 		}
 		if (sgr_unlock(process_selinux) == 0) {
 			eprintf(_("%s: failed to unlock %s\n"), Prog, sgr_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sgr_dbname());
-			/* continue */
 		}
 		lk.sgr = false;
 	}
@@ -1539,12 +1533,12 @@ static void close_files(const struct option_flags *flags)
 		if (gr_close(process_selinux) == 0) {
 			eprintf(_("%s: failure while writing changes to %s\n"), Prog, gr_dbname());
 			SYSLOG(LOG_ERR, "failure while writing changes to %s", gr_dbname());
-			fail_exit(E_GRP_UPDATE, process_selinux);
+			ret = E_GRP_UPDATE;
+			goto fail;
 		}
 		if (gr_unlock(process_selinux) == 0) {
 			eprintf(_("%s: failed to unlock %s\n"), Prog, gr_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", gr_dbname());
-			/* continue */
 		}
 		lk.gr = false;
 	}
@@ -1552,12 +1546,12 @@ static void close_files(const struct option_flags *flags)
 		if (spw_close(process_selinux) == 0) {
 			eprintf(_("%s: failure while writing changes to %s\n"), Prog, spw_dbname());
 			SYSLOG(LOG_ERR, "failure while writing changes to %s", spw_dbname());
-			fail_exit(E_PW_UPDATE, process_selinux);
+			ret = E_PW_UPDATE;
+			goto fail;
 		}
 		if (spw_unlock(process_selinux) == 0) {
 			eprintf(_("%s: failed to unlock %s\n"), Prog, spw_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", spw_dbname());
-			/* continue */
 		}
 		lk.spw = false;
 	}
@@ -1565,25 +1559,44 @@ static void close_files(const struct option_flags *flags)
 		if (pw_close(process_selinux) == 0) {
 			eprintf(_("%s: failure while writing changes to %s\n"), Prog, pw_dbname());
 			SYSLOG(LOG_ERR, "failure while writing changes to %s", pw_dbname());
-			fail_exit(E_PW_UPDATE, process_selinux);
+			ret = E_PW_UPDATE;
+			goto fail;
 		}
 		if (pw_unlock(process_selinux) == 0) {
 			eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", pw_dbname());
-			/* continue */
 		}
 		lk.pw = false;
 	}
 
-	/*
-	 * Close the DBM and/or flat files
-	 */
-#ifdef	SHADOWGRP
+#ifdef SHADOWGRP
 	endsgent();
 #endif
 	endgrent();
 	endspent();
 	endpwent();
+	return 0;
+fail:
+	unlock_db(process_selinux);
+	return ret;
+}
+
+/*
+ * close_files - close all of the files that were opened
+ *
+ *	close_files() closes all of the files that were opened for this new
+ *	user. This causes any modified entries to be written out.
+ */
+static void close_files(const struct option_flags *flags)
+{
+	int   ret;
+	bool  process_selinux;
+
+	process_selinux = !flags->chroot && !flags->prefix;
+
+	ret = close_db(process_selinux);
+	if (ret != 0)
+		fail_exit(ret, process_selinux);
 }
 
 /*

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -1569,88 +1569,130 @@ static void close_files(const struct option_flags *flags)
 		fail_exit(ret, process_selinux);
 }
 
-/*
- * open_files - lock and open the password files
- *
- *	open_files() opens the two password files.
- */
-static void
-open_files(bool process_selinux)
+// open_db - lock and open database files
+static int
+open_db(struct lk_db_files *f, bool process_selinux)
 {
-	if (true) {
+	int  ret;
+
+	if (f->spw)
+		f->pw = true;
+	if (f->pw) {
 		if (pw_lock() == 0) {
 			eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, pw_dbname());
-			fail_exit(E_PW_UPDATE, process_selinux);
+			ret = E_PW_UPDATE;
+			goto fail;
 		}
 		lk.pw = true;
 		if (pw_open(O_CREAT | O_RDWR) == 0) {
 			eprintf(_("%s: cannot open %s\n"), Prog, pw_dbname());
-			fail_exit(E_PW_UPDATE, process_selinux);
+			ret = E_PW_UPDATE;
+			goto fail;
 		}
 	}
-	if (is_shadow_pwd && (lflg || pflg || eflg || fflg || Lflg || Uflg)) {
+	if (f->spw) {
 		if (spw_lock() == 0) {
 			eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, spw_dbname());
-			fail_exit(E_PW_UPDATE, process_selinux);
+			ret = E_PW_UPDATE;
+			goto fail;
 		}
 		lk.spw = true;
 		if (spw_open(O_CREAT | O_RDWR) == 0) {
 			eprintf(_("%s: cannot open %s\n"), Prog, spw_dbname());
-			fail_exit(E_PW_UPDATE, process_selinux);
+			ret = E_PW_UPDATE;
+			goto fail;
 		}
 	}
-	if (Gflg || lflg) {
-		/*
-		 * Lock and open the group file. This will load all of the
-		 * group entries.
-		 */
+
+#ifdef SHADOWGRP
+	if (f->sgr)
+		f->gr = true;
+#endif
+	if (f->gr) {
 		if (gr_lock() == 0) {
 			eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, gr_dbname());
-			fail_exit(E_GRP_UPDATE, process_selinux);
+			ret = E_GRP_UPDATE;
+			goto fail;
 		}
 		lk.gr = true;
 		if (gr_open(O_CREAT | O_RDWR) == 0) {
 			eprintf(_("%s: cannot open %s\n"), Prog, gr_dbname());
-			fail_exit(E_GRP_UPDATE, process_selinux);
+			ret = E_GRP_UPDATE;
+			goto fail;
 		}
 	}
 #ifdef SHADOWGRP
-	if ((Gflg || lflg) && is_shadow_grp) {
+	if (f->sgr) {
 		if (sgr_lock() == 0) {
 			eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, sgr_dbname());
-			fail_exit(E_GRP_UPDATE, process_selinux);
+			ret = E_GRP_UPDATE;
+			goto fail;
 		}
 		lk.sgr = true;
 		if (sgr_open(O_CREAT | O_RDWR) == 0) {
 			eprintf(_("%s: cannot open %s\n"), Prog, sgr_dbname());
-			fail_exit(E_GRP_UPDATE, process_selinux);
+			ret = E_GRP_UPDATE;
+			goto fail;
 		}
 	}
 #endif
+
 #ifdef ENABLE_SUBIDS
-	if (vflg || Vflg) {
+	if (f->subuid) {
 		if (sub_uid_lock() == 0) {
 			eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, sub_uid_dbname());
-			fail_exit(E_SUB_UID_UPDATE, process_selinux);
+			ret = E_SUB_UID_UPDATE;
+			goto fail;
 		}
 		lk.subuid = true;
 		if (sub_uid_open(O_CREAT | O_RDWR) == 0) {
 			eprintf(_("%s: cannot open %s\n"), Prog, sub_uid_dbname());
-			fail_exit(E_SUB_UID_UPDATE, process_selinux);
+			ret = E_SUB_UID_UPDATE;
+			goto fail;
 		}
 	}
-	if (wflg || Wflg) {
+	if (f->subgid) {
 		if (sub_gid_lock() == 0) {
 			eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, sub_gid_dbname());
-			fail_exit(E_SUB_GID_UPDATE, process_selinux);
+			ret = E_SUB_GID_UPDATE;
+			goto fail;
 		}
 		lk.subgid = true;
 		if (sub_gid_open(O_CREAT | O_RDWR) == 0) {
 			eprintf(_("%s: cannot open %s\n"), Prog, sub_gid_dbname());
-			fail_exit(E_SUB_GID_UPDATE, process_selinux);
+			ret = E_SUB_GID_UPDATE;
+			goto fail;
 		}
 	}
 #endif
+	return 0;
+fail:
+	unlock_db(process_selinux);
+	return ret;
+}
+
+
+static void
+open_files(bool process_selinux)
+{
+	int  ret;
+
+	struct lk_db_files  f = {
+		.pw = true,
+		.spw = is_shadow_pwd && (lflg || pflg || eflg || fflg || Lflg || Uflg),
+		.gr = Gflg || lflg,
+	#ifdef SHADOWGRP
+		.sgr = (Gflg || lflg) && is_shadow_grp,
+	#endif
+	#ifdef ENABLE_SUBIDS
+		.subuid = vflg || Vflg,
+		.subgid = wflg || Wflg,
+	#endif
+	};
+
+	ret = open_db(&f, process_selinux);
+	if (ret != 0)
+		fail_exit(ret, process_selinux);
 }
 
 /*

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -1500,22 +1500,22 @@ static void close_files(const struct option_flags *flags)
 	}
 #endif				/* ENABLE_SUBIDS */
 
-	if (gr_locked) {
 #ifdef SHADOWGRP
-		if (sgr_locked) {
-			if (sgr_close(process_selinux) == 0) {
-				eprintf(_("%s: failure while writing changes to %s\n"), Prog, sgr_dbname());
-				SYSLOG(LOG_ERR, "failure while writing changes to %s", sgr_dbname());
-				fail_exit(E_GRP_UPDATE, process_selinux);
-			}
-			if (sgr_unlock(process_selinux) == 0) {
-				eprintf(_("%s: failed to unlock %s\n"), Prog, sgr_dbname());
-				SYSLOG(LOG_ERR, "failed to unlock %s", sgr_dbname());
-				/* continue */
-			}
-			sgr_locked = false;
+	if (sgr_locked) {
+		if (sgr_close(process_selinux) == 0) {
+			eprintf(_("%s: failure while writing changes to %s\n"), Prog, sgr_dbname());
+			SYSLOG(LOG_ERR, "failure while writing changes to %s", sgr_dbname());
+			fail_exit(E_GRP_UPDATE, process_selinux);
 		}
+		if (sgr_unlock(process_selinux) == 0) {
+			eprintf(_("%s: failed to unlock %s\n"), Prog, sgr_dbname());
+			SYSLOG(LOG_ERR, "failed to unlock %s", sgr_dbname());
+			/* continue */
+		}
+		sgr_locked = false;
+	}
 #endif
+	if (gr_locked) {
 		if (gr_close(process_selinux) == 0) {
 			eprintf(_("%s: failure while writing changes to %s\n"), Prog, gr_dbname());
 			SYSLOG(LOG_ERR, "failure while writing changes to %s", gr_dbname());

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -659,12 +659,10 @@ static void new_spent (struct spwd *spent, bool process_selinux)
 	}
 }
 
-/*
- * fail_exit - exit with an error code after unlocking files
- */
-NORETURN
+
+// unlock_db - unlock database files
 static void
-fail_exit(int code, bool process_selinux)
+unlock_db(bool process_selinux)
 {
 #ifdef ENABLE_SUBIDS
 	if (lk.subgid) {
@@ -683,8 +681,8 @@ fail_exit(int code, bool process_selinux)
 			lk.subuid = false;
 		}
 	}
-#endif				/* ENABLE_SUBIDS */
-#ifdef	SHADOWGRP
+#endif
+#ifdef SHADOWGRP
 	if (lk.sgr) {
 		if (sgr_unlock(process_selinux) == 0) {
 			eprintf(_("%s: failed to unlock %s\n"), Prog, sgr_dbname());
@@ -718,6 +716,17 @@ fail_exit(int code, bool process_selinux)
 			lk.pw = false;
 		}
 	}
+}
+
+
+/*
+ * fail_exit - exit with an error code after unlocking files
+ */
+NORETURN
+static void
+fail_exit(int code, bool process_selinux)
+{
+	unlock_db(process_selinux);
 
 #ifdef WITH_AUDIT
 	audit_logger (AUDIT_USER_MGMT,

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -659,18 +659,18 @@ static void new_spent (struct spwd *spent, bool process_selinux)
  */
 NORETURN
 static void
-fail_exit (int code, bool process_selinux)
+fail_exit(int code, bool process_selinux)
 {
 #ifdef ENABLE_SUBIDS
 	if (sub_gid_locked) {
-		if (sub_gid_unlock (process_selinux) == 0) {
-			eprintf(_("%s: failed to unlock %s\n"), Prog, sub_gid_dbname ());
+		if (sub_gid_unlock(process_selinux) == 0) {
+			eprintf(_("%s: failed to unlock %s\n"), Prog, sub_gid_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sub_gid_dbname());
 			/* continue */
 		}
 	}
 	if (sub_uid_locked) {
-		if (sub_uid_unlock (process_selinux) == 0) {
+		if (sub_uid_unlock(process_selinux) == 0) {
 			eprintf(_("%s: failed to unlock %s\n"), Prog, sub_uid_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sub_uid_dbname());
 			/* continue */
@@ -679,7 +679,7 @@ fail_exit (int code, bool process_selinux)
 #endif				/* ENABLE_SUBIDS */
 #ifdef	SHADOWGRP
 	if (sgr_locked) {
-		if (sgr_unlock (process_selinux) == 0) {
+		if (sgr_unlock(process_selinux) == 0) {
 			eprintf(_("%s: failed to unlock %s\n"), Prog, sgr_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sgr_dbname());
 			/* continue */
@@ -687,21 +687,21 @@ fail_exit (int code, bool process_selinux)
 	}
 #endif
 	if (gr_locked) {
-		if (gr_unlock (process_selinux) == 0) {
+		if (gr_unlock(process_selinux) == 0) {
 			eprintf(_("%s: failed to unlock %s\n"), Prog, gr_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", gr_dbname());
 			/* continue */
 		}
 	}
 	if (spw_locked) {
-		if (spw_unlock (process_selinux) == 0) {
+		if (spw_unlock(process_selinux) == 0) {
 			eprintf(_("%s: failed to unlock %s\n"), Prog, spw_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", spw_dbname());
 			/* continue */
 		}
 	}
 	if (pw_locked) {
-		if (pw_unlock (process_selinux) == 0) {
+		if (pw_unlock(process_selinux) == 0) {
 			eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", pw_dbname());
 			/* continue */
@@ -1473,12 +1473,12 @@ static void close_files(const struct option_flags *flags)
 
 #ifdef ENABLE_SUBIDS
 	if (sub_gid_locked) {
-		if (sub_gid_close (process_selinux) == 0) {
+		if (sub_gid_close(process_selinux) == 0) {
 			eprintf(_("%s: failure while writing changes to %s\n"), Prog, sub_gid_dbname());
 			SYSLOG(LOG_ERR, "failure while writing changes to %s", sub_gid_dbname());
-			fail_exit (E_SUB_GID_UPDATE, process_selinux);
+			fail_exit(E_SUB_GID_UPDATE, process_selinux);
 		}
-		if (sub_gid_unlock (process_selinux) == 0) {
+		if (sub_gid_unlock(process_selinux) == 0) {
 			eprintf(_("%s: failed to unlock %s\n"), Prog, sub_gid_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sub_gid_dbname());
 			/* continue */
@@ -1486,12 +1486,12 @@ static void close_files(const struct option_flags *flags)
 		sub_gid_locked = false;
 	}
 	if (sub_uid_locked) {
-		if (sub_uid_close (process_selinux) == 0) {
+		if (sub_uid_close(process_selinux) == 0) {
 			eprintf(_("%s: failure while writing changes to %s\n"), Prog, sub_uid_dbname());
 			SYSLOG(LOG_ERR, "failure while writing changes to %s", sub_uid_dbname());
-			fail_exit (E_SUB_UID_UPDATE, process_selinux);
+			fail_exit(E_SUB_UID_UPDATE, process_selinux);
 		}
-		if (sub_uid_unlock (process_selinux) == 0) {
+		if (sub_uid_unlock(process_selinux) == 0) {
 			eprintf(_("%s: failed to unlock %s\n"), Prog, sub_uid_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sub_uid_dbname());
 			/* continue */
@@ -1503,14 +1503,12 @@ static void close_files(const struct option_flags *flags)
 	if (gr_locked) {
 #ifdef SHADOWGRP
 		if (is_shadow_grp) {
-			if (sgr_close (process_selinux) == 0) {
-				eprintf(_("%s: failure while writing changes to %s\n"),
-				         Prog, sgr_dbname ());
-				SYSLOG(LOG_ERR, "failure while writing changes to %s",
-				       sgr_dbname());
-				fail_exit (E_GRP_UPDATE, process_selinux);
+			if (sgr_close(process_selinux) == 0) {
+				eprintf(_("%s: failure while writing changes to %s\n"), Prog, sgr_dbname());
+				SYSLOG(LOG_ERR, "failure while writing changes to %s", sgr_dbname());
+				fail_exit(E_GRP_UPDATE, process_selinux);
 			}
-			if (sgr_unlock (process_selinux) == 0) {
+			if (sgr_unlock(process_selinux) == 0) {
 				eprintf(_("%s: failed to unlock %s\n"), Prog, sgr_dbname());
 				SYSLOG(LOG_ERR, "failed to unlock %s", sgr_dbname());
 				/* continue */
@@ -1518,14 +1516,12 @@ static void close_files(const struct option_flags *flags)
 			sgr_locked = false;
 		}
 #endif
-		if (gr_close (process_selinux) == 0) {
-			eprintf(_("%s: failure while writing changes to %s\n"),
-			         Prog, gr_dbname ());
-			SYSLOG(LOG_ERR, "failure while writing changes to %s",
-			       gr_dbname());
-			fail_exit (E_GRP_UPDATE, process_selinux);
+		if (gr_close(process_selinux) == 0) {
+			eprintf(_("%s: failure while writing changes to %s\n"), Prog, gr_dbname());
+			SYSLOG(LOG_ERR, "failure while writing changes to %s", gr_dbname());
+			fail_exit(E_GRP_UPDATE, process_selinux);
 		}
-		if (gr_unlock (process_selinux) == 0) {
+		if (gr_unlock(process_selinux) == 0) {
 			eprintf(_("%s: failed to unlock %s\n"), Prog, gr_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", gr_dbname());
 			/* continue */
@@ -1533,25 +1529,24 @@ static void close_files(const struct option_flags *flags)
 		gr_locked = false;
 	}
 	if (spw_locked) {
-		if (spw_close (process_selinux) == 0) {
-			eprintf(_("%s: failure while writing changes to %s\n"),
-				Prog, spw_dbname ());
+		if (spw_close(process_selinux) == 0) {
+			eprintf(_("%s: failure while writing changes to %s\n"), Prog, spw_dbname());
 			SYSLOG(LOG_ERR, "failure while writing changes to %s", spw_dbname());
-			fail_exit (E_PW_UPDATE, process_selinux);
+			fail_exit(E_PW_UPDATE, process_selinux);
 		}
-		if (spw_unlock (process_selinux) == 0) {
+		if (spw_unlock(process_selinux) == 0) {
 			eprintf(_("%s: failed to unlock %s\n"), Prog, spw_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", spw_dbname());
 			/* continue */
 		}
 		spw_locked = false;
 	}
-	if (pw_close (process_selinux) == 0) {
+	if (pw_close(process_selinux) == 0) {
 		eprintf(_("%s: failure while writing changes to %s\n"), Prog, pw_dbname());
 		SYSLOG(LOG_ERR, "failure while writing changes to %s", pw_dbname());
-		fail_exit (E_PW_UPDATE, process_selinux);
+		fail_exit(E_PW_UPDATE, process_selinux);
 	}
-	if (pw_unlock (process_selinux) == 0) {
+	if (pw_unlock(process_selinux) == 0) {
 		eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
 		SYSLOG(LOG_ERR, "failed to unlock %s", pw_dbname());
 		/* continue */
@@ -1562,11 +1557,11 @@ static void close_files(const struct option_flags *flags)
 	 * Close the DBM and/or flat files
 	 */
 #ifdef	SHADOWGRP
-	endsgent ();
+	endsgent();
 #endif
-	endgrent ();
-	endspent ();
-	endpwent ();
+	endgrent();
+	endspent();
+	endpwent();
 }
 
 /*
@@ -1574,28 +1569,27 @@ static void close_files(const struct option_flags *flags)
  *
  *	open_files() opens the two password files.
  */
-static void open_files (bool process_selinux)
+static void
+open_files(bool process_selinux)
 {
-	if (pw_lock () == 0) {
-		eprintf(_("%s: cannot lock %s; try again later.\n"),
-		         Prog, pw_dbname ());
-		fail_exit (E_PW_UPDATE, process_selinux);
+	if (pw_lock() == 0) {
+		eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, pw_dbname());
+		fail_exit(E_PW_UPDATE, process_selinux);
 	}
 	pw_locked = true;
-	if (pw_open (O_CREAT | O_RDWR) == 0) {
+	if (pw_open(O_CREAT | O_RDWR) == 0) {
 		eprintf(_("%s: cannot open %s\n"), Prog, pw_dbname());
-		fail_exit (E_PW_UPDATE, process_selinux);
+		fail_exit(E_PW_UPDATE, process_selinux);
 	}
 	if (is_shadow_pwd && (lflg || pflg || eflg || fflg || Lflg || Uflg)) {
-		if (spw_lock () == 0) {
-			eprintf(_("%s: cannot lock %s; try again later.\n"),
-				Prog, spw_dbname ());
-			fail_exit (E_PW_UPDATE, process_selinux);
+		if (spw_lock() == 0) {
+			eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, spw_dbname());
+			fail_exit(E_PW_UPDATE, process_selinux);
 		}
 		spw_locked = true;
-		if (is_shadow_pwd && (spw_open (O_CREAT | O_RDWR) == 0)) {
+		if (is_shadow_pwd && (spw_open(O_CREAT | O_RDWR) == 0)) {
 			eprintf(_("%s: cannot open %s\n"), Prog, spw_dbname());
-			fail_exit (E_PW_UPDATE, process_selinux);
+			fail_exit(E_PW_UPDATE, process_selinux);
 		}
 	}
 
@@ -1604,52 +1598,48 @@ static void open_files (bool process_selinux)
 		 * Lock and open the group file. This will load all of the
 		 * group entries.
 		 */
-		if (gr_lock () == 0) {
-			eprintf(_("%s: cannot lock %s; try again later.\n"),
-			         Prog, gr_dbname ());
-			fail_exit (E_GRP_UPDATE, process_selinux);
+		if (gr_lock() == 0) {
+			eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, gr_dbname());
+			fail_exit(E_GRP_UPDATE, process_selinux);
 		}
 		gr_locked = true;
-		if (gr_open (O_CREAT | O_RDWR) == 0) {
+		if (gr_open(O_CREAT | O_RDWR) == 0) {
 			eprintf(_("%s: cannot open %s\n"), Prog, gr_dbname());
-			fail_exit (E_GRP_UPDATE, process_selinux);
+			fail_exit(E_GRP_UPDATE, process_selinux);
 		}
 #ifdef SHADOWGRP
-		if (is_shadow_grp && (sgr_lock () == 0)) {
-			eprintf(_("%s: cannot lock %s; try again later.\n"),
-			         Prog, sgr_dbname ());
-			fail_exit (E_GRP_UPDATE, process_selinux);
+		if (is_shadow_grp && (sgr_lock() == 0)) {
+			eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, sgr_dbname());
+			fail_exit(E_GRP_UPDATE, process_selinux);
 		}
 		sgr_locked = true;
-		if (is_shadow_grp && (sgr_open (O_CREAT | O_RDWR) == 0)) {
+		if (is_shadow_grp && (sgr_open(O_CREAT | O_RDWR) == 0)) {
 			eprintf(_("%s: cannot open %s\n"), Prog, sgr_dbname());
-			fail_exit (E_GRP_UPDATE, process_selinux);
+			fail_exit(E_GRP_UPDATE, process_selinux);
 		}
 #endif
 	}
 #ifdef ENABLE_SUBIDS
 	if (vflg || Vflg) {
-		if (sub_uid_lock () == 0) {
-			eprintf(_("%s: cannot lock %s; try again later.\n"),
-			         Prog, sub_uid_dbname ());
-			fail_exit (E_SUB_UID_UPDATE, process_selinux);
+		if (sub_uid_lock() == 0) {
+			eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, sub_uid_dbname());
+			fail_exit(E_SUB_UID_UPDATE, process_selinux);
 		}
 		sub_uid_locked = true;
-		if (sub_uid_open (O_CREAT | O_RDWR) == 0) {
+		if (sub_uid_open(O_CREAT | O_RDWR) == 0) {
 			eprintf(_("%s: cannot open %s\n"), Prog, sub_uid_dbname());
-			fail_exit (E_SUB_UID_UPDATE, process_selinux);
+			fail_exit(E_SUB_UID_UPDATE, process_selinux);
 		}
 	}
 	if (wflg || Wflg) {
-		if (sub_gid_lock () == 0) {
-			eprintf(_("%s: cannot lock %s; try again later.\n"),
-			         Prog, sub_gid_dbname ());
-			fail_exit (E_SUB_GID_UPDATE, process_selinux);
+		if (sub_gid_lock() == 0) {
+			eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, sub_gid_dbname());
+			fail_exit(E_SUB_GID_UPDATE, process_selinux);
 		}
 		sub_gid_locked = true;
-		if (sub_gid_open (O_CREAT | O_RDWR) == 0) {
+		if (sub_gid_open(O_CREAT | O_RDWR) == 0) {
 			eprintf(_("%s: cannot open %s\n"), Prog, sub_gid_dbname());
-			fail_exit (E_SUB_GID_UPDATE, process_selinux);
+			fail_exit(E_SUB_GID_UPDATE, process_selinux);
 		}
 	}
 #endif				/* ENABLE_SUBIDS */

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -1577,14 +1577,16 @@ static void close_files(const struct option_flags *flags)
 static void
 open_files(bool process_selinux)
 {
-	if (pw_lock() == 0) {
-		eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, pw_dbname());
-		fail_exit(E_PW_UPDATE, process_selinux);
-	}
-	lk.pw = true;
-	if (pw_open(O_CREAT | O_RDWR) == 0) {
-		eprintf(_("%s: cannot open %s\n"), Prog, pw_dbname());
-		fail_exit(E_PW_UPDATE, process_selinux);
+	if (true) {
+		if (pw_lock() == 0) {
+			eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, pw_dbname());
+			fail_exit(E_PW_UPDATE, process_selinux);
+		}
+		lk.pw = true;
+		if (pw_open(O_CREAT | O_RDWR) == 0) {
+			eprintf(_("%s: cannot open %s\n"), Prog, pw_dbname());
+			fail_exit(E_PW_UPDATE, process_selinux);
+		}
 	}
 	if (is_shadow_pwd && (lflg || pflg || eflg || fflg || Lflg || Uflg)) {
 		if (spw_lock() == 0) {
@@ -1597,7 +1599,6 @@ open_files(bool process_selinux)
 			fail_exit(E_PW_UPDATE, process_selinux);
 		}
 	}
-
 	if (Gflg || lflg) {
 		/*
 		 * Lock and open the group file. This will load all of the
@@ -1612,20 +1613,20 @@ open_files(bool process_selinux)
 			eprintf(_("%s: cannot open %s\n"), Prog, gr_dbname());
 			fail_exit(E_GRP_UPDATE, process_selinux);
 		}
-#ifdef SHADOWGRP
-		if (is_shadow_grp) {
-			if (sgr_lock() == 0) {
-				eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, sgr_dbname());
-				fail_exit(E_GRP_UPDATE, process_selinux);
-			}
-			lk.sgr = true;
-			if (sgr_open(O_CREAT | O_RDWR) == 0) {
-				eprintf(_("%s: cannot open %s\n"), Prog, sgr_dbname());
-				fail_exit(E_GRP_UPDATE, process_selinux);
-			}
-		}
-#endif
 	}
+#ifdef SHADOWGRP
+	if ((Gflg || lflg) && is_shadow_grp) {
+		if (sgr_lock() == 0) {
+			eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, sgr_dbname());
+			fail_exit(E_GRP_UPDATE, process_selinux);
+		}
+		lk.sgr = true;
+		if (sgr_open(O_CREAT | O_RDWR) == 0) {
+			eprintf(_("%s: cannot open %s\n"), Prog, sgr_dbname());
+			fail_exit(E_GRP_UPDATE, process_selinux);
+		}
+	}
+#endif
 #ifdef ENABLE_SUBIDS
 	if (vflg || Vflg) {
 		if (sub_uid_lock() == 0) {
@@ -1649,7 +1650,7 @@ open_files(bool process_selinux)
 			fail_exit(E_SUB_GID_UPDATE, process_selinux);
 		}
 	}
-#endif				/* ENABLE_SUBIDS */
+#endif
 }
 
 /*

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -671,14 +671,16 @@ fail_exit(int code, bool process_selinux)
 		if (sub_gid_unlock(process_selinux) == 0) {
 			eprintf(_("%s: failed to unlock %s\n"), Prog, sub_gid_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sub_gid_dbname());
-			/* continue */
+		} else {
+			lk.subgid = false;
 		}
 	}
 	if (lk.subuid) {
 		if (sub_uid_unlock(process_selinux) == 0) {
 			eprintf(_("%s: failed to unlock %s\n"), Prog, sub_uid_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sub_uid_dbname());
-			/* continue */
+		} else {
+			lk.subuid = false;
 		}
 	}
 #endif				/* ENABLE_SUBIDS */
@@ -687,7 +689,8 @@ fail_exit(int code, bool process_selinux)
 		if (sgr_unlock(process_selinux) == 0) {
 			eprintf(_("%s: failed to unlock %s\n"), Prog, sgr_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", sgr_dbname());
-			/* continue */
+		} else {
+			lk.sgr = false;
 		}
 	}
 #endif
@@ -695,21 +698,24 @@ fail_exit(int code, bool process_selinux)
 		if (gr_unlock(process_selinux) == 0) {
 			eprintf(_("%s: failed to unlock %s\n"), Prog, gr_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", gr_dbname());
-			/* continue */
+		} else {
+			lk.gr = false;
 		}
 	}
 	if (lk.spw) {
 		if (spw_unlock(process_selinux) == 0) {
 			eprintf(_("%s: failed to unlock %s\n"), Prog, spw_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", spw_dbname());
-			/* continue */
+		} else {
+			lk.spw = false;
 		}
 	}
 	if (lk.pw) {
 		if (pw_unlock(process_selinux) == 0) {
 			eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
 			SYSLOG(LOG_ERR, "failed to unlock %s", pw_dbname());
-			/* continue */
+		} else {
+			lk.pw = false;
 		}
 	}
 

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -1502,7 +1502,7 @@ static void close_files(const struct option_flags *flags)
 
 	if (gr_locked) {
 #ifdef SHADOWGRP
-		if (is_shadow_grp) {
+		if (sgr_locked) {
 			if (sgr_close(process_selinux) == 0) {
 				eprintf(_("%s: failure while writing changes to %s\n"), Prog, sgr_dbname());
 				SYSLOG(LOG_ERR, "failure while writing changes to %s", sgr_dbname());
@@ -1541,17 +1541,19 @@ static void close_files(const struct option_flags *flags)
 		}
 		spw_locked = false;
 	}
-	if (pw_close(process_selinux) == 0) {
-		eprintf(_("%s: failure while writing changes to %s\n"), Prog, pw_dbname());
-		SYSLOG(LOG_ERR, "failure while writing changes to %s", pw_dbname());
-		fail_exit(E_PW_UPDATE, process_selinux);
+	if (pw_locked) {
+		if (pw_close(process_selinux) == 0) {
+			eprintf(_("%s: failure while writing changes to %s\n"), Prog, pw_dbname());
+			SYSLOG(LOG_ERR, "failure while writing changes to %s", pw_dbname());
+			fail_exit(E_PW_UPDATE, process_selinux);
+		}
+		if (pw_unlock(process_selinux) == 0) {
+			eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
+			SYSLOG(LOG_ERR, "failed to unlock %s", pw_dbname());
+			/* continue */
+		}
+		pw_locked = false;
 	}
-	if (pw_unlock(process_selinux) == 0) {
-		eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
-		SYSLOG(LOG_ERR, "failed to unlock %s", pw_dbname());
-		/* continue */
-	}
-	pw_locked = false;
 
 	/*
 	 * Close the DBM and/or flat files

--- a/src/usermod.c
+++ b/src/usermod.c
@@ -1486,6 +1486,7 @@ close_db(bool process_selinux)
 {
 	int  ret;
 
+	ret = 0;
 #ifdef ENABLE_SUBIDS
 	if (lk.subgid) {
 		if (sub_gid_close(process_selinux) == 0) {
@@ -1494,11 +1495,6 @@ close_db(bool process_selinux)
 			ret = E_SUB_GID_UPDATE;
 			goto fail;
 		}
-		if (sub_gid_unlock(process_selinux) == 0) {
-			eprintf(_("%s: failed to unlock %s\n"), Prog, sub_gid_dbname());
-			SYSLOG(LOG_ERR, "failed to unlock %s", sub_gid_dbname());
-		}
-		lk.subgid = false;
 	}
 	if (lk.subuid) {
 		if (sub_uid_close(process_selinux) == 0) {
@@ -1507,11 +1503,6 @@ close_db(bool process_selinux)
 			ret = E_SUB_UID_UPDATE;
 			goto fail;
 		}
-		if (sub_uid_unlock(process_selinux) == 0) {
-			eprintf(_("%s: failed to unlock %s\n"), Prog, sub_uid_dbname());
-			SYSLOG(LOG_ERR, "failed to unlock %s", sub_uid_dbname());
-		}
-		lk.subuid = false;
 	}
 #endif
 #ifdef SHADOWGRP
@@ -1522,11 +1513,6 @@ close_db(bool process_selinux)
 			ret = E_GRP_UPDATE;
 			goto fail;
 		}
-		if (sgr_unlock(process_selinux) == 0) {
-			eprintf(_("%s: failed to unlock %s\n"), Prog, sgr_dbname());
-			SYSLOG(LOG_ERR, "failed to unlock %s", sgr_dbname());
-		}
-		lk.sgr = false;
 	}
 #endif
 	if (lk.gr) {
@@ -1536,11 +1522,6 @@ close_db(bool process_selinux)
 			ret = E_GRP_UPDATE;
 			goto fail;
 		}
-		if (gr_unlock(process_selinux) == 0) {
-			eprintf(_("%s: failed to unlock %s\n"), Prog, gr_dbname());
-			SYSLOG(LOG_ERR, "failed to unlock %s", gr_dbname());
-		}
-		lk.gr = false;
 	}
 	if (lk.spw) {
 		if (spw_close(process_selinux) == 0) {
@@ -1549,11 +1530,6 @@ close_db(bool process_selinux)
 			ret = E_PW_UPDATE;
 			goto fail;
 		}
-		if (spw_unlock(process_selinux) == 0) {
-			eprintf(_("%s: failed to unlock %s\n"), Prog, spw_dbname());
-			SYSLOG(LOG_ERR, "failed to unlock %s", spw_dbname());
-		}
-		lk.spw = false;
 	}
 	if (lk.pw) {
 		if (pw_close(process_selinux) == 0) {
@@ -1562,11 +1538,6 @@ close_db(bool process_selinux)
 			ret = E_PW_UPDATE;
 			goto fail;
 		}
-		if (pw_unlock(process_selinux) == 0) {
-			eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
-			SYSLOG(LOG_ERR, "failed to unlock %s", pw_dbname());
-		}
-		lk.pw = false;
 	}
 
 #ifdef SHADOWGRP
@@ -1575,7 +1546,6 @@ close_db(bool process_selinux)
 	endgrent();
 	endspent();
 	endpwent();
-	return 0;
 fail:
 	unlock_db(process_selinux);
 	return ret;


### PR DESCRIPTION
This is a cleanup before starting to work on moving this to lib/ and using it everywhere.

Cc: @jcpunk, @stoeckmann

---

Revisions:

<details>
<summary>v2</summary>

-  Don't compact conditionals.

```
$ git rd 
 1:  f3527e58 =  1:  f3527e58 src/usermod.c: wsfix
 2:  7569e1eb =  2:  7569e1eb src/usermod.c: Remove dead code
 3:  dd7ff117 =  3:  dd7ff117 src/usermod.c: Set 'sgr_locked = true' only if we really locked
 4:  cebb97ac =  4:  cebb97ac src/usermod.c: Only close files if they were locked
 5:  924c8fae =  5:  924c8fae src/usermod.c: Remove unnecessary nesting
 6:  bf95899d =  6:  bf95899d src/usermod.c: Merge variables into structure
 7:  3063065e =  7:  3063065e src/usermod.c: fail_exit(): Unset lk fields after unlocking
 8:  37fa83a1 =  8:  37fa83a1 src/usermod.c: Split unlock_db() helper from fail_exit()
 9:  c096177f =  9:  c096177f src/usermod.c: Split close_db() helper from close_files()
10:  f824c16d = 10:  f824c16d src/usermod.c: close_db(): First close all files, then unlock all files
11:  431f9888 <  -:  -------- src/usermod.c: close_db(): Compact conditionals
12:  32eb81b6 = 11:  ffa3e457 src/usermod.c: open_files(): Refactor conditionals
13:  36487877 = 12:  720ee763 src/usermod.c: Split open_db() from open_files()
```
</details>

<details>
<summary>v2b</summary>

-  Rebase

```
$ git rd 
 1:  f3527e58 =  1:  cbb38e0b src/usermod.c: wsfix
 2:  7569e1eb =  2:  571a4429 src/usermod.c: Remove dead code
 3:  dd7ff117 =  3:  885d6025 src/usermod.c: Set 'sgr_locked = true' only if we really locked
 4:  cebb97ac =  4:  bf195bdb src/usermod.c: Only close files if they were locked
 5:  924c8fae =  5:  1afafd75 src/usermod.c: Remove unnecessary nesting
 6:  bf95899d =  6:  adcc49ee src/usermod.c: Merge variables into structure
 7:  3063065e =  7:  b2a024d5 src/usermod.c: fail_exit(): Unset lk fields after unlocking
 8:  37fa83a1 =  8:  8b932f19 src/usermod.c: Split unlock_db() helper from fail_exit()
 9:  c096177f =  9:  f4753f50 src/usermod.c: Split close_db() helper from close_files()
10:  f824c16d = 10:  830dcf20 src/usermod.c: close_db(): First close all files, then unlock all files
11:  ffa3e457 = 11:  fae19e8f src/usermod.c: open_files(): Refactor conditionals
12:  720ee763 = 12:  a0eeda31 src/usermod.c: Split open_db() from open_files()
```
</details>

<details>
<summary>v2c</summary>

-  Rebase

```
$ git rd 
 1:  cbb38e0b21f5 =  1:  c621a4cb2faf src/usermod.c: wsfix
 2:  571a4429c999 =  2:  35756b8276f8 src/usermod.c: Remove dead code
 3:  885d6025618e =  3:  1b2c685b7283 src/usermod.c: Set 'sgr_locked = true' only if we really locked
 4:  bf195bdbd7e8 =  4:  7d5e49c139c7 src/usermod.c: Only close files if they were locked
 5:  1afafd75d3f6 =  5:  80116f8d2dd0 src/usermod.c: Remove unnecessary nesting
 6:  adcc49eea021 =  6:  0b00fa559a56 src/usermod.c: Merge variables into structure
 7:  b2a024d55cdf =  7:  df14ce72973e src/usermod.c: fail_exit(): Unset lk fields after unlocking
 8:  8b932f19fea1 =  8:  aaf4d0b737db src/usermod.c: Split unlock_db() helper from fail_exit()
 9:  f4753f50b1a1 =  9:  3345dc0e8c24 src/usermod.c: Split close_db() helper from close_files()
10:  830dcf201bcf = 10:  8cf4bb78e710 src/usermod.c: close_db(): First close all files, then unlock all files
11:  fae19e8f58b1 = 11:  14d566ad88f8 src/usermod.c: open_files(): Refactor conditionals
12:  a0eeda3163ee = 12:  eac7f42a30b9 src/usermod.c: Split open_db() from open_files()
```
</details>

<details>
<summary>v2d</summary>

-  Rebase

```
$ git rd 
 1:  c621a4cb2faf =  1:  541a718d5d3d src/usermod.c: wsfix
 2:  35756b8276f8 =  2:  dda5cd869d56 src/usermod.c: Remove dead code
 3:  1b2c685b7283 =  3:  a8ca0752d5bf src/usermod.c: Set 'sgr_locked = true' only if we really locked
 4:  7d5e49c139c7 =  4:  2a20419a53da src/usermod.c: Only close files if they were locked
 5:  80116f8d2dd0 =  5:  7fe8f78881d5 src/usermod.c: Remove unnecessary nesting
 6:  0b00fa559a56 =  6:  954dcbb48890 src/usermod.c: Merge variables into structure
 7:  df14ce72973e =  7:  3ea89e61e889 src/usermod.c: fail_exit(): Unset lk fields after unlocking
 8:  aaf4d0b737db =  8:  a6c2f53481ea src/usermod.c: Split unlock_db() helper from fail_exit()
 9:  3345dc0e8c24 =  9:  86d6ce0dbd34 src/usermod.c: Split close_db() helper from close_files()
10:  8cf4bb78e710 = 10:  d9f131f644aa src/usermod.c: close_db(): First close all files, then unlock all files
11:  14d566ad88f8 = 11:  015128282c22 src/usermod.c: open_files(): Refactor conditionals
12:  eac7f42a30b9 = 12:  9be4a394be4c src/usermod.c: Split open_db() from open_files()
```
</details>

<details>
<summary>v3</summary>

-  Rebase

```
$ git rd -U0
 1:  541a718d5d3d !  1:  59ee26edce80 src/usermod.c: wsfix
    @@ src/usermod.c: static void new_spent (struct spwd *spent, bool process_selinux)
    --                  fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, sub_gid_dbname ());
    +-                  eprintf(_("%s: failed to unlock %s\n"), Prog, sub_gid_dbname ());
    @@ src/usermod.c: static void new_spent (struct spwd *spent, bool process_selinux)
    -+                  fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, sub_gid_dbname());
    ++                  eprintf(_("%s: failed to unlock %s\n"), Prog, sub_gid_dbname());
    @@ src/usermod.c: static void new_spent (struct spwd *spent, bool process_selinux)
    --                  fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, sub_uid_dbname ());
    @@ src/usermod.c: static void new_spent (struct spwd *spent, bool process_selinux)
    -+                  fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, sub_uid_dbname());
    +                   eprintf(_("%s: failed to unlock %s\n"), Prog, sub_uid_dbname());
    @@ src/usermod.c: static void new_spent (struct spwd *spent, bool process_selinux)
    -           }
    @@ src/usermod.c: fail_exit (int code, bool process_selinux)
    --                  fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, sgr_dbname ());
    @@ src/usermod.c: fail_exit (int code, bool process_selinux)
    -+                  fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, sgr_dbname());
    +                   eprintf(_("%s: failed to unlock %s\n"), Prog, sgr_dbname());
    @@ src/usermod.c: fail_exit (int code, bool process_selinux)
    -           }
    +@@ src/usermod.c: fail_exit (int code, bool process_selinux)
    @@ src/usermod.c: fail_exit (int code, bool process_selinux)
    --                  fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, gr_dbname ());
    @@ src/usermod.c: fail_exit (int code, bool process_selinux)
    -+                  fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, gr_dbname());
    +                   eprintf(_("%s: failed to unlock %s\n"), Prog, gr_dbname());
    @@ src/usermod.c: fail_exit (int code, bool process_selinux)
    --                  fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, spw_dbname ());
    @@ src/usermod.c: fail_exit (int code, bool process_selinux)
    -+                  fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, spw_dbname());
    +                   eprintf(_("%s: failed to unlock %s\n"), Prog, spw_dbname());
    @@ src/usermod.c: fail_exit (int code, bool process_selinux)
    --                  fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, pw_dbname ());
    @@ src/usermod.c: fail_exit (int code, bool process_selinux)
    -+                  fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, pw_dbname());
    +                   eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
    @@ src/usermod.c: fail_exit (int code, bool process_selinux)
    -           }
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    --                  fprintf (stderr, _("%s: failure while writing changes to %s\n"), Prog, sub_gid_dbname ());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -+                  fprintf(stderr, _("%s: failure while writing changes to %s\n"), Prog, sub_gid_dbname());
    +                   eprintf(_("%s: failure while writing changes to %s\n"), Prog, sub_gid_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    --                  fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, sub_gid_dbname ());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -+                  fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, sub_gid_dbname());
    +                   eprintf(_("%s: failed to unlock %s\n"), Prog, sub_gid_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -           }
    +@@ src/usermod.c: static void close_files(const struct option_flags *flags)
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    --                  fprintf (stderr, _("%s: failure while writing changes to %s\n"), Prog, sub_uid_dbname ());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -+                  fprintf(stderr, _("%s: failure while writing changes to %s\n"), Prog, sub_uid_dbname());
    +                   eprintf(_("%s: failure while writing changes to %s\n"), Prog, sub_uid_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    --                  fprintf (stderr, _("%s: failed to unlock %s\n"), Prog, sub_uid_dbname ());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -+                  fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, sub_uid_dbname());
    +                   eprintf(_("%s: failed to unlock %s\n"), Prog, sub_uid_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -           }
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    --                          fprintf (stderr,
    --                                   _("%s: failure while writing changes to %s\n"),
    +-                          eprintf(_("%s: failure while writing changes to %s\n"),
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -+                          fprintf(stderr, _("%s: failure while writing changes to %s\n"), Prog, sgr_dbname());
    ++                          eprintf(_("%s: failure while writing changes to %s\n"), Prog, sgr_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    --                          fprintf (stderr,
    --                                   _("%s: failed to unlock %s\n"),
    --                                   Prog, sgr_dbname ());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -+                          fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, sgr_dbname());
    +                           eprintf(_("%s: failed to unlock %s\n"), Prog, sgr_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -                   }
    +@@ src/usermod.c: static void close_files(const struct option_flags *flags)
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    --                  fprintf (stderr,
    --                           _("%s: failure while writing changes to %s\n"),
    +-                  eprintf(_("%s: failure while writing changes to %s\n"),
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -+                  fprintf(stderr, _("%s: failure while writing changes to %s\n"), Prog, gr_dbname());
    ++                  eprintf(_("%s: failure while writing changes to %s\n"), Prog, gr_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    --                  fprintf (stderr,
    --                           _("%s: failed to unlock %s\n"),
    --                           Prog, gr_dbname ());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -+                  fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, gr_dbname());
    +                   eprintf(_("%s: failed to unlock %s\n"), Prog, gr_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -           }
    +@@ src/usermod.c: static void close_files(const struct option_flags *flags)
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    --                  fprintf (stderr,
    --                          _("%s: failure while writing changes to %s\n"),
    +-                  eprintf(_("%s: failure while writing changes to %s\n"),
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -+                  fprintf(stderr, _("%s: failure while writing changes to %s\n"), Prog, spw_dbname());
    ++                  eprintf(_("%s: failure while writing changes to %s\n"), Prog, spw_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    --                  fprintf (stderr,
    --                           _("%s: failed to unlock %s\n"),
    --                           Prog, spw_dbname ());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -+                  fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, spw_dbname());
    +                   eprintf(_("%s: failed to unlock %s\n"), Prog, spw_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    --          fprintf (stderr,
    --                   _("%s: failure while writing changes to %s\n"),
    --                   Prog, pw_dbname ());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -+          fprintf(stderr, _("%s: failure while writing changes to %s\n"), Prog, pw_dbname());
    +           eprintf(_("%s: failure while writing changes to %s\n"), Prog, pw_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    --          fprintf (stderr,
    --                   _("%s: failed to unlock %s\n"),
    --                   Prog, pw_dbname ());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -+          fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, pw_dbname());
    +           eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -   }
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    --          fprintf (stderr,
    --                   _("%s: cannot lock %s; try again later.\n"),
    +-          eprintf(_("%s: cannot lock %s; try again later.\n"),
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -+          fprintf(stderr, _("%s: cannot lock %s; try again later.\n"), Prog, pw_dbname());
    ++          eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, pw_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    --          fprintf (stderr,
    --                   _("%s: cannot open %s\n"),
    --                   Prog, pw_dbname ());
    --          fail_exit (E_PW_UPDATE, process_selinux);
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -+          fprintf(stderr, _("%s: cannot open %s\n"), Prog, pw_dbname());
    +           eprintf(_("%s: cannot open %s\n"), Prog, pw_dbname());
    +-          fail_exit (E_PW_UPDATE, process_selinux);
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    --                  fprintf (stderr,
    --                          _("%s: cannot lock %s; try again later.\n"),
    +-                  eprintf(_("%s: cannot lock %s; try again later.\n"),
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -+                  fprintf(stderr, _("%s: cannot lock %s; try again later.\n"), Prog, spw_dbname());
    ++                  eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, spw_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    --                  fprintf (stderr,
    --                          _("%s: cannot open %s\n"),
    --                          Prog, spw_dbname ());
    --                  fail_exit (E_PW_UPDATE, process_selinux);
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -+                  fprintf(stderr, _("%s: cannot open %s\n"), Prog, spw_dbname());
    +                   eprintf(_("%s: cannot open %s\n"), Prog, spw_dbname());
    +-                  fail_exit (E_PW_UPDATE, process_selinux);
    @@ src/usermod.c: static void open_files (bool process_selinux)
    --                  fprintf (stderr,
    --                           _("%s: cannot lock %s; try again later.\n"),
    +-                  eprintf(_("%s: cannot lock %s; try again later.\n"),
    @@ src/usermod.c: static void open_files (bool process_selinux)
    -+                  fprintf(stderr, _("%s: cannot lock %s; try again later.\n"), Prog, gr_dbname());
    ++                  eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, gr_dbname());
    @@ src/usermod.c: static void open_files (bool process_selinux)
    --                  fprintf (stderr,
    --                           _("%s: cannot open %s\n"),
    --                           Prog, gr_dbname ());
    --                  fail_exit (E_GRP_UPDATE, process_selinux);
    @@ src/usermod.c: static void open_files (bool process_selinux)
    -+                  fprintf(stderr, _("%s: cannot open %s\n"), Prog, gr_dbname());
    +                   eprintf(_("%s: cannot open %s\n"), Prog, gr_dbname());
    +-                  fail_exit (E_GRP_UPDATE, process_selinux);
    @@ src/usermod.c: static void open_files (bool process_selinux)
    --                  fprintf (stderr,
    --                           _("%s: cannot lock %s; try again later.\n"),
    +-                  eprintf(_("%s: cannot lock %s; try again later.\n"),
    @@ src/usermod.c: static void open_files (bool process_selinux)
    -+                  fprintf(stderr, _("%s: cannot lock %s; try again later.\n"), Prog, sgr_dbname());
    ++                  eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, sgr_dbname());
    @@ src/usermod.c: static void open_files (bool process_selinux)
    --                  fprintf (stderr,
    --                           _("%s: cannot open %s\n"),
    --                           Prog, sgr_dbname ());
    --                  fail_exit (E_GRP_UPDATE, process_selinux);
    @@ src/usermod.c: static void open_files (bool process_selinux)
    -+                  fprintf(stderr, _("%s: cannot open %s\n"), Prog, sgr_dbname());
    +                   eprintf(_("%s: cannot open %s\n"), Prog, sgr_dbname());
    +-                  fail_exit (E_GRP_UPDATE, process_selinux);
    @@ src/usermod.c: static void open_files (bool process_selinux)
    --                  fprintf (stderr,
    --                           _("%s: cannot lock %s; try again later.\n"),
    +-                  eprintf(_("%s: cannot lock %s; try again later.\n"),
    @@ src/usermod.c: static void open_files (bool process_selinux)
    -+                  fprintf(stderr, _("%s: cannot lock %s; try again later.\n"), Prog, sub_uid_dbname());
    ++                  eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, sub_uid_dbname());
    @@ src/usermod.c: static void open_files (bool process_selinux)
    --                  fprintf (stderr,
    --                           _("%s: cannot open %s\n"),
    --                           Prog, sub_uid_dbname ());
    --                  fail_exit (E_SUB_UID_UPDATE, process_selinux);
    @@ src/usermod.c: static void open_files (bool process_selinux)
    -+                  fprintf(stderr, _("%s: cannot open %s\n"), Prog, sub_uid_dbname());
    +                   eprintf(_("%s: cannot open %s\n"), Prog, sub_uid_dbname());
    +-                  fail_exit (E_SUB_UID_UPDATE, process_selinux);
    @@ src/usermod.c: static void open_files (bool process_selinux)
    --                  fprintf (stderr,
    --                           _("%s: cannot lock %s; try again later.\n"),
    +-                  eprintf(_("%s: cannot lock %s; try again later.\n"),
    @@ src/usermod.c: static void open_files (bool process_selinux)
    -+                  fprintf(stderr, _("%s: cannot lock %s; try again later.\n"), Prog, sub_gid_dbname());
    ++                  eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, sub_gid_dbname());
    @@ src/usermod.c: static void open_files (bool process_selinux)
    --                  fprintf (stderr,
    --                           _("%s: cannot open %s\n"),
    --                           Prog, sub_gid_dbname ());
    --                  fail_exit (E_SUB_GID_UPDATE, process_selinux);
    @@ src/usermod.c: static void open_files (bool process_selinux)
    -+                  fprintf(stderr, _("%s: cannot open %s\n"), Prog, sub_gid_dbname());
    +                   eprintf(_("%s: cannot open %s\n"), Prog, sub_gid_dbname());
    +-                  fail_exit (E_SUB_GID_UPDATE, process_selinux);
 2:  dda5cd869d56 !  2:  a19c2c329ca5 src/usermod.c: Remove dead code
    @@ src/usermod.c: open_files(bool process_selinux)
    -                   fprintf(stderr, _("%s: cannot open %s\n"), Prog, spw_dbname());
    +                   eprintf(_("%s: cannot open %s\n"), Prog, spw_dbname());
 3:  a8ca0752d5bf !  3:  e7b7a9b09343 src/usermod.c: Set 'sgr_locked = true' only if we really locked
    @@ src/usermod.c: open_files(bool process_selinux)
    --                  fprintf(stderr, _("%s: cannot lock %s; try again later.\n"), Prog, sgr_dbname());
    +-                  eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, sgr_dbname());
    @@ src/usermod.c: open_files(bool process_selinux)
    --                  fprintf(stderr, _("%s: cannot open %s\n"), Prog, sgr_dbname());
    +-                  eprintf(_("%s: cannot open %s\n"), Prog, sgr_dbname());
    @@ src/usermod.c: open_files(bool process_selinux)
    -+                          fprintf(stderr, _("%s: cannot lock %s; try again later.\n"), Prog, sgr_dbname());
    ++                          eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, sgr_dbname());
    @@ src/usermod.c: open_files(bool process_selinux)
    -+                          fprintf(stderr, _("%s: cannot open %s\n"), Prog, sgr_dbname());
    ++                          eprintf(_("%s: cannot open %s\n"), Prog, sgr_dbname());
 4:  2a20419a53da !  4:  76ead6137f24 src/usermod.c: Only close files if they were locked
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -                           fprintf(stderr, _("%s: failure while writing changes to %s\n"), Prog, sgr_dbname());
    +                           eprintf(_("%s: failure while writing changes to %s\n"), Prog, sgr_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    --          fprintf(stderr, _("%s: failure while writing changes to %s\n"), Prog, pw_dbname());
    +-          eprintf(_("%s: failure while writing changes to %s\n"), Prog, pw_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -+                  fprintf(stderr, _("%s: failure while writing changes to %s\n"), Prog, pw_dbname());
    ++                  eprintf(_("%s: failure while writing changes to %s\n"), Prog, pw_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -+                  fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, pw_dbname());
    ++                  eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    --          fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, pw_dbname());
    +-          eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
 5:  7fe8f78881d5 !  5:  2fc75d687080 src/usermod.c: Remove unnecessary nesting
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    --                          fprintf(stderr, _("%s: failure while writing changes to %s\n"), Prog, sgr_dbname());
    +-                          eprintf(_("%s: failure while writing changes to %s\n"), Prog, sgr_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    --                          fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, sgr_dbname());
    +-                          eprintf(_("%s: failed to unlock %s\n"), Prog, sgr_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -+                  fprintf(stderr, _("%s: failure while writing changes to %s\n"), Prog, sgr_dbname());
    ++                  eprintf(_("%s: failure while writing changes to %s\n"), Prog, sgr_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -+                  fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, sgr_dbname());
    ++                  eprintf(_("%s: failed to unlock %s\n"), Prog, sgr_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -                   fprintf(stderr, _("%s: failure while writing changes to %s\n"), Prog, gr_dbname());
    +                   eprintf(_("%s: failure while writing changes to %s\n"), Prog, gr_dbname());
 6:  954dcbb48890 !  6:  19a5e1310fc2 src/usermod.c: Merge variables into structure
    @@ src/usermod.c: static void
    -                   fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, sub_gid_dbname());
    +                   eprintf(_("%s: failed to unlock %s\n"), Prog, sub_gid_dbname());
    @@ src/usermod.c: static void
    -                   fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, sub_uid_dbname());
    +                   eprintf(_("%s: failed to unlock %s\n"), Prog, sub_uid_dbname());
    @@ src/usermod.c: fail_exit(int code, bool process_selinux)
    -                   fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, sgr_dbname());
    +                   eprintf(_("%s: failed to unlock %s\n"), Prog, sgr_dbname());
    @@ src/usermod.c: fail_exit(int code, bool process_selinux)
    -                   fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, gr_dbname());
    +                   eprintf(_("%s: failed to unlock %s\n"), Prog, gr_dbname());
    @@ src/usermod.c: fail_exit(int code, bool process_selinux)
    -                   fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, spw_dbname());
    +                   eprintf(_("%s: failed to unlock %s\n"), Prog, spw_dbname());
    @@ src/usermod.c: fail_exit(int code, bool process_selinux)
    -                   fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, pw_dbname());
    +                   eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -                   fprintf(stderr, _("%s: failure while writing changes to %s\n"), Prog, sub_gid_dbname());
    +                   eprintf(_("%s: failure while writing changes to %s\n"), Prog, sub_gid_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -                   fprintf(stderr, _("%s: failure while writing changes to %s\n"), Prog, sub_uid_dbname());
    +                   eprintf(_("%s: failure while writing changes to %s\n"), Prog, sub_uid_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -                   fprintf(stderr, _("%s: failure while writing changes to %s\n"), Prog, sgr_dbname());
    +                   eprintf(_("%s: failure while writing changes to %s\n"), Prog, sgr_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -                   fprintf(stderr, _("%s: failure while writing changes to %s\n"), Prog, gr_dbname());
    +                   eprintf(_("%s: failure while writing changes to %s\n"), Prog, gr_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -                   fprintf(stderr, _("%s: failure while writing changes to %s\n"), Prog, spw_dbname());
    +                   eprintf(_("%s: failure while writing changes to %s\n"), Prog, spw_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -                   fprintf(stderr, _("%s: failure while writing changes to %s\n"), Prog, pw_dbname());
    +                   eprintf(_("%s: failure while writing changes to %s\n"), Prog, pw_dbname());
    @@ src/usermod.c: open_files(bool process_selinux)
    -           fprintf(stderr, _("%s: cannot lock %s; try again later.\n"), Prog, pw_dbname());
    +           eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, pw_dbname());
    @@ src/usermod.c: open_files(bool process_selinux)
    -           fprintf(stderr, _("%s: cannot open %s\n"), Prog, pw_dbname());
    +           eprintf(_("%s: cannot open %s\n"), Prog, pw_dbname());
    @@ src/usermod.c: open_files(bool process_selinux)
    -                   fprintf(stderr, _("%s: cannot lock %s; try again later.\n"), Prog, spw_dbname());
    +                   eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, spw_dbname());
    @@ src/usermod.c: open_files(bool process_selinux)
    -                   fprintf(stderr, _("%s: cannot open %s\n"), Prog, spw_dbname());
    +                   eprintf(_("%s: cannot open %s\n"), Prog, spw_dbname());
    @@ src/usermod.c: open_files(bool process_selinux)
    -                   fprintf(stderr, _("%s: cannot lock %s; try again later.\n"), Prog, gr_dbname());
    +                   eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, gr_dbname());
    @@ src/usermod.c: open_files(bool process_selinux)
    -                   fprintf(stderr, _("%s: cannot open %s\n"), Prog, gr_dbname());
    +                   eprintf(_("%s: cannot open %s\n"), Prog, gr_dbname());
    @@ src/usermod.c: open_files(bool process_selinux)
    -                           fprintf(stderr, _("%s: cannot lock %s; try again later.\n"), Prog, sgr_dbname());
    +                           eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, sgr_dbname());
    @@ src/usermod.c: open_files(bool process_selinux)
    -                           fprintf(stderr, _("%s: cannot open %s\n"), Prog, sgr_dbname());
    +                           eprintf(_("%s: cannot open %s\n"), Prog, sgr_dbname());
    @@ src/usermod.c: open_files(bool process_selinux)
    -                   fprintf(stderr, _("%s: cannot lock %s; try again later.\n"), Prog, sub_uid_dbname());
    +                   eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, sub_uid_dbname());
    @@ src/usermod.c: open_files(bool process_selinux)
    -                   fprintf(stderr, _("%s: cannot open %s\n"), Prog, sub_uid_dbname());
    +                   eprintf(_("%s: cannot open %s\n"), Prog, sub_uid_dbname());
    @@ src/usermod.c: open_files(bool process_selinux)
    -                   fprintf(stderr, _("%s: cannot lock %s; try again later.\n"), Prog, sub_gid_dbname());
    +                   eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, sub_gid_dbname());
    @@ src/usermod.c: open_files(bool process_selinux)
    -                   fprintf(stderr, _("%s: cannot open %s\n"), Prog, sub_gid_dbname());
    +                   eprintf(_("%s: cannot open %s\n"), Prog, sub_gid_dbname());
 7:  3ea89e61e889 !  7:  b778c766d298 src/usermod.c: fail_exit(): Unset lk fields after unlocking
    @@ src/usermod.c: fail_exit(int code, bool process_selinux)
    -                   fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, sub_gid_dbname());
    +                   eprintf(_("%s: failed to unlock %s\n"), Prog, sub_gid_dbname());
    @@ src/usermod.c: fail_exit(int code, bool process_selinux)
    -                   fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, sub_uid_dbname());
    +                   eprintf(_("%s: failed to unlock %s\n"), Prog, sub_uid_dbname());
    @@ src/usermod.c: fail_exit(int code, bool process_selinux)
    -                   fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, sgr_dbname());
    +                   eprintf(_("%s: failed to unlock %s\n"), Prog, sgr_dbname());
    @@ src/usermod.c: fail_exit(int code, bool process_selinux)
    -                   fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, gr_dbname());
    +                   eprintf(_("%s: failed to unlock %s\n"), Prog, gr_dbname());
    @@ src/usermod.c: fail_exit(int code, bool process_selinux)
    -                   fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, spw_dbname());
    +                   eprintf(_("%s: failed to unlock %s\n"), Prog, spw_dbname());
    @@ src/usermod.c: fail_exit(int code, bool process_selinux)
    -                   fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, pw_dbname());
    +                   eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
 8:  a6c2f53481ea !  8:  c975eea58d4e src/usermod.c: Split unlock_db() helper from fail_exit()
    @@ src/usermod.c: fail_exit(int code, bool process_selinux)
    -                   fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, sgr_dbname());
    +                   eprintf(_("%s: failed to unlock %s\n"), Prog, sgr_dbname());
 9:  86d6ce0dbd34 !  9:  871e5bc57d51 src/usermod.c: Split close_db() helper from close_files()
    @@ src/usermod.c: process_flags(int argc, char **argv, struct option_flags *flags)
    -                   fprintf(stderr, _("%s: failure while writing changes to %s\n"), Prog, sub_gid_dbname());
    +                   eprintf(_("%s: failure while writing changes to %s\n"), Prog, sub_gid_dbname());
    @@ src/usermod.c: process_flags(int argc, char **argv, struct option_flags *flags)
    -                   fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, sub_gid_dbname());
    +                   eprintf(_("%s: failed to unlock %s\n"), Prog, sub_gid_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -                   fprintf(stderr, _("%s: failure while writing changes to %s\n"), Prog, sub_uid_dbname());
    +                   eprintf(_("%s: failure while writing changes to %s\n"), Prog, sub_uid_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -                   fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, sub_uid_dbname());
    +                   eprintf(_("%s: failed to unlock %s\n"), Prog, sub_uid_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -                   fprintf(stderr, _("%s: failure while writing changes to %s\n"), Prog, sgr_dbname());
    +                   eprintf(_("%s: failure while writing changes to %s\n"), Prog, sgr_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -                   fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, sgr_dbname());
    +                   eprintf(_("%s: failed to unlock %s\n"), Prog, sgr_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -                   fprintf(stderr, _("%s: failure while writing changes to %s\n"), Prog, gr_dbname());
    +                   eprintf(_("%s: failure while writing changes to %s\n"), Prog, gr_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -                   fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, gr_dbname());
    +                   eprintf(_("%s: failed to unlock %s\n"), Prog, gr_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -                   fprintf(stderr, _("%s: failure while writing changes to %s\n"), Prog, spw_dbname());
    +                   eprintf(_("%s: failure while writing changes to %s\n"), Prog, spw_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -                   fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, spw_dbname());
    +                   eprintf(_("%s: failed to unlock %s\n"), Prog, spw_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -                   fprintf(stderr, _("%s: failure while writing changes to %s\n"), Prog, pw_dbname());
    +                   eprintf(_("%s: failure while writing changes to %s\n"), Prog, pw_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -                   fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, pw_dbname());
    +                   eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
10:  d9f131f644aa ! 10:  bac5d19d81d5 src/usermod.c: close_db(): First close all files, then unlock all files
    @@ src/usermod.c: close_db(bool process_selinux)
    --                  fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, sub_gid_dbname());
    +-                  eprintf(_("%s: failed to unlock %s\n"), Prog, sub_gid_dbname());
    @@ src/usermod.c: close_db(bool process_selinux)
    --                  fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, sub_uid_dbname());
    +-                  eprintf(_("%s: failed to unlock %s\n"), Prog, sub_uid_dbname());
    @@ src/usermod.c: close_db(bool process_selinux)
    --                  fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, sgr_dbname());
    +-                  eprintf(_("%s: failed to unlock %s\n"), Prog, sgr_dbname());
    @@ src/usermod.c: close_db(bool process_selinux)
    --                  fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, gr_dbname());
    +-                  eprintf(_("%s: failed to unlock %s\n"), Prog, gr_dbname());
    @@ src/usermod.c: close_db(bool process_selinux)
    --                  fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, spw_dbname());
    +-                  eprintf(_("%s: failed to unlock %s\n"), Prog, spw_dbname());
    @@ src/usermod.c: close_db(bool process_selinux)
    --                  fprintf(stderr, _("%s: failed to unlock %s\n"), Prog, pw_dbname());
    +-                  eprintf(_("%s: failed to unlock %s\n"), Prog, pw_dbname());
11:  015128282c22 ! 11:  170626affc8c src/usermod.c: open_files(): Refactor conditionals
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    --          fprintf(stderr, _("%s: cannot lock %s; try again later.\n"), Prog, pw_dbname());
    +-          eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, pw_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    --          fprintf(stderr, _("%s: cannot open %s\n"), Prog, pw_dbname());
    +-          eprintf(_("%s: cannot open %s\n"), Prog, pw_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -+                  fprintf(stderr, _("%s: cannot lock %s; try again later.\n"), Prog, pw_dbname());
    ++                  eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, pw_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -+                  fprintf(stderr, _("%s: cannot open %s\n"), Prog, pw_dbname());
    ++                  eprintf(_("%s: cannot open %s\n"), Prog, pw_dbname());
    @@ src/usermod.c: open_files(bool process_selinux)
    -                   fprintf(stderr, _("%s: cannot open %s\n"), Prog, gr_dbname());
    +                   eprintf(_("%s: cannot open %s\n"), Prog, gr_dbname());
    @@ src/usermod.c: open_files(bool process_selinux)
    --                          fprintf(stderr, _("%s: cannot lock %s; try again later.\n"), Prog, sgr_dbname());
    +-                          eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, sgr_dbname());
    @@ src/usermod.c: open_files(bool process_selinux)
    --                          fprintf(stderr, _("%s: cannot open %s\n"), Prog, sgr_dbname());
    +-                          eprintf(_("%s: cannot open %s\n"), Prog, sgr_dbname());
    @@ src/usermod.c: open_files(bool process_selinux)
    -+                  fprintf(stderr, _("%s: cannot lock %s; try again later.\n"), Prog, sgr_dbname());
    ++                  eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, sgr_dbname());
    @@ src/usermod.c: open_files(bool process_selinux)
    -+                  fprintf(stderr, _("%s: cannot open %s\n"), Prog, sgr_dbname());
    ++                  eprintf(_("%s: cannot open %s\n"), Prog, sgr_dbname());
12:  9be4a394be4c ! 12:  e2533617bab1 src/usermod.c: Split open_db() from open_files()
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -                   fprintf(stderr, _("%s: cannot lock %s; try again later.\n"), Prog, pw_dbname());
    +                   eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, pw_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -                   fprintf(stderr, _("%s: cannot open %s\n"), Prog, pw_dbname());
    +                   eprintf(_("%s: cannot open %s\n"), Prog, pw_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -                   fprintf(stderr, _("%s: cannot lock %s; try again later.\n"), Prog, spw_dbname());
    +                   eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, spw_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -                   fprintf(stderr, _("%s: cannot open %s\n"), Prog, spw_dbname());
    +                   eprintf(_("%s: cannot open %s\n"), Prog, spw_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -                   fprintf(stderr, _("%s: cannot lock %s; try again later.\n"), Prog, gr_dbname());
    +                   eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, gr_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -                   fprintf(stderr, _("%s: cannot open %s\n"), Prog, gr_dbname());
    +                   eprintf(_("%s: cannot open %s\n"), Prog, gr_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -                   fprintf(stderr, _("%s: cannot lock %s; try again later.\n"), Prog, sgr_dbname());
    +                   eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, sgr_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -                   fprintf(stderr, _("%s: cannot open %s\n"), Prog, sgr_dbname());
    +                   eprintf(_("%s: cannot open %s\n"), Prog, sgr_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -                   fprintf(stderr, _("%s: cannot lock %s; try again later.\n"), Prog, sub_uid_dbname());
    +                   eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, sub_uid_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -                   fprintf(stderr, _("%s: cannot open %s\n"), Prog, sub_uid_dbname());
    +                   eprintf(_("%s: cannot open %s\n"), Prog, sub_uid_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -                   fprintf(stderr, _("%s: cannot lock %s; try again later.\n"), Prog, sub_gid_dbname());
    +                   eprintf(_("%s: cannot lock %s; try again later.\n"), Prog, sub_gid_dbname());
    @@ src/usermod.c: static void close_files(const struct option_flags *flags)
    -                   fprintf(stderr, _("%s: cannot open %s\n"), Prog, sub_gid_dbname());
    +                   eprintf(_("%s: cannot open %s\n"), Prog, sub_gid_dbname());
```
</details>