### PR TITLE
fix: memory leak of ngrp in updates_groups()

### DIFF
--- a/lib/list.c
+++ b/lib/list.c
@@ -67,6 +67,8 @@ add_list(/*@returned@*/ /*@only@*/char **list, const char *member)
 	tmp[i] = xstrdup (member);
 	tmp[i+1] = NULL;
 
+	free (list);
+
 	return tmp;
 }
 

--- a/lib/list.c
+++ b/lib/list.c
@@ -121,6 +121,8 @@ del_list(/*@returned@*/ /*@only@*/char **list, const char *member)
 		if (!streq(list[i], member)) {
 			tmp[j] = list[i];
 			j++;
+		} else {
+			free (list[i]);
 		}
 	}
 

--- a/lib/list.c
+++ b/lib/list.c
@@ -128,6 +128,8 @@ del_list(/*@returned@*/ /*@only@*/char **list, const char *member)
 
 	tmp[j] = NULL;
 
+	free (list);
+
 	return tmp;
 }
 

--- a/src/groupadd.c
+++ b/src/groupadd.c
@@ -67,8 +67,6 @@ static const char Prog[] = "groupadd";
 static /*@null@*/char *group_name;
 static gid_t group_id;
 static /*@null@*/char *group_passwd;
-static /*@null@*/char *empty_list = NULL;
-
 static const char *prefix = "";
 static char *user_list;
 
@@ -151,7 +149,7 @@ static void new_grent (struct group *grent)
 		grent->gr_passwd = SHADOW_PASSWD_STRING;	/* XXX warning: const */
 	}
 	grent->gr_gid = group_id;
-	grent->gr_mem = &empty_list;
+	grent->gr_mem = comma_to_list("");
 }
 
 #ifdef	SHADOWGRP
@@ -170,8 +168,8 @@ static void new_sgent (struct sgrp *sgent)
 	} else {
 		sgent->sg_passwd = "!";	/* XXX warning: const */
 	}
-	sgent->sg_adm = &empty_list;
-	sgent->sg_mem = &empty_list;
+	sgent->sg_adm = comma_to_list("");
+	sgent->sg_mem = comma_to_list("");
 }
 #endif				/* SHADOWGRP */
 
@@ -247,6 +245,14 @@ grp_update(void)
 		         Prog, sgr_dbname (), sgrp.sg_namp);
 		fail_exit (E_GRP_UPDATE);
 	}
+#endif				/* SHADOWGRP */
+	free_list(grp.gr_mem);
+	free(grp.gr_mem);
+#ifdef	SHADOWGRP
+	free_list(sgrp.sg_mem);
+	free(sgrp.sg_mem);
+	free_list(sgrp.sg_adm);
+	free(sgrp.sg_adm);
 #endif				/* SHADOWGRP */
 }
 

--- a/src/groupmod.c
+++ b/src/groupmod.c
@@ -241,7 +241,7 @@ grp_update(void)
 			sgrp.sg_namp   = xstrdup (grp.gr_name);
 			sgrp.sg_passwd = xstrdup (grp.gr_passwd);
 			sgrp.sg_adm    = &empty;
-			sgrp.sg_mem    = dup_list (grp.gr_mem);
+			sgrp.sg_mem    = grp.gr_mem;
 			new_sgent (&sgrp);
 			osgrp = &sgrp; /* entry needs to be committed */
 		}

--- a/src/groupmod.c
+++ b/src/groupmod.c
@@ -259,8 +259,7 @@ grp_update(void)
 			grp.gr_mem[0] = NULL;
 		} else {
 			// append to existing groups
-			if (NULL != grp.gr_mem[0])
-				grp.gr_mem = dup_list (grp.gr_mem);
+			grp.gr_mem = dup_list (grp.gr_mem);
 		}
 #ifdef	SHADOWGRP
 		if (NULL != osgrp) {
@@ -268,8 +267,7 @@ grp_update(void)
 				sgrp.sg_mem = xmalloc_T(1, char *);
 				sgrp.sg_mem[0] = NULL;
 			} else {
-				if (NULL != sgrp.sg_mem[0])
-					sgrp.sg_mem = dup_list(sgrp.sg_mem);
+				sgrp.sg_mem = dup_list(sgrp.sg_mem);
 			}
 		}
 #endif				/* SHADOWGRP */

--- a/src/groupmod.c
+++ b/src/groupmod.c
@@ -325,6 +325,16 @@ grp_update(void)
 		}
 	}
 #endif				/* SHADOWGRP */
+	if (NULL != user_list) {
+		free_list(grp.gr_mem);
+		free(grp.gr_mem);
+#ifdef	SHADOWGRP
+		if (NULL != osgrp) {
+			free_list(sgrp.sg_mem);
+			free(sgrp.sg_mem);
+		}
+#endif				/* SHADOWGRP */
+	}
 }
 
 /*


### PR DESCRIPTION
    In src/userdel.c:update_groups(), the 'ngrp' pointer was not freed
    after use, leading to a memory leak. Added free(ngrp) call.

    In src/userdel.c:update_groups(), the 'nsgrp' pointer was not freed
    between loop iterations, leading to cumulative memory leaks. Added
    free(nsgrp) call before proceeding to next iteration.
