### PR TITLE
lib/, src/: Use LOGIN_NAME_MAX instead of sysconf(_SC_LOGIN_NAME_MAX)

### DIFF
--- a/lib/chkname.c
+++ b/lib/chkname.c
@@ -102,7 +102,7 @@ is_valid_name(const char *name)
 bool
 is_valid_user_name(const char *name)
 {
-	if (strlen(name) >= login_name_max_size()) {
+	if (strlen(name) >= LOGIN_NAME_MAX) {
 		errno = EOVERFLOW;
 		return false;
 	}

--- a/lib/sysconf.c
+++ b/lib/sysconf.c
@@ -9,26 +9,10 @@
 #include <unistd.h>
 
 
-#ifndef  LOGIN_NAME_MAX
-# define LOGIN_NAME_MAX  256
-#endif
-
 #ifndef  NGROUPS_MAX
 # define NGROUPS_MAX  65536
 #endif
 
-
-size_t
-login_name_max_size(void)
-{
-	long  conf;
-
-	conf = sysconf(_SC_LOGIN_NAME_MAX);
-	if (conf == -1)
-		return LOGIN_NAME_MAX;
-
-	return conf;
-}
 
 size_t
 ngroups_max_size(void)

--- a/lib/sysconf.h
+++ b/lib/sysconf.h
@@ -9,10 +9,15 @@
 
 #include "config.h"
 
+#include <limits.h>
 #include <stddef.h>
 
 
-extern size_t login_name_max_size(void);
+#ifndef  LOGIN_NAME_MAX
+# define LOGIN_NAME_MAX  256
+#endif
+
+
 extern size_t ngroups_max_size(void);
 
 #endif  // include guard

--- a/src/login.c
+++ b/src/login.c
@@ -18,6 +18,7 @@
 #include <lastlog.h>
 #endif 				/* ENABLE_LASTLOG */
 #endif				/* !USE_PAM */
+#include <limits.h>
 #include <pwd.h>
 #include <signal.h>
 #include <stdio.h>
@@ -831,16 +832,13 @@ int main (int argc, char **argv)
 
 		failed = false;	/* haven't failed authentication yet */
 		if (NULL == username) {	/* need to get a login id */
-			size_t  max_size;
-
-			max_size = login_name_max_size();
 			if (subroot) {
 				closelog ();
 				exit (1);
 			}
 			preauth_flag = false;
-			username = xmalloc_T(max_size, char);
-			login_prompt(username, max_size);
+			username = xmalloc_T(LOGIN_NAME_MAX, char);
+			login_prompt(username, LOGIN_NAME_MAX);
 
 			if (streq(username, "")) {
 				/* Prompt for a new login */

--- a/tests/unit/test_chkname.c
+++ b/tests/unit/test_chkname.c
@@ -4,6 +4,7 @@
  */
 
 
+#include <limits.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdlib.h>
@@ -130,19 +131,17 @@ test_is_valid_user_name_nok_otherchars(MAYBE_UNUSED void ** _1)
 static void
 test_is_valid_user_name_long(MAYBE_UNUSED void ** _1)
 {
-	size_t  max;
-	char    *name;
+	char  *name;
 
-	max = sysconf(_SC_LOGIN_NAME_MAX);
-	name = malloc_T(max + 1, char);
+	name = malloc_T(LOGIN_NAME_MAX + 1, char);
 	assert_true(name != NULL);
 
-	memset(name, '_', max);
+	memset(name, '_', LOGIN_NAME_MAX);
 
-	stpcpy(&name[max], "");
+	stpcpy(&name[LOGIN_NAME_MAX], "");
 	assert_true(false == is_valid_user_name(name));
 
-	stpcpy(&name[max - 1], "");
+	stpcpy(&name[LOGIN_NAME_MAX - 1], "");
 	assert_true(is_valid_user_name(name));
 
 	free(name);


### PR DESCRIPTION
This provides safer guarantees.  We should be conservative in what we accept.

Closes: <https://github.com/shadow-maint/shadow/issues/1636>
Cc: @ikerexxe , @hallyn , @thkukuk 

---

Revisions:

<details>
<summary>v2</summary>

-  Simplify surrounding code, by using LOGIN_NAME_MAX directly.  [@ikerexxe ]

```
$ git rd 
1:  f54b7c237f88 ! 1:  60317ca685a4 lib/, src/: Use LOGIN_NAME_MAX instead of sysconf(_SC_LOGIN_NAME_MAX)
    @@ lib/sysconf.h
     
      ## src/login.c ##
     @@ src/login.c: int main (int argc, char **argv)
    -           if (NULL == username) { /* need to get a login id */
    -                   size_t  max_size;
      
    +           failed = false; /* haven't failed authentication yet */
    +           if (NULL == username) { /* need to get a login id */
    +-                  size_t  max_size;
    +-
     -                  max_size = login_name_max_size();
    -+                  max_size = LOGIN_NAME_MAX;
                        if (subroot) {
                                closelog ();
                                exit (1);
    +                   }
    +                   preauth_flag = false;
    +-                  username = xmalloc_T(max_size, char);
    +-                  login_prompt(username, max_size);
    ++                  username = xmalloc_T(LOGIN_NAME_MAX, char);
    ++                  login_prompt(username, LOGIN_NAME_MAX);
    + 
    +                   if (streq(username, "")) {
    +                           /* Prompt for a new login */
```
</details>

<details>
<summary>v3</summary>

-  Add missing includes.
-  Change tests/ too.

```
$ git rd 
1:  60317ca685a4 ! 1:  7c05e222c84e lib/, src/: Use LOGIN_NAME_MAX instead of sysconf(_SC_LOGIN_NAME_MAX)
    @@ Metadata
     Author: Alejandro Colomar <alx@kernel.org>
     
      ## Commit message ##
    -    lib/, src/: Use LOGIN_NAME_MAX instead of sysconf(_SC_LOGIN_NAME_MAX)
    +    lib/, src/, tests/: Use LOGIN_NAME_MAX instead of sysconf(_SC_LOGIN_NAME_MAX)
     
         This provides safer guarantees.  We should be conservative in what we
         accept.
    @@ lib/sysconf.c
     
      ## lib/sysconf.h ##
     @@
    + 
    + #include "config.h"
    + 
    ++#include <limits.h>
      #include <stddef.h>
      
      
    @@ lib/sysconf.h
      #endif  // include guard
     
      ## src/login.c ##
    +@@
    + #include <lastlog.h>
    + #endif                            /* ENABLE_LASTLOG */
    + #endif                            /* !USE_PAM */
    ++#include <limits.h>
    + #include <pwd.h>
    + #include <signal.h>
    + #include <stdio.h>
     @@ src/login.c: int main (int argc, char **argv)
      
                failed = false; /* haven't failed authentication yet */
    @@ src/login.c: int main (int argc, char **argv)
      
                        if (streq(username, "")) {
                                /* Prompt for a new login */
    +
    + ## tests/unit/test_chkname.c ##
    +@@
    +  */
    + 
    + 
    ++#include <limits.h>
    + #include <stdbool.h>
    + #include <stddef.h>
    + #include <stdlib.h>
    +@@ tests/unit/test_chkname.c: test_is_valid_user_name_nok_otherchars(MAYBE_UNUSED void ** _1)
    + static void
    + test_is_valid_user_name_long(MAYBE_UNUSED void ** _1)
    + {
    +-  size_t  max;
    +-  char    *name;
    ++  char  *name;
    + 
    +-  max = sysconf(_SC_LOGIN_NAME_MAX);
    +-  name = malloc_T(max + 1, char);
    ++  name = malloc_T(LOGIN_NAME_MAX + 1, char);
    +   assert_true(name != NULL);
    + 
    +-  memset(name, '_', max);
    ++  memset(name, '_', LOGIN_NAME_MAX);
    + 
    +-  stpcpy(&name[max], "");
    ++  stpcpy(&name[LOGIN_NAME_MAX], "");
    +   assert_true(false == is_valid_user_name(name));
    + 
    +-  stpcpy(&name[max - 1], "");
    ++  stpcpy(&name[LOGIN_NAME_MAX - 1], "");
    +   assert_true(is_valid_user_name(name));
    + 
    +   free(name);
```
</details>