### PR TITLE
userdel: fix user busy detection for threads

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -4,8 +4,10 @@ autoreconf -v -f --install "$(dirname "$0")" || exit 1
 
 CFLAGS="-O2"
 CFLAGS="$CFLAGS -Wall"
+CFLAGS="$CFLAGS -Wformat=2"
 CFLAGS="$CFLAGS -Wextra"
 CFLAGS="$CFLAGS -Werror=discarded-qualifiers"
+CFLAGS="$CFLAGS -Werror=format"
 CFLAGS="$CFLAGS -Werror=implicit-function-declaration"
 CFLAGS="$CFLAGS -Werror=implicit-int"
 CFLAGS="$CFLAGS -Werror=incompatible-pointer-types"

--- a/lib/user_busy.c
+++ b/lib/user_busy.c
@@ -216,7 +216,7 @@ static int user_busy_processes (const char *name, uid_t uid)
 		}
 
 		/* Check if the process is in our chroot */
-		stprintf_a(root_path, "/proc/%lu/root", (unsigned long) pid);
+		stprintf_a(root_path, "/proc/%d/root", pid);
 		if (stat (root_path, &sbroot_process) != 0) {
 			continue;
 		}
@@ -236,7 +236,7 @@ static int user_busy_processes (const char *name, uid_t uid)
 			return 1;
 		}
 
-		stprintf_a(task_path, "/proc/%lu/task", (unsigned long) pid);
+		stprintf_a(task_path, "/proc/%d/task", pid);
 		task_dir = opendir (task_path);
 		if (task_dir != NULL) {
 			while (NULL != (ent = readdir(task_dir))) {

--- a/lib/user_busy.c
+++ b/lib/user_busy.c
@@ -36,7 +36,7 @@
 
 
 #ifdef __linux__
-static int check_status (const char *name, const char *sname, uid_t uid);
+static int check_status (const char *name, uid_t uid, pid_t pid, pid_t tid);
 static int user_busy_processes (const char *name, uid_t uid);
 #else				/* !__linux__ */
 static int user_busy_utmp (const char *name);
@@ -94,13 +94,13 @@ user_busy_utmp(const char *name)
 #ifdef __linux__
 #ifdef ENABLE_SUBIDS
 #define in_parentuid_range(uid) ((uid) >= parentuid && (uid) < parentuid + range)
-static int different_namespace (const char *sname)
+static int different_namespace (pid_t pid, pid_t tid)
 {
 	/* 41: /proc/xxxxxxxxxx/task/xxxxxxxxxx/ns/user + \0 */
 	char     path[41];
 	char     buf[512], buf2[512];
 
-	stprintf_a(path, "/proc/%s/ns/user", sname);
+	stprintf_a(path, "/proc/%d/task/%d/ns/user", pid, tid);
 
 	if (readlinknul_a(path, buf) == -1)
 		return 0;
@@ -116,14 +116,14 @@ static int different_namespace (const char *sname)
 #endif                          /* ENABLE_SUBIDS */
 
 
-static int check_status (const char *name, const char *sname, uid_t uid)
+static int check_status (const char *name, uid_t uid, pid_t pid, pid_t tid)
 {
 	/* 40: /proc/xxxxxxxxxx/task/xxxxxxxxxx/status + \0 */
 	char  status[40];
 	char  line[1024];
 	FILE  *sfile;
 
-	stprintf_a(status, "/proc/%s/status", sname);
+	stprintf_a(status, "/proc/%d/task/%d/status", pid, tid);
 
 	sfile = fopen (status, "r");
 	if (NULL == sfile) {
@@ -144,7 +144,7 @@ static int check_status (const char *name, const char *sname, uid_t uid)
 					return 1;
 				}
 #ifdef ENABLE_SUBIDS
-				if (    different_namespace (sname)
+				if (    different_namespace (pid, tid)
 				     && (   have_sub_uids(name, ruid, 1)
 				         || have_sub_uids(name, euid, 1)
 				         || have_sub_uids(name, suid, 1))
@@ -225,7 +225,7 @@ static int user_busy_processes (const char *name, uid_t uid)
 			continue;
 		}
 
-		if (check_status (name, tmp_d_name, uid) != 0) {
+		if (check_status (name, uid, pid, pid) != 0) {
 			(void) closedir (proc);
 #ifdef ENABLE_SUBIDS
 			sub_uid_close(true);
@@ -241,17 +241,13 @@ static int user_busy_processes (const char *name, uid_t uid)
 		if (task_dir != NULL) {
 			while (NULL != (ent = readdir(task_dir))) {
 				pid_t tid;
-				/* 27: xxxxxxxxxx/task/xxxxxxxxxx + \0 */
-				char  tid_sname[27];
-
 				if (get_pid(ent->d_name, &tid) == -1) {
 					continue;
 				}
 				if (tid == pid) {
 					continue;
 				}
-				stprintf_a(tid_sname, "%ld/task/%ld", (long) pid, (long) tid);
-				if (check_status (name, tid_sname, uid) != 0) {
+				if (check_status (name, uid, pid, tid) != 0) {
 					(void) closedir (proc);
 					(void) closedir (task_dir);
 #ifdef ENABLE_SUBIDS

--- a/lib/user_busy.c
+++ b/lib/user_busy.c
@@ -241,13 +241,17 @@ static int user_busy_processes (const char *name, uid_t uid)
 		if (task_dir != NULL) {
 			while (NULL != (ent = readdir(task_dir))) {
 				pid_t tid;
+				/* 27: xxxxxxxxxx/task/xxxxxxxxxx + \0 */
+				char  tid_sname[27];
+
 				if (get_pid(ent->d_name, &tid) == -1) {
 					continue;
 				}
 				if (tid == pid) {
 					continue;
 				}
-				if (check_status (name, task_path+6, uid) != 0) {
+				stprintf_a(tid_sname, "%ld/task/%ld", (long) pid, (long) tid);
+				if (check_status (name, tid_sname, uid) != 0) {
 					(void) closedir (proc);
 					(void) closedir (task_dir);
 #ifdef ENABLE_SUBIDS
@@ -272,4 +276,3 @@ static int user_busy_processes (const char *name, uid_t uid)
 	return 0;
 }
 #endif				/* __linux__ */
-

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -100,6 +100,7 @@ test_snprintf_SOURCES = \
     $(NULL)
 test_snprintf_CFLAGS = \
     $(AM_CFLAGS) \
+    -Wno-format-zero-length \
     $(NULL)
 test_snprintf_LDFLAGS = \
     $(NULL)


### PR DESCRIPTION
On Linux, userdel/usermod check all /proc/<pid> status files to ensure a to-be-modified user has no more running tasks, or abort modification otherwise.

However, the check failed to detect threads running as the user if the corresponding main thread ran as a different user. The user is deleted despite still being busy. This is due to passing a wrong value to check_status. The caller passed "<pid>/task", rather than "<pid>/task/<tid>". In consequence check_status tried to open "/proc/<pid>/task/status" - a wrong path that never exists - open fails, and check_status always returns 0. The correct status file name would have been "/proc/<pid>/task/<tid>/status" instead.

The bug can only be reproduced by rather exotic code using raw syscalls. POSIX does not allow threads to have different UIDs.

To fix it, construct the correct path to the tid status file. Also change the interface of check_status and different_namespace to take pid and tid instead of a partially constructed path string. This is simpler and makes similar bugs less likely.

Behavior without fix:

```sh
userdel testuser  # testuser has threads with tid uid != pid uid
``` 
=> no output, testuser deleted despite being busy

With the fix:

```
userdel testuser  # testuser has threads with tid uid != pid uid
userdel: user testuser is currently used by process 178863
```
=> testuser detected as busy, not deleted