### PR TITLE
lib/getdef.c: def_load(): Don't handle '"' specially

### DIFF
--- a/lib/getdef.c
+++ b/lib/getdef.c
@@ -574,8 +574,7 @@ static void def_load (void)
 		if (s == NULL)
 			continue;	/* only 1 field?? */
 
-		value = stpspn(s, " \"\t");	/* next nonwhite */
-		stpsep(value, "\"");
+		value = stpspn(s, " \t");
 
 		/*
 		 * Store the value in def_table.


### PR DESCRIPTION
That handling of `"` in login.defs(5) is undocumented, and doesn't seem very robust:

	name "this value"string

The line above will be taken as if the value was 'this value', with the remainder completely ignored.  Another weird case is:

	name value"string

where the value is 'value'.

Since this is undocumented, brittle, and most likely not used, let's remove it entirely.  After all, it's entirely useless.

The following entry

	name value string

is interpreted as having a value of 'value string', as one would expect. The quotations don't provide absolutely any value (they don't serve to escape any characters) at all, and seem dangerous instead.

Fixes: 45c6603cc86c (2007-10-07; "[svn-upgrade] Integrating new upstream version, shadow (19990709)")
Closes: <https://github.com/shadow-maint/shadow/issues/1674>

---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git rd 
1:  12ef7891e73c = 1:  bbcf31db2938 lib/getdef.c: def_load(): Don't handle '"' specially
```
</details>

<details>
<summary>v1c</summary>

-  Reviewed-by: @ikerexxe 

```
$ git rd 
1:  bbcf31db2938 ! 1:  26d5163c7c71 lib/getdef.c: def_load(): Don't handle '"' specially
    @@ Commit message
     
         Fixes: 45c6603cc86c (2007-10-07; "[svn-upgrade] Integrating new upstream version, shadow (19990709)")
         Closes: <https://github.com/shadow-maint/shadow/issues/1674>
    +    Reviewed-by: Iker Pedrosa <ipedrosa@redhat.com>
         Signed-off-by: Alejandro Colomar <alx@kernel.org>
     
      ## lib/getdef.c ##
```
</details>