### PR TITLE
Fix find free range 1629

### DIFF
--- a/lib/subordinateio.c
+++ b/lib/subordinateio.c
@@ -360,6 +360,9 @@ find_free_range(struct commonio_db *db, id_t min, id_t max, unsigned long count)
 	while (NULL != (range = commonio_next(db))) {
 		intmax_t  first, last;
 
+		if (range->count == 0)
+			continue;
+
 		first = range->start;
 		last = first - 1LL + range->count;
 

--- a/lib/subordinateio.c
+++ b/lib/subordinateio.c
@@ -14,6 +14,7 @@
 #include "getdef.h"
 #include "../libsubid/subid.h"
 #include <sys/types.h>
+#include <sys/param.h>
 #include <pwd.h>
 #include <ctype.h>
 #include <fcntl.h>
@@ -113,10 +114,13 @@ subordinate_parse(const char *line)
 	if (streq(fields[2], ""))
 		return NULL;
 	range.owner = fields[0];
-	if (str2ul(&range.start, fields[1]) == -1)
+	if (a2ul(&range.start, fields[1], NULL, 0, 0, maxof(id_t)) == -1)
 		return NULL;
-	if (str2ul(&range.count, fields[2]) == -1)
+	if (a2ul(&range.count, fields[2], NULL, 0, 0,
+	         MIN(maxof(id_t) + 1LL - range.start, maxof(id_t))) == -1)
+	{
 		return NULL;
+	}
 
 	return &range;
 }

--- a/lib/subordinateio.c
+++ b/lib/subordinateio.c
@@ -17,6 +17,7 @@
 #include <pwd.h>
 #include <ctype.h>
 #include <fcntl.h>
+#include <stdint.h>
 #include <string.h>
 
 #include "alloc/malloc.h"
@@ -29,6 +30,9 @@
 #include "string/strcmp/streq.h"
 #include "string/strtok/strsep2arr.h"
 #include "typetraits.h"
+
+#undef NDEBUG
+#include <assert.h>
 
 
 #define ID_SIZE 31
@@ -333,10 +337,13 @@ static int subordinate_range_cmp (const void *p1, const void *p2)
 static id_t
 find_free_range(struct commonio_db *db, id_t min, id_t max, unsigned long count)
 {
-	id_t                           low, high;
+	static_assert(sizeof(long long) > sizeof(id_t), "");
+
+	intmax_t                       n, low, high;
 	const struct subordinate_range *range;
 
-	if (count == 0 || max < min || count - 1 > max - min) {
+	n = count;
+	if (n == 0 || max < min || n > max - min + 1LL) {
 		errno = ERANGE;
 		return -1;
 	}
@@ -347,21 +354,21 @@ find_free_range(struct commonio_db *db, id_t min, id_t max, unsigned long count)
 
 	low = min;
 	while (NULL != (range = commonio_next(db))) {
-		id_t  first, last;
+		intmax_t  first, last;
 
 		first = range->start;
-		last = first + range->count - 1;
+		last = first - 1LL + range->count;
 
 		/* Find the top end of the hole before this range */
 		high = first;
 
 		/* Don't allocate IDs after max (included) */
-		if (high > max + 1) {
-			high = max + 1;
+		if (high > max + 1LL) {
+			high = max + 1LL;
 		}
 
 		/* Is the hole before this range large enough? */
-		if ((high > low) && ((high - low) >= count))
+		if ((high > low) && ((high - low) >= n))
 			return low;
 
 		/* Compute the low end of the next hole */
@@ -372,7 +379,7 @@ find_free_range(struct commonio_db *db, id_t min, id_t max, unsigned long count)
 	}
 
 	/* Is the remaining unclaimed area large enough? */
-	if (((max - low) + 1) >= count)
+	if (max - low >= n - 1)
 		return low;
 fail:
 	errno = EUSERS;


### PR DESCRIPTION
Fixes the security regression from de7f1c78f70f8df4b2956f7363da3774348bc58e (overlapping subordinate ID ranges, #1629), continuing @MillaFleurs' work from #1630 with all review comments applied. Kept Co-authored-by: Dan Anderson <https://github.com/MillaFleurs> in both commits as requested.

Closes #1629
Replaces #1630

Full disclosure carried over from the original PR: this was found with N184, @MillaFleurs' open source bug and security vulnerability scanner (https://github.com/MillaFleurs/N184).