### PR TITLE
useradd: skip btrfs subvolume creation for system users

### DIFF
--- a/man/useradd.8.xml
+++ b/man/useradd.8.xml
@@ -157,6 +157,19 @@
 		regardless of any configuration file settings.
 	  </para>
 	  <para>
+	    Subvolumes are only created for regular users,
+	    whose UID is within the
+	    <option>UID_MIN</option>-<option>UID_MAX</option>
+	    range defined in <filename>/etc/login.defs</filename>.
+	    System users get a regular home directory instead.
+	    Set the <option>BTRFS_SUBVOLUME_SYSTEM</option> variable
+	    in <filename>/etc/default/useradd</filename>
+	    to <replaceable>yes</replaceable>
+	    to create subvolumes for system users as well.
+	    If this variable is not set,
+	    the default value is no.
+	  </para>
+	  <para>
 	    If the parent directory of the user's home directory is
 	    <emphasis>not</emphasis> on a Btrfs filesystem,
 	    <command>useradd</command> will <emphasis>not</emphasis> create a

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -114,6 +114,7 @@ static const char *def_template = SKEL_DIR;
 static const char *def_usrtemplate = USRSKELDIR;
 static const char *def_create_mail_spool = "yes";
 static const char *def_btrfs_subvolume_home = "no";
+static const char *def_btrfs_subvolume_system = "no";
 static const char *def_log_init = "yes";
 
 static long def_inactive = -1;
@@ -223,6 +224,7 @@ static bool home_added = false;
 #define DUSRSKEL		"USRSKEL"
 #define DCREATE_MAIL_SPOOL	"CREATE_MAIL_SPOOL"
 #define DBTRFS_SUBVOLUME_HOME	"BTRFS_SUBVOLUME_HOME"
+#define DBTRFS_SUBVOLUME_SYSTEM	"BTRFS_SUBVOLUME_SYSTEM"
 #define DLOG_INIT		"LOG_INIT"
 
 /* local function prototypes */
@@ -478,6 +480,15 @@ get_defaults(const struct option_flags *flags)
 		}
 
 		/*
+		 * Create subvolume homes also for system users?
+		 */
+		else if (streq(buf, DBTRFS_SUBVOLUME_SYSTEM)) {
+			if (streq(ccp, ""))
+				ccp = "no";
+			def_btrfs_subvolume_system = xstrdup(ccp);
+		}
+
+		/*
 		 * By default do we add the user to the lastlog and faillog databases ?
 		 */
 		else if (streq(buf, DLOG_INIT)) {
@@ -512,6 +523,7 @@ static void show_defaults (void)
 	printf ("USRSKEL=%s\n", def_usrtemplate);
 	printf ("CREATE_MAIL_SPOOL=%s\n", def_create_mail_spool);
 	printf ("BTRFS_SUBVOLUME_HOME=%s\n", def_btrfs_subvolume_home);
+	printf ("BTRFS_SUBVOLUME_SYSTEM=%s\n", def_btrfs_subvolume_system);
 	printf ("LOG_INIT=%s\n", def_log_init);
 }
 
@@ -536,6 +548,7 @@ set_defaults(void)
 	bool  out_usrskel = false;
 	bool  out_create_mail_spool = false;
 	bool  out_btrfs_subvolume_home = false;
+	bool  out_btrfs_subvolume_system = false;
 	bool  out_log_init = false;
 	char  buf[1024];
 	char  *new_file = NULL;
@@ -657,6 +670,11 @@ set_defaults(void)
 			        DBTRFS_SUBVOLUME_HOME "=%s\n",
 			        def_btrfs_subvolume_home);
 			out_btrfs_subvolume_home = true;
+		} else if (!out_btrfs_subvolume_system && streq(buf, DBTRFS_SUBVOLUME_SYSTEM)) {
+			fprintf(ofp,
+			        DBTRFS_SUBVOLUME_SYSTEM "=%s\n",
+			        def_btrfs_subvolume_system);
+			out_btrfs_subvolume_system = true;
 		} else if (!out_log_init && streq(buf, DLOG_INIT)) {
 			fprintf(ofp, DLOG_INIT "=%s\n", def_log_init);
 			out_log_init = true;
@@ -693,6 +711,8 @@ set_defaults(void)
 		fprintf (ofp, DCREATE_MAIL_SPOOL "=%s\n", def_create_mail_spool);
 	if (!out_btrfs_subvolume_home)
 		fprintf (ofp, DBTRFS_SUBVOLUME_HOME "=%s\n", def_btrfs_subvolume_home);
+	if (!out_btrfs_subvolume_system)
+		fprintf (ofp, DBTRFS_SUBVOLUME_SYSTEM "=%s\n", def_btrfs_subvolume_system);
 	if (!out_log_init)
 		fprintf (ofp, DLOG_INIT "=%s\n", def_log_init);
 	/*
@@ -2211,10 +2231,20 @@ usr_update (unsigned long subuid_count, unsigned long subgid_count,
 static bool
 want_btrfs_subvolume(const char *path)
 {
+	uid_t  min, max;
+
 	if (!subvolflg)
 		return false;
+	if (strlen(prefix_user_home) - strlen(path) > 1)
+		return false;
 
-	return strlen(prefix_user_home) - strlen(path) <= 1;
+	if (strcaseeq(def_btrfs_subvolume_system, "yes"))
+		return true;
+
+	min = getdef_ulong("UID_MIN", 1000UL);
+	max = getdef_ulong("UID_MAX", 60000UL);
+
+	return user_id >= min && user_id <= max;
 }
 #endif
 

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -2207,6 +2207,17 @@ usr_update (unsigned long subuid_count, unsigned long subgid_count,
 	}
 }
 
+#if WITH_BTRFS
+static bool
+want_btrfs_subvolume(const char *path)
+{
+	if (!subvolflg)
+		return false;
+
+	return strlen(prefix_user_home) - strlen(path) <= 1;
+}
+#endif
+
 /*
  * create_home - create the user's home directory
  *
@@ -2264,7 +2275,7 @@ static void create_home(const struct option_flags *flags)
 
 		dir_created = false;
 #if WITH_BTRFS
-		if (subvolflg && (strlen(prefix_user_home) - (int)strlen(path)) <= 1) {
+		if (want_btrfs_subvolume(path)) {
 			char *btrfs_check = strdup(path);
 			struct statfs  sfs;
 

--- a/tests/system/framework/hosts/shadow.py
+++ b/tests/system/framework/hosts/shadow.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import PurePosixPath
 from typing import Any
 
-from pytest_mh import MultihostUtility
+from pytest_mh import MultihostUtility, mh_utility_used
 from pytest_mh.conn import ProcessLogLevel
 
 from .base import BaseHost, BaseLinuxHost
@@ -275,104 +275,162 @@ class ShadowHost(BaseHost, BaseLinuxHost):
                 break
 
 
-class LoginDefsConfig(MultihostUtility[ShadowHost]):
+class KeyValueFileConfig(MultihostUtility[ShadowHost]):
     """
-    Manage /etc/login.defs configuration.
+    Manage a key-value configuration file with dictionary-like access.
+
+    This works with any file that holds one ``KEY<separator>VALUE`` pair per
+    line and uses ``#`` for comments, for example /etc/login.defs (separated
+    by a space) or /etc/default/useradd (separated by ``=``).
 
     Usage:
         # Set a value
-        shadow.login_defs["CREATE_HOME"] = "no"
+        config["KEY"] = "value"
 
         # Get a value
-        value = shadow.login_defs["CREATE_HOME"]
+        value = config["KEY"]
 
         # Remove an option
-        del shadow.login_defs["CREATE_HOME"]
+        del config["KEY"]
+
+    The file is backed up on setup and restored on teardown. If the file
+    or its parent directory does not exist, it is created on setup and
+    removed again on teardown.
     """
 
-    def __init__(self, host: ShadowHost) -> None:
+    def __init__(self, host: ShadowHost, path: str, separator: str = " ") -> None:
+        """
+        :param host: Multihost host.
+        :type host: ShadowHost
+        :param path: Path to the configuration file.
+        :type path: str
+        :param separator: Separator between key and value, ``" "`` or ``"="``.
+        :type separator: str
+        """
         super().__init__(host)
+        self.path: str = path
+        self.separator: str = separator
         self._backup_path: str | None = None
+        self._file_existed: bool = False
+        self._dir_created: str | None = None
+
+    def _ensure_exists(self) -> None:
+        """
+        Make sure the parent directory and the file exist, creating them
+        when missing. Anything created here is removed on teardown.
+        """
+        parent = str(PurePosixPath(self.path).parent)
+        if not self.host.fs.exists(parent):
+            self.host.conn.run(f"mkdir -p '{parent}'", log_level=ProcessLogLevel.Error)
+            if self._dir_created is None:
+                self._dir_created = parent
+
+        if not self.host.fs.exists(self.path):
+            self.host.conn.run(f"touch '{self.path}'", log_level=ProcessLogLevel.Error)
 
     def setup(self) -> None:
         """
-        Backup the original /etc/login.defs file.
+        Backup the original file.
         Called automatically by the framework.
         """
-        if self.host.fs.exists("/etc/login.defs"):
+        if self.host.fs.exists(self.path):
+            self._file_existed = True
             result = self.host.conn.run(
-                """
+                f"""
                 set -ex
                 backup_path=`mktemp`
-                cp /etc/login.defs $backup_path
+                cp '{self.path}' $backup_path
                 echo $backup_path
                 """,
                 log_level=ProcessLogLevel.Error,
             )
             self._backup_path = result.stdout_lines[-1].strip()
 
+        self._ensure_exists()
+
     def teardown(self) -> None:
         """
-        Restore the original /etc/login.defs file.
+        Restore the original file.
         Called automatically by the framework.
         """
-        if self._backup_path and self.host.fs.exists(self._backup_path):
-            self.host.conn.run(f"mv {self._backup_path} /etc/login.defs")
+        if self._file_existed:
+            if self._backup_path and self.host.fs.exists(self._backup_path):
+                self.host.conn.run(f"mv '{self._backup_path}' '{self.path}'")
+        else:
+            self.host.conn.run(f"rm -f '{self.path}'", raise_on_error=False)
 
+        if self._dir_created is not None:
+            self.host.conn.run(f"rmdir '{self._dir_created}'", raise_on_error=False)
+
+    @mh_utility_used
     def __getitem__(self, key: str) -> str:
         """
-        Get a value from /etc/login.defs.
+        Get a value from the file.
 
         :param key: Option name (e.g., 'CREATE_HOME')
         :type key: str
         :return: Current value
         :rtype: str
         """
-        result = self.host.conn.run(
-            f"grep -E '^{key}\\s+' /etc/login.defs | tail -1 | awk '{{print $2}}'", raise_on_error=False
-        )
+        self._ensure_exists()
+
+        if self.separator == "=":
+            cmd = f"grep -E '^{key}=' {self.path} | tail -1 | cut -d= -f2-"
+        else:
+            cmd = f"grep -E '^{key}\\s+' {self.path} | tail -1 | awk '{{print $2}}'"
+
+        result = self.host.conn.run(cmd, raise_on_error=False)
         if result.rc != 0 or not result.stdout.strip():
             return ""
         return result.stdout.strip()
 
+    @mh_utility_used
     def __setitem__(self, key: str, value: str) -> None:
         """
-        Set a value in /etc/login.defs.
+        Set a value in the file.
 
         :param key: Option name (e.g., 'CREATE_HOME')
         :type key: str
         :param value: Value to set (can contain special characters like /, &, etc.)
         :type value: str
         """
-        self.logger.info(f"Setting {key}={value} in /etc/login.defs on {self.host.hostname}")
+        self._ensure_exists()
+        self.logger.info(f"Setting {key}={value} in {self.path} on {self.host.hostname}")
+
+        sep = self.separator
+        grep_match = "=" if sep == "=" else "\\s"
+        awk_match = "=" if sep == "=" else "\\\\s"
 
         # Escape special characters for awk
         escaped_value = value.replace("/", "\\/")
 
         self.host.conn.run(
             f"""
-            if grep -q '^{key}\\s' /etc/login.defs; then
+            if grep -q '^{key}{grep_match}' {self.path}; then
                 awk -v key="{key}" -v val="{escaped_value}" \\
-                    '{{if ($0 ~ "^" key "\\\\s") print key " " val; else print $0}}' \\
-                    /etc/login.defs > /etc/login.defs.tmp && mv /etc/login.defs.tmp /etc/login.defs
-            elif grep -q '^#\\s*{key}\\s' /etc/login.defs; then
+                    '{{if ($0 ~ "^" key "{awk_match}") print key "{sep}" val; else print $0}}' \\
+                    {self.path} > {self.path}.tmp && mv {self.path}.tmp {self.path}
+            elif grep -q '^#\\s*{key}{grep_match}' {self.path}; then
                 awk -v key="{key}" -v val="{escaped_value}" \\
-                    '{{if ($0 ~ "^#\\\\s*" key "\\\\s") print key " " val; else print $0}}' \\
-                    /etc/login.defs > /etc/login.defs.tmp && mv /etc/login.defs.tmp /etc/login.defs
+                    '{{if ($0 ~ "^#\\\\s*" key "{awk_match}") print key "{sep}" val; else print $0}}' \\
+                    {self.path} > {self.path}.tmp && mv {self.path}.tmp {self.path}
             else
-                echo '{key} {value}' >> /etc/login.defs
+                echo '{key}{sep}{value}' >> {self.path}
             fi
             """,
             log_level=ProcessLogLevel.Error,
         )
 
+    @mh_utility_used
     def __delitem__(self, key: str) -> None:
         """
-        Remove an option from /etc/login.defs (comment it out).
+        Remove an option from the file (comment it out).
 
         :param key: Option name to remove
         :type key: str
         """
-        self.logger.info(f"Removing {key} from /etc/login.defs on {self.host.hostname}")
+        self._ensure_exists()
+        self.logger.info(f"Removing {key} from {self.path} on {self.host.hostname}")
 
-        self.host.conn.run(f"sed -i 's/^{key}\\s.*/#&/' /etc/login.defs", log_level=ProcessLogLevel.Error)
+        match = "=" if self.separator == "=" else "\\s"
+        self.host.conn.run(f"sed -i 's/^{key}{match}.*/#&/' {self.path}", log_level=ProcessLogLevel.Error)

--- a/tests/system/framework/roles/shadow.py
+++ b/tests/system/framework/roles/shadow.py
@@ -7,7 +7,7 @@ from typing import Dict, Tuple
 
 from pytest_mh.conn import ProcessLogLevel, ProcessResult
 
-from ..hosts.shadow import LoginDefsConfig, ShadowHost
+from ..hosts.shadow import KeyValueFileConfig, ShadowHost
 from ..misc.errors import ExpectScriptError
 from .base import BaseLinuxRole
 
@@ -31,7 +31,10 @@ class Shadow(BaseLinuxRole[ShadowHost]):
         Set up the environment.
         """
         super().__init__(*args, **kwargs)
-        self.login_defs: LoginDefsConfig = LoginDefsConfig(self.host).postpone_setup()
+        self.login_defs: KeyValueFileConfig = KeyValueFileConfig(self.host, "/etc/login.defs", " ").postpone_setup()
+        self.useradd_defaults: KeyValueFileConfig = KeyValueFileConfig(
+            self.host, "/etc/default/useradd", "="
+        ).postpone_setup()
 
     def teardown(self) -> None:
         """

--- a/tests/system/tests/privileged/test_privileged_useradd.py
+++ b/tests/system/tests/privileged/test_privileged_useradd.py
@@ -33,3 +33,55 @@ def test_useradd__btrfs_subvolume_home(shadow: Shadow) -> None:
         assert shadow.fs.exists("/home/tuser"), "Home directory should exist"
 
         assert shadow.host.btrfs.subvolume_exists("/home", "tuser")
+
+
+def test_useradd__btrfs_subvolume_home_system_user(shadow: Shadow) -> None:
+    """
+    :title: Btrfs subvolume home is skipped for system users by default
+    :steps:
+        1. Create a system user, requesting its home directory as a Btrfs subvolume
+        2. Verify the user is a system user
+        3. Verify the home directory exists
+        4. Verify the home directory is not a Btrfs subvolume
+    :expectedresults:
+        1. The user is created
+        2. The UID is in the system range
+        3. The user home directory exists at /home/tsysuser
+        4. /home/tsysuser is a regular directory, not a subvolume
+    :customerscenario: False
+    """
+    with shadow.host.btrfs.loopback_mount("/home"):
+        shadow.useradd("tsysuser -r -m --btrfs-subvolume-home")
+
+        passwd_entry = shadow.tools.getent.passwd("tsysuser")
+        assert passwd_entry is not None, "User should be found"
+        assert passwd_entry.uid is not None and passwd_entry.uid < 1000, "User should be a system user"
+
+        assert shadow.fs.exists("/home/tsysuser"), "Home directory should exist"
+
+        assert not shadow.host.btrfs.subvolume_exists("/home", "tsysuser"), "Home should not be a subvolume"
+
+
+def test_useradd__btrfs_subvolume_home_system_user_enabled(shadow: Shadow) -> None:
+    """
+    :title: Btrfs subvolume home is created for system users with BTRFS_SUBVOLUME_SYSTEM=yes
+    :setup:
+        1. Enable Btrfs subvolume creation for system users in the useradd defaults
+    :steps:
+        1. Create a system user, requesting its home directory as a Btrfs subvolume
+        2. Verify the home directory exists
+        3. Verify the home directory is a Btrfs subvolume
+    :expectedresults:
+        1. The user is created
+        2. The user home directory exists at /home/tsysuser
+        3. /home/tsysuser is listed as a Btrfs subvolume
+    :customerscenario: False
+    """
+    with shadow.host.btrfs.loopback_mount("/home"):
+        shadow.useradd_defaults["BTRFS_SUBVOLUME_SYSTEM"] = "yes"
+
+        shadow.useradd("tsysuser -r -m --btrfs-subvolume-home")
+
+        assert shadow.fs.exists("/home/tsysuser"), "Home directory should exist"
+
+        assert shadow.host.btrfs.subvolume_exists("/home", "tsysuser"), "Home should be a subvolume"


### PR DESCRIPTION
Gate subvolume creation on user_id >= UID_MIN to exclude system users regardless of their home path.

Fixes: c1d36a8acb1d (2019-05-04; "Add support for btrfs subvolumes for user homes")