### PR TITLE
login: Clean up PAM resource handling

### DIFF
--- a/src/login.c
+++ b/src/login.c
@@ -801,7 +801,13 @@ int main (int argc, char **argv)
  	/* Open the PAM session */
 	get_pam_user (&pam_user);
 	retcode = pam_open_session (pamh, hushed (pam_user) ? PAM_SILENT : 0);
-	PAM_FAIL_CHECK;
+	if (retcode != PAM_SUCCESS) {
+		fprintf(stderr,"\n%s\n", pam_strerror(pamh, retcode));
+		SYSLOG(LOG_ERR,"%s",pam_strerror(pamh, retcode));
+		pam_setcred(pamh, PAM_DELETE_CRED);
+		pam_end(pamh, retcode);
+		exit(1);
+	}
 
 #else				/* ! USE_PAM */
 	while (true) {	/* repeatedly get login/password pairs */


### PR DESCRIPTION
- login opens session first, then sets credentials. This follows the old [X/Open RFC 86.0](http://www.opengroup.org/rfc/mirror-rfc/rfc86.0.txt) Appendix B example but violates Linux-PAM's `pam_setcred(3)` manual page. It also violates su's cred/session order. Other examples of cred/session tools: util-linux login and su, and gdm
- Do not call `pam_close_session` if `pam_open_session` was never called
- Delete credentials if `pam_open_session` fails

See pam_setcred(3):
https://github.com/linux-pam/linux-pam/blob/cf2fc5ff7b4a8555fda2a5ebe5f6ab0e45c22996/doc/man/pam_setcred.3.xml#L33-L43