### PR TITLE
groupadd: fix system account help text

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -1291,6 +1291,9 @@ msgstr ""
 msgid "  -r, --system                  create a system account\n"
 msgstr "  -r, --system                  Ein Systemkonto erstellen\n"
 
+msgid "  -r, --system                  create a system group\n"
+msgstr "  -r, --system                  Eine Systemgruppe erstellen\n"
+
 #, fuzzy
 #| msgid "  -l, --list                    list the members of the group\n"
 msgid ""

--- a/po/shadow.pot
+++ b/po/shadow.pot
@@ -1131,6 +1131,9 @@ msgstr ""
 msgid "  -r, --system                  create a system account\n"
 msgstr ""
 
+msgid "  -r, --system                  create a system group\n"
+msgstr ""
+
 msgid ""
 "  -U, --users USERS             comma-separated list of users to add as\n"
 "\t                         members of this group\n"

--- a/src/groupadd.c
+++ b/src/groupadd.c
@@ -116,7 +116,7 @@ usage (int status)
 	(void) fputs (_("  -o, --non-unique              allow to create groups with duplicate\n"
 	                "                                (non-unique) GID\n"), usageout);
 	(void) fputs (_("  -p, --password PASSWORD       use this encrypted password for the new group\n"), usageout);
-	(void) fputs (_("  -r, --system                  create a system account\n"), usageout);
+	(void) fputs (_("  -r, --system                  create a system group\n"), usageout);
 	(void) fputs (_("  -R, --root CHROOT_DIR         directory to chroot into\n"), usageout);
 	(void) fputs (_("  -P, --prefix PREFIX_DIR       directory prefix\n"), usageout);
 	(void) fputs (_("  -U, --users USERS             comma-separated list of users to add as\n"


### PR DESCRIPTION
We found a little error in the description of `groupadd` where a line from the `useradd` help text found its way into the wrong place. This change matches the man page content (at least in english) and should fix it in the `en` and `de` locales