### PR TITLE
man/cs: fix distribution of Czech man pages

### DIFF
--- a/man/cs/Makefile.am
+++ b/man/cs/Makefile.am
@@ -15,3 +15,9 @@ man_MANS = \
 	man5/shadow.5 \
 	man1/su.1 \
 	man8/vipw.8
+
+if ENABLE_LASTLOG
+man_MANS += man8/lastlog.8
+endif
+
+EXTRA_DIST = $(man_MANS)


### PR DESCRIPTION
The Czech Makefile.am was accidentally truncated during the groupmems removal. This caused the Czech man pages to be excluded from the release tarballs.

Restoring the Makefile.am and regenerating the release fixes the problem.

Fixes: 388ce70d ("*/: groupmems(8): Remove program")
Closes: https://github.com/shadow-maint/shadow/issues/1666