### PR TITLE
po: tell xgettext that we want line numbers

### DIFF
--- a/man/po/Makefile.in
+++ b/man/po/Makefile.in
@@ -104,7 +104,7 @@ $(DOMAIN).pot-update: $(XMLFILES) $(srcdir)/XMLFILES remove-potcdate.sed
 		fi; \
 		files="$$files $$outbase"; \
 	done; \
-	cd $$tmpdir; itstool -d -o $(DOMAIN).po $$files; \
+	cd $$tmpdir; itstool -d $$files | msgattrib --no-location -o $(DOMAIN).po; \
 	sed -i '1i \
 # To re-generate, run "cd man/po; make update-po"' $$tmpdir/$(DOMAIN).po; \
 	cd $$origdir; \

--- a/po/Makevars
+++ b/po/Makevars
@@ -8,7 +8,7 @@ subdir = po
 top_builddir = ..
 
 # These options get passed to xgettext.
-XGETTEXT_OPTIONS = --keyword=_ --keyword=N_ --no-location
+XGETTEXT_OPTIONS = --keyword=_ --keyword=N_
 
 # This is the copyright holder that gets inserted into the header of the
 # $(DOMAIN).pot file.  Set this to the copyright holder of the surrounding


### PR DESCRIPTION
This helps translators find the origin of each entry.

On the other hand, in man/po/ tell msgmerge not to add file:line.