### PR TITLE
Tests: Add a new user with home directory creation

### DIFF
--- a/tests/system/framework/hosts/shadow.py
+++ b/tests/system/framework/hosts/shadow.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import PurePosixPath
 from typing import Any
 
+from pytest_mh import MultihostUtility
 from pytest_mh.conn import ProcessLogLevel
 
 from .base import BaseHost, BaseLinuxHost
@@ -201,3 +202,106 @@ class ShadowHost(BaseHost, BaseLinuxHost):
             if x["origin"] == origin:
                 self._verify_files.remove(x)
                 break
+
+
+class LoginDefsConfig(MultihostUtility[ShadowHost]):
+    """
+    Manage /etc/login.defs configuration.
+
+    Usage:
+        # Set a value
+        shadow.login_defs["CREATE_HOME"] = "no"
+
+        # Get a value
+        value = shadow.login_defs["CREATE_HOME"]
+
+        # Remove an option
+        del shadow.login_defs["CREATE_HOME"]
+    """
+
+    def __init__(self, host: ShadowHost) -> None:
+        super().__init__(host)
+        self._backup_path: str | None = None
+
+    def setup(self) -> None:
+        """
+        Backup the original /etc/login.defs file.
+        Called automatically by the framework.
+        """
+        if self.host.fs.exists("/etc/login.defs"):
+            result = self.host.conn.run(
+                """
+                set -ex
+                backup_path=`mktemp`
+                cp /etc/login.defs $backup_path
+                echo $backup_path
+                """,
+                log_level=ProcessLogLevel.Error,
+            )
+            self._backup_path = result.stdout_lines[-1].strip()
+
+    def teardown(self) -> None:
+        """
+        Restore the original /etc/login.defs file.
+        Called automatically by the framework.
+        """
+        if self._backup_path and self.host.fs.exists(self._backup_path):
+            self.host.conn.run(f"mv {self._backup_path} /etc/login.defs")
+
+    def __getitem__(self, key: str) -> str:
+        """
+        Get a value from /etc/login.defs.
+
+        :param key: Option name (e.g., 'CREATE_HOME')
+        :type key: str
+        :return: Current value
+        :rtype: str
+        """
+        result = self.host.conn.run(
+            f"grep -E '^{key}\\s+' /etc/login.defs | tail -1 | awk '{{print $2}}'", raise_on_error=False
+        )
+        if result.rc != 0 or not result.stdout.strip():
+            return ""
+        return result.stdout.strip()
+
+    def __setitem__(self, key: str, value: str) -> None:
+        """
+        Set a value in /etc/login.defs.
+
+        :param key: Option name (e.g., 'CREATE_HOME')
+        :type key: str
+        :param value: Value to set (can contain special characters like /, &, etc.)
+        :type value: str
+        """
+        self.logger.info(f"Setting {key}={value} in /etc/login.defs on {self.host.hostname}")
+
+        # Escape special characters for awk
+        escaped_value = value.replace("/", "\\/")
+
+        self.host.conn.run(
+            f"""
+            if grep -q '^{key}\\s' /etc/login.defs; then
+                awk -v key="{key}" -v val="{escaped_value}" \\
+                    '{{if ($0 ~ "^" key "\\\\s") print key " " val; else print $0}}' \\
+                    /etc/login.defs > /etc/login.defs.tmp && mv /etc/login.defs.tmp /etc/login.defs
+            elif grep -q '^#\\s*{key}\\s' /etc/login.defs; then
+                awk -v key="{key}" -v val="{escaped_value}" \\
+                    '{{if ($0 ~ "^#\\\\s*" key "\\\\s") print key " " val; else print $0}}' \\
+                    /etc/login.defs > /etc/login.defs.tmp && mv /etc/login.defs.tmp /etc/login.defs
+            else
+                echo '{key} {value}' >> /etc/login.defs
+            fi
+            """,
+            log_level=ProcessLogLevel.Error,
+        )
+
+    def __delitem__(self, key: str) -> None:
+        """
+        Remove an option from /etc/login.defs (comment it out).
+
+        :param key: Option name to remove
+        :type key: str
+        """
+        self.logger.info(f"Removing {key} from /etc/login.defs on {self.host.hostname}")
+
+        self.host.conn.run(f"sed -i 's/^{key}\\s.*/#&/' /etc/login.defs", log_level=ProcessLogLevel.Error)

--- a/tests/system/framework/roles/shadow.py
+++ b/tests/system/framework/roles/shadow.py
@@ -7,7 +7,7 @@ from typing import Dict, Tuple
 
 from pytest_mh.conn import ProcessLogLevel, ProcessResult
 
-from ..hosts.shadow import ShadowHost
+from ..hosts.shadow import LoginDefsConfig, ShadowHost
 from ..misc.errors import ExpectScriptError
 from .base import BaseLinuxRole
 
@@ -31,6 +31,7 @@ class Shadow(BaseLinuxRole[ShadowHost]):
         Set up the environment.
         """
         super().__init__(*args, **kwargs)
+        self.login_defs: LoginDefsConfig = LoginDefsConfig(self.host).postpone_setup()
 
     def teardown(self) -> None:
         """

--- a/tests/system/tests/test_useradd.py
+++ b/tests/system/tests/test_useradd.py
@@ -566,3 +566,35 @@ def test_useradd_default_primary_group_with_supplementary(shadow: Shadow):
         group_entry = shadow.tools.getent.group(group_name)
         assert group_entry is not None, f"Group {group_name} should exist"
         assert username in group_entry.members, f"User {username} should be a member of {group_name} group"
+
+
+@pytest.mark.topology(KnownTopology.Shadow)
+def test_useradd__create_homedir(shadow: Shadow):
+    """
+    :title: Add a new user with home directory creation
+    :setup:
+        1. Set CREATE_HOME=no in /etc/login.defs to ensure home directory isn't created by default
+        2. Create user with --create-home option
+    :steps:
+        1. Check passwd and group entry
+        2. Verify home directory exists
+    :expectedresults:
+        1. Passwd and group entry exists with correct attributes
+        2. Home directory is created at /home/test1
+    :customerscenario: False
+    """
+    shadow.login_defs["CREATE_HOME"] = "no"
+
+    shadow.useradd("--create-home test1")
+
+    passwd_entry = shadow.tools.getent.passwd("test1")
+    assert passwd_entry is not None, "User test1 should be found in passwd"
+    assert passwd_entry.name == "test1", "Incorrect username"
+    assert passwd_entry.home == "/home/test1", "Incorrect home directory"
+
+    group_entry = shadow.tools.getent.group("test1")
+    assert group_entry is not None, "Group test1 should be found"
+    assert group_entry.name == "test1", "Incorrect group name"
+
+    home_dir = "/home/test1"
+    assert shadow.fs.exists(home_dir), f"Home directory {home_dir} should exist even with CREATE_HOME=no"

--- a/tests/system/tests/test_useradd.py
+++ b/tests/system/tests/test_useradd.py
@@ -566,3 +566,35 @@ def test_useradd_default_primary_group_with_supplementary(shadow: Shadow):
         group_entry = shadow.tools.getent.group(group_name)
         assert group_entry is not None, f"Group {group_name} should exist"
         assert username in group_entry.members, f"User {username} should be a member of {group_name} group"
+
+
+@pytest.mark.topology(KnownTopology.Shadow)
+def test_useradd__create_homedir(shadow: Shadow):
+    """
+    :title: Add a new user with home directory creation
+    :setup:
+        1. Set CREATE_HOME=no in /etc/login.defs to ensure home directory isn't created by default
+        2. Create user with --create-home option
+    :steps:
+        1. Check passwd and group entry
+        2. Verify home directory exists
+    :expectedresults:
+        1. Passwd and group entry exists with correct attributes
+        2. Home directory is created at /home/test1
+    :customerscenario: False
+    """
+    shadow.login_defs["CREATE_HOME"] = "no"
+
+    shadow.useradd("--create-home test1")
+
+    passwd_entry = shadow.tools.getent.passwd("test1")
+    assert passwd_entry is not None, "User test1 should be found in passwd"
+    assert passwd_entry.name == "test1", "Incorrect username"
+    assert passwd_entry.home == "/home/test1", "Incorrect home directory"
+
+    group_entry = shadow.tools.getent.group("test1")
+    assert group_entry is not None, "Group test1 should be found"
+    assert group_entry.name == "test1", "Incorrect group name"
+
+    home_dir = "/home/test1"
+    assert shadow.fs.exists(home_dir), f"Home directory {home_dir} should exist when using --create-home flag"


### PR DESCRIPTION
This is the transformation to Python of the test located in `tests/usertools/01/17_useradd_create_homedir.test` which checks that `useradd` can add a new user with --create-home

Implement CREATE_HOME is set to no