### PR TITLE
lib/string/README: [v]aprintf(3) are in libc

### DIFF
--- a/lib/string/README
+++ b/lib/string/README
@@ -21,7 +21,7 @@ Don't use some libc functions without Really Good Reasons:
 
 <stdio.h>
     asprintf(3)
-	Use aprintf() instead.
+	Use aprintf(3) instead.
 	It is difficult to handle errors after asprintf(3).
 	Also, it makes it more difficult for static analyzers to check
 	that memory is later free(3)d appropriately.
@@ -209,7 +209,7 @@ strcpy/ - String copying
 
 sprintf/ - Formatted string creation
 
-    aprintf()
+    aprintf(3)
 	sprintf(3) variant that allocates.
 	It has better interface than asprintf(3).
 


### PR DESCRIPTION
```
[v]aprintf(3) are now part of a libc implementation: gnulib.
They are also documented in a manual page.  Thus, refer to them as
[v]aprintf(3).
```

I'm also working on a patch set to add these APIs to glibc.
<https://inbox.sourceware.org/libc-alpha/abSVWeS3nHmkZSKn@devuan/T/#t>

And the C Committee has also showed strong interest in standardization of this pair of functions.
<https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3750.txt>