### PR TITLE
fix: memory leak of nsgrp in src/useradd.c grp_update()

### DIFF
--- a/src/useradd.c
+++ b/src/useradd.c
@@ -1131,6 +1131,7 @@ static void grp_update (bool process_selinux)
 #endif
 		SYSLOG(LOG_INFO, "add '%s' to shadow group '%s'",
 		       user_name, nsgrp->sg_namp);
+		free (nsgrp);
 	}
 #endif				/* SHADOWGRP */
 }

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -1068,6 +1068,7 @@ static void grp_update (bool process_selinux)
 #endif
 		SYSLOG(LOG_INFO, "add '%s' to group '%s'", user_name, ngrp->gr_name);
 	}
+	free (ngrp);
 
 #ifdef	SHADOWGRP
 	if (!is_shadow_grp)


### PR DESCRIPTION
    In src/useradd.c:grp_update(), the 'nsgrp' pointer is allocated in
    a loop but not freed on each iteration, causing cumulative memory
    leaks. Added free(nsgrp) call at the end of each loop cycle.

    In src/useradd.c:grp_update(), the 'ngrp' pointer was allocated but
    not freed after use, leading to a memory leak. Added free(ngrp)
    call after the last use of the pointer.
