### PR TITLE
Fix bug from de7f1c78f70f8df4b2956f7363da3774348bc58e that caused security regression

### DIFF
--- a/lib/subordinateio.c
+++ b/lib/subordinateio.c
@@ -333,11 +333,12 @@ static int subordinate_range_cmp (const void *p1, const void *p2)
 static id_t
 find_free_range(struct commonio_db *db, id_t min, id_t max, unsigned long count)
 {
-	uintmax_t                      low, max_id;
+	intmax_t                       low, max_id;
 	const struct subordinate_range *range;
 
 	if (count == 0 || max < min
-	    || (uintmax_t) count - 1 > (uintmax_t) max - min) {
+	    || (uintmax_t) count - 1 > (uintmax_t) max - min)
+	{
 		errno = ERANGE;
 		return -1;
 	}
@@ -346,38 +347,40 @@ find_free_range(struct commonio_db *db, id_t min, id_t max, unsigned long count)
 	commonio_sort (db, subordinate_range_cmp);
 	commonio_rewind(db);
 
-	low = (uintmax_t) min;
-	max_id = (uintmax_t) max;
+	low = min;
+	max_id = max;
 	while (NULL != (range = commonio_next(db))) {
-		uintmax_t  first, last;
+		intmax_t  first, last;
 
 		if (range->count == 0)
 			continue;
 
 		first = range->start;
 		if (__builtin_add_overflow(first, range->count - 1, &last))
-			last = UINTMAX_MAX;
+			last = INTMAX_MAX;
 
 		/*
-		 * Check the hole before this range as an inclusive interval.
-		 * This avoids constructing max + 1, which wraps when max is
-		 * the largest representable id_t value.
+		 * Ranges are sorted by start, and low has been advanced past
+		 * every range seen so far, so the gap [low, first - 1] (clamped
+		 * to max) contains no existing range.  A block that fits in
+		 * this gap lies below first, hence below every later range too,
+		 * so it cannot overlap any allocation.
 		 */
 		if (first > low) {
-			uintmax_t high = first - 1;
+			intmax_t high = first - 1;
 
 			/* Don't allocate IDs after max (included). */
 			if (high > max_id)
 				high = max_id;
 
 			/* Is the hole before this range large enough? */
-			if ((high >= low) && ((high - low + 1) >= count))
-				return (id_t) low;
+			if ((high >= low) && ((high - low + 1) >= (intmax_t) count))
+				return low;
 		}
 
 		/* Compute the low end of the next hole */
 		if (last >= low) {
-			if (last == UINTMAX_MAX)
+			if (last == INTMAX_MAX)
 				goto fail;
 			low = last + 1;
 		}
@@ -386,8 +389,8 @@ find_free_range(struct commonio_db *db, id_t min, id_t max, unsigned long count)
 	}
 
 	/* Is the remaining unclaimed area large enough? */
-	if (((max_id - low) + 1) >= count)
-		return (id_t) low;
+	if (((max_id - low) + 1) >= (intmax_t) count)
+		return low;
 fail:
 	errno = EUSERS;
 	return -1;

--- a/lib/subordinateio.c
+++ b/lib/subordinateio.c
@@ -17,6 +17,7 @@
 #include <pwd.h>
 #include <ctype.h>
 #include <fcntl.h>
+#include <stdint.h>
 #include <string.h>
 
 #include "alloc/malloc.h"
@@ -332,10 +333,11 @@ static int subordinate_range_cmp (const void *p1, const void *p2)
 static id_t
 find_free_range(struct commonio_db *db, id_t min, id_t max, unsigned long count)
 {
-	id_t                           low, high;
+	uintmax_t                      low, max_id;
 	const struct subordinate_range *range;
 
-	if (count == 0 || max < min || count - 1 > max - min) {
+	if (count == 0 || max < min
+	    || (uintmax_t) count - 1 > (uintmax_t) max - min) {
 		errno = ERANGE;
 		return -1;
 	}
@@ -344,35 +346,48 @@ find_free_range(struct commonio_db *db, id_t min, id_t max, unsigned long count)
 	commonio_sort (db, subordinate_range_cmp);
 	commonio_rewind(db);
 
-	low = min;
+	low = (uintmax_t) min;
+	max_id = (uintmax_t) max;
 	while (NULL != (range = commonio_next(db))) {
-		id_t  first, last;
+		uintmax_t  first, last;
+
+		if (range->count == 0)
+			continue;
 
 		first = range->start;
-		last = first + range->count - 1;
+		if (__builtin_add_overflow(first, range->count - 1, &last))
+			last = UINTMAX_MAX;
 
-		/* Find the top end of the hole before this range */
-		high = first;
+		/*
+		 * Check the hole before this range as an inclusive interval.
+		 * This avoids constructing max + 1, which wraps when max is
+		 * the largest representable id_t value.
+		 */
+		if (first > low) {
+			uintmax_t high = first - 1;
 
-		/* Don't allocate IDs after max (included) */
-		if (high > max + 1) {
-			high = max + 1;
+			/* Don't allocate IDs after max (included). */
+			if (high > max_id)
+				high = max_id;
+
+			/* Is the hole before this range large enough? */
+			if ((high >= low) && ((high - low + 1) >= count))
+				return (id_t) low;
 		}
 
-		/* Is the hole before this range large enough? */
-		if ((high > low) && ((high - low) >= count))
-			return low;
-
 		/* Compute the low end of the next hole */
-		if (low < (last + 1))
+		if (last >= low) {
+			if (last == UINTMAX_MAX)
+				goto fail;
 			low = last + 1;
-		if (low > max)
+		}
+		if (low > max_id)
 			goto fail;
 	}
 
 	/* Is the remaining unclaimed area large enough? */
-	if (((max - low) + 1) >= count)
-		return low;
+	if (((max_id - low) + 1) >= count)
+		return (id_t) low;
 fail:
 	errno = EUSERS;
 	return -1;
@@ -1128,4 +1143,3 @@ void free_subid_pointer(void *ptr)
 #else				/* !ENABLE_SUBIDS */
 extern int ISO_C_forbids_an_empty_translation_unit;
 #endif				/* !ENABLE_SUBIDS */
-


### PR DESCRIPTION
In a nutshell, the commit updated lib/subordinateio.c which now allows creation of overlapping subordinate ID ranges.  This is caused because the commit changed from unsigned long to id_t.   The bug is that the internal algorithm still used an exclusive endpoint expression, max + 1, which was only safe while the intermediate type was wide enough.  So find_free_range() accepts max as an inclusive ID ceiling, but internally compares holes against max + 1.  

When max is (id_t)-1 on an unsigned-ID build, max + 1 wraps to zero. new_subid_range() passes exactly that value as the ceiling.

This patch fixes the above issue as detailed in #1629 

Full Disclosure: This was found with N184, my open source bug and security vulnerability scanner, although this bug report (and patch) are my own work.  You can learn more about N184 here: https://github.com/MillaFleurs/N184