### PR TITLE
[:blank:]

### DIFF
--- a/lib/fields.c
+++ b/lib/fields.c
@@ -78,8 +78,8 @@ change_field(char *buf, size_t maxsize, const char *prompt)
 		 * makes it possible to change the field to empty, by
 		 * entering a space.  --marekm
 		 */
-		stpcpy(stprspn(newf, " \t"), "");
-		cp = stpspn(newf, " \t");
+		stpcpy(stprspn(newf, CTYPE_BLANK_C), "");
+		cp = stpspn(newf, CTYPE_BLANK_C);
 		strcpy (buf, cp);
 	}
 }

--- a/lib/getdef.c
+++ b/lib/getdef.c
@@ -9,8 +9,6 @@
 
 #include "config.h"
 
-#ident "$Id$"
-
 #include <ctype.h>
 #include <errno.h>
 #include <stddef.h>
@@ -30,6 +28,7 @@
 #include "prototypes.h"
 #include "shadowlog.h"
 #include "sizeof.h"
+#include "string/ctype/isascii.h"
 #include "string/sprintf/aprintf.h"
 #include "string/strcmp/strcaseeq.h"
 #include "string/strcmp/streq.h"
@@ -488,7 +487,7 @@ static void def_load (void)
 	 */
 	def_loaded = true;
 
-	error = econf_readDirs (&defs_file, vendordir, sysconfdir, "login", "defs", " \t", "#");
+	error = econf_readDirs (&defs_file, vendordir, sysconfdir, "login", "defs", CTYPE_BLANK_C, "#");
 	if (error) {
 		if (error == ECONF_NOFILE)
 			return;
@@ -566,15 +565,15 @@ static void def_load (void)
 		/*
 		 * Break the line into two fields.
 		 */
-		name = stpspn(buf, " \t");	/* first nonwhite */
+		name = stpspn(buf, CTYPE_BLANK_C);	/* first nonwhite */
 		if (streq(name, "") || strprefix(name, "#"))
 			continue;	/* comment or empty */
 
-		s = stpsep(name, " \t");  /* next field */
+		s = stpsep(name, CTYPE_BLANK_C);  /* next field */
 		if (s == NULL)
 			continue;	/* only 1 field?? */
 
-		value = stpspn(s, " \t");
+		value = stpspn(s, CTYPE_BLANK_C);
 
 		/*
 		 * Store the value in def_table.

--- a/lib/limits.c
+++ b/lib/limits.c
@@ -17,8 +17,6 @@
 
 #ifndef USE_PAM
 
-#ident "$Id$"
-
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <stdio.h>
@@ -32,6 +30,7 @@
 
 #include "atoi/a2i.h"
 #include "io/fgets/fgets.h"
+#include "string/ctype/isascii.h"
 #include "string/memset/memzero.h"
 #include "string/strcmp/streq.h"
 #include "string/strcmp/strprefix.h"
@@ -183,7 +182,7 @@ static int do_user_limits (const char *buf, const char *name)
 	int retval = 0;
 	bool reported = false;
 
-	pp = stpspn(buf, " \t");
+	pp = stpspn(buf, CTYPE_BLANK_C);
 
 	/* The special limit string "-" results in no limit for all known
 	 * limits.

--- a/lib/loginprompt.c
+++ b/lib/loginprompt.c
@@ -18,6 +18,7 @@
 #include "getdef.h"
 #include "io/fgets/fgets.h"
 #include "prototypes.h"
+#include "string/ctype/isascii.h"
 #include "string/memset/memzero.h"
 #include "string/strcpy/strtcpy.h"
 #include "string/strspn/stpspn.h"
@@ -94,7 +95,7 @@ login_prompt(char *name, int namesize)
 	 * Then copy the rest (up to the end) into the username.
 	 */
 
-	cp = stpspn(buf, " \t");
+	cp = stpspn(buf, CTYPE_BLANK_C);
 	strtcpy(name, cp, namesize);
 
 	/*

--- a/lib/nss.c
+++ b/lib/nss.c
@@ -14,6 +14,7 @@
 #include "prototypes.h"
 #include "../libsubid/subid.h"
 #include "shadowlog.h"
+#include "string/ctype/isascii.h"
 #include "string/sprintf/stprintf.h"
 #include "string/strcmp/strcaseprefix.h"
 #include "string/strcmp/streq.h"
@@ -91,7 +92,7 @@ nss_init(const char *nsswitch_path) {
 		if (!strcaseprefix(line, "subid:"))
 			continue;
 		p = &line[6];
-		p = stpspn(p, " \t");
+		p = stpspn(p, CTYPE_BLANK_C);
 		if (!streq(p, ""))
 			break;
 		p = NULL;
@@ -99,7 +100,7 @@ nss_init(const char *nsswitch_path) {
 	if (p == NULL) {
 		goto null_subid;
 	}
-	stpsep(p, " \t");
+	stpsep(p, CTYPE_BLANK_C);
 	if (streq(p, "")) {
 		fprintf(log_get_logfd(), "No usable subid NSS module found, using files\n");
 		// subid_nss has to be null here, but to ease reviews:

--- a/lib/setupenv.c
+++ b/lib/setupenv.c
@@ -25,6 +25,7 @@
 #include "getdef.h"
 #include "io/fgets/fgets.h"
 #include "shadowlog.h"
+#include "string/ctype/isascii.h"
 #include "string/sprintf/aprintf.h"
 #include "string/strcmp/streq.h"
 #include "string/strcmp/strprefix.h"
@@ -60,7 +61,7 @@ static void read_env_file (const char *filename)
 
 		cp = buf;
 		/* ignore whitespace and comments */
-		cp = stpspn(cp, " \t");
+		cp = stpspn(cp, CTYPE_BLANK_C);
 		if (streq(cp, "") || strprefix(cp, "#")) {
 			continue;
 		}
@@ -72,7 +73,7 @@ static void read_env_file (const char *filename)
 		val = stpsep(cp, "=");
 		if (val == NULL)
 			continue;
-		if (strpbrk(name, " \t"))
+		if (strpbrk(name, CTYPE_BLANK_C))
 			continue;
 		/*
 		 * XXX - should handle quotes, backslash escapes, etc.

--- a/lib/string/ctype/isascii.h
+++ b/lib/string/ctype/isascii.h
@@ -23,7 +23,8 @@
 #define CTYPE_UPPER_C     "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 #define CTYPE_DIGIT_C     "0123456789"
 #define CTYPE_PUNCT_C     "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
-#define CTYPE_SPACE_C     " \t\n\v\f\r"
+#define CTYPE_BLANK_C     " \t"
+#define CTYPE_SPACE_C     CTYPE_BLANK_C "\n\v\f\r"
 #define CTYPE_ALPHA_C     CTYPE_LOWER_C CTYPE_UPPER_C
 #define CTYPE_ALNUM_C     CTYPE_ALPHA_C CTYPE_DIGIT_C
 #define CTYPE_GRAPH_C     CTYPE_ALNUM_C CTYPE_PUNCT_C
@@ -39,6 +40,7 @@
 #define isupper_c(c)      (!streq(strchrnul(CTYPE_UPPER_C, c), ""))
 #define isdigit_c(c)      (!streq(strchrnul(CTYPE_DIGIT_C, c), ""))
 #define ispunct_c(c)      (!streq(strchrnul(CTYPE_PUNCT_C, c), ""))
+#define isblank_c(c)      (!streq(strchrnul(CTYPE_BLANK_C, c), ""))
 #define isspace_c(c)      (!streq(strchrnul(CTYPE_SPACE_C, c), ""))
 #define isalpha_c(c)      (!streq(strchrnul(CTYPE_ALPHA_C, c), ""))
 #define isalnum_c(c)      (!streq(strchrnul(CTYPE_ALNUM_C, c), ""))

--- a/src/login_nopam.c
+++ b/src/login_nopam.c
@@ -27,8 +27,6 @@
 #endif
 
 #ifndef USE_PAM
-#ident "$Id$"
-
     /*
      * This module implements a simple but effective form of login access
      * control based on login names and on host (or domain) names, internet
@@ -62,6 +60,7 @@
 #include "io/syslog.h"
 #include "prototypes.h"
 #include "sizeof.h"
+#include "string/ctype/isascii.h"
 #include "string/strcmp/strcaseeq.h"
 #include "string/strcmp/streq.h"
 #include "string/strcmp/strprefix.h"
@@ -117,7 +116,7 @@ login_access(const char *user, const char *from)
 			if (strprefix(line, "#")) {
 				continue;	/* comment line */
 			}
-			stpcpy(stprspn(line, " \t"), "");
+			stpcpy(stprspn(line, CTYPE_BLANK_C), "");
 			if (streq(line, "")) {	/* skip blank lines */
 				continue;
 			}

--- a/src/suauth.c
+++ b/src/suauth.c
@@ -21,6 +21,7 @@
 #include "io/fgets/fgets.h"
 #include "io/syslog.h"
 #include "prototypes.h"
+#include "string/ctype/isascii.h"
 #include "string/strcmp/streq.h"
 #include "string/strcmp/strprefix.h"
 #include "string/strspn/stpspn.h"
@@ -85,9 +86,9 @@ check_su_auth(const char *actual_id, const char *wanted_id, bool su_to_root)
 			continue;
 		}
 
-		stpcpy(stprspn(temp, " \t"), "");
+		stpcpy(stprspn(temp, CTYPE_BLANK_C), "");
 
-		p = stpspn(temp, " \t");
+		p = stpspn(temp, CTYPE_BLANK_C);
 		if (strprefix(p, "#") || streq(p, ""))
 			continue;
 


### PR DESCRIPTION
`CTYPE_BLANK_C` is easier to grep than `" \t"`.

---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git rd 
1:  b39acc090c10 = 1:  f2ac26ca386e lib/string/ctype/isascii.h: CTYPE_BLANK_C, isblank_c(): Add macros for [:blank:]
2:  984f2298df96 = 2:  2ec22a1c30c1 lib/, src/: Use CTYPE_BLANK_C instead of its pattern
```
</details>

<details>
<summary>v1c</summary>

-  Rebase

```
$ git rd -U0
1:  5d54a1af5bf0 ! 1:  0ae1f732836c lib/, src/, lib/string/strspn/: Compact files
    @@ lib/Makefile.am: libshadow_la_SOURCES = \
    -   string/strdup/strndup.h \
    +   string/strdup/strdup.h \
    @@ lib/limits.c
    - #include "string/memset/memzero.h"
    + #include "memory/memset/memzero.h"
    @@ lib/loginprompt.c
    + #include "memory/memset/memzero.h"
    @@ lib/loginprompt.c
    - #include "string/memset/memzero.h"
2:  ae68c2496de4 = 2:  e55757fbbd07 lib/limits.c: Use stpspn() to simplify
3:  80260a9e78e8 ! 3:  a7654ba8fd43 lib/, src/, lib/string/strcmp/: Compact files
    @@ src/useradd.c
    - #include "string/memset/memzero.h"
    + #include "sssd.h"
```
</details>