### PR TITLE
tests/unit/test_exit_if_null.c: Ignore "-Walloc-size-larger-than="

### DIFF
--- a/tests/unit/test_exit_if_null.c
+++ b/tests/unit/test_exit_if_null.c
@@ -61,7 +61,10 @@ test_exit_if_null_exit(MAYBE_UNUSED void ** _1)
 	switch (setjmp(jmpb)) {
 	case 0:
 		p = "called";
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Walloc-size-larger-than="
 		p = xmalloc_T(SIZE_MAX, char);
+#pragma GCC diagnostic pop
 		assert_unreachable();
 		break;
 	case EXIT_CALLED:


### PR DESCRIPTION
We're intentionally passing a bogus size, to cause a malloc(3) error.

Closes: https://github.com/shadow-maint/shadow/issues/1686