### PR TITLE
src/login_nopam.c: Simplify some code

### DIFF
--- a/lib/prototypes.h
+++ b/lib/prototypes.h
@@ -201,7 +201,7 @@ extern void dolastlog (
 #endif /* ENABLE_LASTLOG */
 
 /* login_nopam.c */
-extern int login_access (const char *user, const char *from);
+extern bool login_access(const char *user, const char *from);
 
 /* loginprompt.c */
 extern void login_prompt (char *, int);

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -86,7 +86,6 @@ login_access(const char *user, const char *from)
 {
 	FILE *fp;
 	char line[BUFSIZ];
-	bool match = false;
 
 	/*
 	 * Process the table one line at a time and stop at the first match.
@@ -101,7 +100,7 @@ login_access(const char *user, const char *from)
 		return true;  // A non-existent table means no access control.
 	}
 
-	for (intmax_t i = 1; !match && fgets_a(line, fp) != NULL; i++) {
+	for (intmax_t i = 1; fgets_a(line, fp) != NULL; i++) {
 		char  *p;
 		char  *perm;	/* becomes permission field */
 		char  *users;	/* becomes list of login names */
@@ -134,12 +133,15 @@ login_access(const char *user, const char *from)
 				TABLE, i);
 			continue;
 		}
-		match = (   list_match(froms, from, from_match)
-			 && list_match(users, user, user_match));
+		if (   list_match(froms, from, from_match)
+		    && list_match(users, user, user_match))
+		{
+			fclose(fp);
+			return !!strprefix(line, "+");
+		}
 	}
-	(void) fclose(fp);
-
-	return (!match || strprefix(line, "+"))?1:0;
+	fclose(fp);
+	return true;
 }
 
 /* list_match - match an item against a list of tokens with exceptions */

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -101,20 +101,16 @@ login_access(const char *user, const char *from)
 		return true;  // A non-existent table means no access control.
 	}
 
-	intmax_t lineno = 0;  /* for diagnostics */
-	while (   !match
-	       && (fgets_a(line, fp) != NULL))
-	{
+	for (intmax_t i = 1; !match && fgets_a(line, fp) != NULL; i++) {
 		char  *p;
 		char  *perm;	/* becomes permission field */
 		char  *users;	/* becomes list of login names */
 		char  *froms;	/* becomes list of terminals or hosts */
 
-		lineno++;
 		if (stpsep(line, "\n") == NULL) {
 			SYSLOG(LOG_ERR,
 				"%s: line %jd: missing newline or line too long",
-				TABLE, lineno);
+				TABLE, i);
 			continue;
 		}
 		if (strprefix(line, "#")) {
@@ -130,12 +126,12 @@ login_access(const char *user, const char *from)
 		froms = strsep(&p, ":");
 		if (froms == NULL || p != NULL) {
 			SYSLOG(LOG_ERR, "%s: line %jd: bad field count",
-			       TABLE, lineno);
+			       TABLE, i);
 			continue;
 		}
 		if (perm[0] != '+' && perm[0] != '-') {
 			SYSLOG(LOG_ERR, "%s: line %jd: bad first field",
-				TABLE, lineno);
+				TABLE, i);
 			continue;
 		}
 		match = (   list_match(froms, from, from_match)

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -137,7 +137,7 @@ login_access(const char *user, const char *from)
 		    && list_match(users, user, user_match))
 		{
 			fclose(fp);
-			return !!strprefix(line, "+");
+			return !!strprefix(perm, "+");
 		}
 	}
 	fclose(fp);

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -309,16 +309,14 @@ static bool from_match (char *tok, const char *string)
 
 		str_len = strlen (string);
 		tok_len = strlen (tok);
-		if (   (str_len > tok_len)
-		    && strcaseeq(tok, string + str_len - tok_len)) {
+		if (str_len > tok_len && strcaseeq(tok, string + str_len - tok_len))
 			return true;
-		}
 	} else if (strcaseeq(tok, "LOCAL")) {	/* LOCAL: no dots */
 		if (!strchr(string, '.'))
 			return true;
-	} else if (   strrspn_(tok, ".")  /* network */
-		   && strprefix(resolve_hostname(string), tok)) {
-		return true;
+	} else if (strrspn_(tok, ".")  /* network */
+		if (strprefix(resolve_hostname(string), tok))
+			return true;
 	}
 	return false;
 }

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -78,7 +78,6 @@
 static bool list_match (char *list, const char *item, bool (*match_fn) (char *, const char *));
 static bool user_match (char *tok, const char *string);
 static bool from_match (char *tok, const char *string);
-static bool string_match (const char *tok, const char *string);
 static const char *resolve_hostname (const char *string);
 
 /* login_access - match username/group and host/tty with access control file */
@@ -229,7 +228,7 @@ static bool user_match (char *tok, const char *string)
 	} else if (strprefix(tok, "@")) {	/* netgroup */
 		return (netgroup_match (tok + 1, NULL, string));
 #endif
-	} else if (string_match (tok, string)) {	/* ALL or exact match */
+	} else if (strcaseeq(tok, "ALL") || strcaseeq(tok, string)) {
 		return true;
 	/* local, no need for xgetgrnam */
 	} else if ((group = getgrnam (tok)) != NULL) {	/* try group membership */
@@ -303,7 +302,7 @@ static bool from_match (char *tok, const char *string)
 		return (netgroup_match (tok + 1, string, NULL));
 	} else
 #endif
-	if (string_match (tok, string)) {	/* ALL or exact match */
+	if (strcaseeq(tok, "ALL") || strcaseeq(tok, string)) {
 		return true;
 	} else if (strprefix(tok, ".")) {  /* domain: match last fields */
 		size_t  str_len, tok_len;
@@ -323,23 +322,6 @@ static bool from_match (char *tok, const char *string)
 	}
 	return false;
 }
-
-/* string_match - match a string against one token */
-static bool string_match (const char *tok, const char *string)
-{
-
-	/*
-	 * If the token has the magic value "ALL" the match always succeeds.
-	 * Otherwise, return true if the token fully matches the string.
-	 */
-	if (strcaseeq(tok, "ALL")) {  /* ALL: always matches */
-		return true;
-	} else if (strcaseeq(tok, string)) {  /* try exact match */
-		return true;
-	}
-	return false;
-}
-
 #else				/* !USE_PAM */
 extern int ISO_C_forbids_an_empty_translation_unit;
 #endif				/* !USE_PAM */

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -86,9 +86,6 @@ login_access(const char *user, const char *from)
 {
 	FILE *fp;
 	char line[BUFSIZ];
-	char *perm;		/* becomes permission field */
-	char *users;		/* becomes list of login names */
-	char *froms;		/* becomes list of terminals or hosts */
 	bool match = false;
 
 	/*
@@ -105,6 +102,9 @@ login_access(const char *user, const char *from)
 		       && (fgets_a(line, fp) != NULL))
 		{
 			char  *p;
+			char  *perm;	/* becomes permission field */
+			char  *users;	/* becomes list of login names */
+			char  *froms;	/* becomes list of terminals or hosts */
 
 			lineno++;
 			if (stpsep(line, "\n") == NULL) {

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -309,14 +309,11 @@ static bool from_match (char *tok, const char *string)
 
 		str_len = strlen (string);
 		tok_len = strlen (tok);
-		if (str_len > tok_len && strcaseeq(tok, string + str_len - tok_len))
-			return true;
+		return str_len > tok_len && strcaseeq(tok, string + str_len - tok_len);
 	} else if (strcaseeq(tok, "LOCAL")) {	/* LOCAL: no dots */
-		if (!strchr(string, '.'))
-			return true;
+		return !strchr(string, '.');
 	} else if (strrspn_(tok, ".")  /* network */
-		if (strprefix(resolve_hostname(string), tok))
-			return true;
+		return !!strprefix(resolve_hostname(string), tok);
 	}
 	return false;
 }

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -100,49 +100,49 @@ login_access(const char *user, const char *from)
 			SYSLOGE(LOG_ERR, "cannot open %s", TABLE);
 		return true;  // A non-existent table means no access control.
 	}
-	{
-		intmax_t lineno = 0;	/* for diagnostics */
-		while (   !match
-		       && (fgets_a(line, fp) != NULL))
-		{
-			char  *p;
-			char  *perm;	/* becomes permission field */
-			char  *users;	/* becomes list of login names */
-			char  *froms;	/* becomes list of terminals or hosts */
 
-			lineno++;
-			if (stpsep(line, "\n") == NULL) {
-				SYSLOG(LOG_ERR,
-					"%s: line %jd: missing newline or line too long",
-					TABLE, lineno);
-				continue;
-			}
-			if (strprefix(line, "#")) {
-				continue;	/* comment line */
-			}
-			stpcpy(stprspn(line, " \t"), "");
-			if (streq(line, "")) {	/* skip blank lines */
-				continue;
-			}
-			p = line;
-			perm = strsep(&p, ":");
-			users = strsep(&p, ":");
-			froms = strsep(&p, ":");
-			if (froms == NULL || p != NULL) {
-				SYSLOG(LOG_ERR, "%s: line %jd: bad field count",
-				       TABLE, lineno);
-				continue;
-			}
-			if (perm[0] != '+' && perm[0] != '-') {
-				SYSLOG(LOG_ERR, "%s: line %jd: bad first field",
-					TABLE, lineno);
-				continue;
-			}
-			match = (   list_match (froms, from, from_match)
-			         && list_match (users, user, user_match));
+	intmax_t lineno = 0;  /* for diagnostics */
+	while (   !match
+	       && (fgets_a(line, fp) != NULL))
+	{
+		char  *p;
+		char  *perm;	/* becomes permission field */
+		char  *users;	/* becomes list of login names */
+		char  *froms;	/* becomes list of terminals or hosts */
+
+		lineno++;
+		if (stpsep(line, "\n") == NULL) {
+			SYSLOG(LOG_ERR,
+				"%s: line %jd: missing newline or line too long",
+				TABLE, lineno);
+			continue;
 		}
-		(void) fclose (fp);
+		if (strprefix(line, "#")) {
+			continue;	/* comment line */
+		}
+		stpcpy(stprspn(line, " \t"), "");
+		if (streq(line, "")) {	/* skip blank lines */
+			continue;
+		}
+		p = line;
+		perm = strsep(&p, ":");
+		users = strsep(&p, ":");
+		froms = strsep(&p, ":");
+		if (froms == NULL || p != NULL) {
+			SYSLOG(LOG_ERR, "%s: line %jd: bad field count",
+			       TABLE, lineno);
+			continue;
+		}
+		if (perm[0] != '+' && perm[0] != '-') {
+			SYSLOG(LOG_ERR, "%s: line %jd: bad first field",
+				TABLE, lineno);
+			continue;
+		}
+		match = (   list_match(froms, from, from_match)
+			 && list_match(users, user, user_match));
 	}
+	(void) fclose(fp);
+
 	return (!match || strprefix(line, "+"))?1:0;
 }
 

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -92,11 +92,15 @@ login_access(const char *user, const char *from)
 	 * Process the table one line at a time and stop at the first match.
 	 * Blank lines and lines that begin with a '#' character are ignored.
 	 * Non-comment lines are broken at the ':' character. All fields are
-	 * mandatory. The first field should be a "+" or "-" character. A
-	 * non-existing table means no access control.
+	 * mandatory. The first field should be a "+" or "-" character.
 	 */
 	fp = fopen (TABLE, "r");
-	if (NULL != fp) {
+	if (fp == NULL) {
+		if (errno != ENOENT)
+			SYSLOGE(LOG_ERR, "cannot open %s", TABLE);
+		return true;  // A non-existent table means no access control.
+	}
+	{
 		intmax_t lineno = 0;	/* for diagnostics */
 		while (   !match
 		       && (fgets_a(line, fp) != NULL))
@@ -138,8 +142,6 @@ login_access(const char *user, const char *from)
 			         && list_match (users, user, user_match));
 		}
 		(void) fclose (fp);
-	} else if (errno != ENOENT) {
-		SYSLOGE(LOG_ERR, "cannot open %s", TABLE);
 	}
 	return (!match || strprefix(line, "+"))?1:0;
 }

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -222,16 +222,16 @@ static bool user_match (char *tok, const char *string)
 	 * the token is a group that contains the username.
 	 */
 	host = stpsep(tok + 1, "@");	/* split user@host pattern */
-	if (host != NULL) {
+	if (host != NULL)
 		return user_match(tok, string) && from_match(host, myhostname());
 #if HAVE_INNETGR
-	} else if (strprefix(tok, "@")) {	/* netgroup */
+	if (strprefix(tok, "@"))	/* netgroup */
 		return (netgroup_match (tok + 1, NULL, string));
 #endif
-	} else if (strcaseeq(tok, "ALL") || strcaseeq(tok, string)) {
+	if (strcaseeq(tok, "ALL") || strcaseeq(tok, string))
 		return true;
 	/* local, no need for xgetgrnam */
-	} else if ((group = getgrnam (tok)) != NULL) {	/* try group membership */
+	if ((group = getgrnam (tok)) != NULL) {	/* try group membership */
 		int i;
 		for (i = 0; NULL != group->gr_mem[i]; i++) {
 			if (strcaseeq(string, group->gr_mem[i])) {
@@ -298,23 +298,22 @@ static bool from_match (char *tok, const char *string)
 	 * if it matches the head of the string.
 	 */
 #if HAVE_INNETGR
-	if (strprefix(tok, "@")) {  /* netgroup */
+	if (strprefix(tok, "@"))  /* netgroup */
 		return (netgroup_match (tok + 1, string, NULL));
-	} else
 #endif
-	if (strcaseeq(tok, "ALL") || strcaseeq(tok, string)) {
+	if (strcaseeq(tok, "ALL") || strcaseeq(tok, string))
 		return true;
-	} else if (strprefix(tok, ".")) {  /* domain: match last fields */
+	if (strprefix(tok, ".")) {  /* domain: match last fields */
 		size_t  str_len, tok_len;
 
 		str_len = strlen (string);
 		tok_len = strlen (tok);
 		return str_len > tok_len && strcaseeq(tok, string + str_len - tok_len);
-	} else if (strcaseeq(tok, "LOCAL")) {	/* LOCAL: no dots */
-		return !strchr(string, '.');
-	} else if (strrspn_(tok, ".")  /* network */
-		return !!strprefix(resolve_hostname(string), tok);
 	}
+	if (strcaseeq(tok, "LOCAL"))  /* LOCAL: no dots */
+		return !strchr(string, '.');
+	if (strrspn_(tok, ".")  /* network */
+		return !!strprefix(resolve_hostname(string), tok);
 	return false;
 }
 #else				/* !USE_PAM */

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -87,12 +87,6 @@ login_access(const char *user, const char *from)
 	FILE *fp;
 	char line[BUFSIZ];
 
-	/*
-	 * Process the table one line at a time and stop at the first match.
-	 * Blank lines and lines that begin with a '#' character are ignored.
-	 * Non-comment lines are broken at the ':' character. All fields are
-	 * mandatory. The first field should be a "+" or "-" character.
-	 */
 	fp = fopen (TABLE, "r");
 	if (fp == NULL) {
 		if (errno != ENOENT)
@@ -112,13 +106,12 @@ login_access(const char *user, const char *from)
 				TABLE, i);
 			continue;
 		}
-		if (strprefix(line, "#")) {
-			continue;	/* comment line */
-		}
-		stpcpy(stprspn(line, " \t"), "");
-		if (streq(line, "")) {	/* skip blank lines */
+		if (strprefix(line, "#"))  // comment line
 			continue;
-		}
+		stpcpy(stprspn(line, " \t"), "");
+		if (streq(line, ""))
+			continue;
+
 		p = line;
 		perm = strsep(&p, ":");
 		users = strsep(&p, ":");

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -81,7 +81,7 @@ static bool from_match (char *tok, const char *string);
 static const char *resolve_hostname (const char *string);
 
 /* login_access - match username/group and host/tty with access control file */
-int
+bool
 login_access(const char *user, const char *from)
 {
 	FILE *fp;


### PR DESCRIPTION
---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git rd 
 1:  3bac26354724 =  1:  537b6a03a677 src/login_nopam.c: Remove string_match()
 2:  9edd0a0e727e !  2:  51b1f587df4a src/login_nopam.c: from_match(): Unify style of conditionals
    @@ src/login_nopam.c: static bool from_match (char *tok, const char *string)
        } else if (strcaseeq(tok, "LOCAL")) {   /* LOCAL: no dots */
                if (!strchr(string, '.'))
                        return true;
    --  } else if (   (!streq(tok, "") && tok[strlen(tok) - 1] == '.') /* network */
    +-  } else if (   strrspn_(tok, ".")  /* network */
     -             && strprefix(resolve_hostname(string), tok)) {
     -          return true;
    -+  } else if (!streq(tok, "") && tok[strlen(tok) - 1] == '.') {  /* network */
    ++  } else if (strrspn_(tok, ".")  /* network */
     +          if (strprefix(resolve_hostname(string), tok))
     +                  return true;
        }
 3:  fadafa8fa947 !  3:  36478c11ea60 src/login_nopam.c: from_match(): return directly in all cases
    @@ src/login_nopam.c: static bool from_match (char *tok, const char *string)
     -          if (!strchr(string, '.'))
     -                  return true;
     +          return !strchr(string, '.');
    -   } else if (!streq(tok, "") && tok[strlen(tok) - 1] == '.') {  /* network */
    +   } else if (strrspn_(tok, ".")  /* network */
     -          if (strprefix(resolve_hostname(string), tok))
     -                  return true;
     +          return !!strprefix(resolve_hostname(string), tok);
 4:  2f39983c89a1 !  4:  fd970d49750a src/login_nopam.c: Don't else after return
    @@ src/login_nopam.c: static bool from_match (char *tok, const char *string)
                return str_len > tok_len && strcaseeq(tok, string + str_len - tok_len);
     -  } else if (strcaseeq(tok, "LOCAL")) {   /* LOCAL: no dots */
     -          return !strchr(string, '.');
    --  } else if (!streq(tok, "") && tok[strlen(tok) - 1] == '.') {  /* network */
    +-  } else if (strrspn_(tok, ".")  /* network */
     -          return !!strprefix(resolve_hostname(string), tok);
        }
     +  if (strcaseeq(tok, "LOCAL"))  /* LOCAL: no dots */
     +          return !strchr(string, '.');
    -+  if (!streq(tok, "") && tok[strlen(tok) - 1] == '.')  /* network */
    ++  if (strrspn_(tok, ".")  /* network */
     +          return !!strprefix(resolve_hostname(string), tok);
        return false;
      }
 5:  320b5ddc98c3 =  5:  a3638b9f27a5 src/login_nopam.c: login_access(): Reduce scope of local variables
 6:  d6264edfdf72 =  6:  1244697a7ee2 src/login_nopam.c: login_access(): Move error handling earlier
 7:  1dbaed7b1ea3 =  7:  566fa2f5b140 src/login_nopam.c: login_access(): Reduce indentation
 8:  30c20ba4ca8c =  8:  d209643e619f src/login_nopam.c: login_access(): Use for instead of while loop
 9:  f999479e2bf9 =  9:  08befd50450d src/login_nopam.c: login_access(): Handle a match earlier
10:  2b5979522d4f = 10:  88841c86aab2 src/login_nopam.c: login_access(): Consistently use 'perm'
11:  dd0fd366ea1b = 11:  a2606232519e src/login_nopam.c: login_access(): Remove redundant comments
12:  3fe331f1e6a8 = 12:  7cc582ca3765 lib/, src/login_nopam.c: login_access(): Return bool
```
</details>

<details>
<summary>v1c</summary>

-  Rebase

```
$ git rd -U0
 1:  537b6a03a677 =  1:  f69c95d33ba8 src/login_nopam.c: Remove string_match()
 2:  51b1f587df4a =  2:  942decabcfbc src/login_nopam.c: from_match(): Unify style of conditionals
 3:  36478c11ea60 =  3:  f07c4e45dac5 src/login_nopam.c: from_match(): return directly in all cases
 4:  fd970d49750a =  4:  4e05fdfd4daa src/login_nopam.c: Don't else after return
 5:  a3638b9f27a5 =  5:  f07fc5dd2223 src/login_nopam.c: login_access(): Reduce scope of local variables
 6:  1244697a7ee2 !  6:  b19a183417c6 src/login_nopam.c: login_access(): Move error handling earlier
    @@ src/login_nopam.c: login_access(const char *user, const char *from)
    -+          if (errno != ENOENT) {
    -+                  int err = errno;
    -+                  SYSLOG(LOG_ERR, "cannot open %s: %s", TABLE, strerror(err));
    -+          }
    ++          if (errno != ENOENT)
    ++                  SYSLOGE(LOG_ERR, "cannot open %s", TABLE);
    @@ src/login_nopam.c: login_access(const char *user, const char *from)
    --          int err = errno;
    --          SYSLOG(LOG_ERR, "cannot open %s: %s", TABLE, strerror(err));
    +-          SYSLOGE(LOG_ERR, "cannot open %s", TABLE);
 7:  566fa2f5b140 !  7:  8d80eddeb001 src/login_nopam.c: login_access(): Reduce indentation
    @@ src/login_nopam.c: login_access(const char *user, const char *from)
    -           }
    +                   SYSLOGE(LOG_ERR, "cannot open %s", TABLE);
 8:  d209643e619f =  8:  6aece11a1af2 src/login_nopam.c: login_access(): Use for instead of while loop
 9:  08befd50450d =  9:  b8f4f15154b1 src/login_nopam.c: login_access(): Handle a match earlier
10:  88841c86aab2 = 10:  ab5c21069395 src/login_nopam.c: login_access(): Consistently use 'perm'
11:  a2606232519e ! 11:  a13b22541367 src/login_nopam.c: login_access(): Remove redundant comments
    @@ src/login_nopam.c: login_access(const char *user, const char *from)
    -           if (errno != ENOENT) {
    +           if (errno != ENOENT)
12:  7cc582ca3765 = 12:  4004c5558149 lib/, src/login_nopam.c: login_access(): Return bool
```
</details>

<details>
<summary>v1d</summary>

-  Rebase

```
$ git rd 
 1:  f69c95d33ba8 =  1:  b91903fd8729 src/login_nopam.c: Remove string_match()
 2:  942decabcfbc =  2:  8ac99961836e src/login_nopam.c: from_match(): Unify style of conditionals
 3:  f07c4e45dac5 =  3:  35f1736825a9 src/login_nopam.c: from_match(): return directly in all cases
 4:  4e05fdfd4daa =  4:  b525713aa954 src/login_nopam.c: Don't else after return
 5:  f07fc5dd2223 =  5:  f176017bfd27 src/login_nopam.c: login_access(): Reduce scope of local variables
 6:  b19a183417c6 =  6:  fb5631253b06 src/login_nopam.c: login_access(): Move error handling earlier
 7:  8d80eddeb001 =  7:  af9c0d6687c6 src/login_nopam.c: login_access(): Reduce indentation
 8:  6aece11a1af2 =  8:  b9914b8defba src/login_nopam.c: login_access(): Use for instead of while loop
 9:  b8f4f15154b1 =  9:  b182a15edcf4 src/login_nopam.c: login_access(): Handle a match earlier
10:  ab5c21069395 = 10:  8de5d4157066 src/login_nopam.c: login_access(): Consistently use 'perm'
11:  a13b22541367 = 11:  6db4f1ba26b9 src/login_nopam.c: login_access(): Remove redundant comments
12:  4004c5558149 = 12:  de7c4c0eb2d3 lib/, src/login_nopam.c: login_access(): Return bool
```
</details>