### PR TITLE
Expand the use of --with-fcaps to other binaries

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -550,7 +550,7 @@ fi
 AM_CONDITIONAL([USE_PAM], [test "X$with_libpam" = "Xyes"])
 
 AC_ARG_WITH([fcaps],
-	[AS_HELP_STRING([--with-fcaps], [use file capabilities instead of suid binaries for newuidmap/newgidmap @<:@default=no@:>@])],
+	[AS_HELP_STRING([--with-fcaps], [use file capabilities instead of suid binaries where possible @<:@default=no@:>@])],
 	[with_fcaps=$withval], [with_fcaps=no])
 AM_CONDITIONAL([FCAPS], [test "x$with_fcaps" = "xyes"])
 

--- a/lib/find_new_sub_gids.c
+++ b/lib/find_new_sub_gids.c
@@ -10,6 +10,7 @@
 
 #include <stdio.h>
 #include <errno.h>
+#include <stdint.h>
 
 #include "prototypes.h"
 #include "subordinateio.h"

--- a/lib/find_new_sub_uids.c
+++ b/lib/find_new_sub_uids.c
@@ -10,6 +10,7 @@
 
 #include <stdio.h>
 #include <errno.h>
+#include <stdint.h>
 
 #include "prototypes.h"
 #include "subordinateio.h"

--- a/lib/pwd_init.c
+++ b/lib/pwd_init.c
@@ -51,6 +51,7 @@ void pwd_init (void)
 	signal (SIGTERM, SIG_IGN);
 	signal (SIGTSTP, SIG_IGN);
 	signal (SIGTTOU, SIG_IGN);
+	signal (SIGXFSZ, SIG_IGN);
 
 	umask (077);
 }

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -61,17 +61,22 @@ noinst_PROGRAMS = sulogin
 
 suidusbins     =
 suidbins       =
-suidubins      = chage chfn chsh gpasswd newgrp
 if WITH_SU
 suidbins      += su
 endif
+
+privubins      = chage chfn chsh gpasswd newgrp
 if !WITH_TCB
-suidubins += passwd
+privubins     += passwd
 endif
 if ENABLE_SUBIDS
-if !FCAPS
-suidubins += newgidmap newuidmap
+privubins     += newgidmap newuidmap
 endif
+
+if FCAPS
+suidubins      =
+else
+suidubins      = $(privubins)
 endif
 
 if WITH_TCB
@@ -142,6 +147,16 @@ if WITH_TCB
 		chown root:shadow $(DESTDIR)$(ubindir)/$$i; \
 		chmod $(sgidperms) $(DESTDIR)$(ubindir)/$$i; \
 	done
+endif
+if FCAPS
+	setcap cap_dac_read_search+ep $(DESTDIR)$(ubindir)/chage
+	setcap cap_setgid,cap_dac_read_search+ep $(DESTDIR)$(ubindir)/newgrp
+	setcap cap_chown,cap_dac_override,cap_fowner+ep $(DESTDIR)$(ubindir)/chfn
+	setcap cap_chown,cap_dac_override,cap_fowner+ep $(DESTDIR)$(ubindir)/chsh
+	setcap cap_chown,cap_dac_override,cap_fowner+ep $(DESTDIR)$(ubindir)/gpasswd
+if !WITH_TCB
+	setcap cap_chown,cap_dac_override,cap_fowner+ep $(DESTDIR)$(ubindir)/passwd
+endif
 endif
 if ENABLE_SUBIDS
 if FCAPS

--- a/src/chfn.c
+++ b/src/chfn.c
@@ -395,13 +395,7 @@ static void update_gecos(const char *user, char *gecos, const struct option_flag
 
 	process_selinux = !flags->chroot;
 
-	/*
-	 * Before going any further, raise the ulimit to prevent colliding
-	 * into a lowered ulimit, and set the real UID to root to protect
-	 * against unexpected signals. Any keyboard signals are set to be
-	 * ignored.
-	 */
-	if (setuid (0) != 0) {
+	if (geteuid () == 0 && setuid (0) != 0) {
 		fputs (_("Cannot change ID to root.\n"), stderr);
 		SYSLOG(LOG_ERR, "can't setuid(0)");
 		fail_exit (E_NOPERM, process_selinux);

--- a/src/chsh.c
+++ b/src/chsh.c
@@ -375,13 +375,7 @@ static void update_shell (const char *user, char *newshell, const struct option_
 
 	process_selinux = !flags->chroot;
 
-	/*
-	 * Before going any further, raise the ulimit to prevent
-	 * colliding into a lowered ulimit, and set the real UID
-	 * to root to protect against unexpected signals. Any
-	 * keyboard signals are set to be ignored.
-	 */
-	if (setuid (0) != 0) {
+	if (geteuid () == 0 && setuid (0) != 0) {
 		SYSLOG(LOG_ERR, "can't setuid(0)");
 		fputs (_("Cannot change ID to root.\n"), stderr);
 		fail_exit (1, process_selinux);

--- a/src/gpasswd.c
+++ b/src/gpasswd.c
@@ -1088,7 +1088,7 @@ int main (int argc, char **argv)
 	 * output, etc.
 	 */
       output:
-	if (setuid (0) != 0) {
+	if (geteuid () == 0 && setuid (0) != 0) {
 		fputs (_("Cannot change ID to root.\n"), stderr);
 		SYSLOG(LOG_ERR, "can't setuid(0)");
 		closelog ();

--- a/src/passwd.c
+++ b/src/passwd.c
@@ -1197,7 +1197,7 @@ main(int argc, char **argv)
 		exit (E_SUCCESS);
 	}
 #endif				/* USE_PAM */
-	if (setuid (0) != 0) {
+	if (geteuid () == 0 && setuid (0) != 0) {
 		(void) fputs (_("Cannot change ID to root.\n"), stderr);
 		SYSLOG(LOG_ERR, "can't setuid(0)");
 		closelog ();


### PR DESCRIPTION
This is defense in depth attack surface reduction.

During recent kernel bugs, PoCs overwrote the kernel page cache to
inject attacker payloads into setuid binaries for execution.

The kernel forms the trusted computing base for shadow, so it's not
technically shadow's responsibility to mitigate.

But it's relatively simple change that gives us protection from both
future or undiscovered bugs in shadow binaries, and limits the number
of useful setuid targets to attackers weaponizing future kernel bugs.