### PR TITLE
man/login.defs.5.xml: clarify documentation for multi-component usage

### DIFF
--- a/man/login.defs.5.xml
+++ b/man/login.defs.5.xml
@@ -145,6 +145,15 @@
       long numeric parameters is machine-dependent.
     </para>
 
+    <para>
+      This configuration file controls the behavior
+      of system tools for user and group management.
+      The parameters may be used by shadow-utils programs, PAM modules,
+      and other system components.
+      The actual behavior depends on the system configuration
+      and which authentication mechanisms are enabled.
+    </para>
+
     <para>The following configuration items are provided:</para>
 
     <variablelist remap='IP'>


### PR DESCRIPTION
The login.defs configuration file is used by multiple system components (shadow-utils, PAM, util-linux), but the documentation was unclear about this reality. This led to confusion about which parameters are relevant on different system configurations.

Add explanatory paragraph clarifying that login.defs parameters may be used by shadow-utils, PAM, and other system components, with behaviour depending on system configuration and enabled authentication mechanisms.