### PR TITLE
lib/tz.c: tz(): Some improvements (default to UTC)

### DIFF
--- a/etc/login.defs
+++ b/etc/login.defs
@@ -143,7 +143,7 @@ HUSHLOGIN_FILE	.hushlogin
 # If defined, either a TZ environment parameter spec or the
 # fully-rooted pathname of a file containing such a spec.
 #
-#ENV_TZ		TZ=CST6CDT
+#ENV_TZ		TZ=UTC
 #ENV_TZ		/etc/tzname
 
 #

--- a/lib/tz.c
+++ b/lib/tz.c
@@ -32,7 +32,7 @@
  */
 /*@observer@*/const char *tz (const char *fname)
 {
-	FILE *fp = NULL;
+	FILE         *fp;
 	const char *result;
 	static char tzbuf[BUFSIZ];
 

--- a/lib/tz.c
+++ b/lib/tz.c
@@ -11,11 +11,9 @@
 
 #ifndef USE_PAM
 
+#include <limits.h>
 #include <stdio.h>
-#include <string.h>
 
-#include "defines.h"
-#include "getdef.h"
 #include "io/fgets/fgets.h"
 #include "prototypes.h"
 #include "string/strtok/stpsep.h"
@@ -32,7 +30,7 @@ const char *
 tz(const char *path)
 {
 	FILE         *fp;
-	static char  buf[BUFSIZ];
+	static char  buf[LINE_MAX + 1];
 
 	fp = fopen(path, "r");
 	if (fp == NULL)

--- a/lib/tz.c
+++ b/lib/tz.c
@@ -39,7 +39,7 @@
 	fp = fopen (fname, "r");
 	if (   (NULL == fp)
 	    || (fgets_a(tzbuf, fp) == NULL)) {
-		result = "TZ=CST6CDT";
+		result = "TZ=UTC";
 	} else {
 		stpsep(tzbuf, "\n");
 		result = tzbuf;

--- a/lib/tz.c
+++ b/lib/tz.c
@@ -33,22 +33,22 @@
 /*@observer@*/const char *tz (const char *fname)
 {
 	FILE         *fp;
-	const char *result;
 	static char tzbuf[BUFSIZ];
 
 	fp = fopen (fname, "r");
 	if (fp == NULL)
 		return "TZ=UTC";
 
-	if (fgets_a(tzbuf, fp) == NULL) {
-		result = "TZ=UTC";
-	} else {
-		stpsep(tzbuf, "\n");
-		result = tzbuf;
-	}
+	if (fgets_a(tzbuf, fp) == NULL)
+		goto def;
+
+	stpsep(tzbuf, "\n");
 
 	fclose(fp);
-	return result;
+	return tzbuf;
+def:
+	fclose(fp);
+	return "TZ=UTC";
 }
 #else				/* !USE_PAM */
 extern int ISO_C_forbids_an_empty_translation_unit;

--- a/lib/tz.c
+++ b/lib/tz.c
@@ -41,8 +41,8 @@
 
 	if (fgets_a(tzbuf, fp) == NULL)
 		goto def;
-
-	stpsep(tzbuf, "\n");
+	if (stpsep(tzbuf, "\n") == NULL)
+		goto def;
 
 	fclose(fp);
 	return tzbuf;

--- a/lib/tz.c
+++ b/lib/tz.c
@@ -1,18 +1,15 @@
-/*
- * SPDX-FileCopyrightText: 1991 - 1994, Julianne Frances Haugh
- * SPDX-FileCopyrightText: 1991 - 1994, Chip Rosenthal
- * SPDX-FileCopyrightText: 1996 - 1998, Marek Michałkiewicz
- * SPDX-FileCopyrightText: 2003 - 2005, Tomasz Kłoczko
- * SPDX-FileCopyrightText: 2007 - 2010, Nicolas François
- *
- * SPDX-License-Identifier: BSD-3-Clause
- */
+// SPDX-FileCopyrightText: 1991-1994, Julianne Frances Haugh
+// SPDX-FileCopyrightText: 1991-1994, Chip Rosenthal
+// SPDX-FileCopyrightText: 1996-1998, Marek Michałkiewicz
+// SPDX-FileCopyrightText: 2003-2005, Tomasz Kłoczko
+// SPDX-FileCopyrightText: 2007-2010, Nicolas François
+// SPDX-FileCopyrightText: 2026, Alejandro Colomar <alx@kernel.org>
+// SPDX-License-Identifier: BSD-3-Clause
+
 
 #include "config.h"
 
 #ifndef USE_PAM
-
-#ident "$Id$"
 
 #include <stdio.h>
 #include <string.h>
@@ -28,24 +25,26 @@
  * tz - return local timezone name
  *
  * tz() determines the name of the local timezone by reading the
- * contents of the file named by ``fname''.
+ * contents of the file named by 'path'.
  */
-/*@observer@*/const char *tz (const char *fname)
+/*@observer@*/
+const char *
+tz(const char *path)
 {
 	FILE         *fp;
-	static char tzbuf[BUFSIZ];
+	static char  buf[BUFSIZ];
 
-	fp = fopen (fname, "r");
+	fp = fopen(path, "r");
 	if (fp == NULL)
 		return "TZ=UTC";
 
-	if (fgets_a(tzbuf, fp) == NULL)
+	if (fgets_a(buf, fp) == NULL)
 		goto def;
-	if (stpsep(tzbuf, "\n") == NULL)
+	if (stpsep(buf, "\n") == NULL)
 		goto def;
 
 	fclose(fp);
-	return tzbuf;
+	return buf;
 def:
 	fclose(fp);
 	return "TZ=UTC";
@@ -53,4 +52,3 @@ def:
 #else				/* !USE_PAM */
 extern int ISO_C_forbids_an_empty_translation_unit;
 #endif				/* !USE_PAM */
-

--- a/lib/tz.c
+++ b/lib/tz.c
@@ -37,18 +37,17 @@
 	static char tzbuf[BUFSIZ];
 
 	fp = fopen (fname, "r");
-	if (   (NULL == fp)
-	    || (fgets_a(tzbuf, fp) == NULL)) {
+	if (fp == NULL)
+		return "TZ=UTC";
+
+	if (fgets_a(tzbuf, fp) == NULL) {
 		result = "TZ=UTC";
 	} else {
 		stpsep(tzbuf, "\n");
 		result = tzbuf;
 	}
 
-	if (NULL != fp) {
-		(void) fclose (fp);
-	}
-
+	fclose(fp);
 	return result;
 }
 #else				/* !USE_PAM */

--- a/lib/tz.c
+++ b/lib/tz.c
@@ -19,6 +19,9 @@
 #include "string/strtok/stpsep.h"
 
 
+#define DEFAULT_TZ  "TZ=UTC"
+
+
 /*
  * tz - return local timezone name
  *
@@ -34,7 +37,7 @@ tz(const char *path)
 
 	fp = fopen(path, "r");
 	if (fp == NULL)
-		return "TZ=UTC";
+		return DEFAULT_TZ;
 
 	if (fgets_a(buf, fp) == NULL)
 		goto def;
@@ -45,7 +48,7 @@ tz(const char *path)
 	return buf;
 def:
 	fclose(fp);
-	return "TZ=UTC";
+	return DEFAULT_TZ;
 }
 #else				/* !USE_PAM */
 extern int ISO_C_forbids_an_empty_translation_unit;

--- a/man/login.defs.d/ENV_TZ.xml
+++ b/man/login.defs.d/ENV_TZ.xml
@@ -11,14 +11,14 @@
       If set, it will be used to define the TZ environment variable when
       a user login. The value can be the name of a timezone preceded by
       <replaceable>TZ=</replaceable> (for example
-      <replaceable>TZ=CST6CDT</replaceable>), or the full path to the file
+      <replaceable>TZ=UTC</replaceable>), or the full path to the file
       containing the timezone specification (for example
       <filename>/etc/tzname</filename>).
     </para>
     <!-- TODO: it can in fact be used to set any other variable-->
     <para>
       If a full path is specified but the file does not exist or cannot be
-      read, the default is to use <replaceable>TZ=CST6CDT</replaceable>.
+      read, the default is to use <replaceable>TZ=UTC</replaceable>.
     </para>
   </listitem>
 </varlistentry>

--- a/tests/newusers/62_create_user_no_aging/config/etc/login.defs
+++ b/tests/newusers/62_create_user_no_aging/config/etc/login.defs
@@ -143,7 +143,7 @@ HUSHLOGIN_FILE	.hushlogin
 # If defined, either a TZ environment parameter spec or the
 # fully-rooted pathname of a file containing such a spec.
 #
-#ENV_TZ		TZ=CST6CDT
+#ENV_TZ		TZ=UTC
 #ENV_TZ		/etc/tzname
 
 #

--- a/tests/system/etc/login.defs
+++ b/tests/system/etc/login.defs
@@ -143,7 +143,7 @@ HUSHLOGIN_FILE	.hushlogin
 # If defined, either a TZ environment parameter spec or the
 # fully-rooted pathname of a file containing such a spec.
 #
-#ENV_TZ		TZ=CST6CDT
+#ENV_TZ		TZ=UTC
 #ENV_TZ		/etc/tzname
 
 #


### PR DESCRIPTION
Default to UTC.  Also, improve readability.  Also, improve error handling.