### PR TITLE
Add LOGIN_SHELL_FALLBACK to FOREIGNDEFS

### DIFF
--- a/lib/getdef.c
+++ b/lib/getdef.c
@@ -80,6 +80,7 @@ struct itemdef {
 	{"LOGIN_ENV_SAFELIST", NULL},		\
 	{"LOGIN_KEEP_USERNAME", NULL},		\
 	{"LOGIN_PLAIN_PROMPT", NULL},		\
+	{"LOGIN_SHELL_FALLBACK", NULL},		\
 	{"MOTD_FIRSTONLY", NULL},		\
 
 


### PR DESCRIPTION
util-linux-2.42 introduced new variable: LOGIN_SHELL_FALLBACK. Add it to known login.defs variables.