### PR TITLE
lib/: memdup_T(): Add parameter 'n'

### DIFF
--- a/lib/string/README
+++ b/lib/string/README
@@ -163,7 +163,7 @@ strdup/ - Memory duplication
 	Like strndup(3), but takes an array.
 
   m/
-    memdup()  // Unimplemented
+    memdup()
 	Duplicate an object.  Returns a pointer to the dup.
     memdup_T()
 	Like memdup(), but with type-safety checks.

--- a/lib/string/strdup/memdup.c
+++ b/lib/string/strdup/memdup.c
@@ -1,7 +1,12 @@
-// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
+// SPDX-FileCopyrightText: 2025-2026, Alejandro Colomar <alx@kernel.org>
 // SPDX-License-Identifier: BSD-3-Clause
 
 
 #include "config.h"
 
 #include "string/strdup/memdup.h"
+
+#include <stddef.h>
+
+
+extern inline void *memdup(const void *p, size_t size);

--- a/lib/string/strdup/memdup.h
+++ b/lib/string/strdup/memdup.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
+// SPDX-FileCopyrightText: 2025-2026, Alejandro Colomar <alx@kernel.org>
 // SPDX-License-Identifier: BSD-3-Clause
 
 
@@ -9,21 +9,39 @@
 #include "config.h"
 
 #include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "alloc/malloc.h"
+#include "attr.h"
+#include "sizeof.h"
 
 
 // memdup_T - memory duplicate type-safe
-#define memdup_T(p, T)   memdup_T_(p, typeas(T))
-#define memdup_T_(p, T)                                               \
-({                                                                    \
-	T  *new_;                                                     \
-                                                                      \
-	new_ = malloc_T(1, T);                                        \
-	if (new_ != NULL)                                             \
-		*new_ = *(p);                                         \
-	new_;                                                         \
-})
+#define memdup_T(p, n, T)   memdup_T_(p, n, typeas(T))
+#define memdup_T_(p, n, T)                                            \
+(                                                                     \
+	_Generic(p, T *: (void)0, const T *: (void)0),                \
+	(T *){memdup(p, (n) * sizeof(T))}                             \
+)
+
+
+ATTR_MALLOC(free)
+inline void *memdup(const void *p, size_t size);
+
+
+// memdup - memory duplicate
+inline void *
+memdup(const void *p, size_t size)
+{
+	void  *dup;
+
+	dup = malloc(size);
+	if (dup == NULL)
+		return NULL;
+
+	return memcpy(dup, p, size);
+}
 
 
 #endif  // include guard

--- a/lib/string/strdup/memdup.h
+++ b/lib/string/strdup/memdup.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
+// SPDX-FileCopyrightText: 2025-2026, Alejandro Colomar <alx@kernel.org>
 // SPDX-License-Identifier: BSD-3-Clause
 
 
@@ -8,22 +8,40 @@
 
 #include "config.h"
 
+#include <memory.h>
 #include <stddef.h>
+#include <stdlib.h>
 
 #include "alloc/malloc.h"
+#include "attr.h"
+#include "sizeof.h"
 
 
 // memdup_T - memory duplicate type-safe
-#define memdup_T(p, T)   memdup_T_(p, typeas(T))
-#define memdup_T_(p, T)                                               \
-({                                                                    \
-	T  *new_;                                                     \
-                                                                      \
-	new_ = malloc_T(1, T);                                        \
-	if (new_ != NULL)                                             \
-		*new_ = *(p);                                         \
-	new_;                                                         \
-})
+#define memdup_T(p, n, T)   memdup_T_(p, n, typeas(T))
+#define memdup_T_(p, n, T)                                            \
+(                                                                     \
+	_Generic(p, T *: (void)0, const T *: (void)0),                \
+	(T *){memdup(p, (n) * sizeof(T))}                             \
+)
+
+
+ATTR_MALLOC(free)
+inline void *memdup(const void *p, size_t size);
+
+
+// memdup - memory duplicate
+inline void *
+memdup(const void *p, size_t size)
+{
+	void  *dup;
+
+	dup = malloc(size);
+	if (dup == NULL)
+		return NULL;
+
+	return memcpy(dup, p, size);
+}
 
 
 #endif  // include guard

--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -182,7 +182,7 @@ get_current_utmp(pid_t main_pid)
 		ut = ut_by_pid ?: ut_by_line;
 
 	if (NULL != ut)
-		ut = memdup_T(ut, struct utmpx);
+		ut = memdup_T(ut, 1, struct utmpx);
 
 	free(ut_by_line);
 	free(ut_by_pid);

--- a/lib/utmp.c
+++ b/lib/utmp.c
@@ -184,7 +184,7 @@ get_current_utmp(pid_t main_pid)
 		ut = ut_by_pid ?: ut_by_line;
 
 	if (NULL != ut)
-		ut = memdup_T(ut, struct utmpx);
+		ut = memdup_T(ut, 1, struct utmpx);
 
 	free(ut_by_line);
 	free(ut_by_pid);


### PR DESCRIPTION
I've found this to be useful elsewhere, where we want to duplicate an array.

We need to implement this through a real memdup() function, because arrays can't be copied with the assignment operator ('='); we need to memcpy(3).

---

Cc: @kees

---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git rd 
1:  ae429ebde2a0 = 1:  3663e90ef0f9 lib/: memdup_T(): Add parameter 'n'
```
</details>

<details>
<summary>v1c</summary>

-  Rebase

```
$ git rd 
1:  3663e90ef0f9 = 1:  c42a1a45c743 lib/: memdup_T(): Add parameter 'n'
```
</details>

<details>
<summary>v1d</summary>

-  Rebase

```
$ git rd 
1:  c42a1a45c743 = 1:  04da7565cdaf lib/: memdup_T(): Add parameter 'n'
```
</details>

<details>
<summary>v2</summary>

-  Use <memory.h> instead of <string.h>. Historically, and morally, it's more appropriate. It's quite portable, so it should be fine, even though it's non-standard. See memory.h(3head).

```
$ git rd 
1:  04da7565cdaf ! 1:  75b8be0a5a7d lib/: memdup_T(): Add parameter 'n'
    @@ lib/string/strdup/memdup.h
      
      #include <stddef.h>
     +#include <stdlib.h>
    -+#include <string.h>
    ++#include <memory.h>
      
      #include "alloc/malloc.h"
     +#include "attr.h"
```
</details>

<details>
<summary>v2b</summary>

-  Fix order of includes.

```
$ git rd 
1:  75b8be0a5a7d ! 1:  765adb3a2634 lib/: memdup_T(): Add parameter 'n'
    @@ lib/string/strdup/memdup.h
      
      
     @@
    + 
      #include "config.h"
      
    ++#include <memory.h>
      #include <stddef.h>
     +#include <stdlib.h>
    -+#include <memory.h>
      
      #include "alloc/malloc.h"
     +#include "attr.h"
```
</details>

<details>
<summary>v2c</summary>

-  Rebase

```
$ git rd 
1:  765adb3a2634 = 1:  8538f93181ae lib/: memdup_T(): Add parameter 'n'
```
</details>

<details>
<summary>v3</summary>

-  Update `lib/string/README`.

```
$ git rd 
1:  8538f93181ae ! 1:  0a111a8d0f1e lib/: memdup_T(): Add parameter 'n'
    @@ Commit message
     
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
    + ## lib/string/README ##
    +@@ lib/string/README: strdup/ - Memory duplication
    +   Like strndup(3), but takes an array.
    + 
    +   m/
    +-    memdup()  // Unimplemented
    ++    memdup()
    +   Duplicate an object.  Returns a pointer to the dup.
    +     memdup_T()
    +   Like memdup(), but with type-safety checks.
    +
      ## lib/string/strdup/memdup.c ##
     @@
     -// SPDX-FileCopyrightText: 2025, Alejandro Colomar <alx@kernel.org>
```
</details>