### PR TITLE
tests/unit/test_chkhash.c: Remove tests for DES

### DIFF
--- a/man/login.defs.5.xml
+++ b/man/login.defs.5.xml
@@ -48,7 +48,7 @@
 <!ENTITY OBSCURE_CHECKS_ENAB   SYSTEM "login.defs.d/OBSCURE_CHECKS_ENAB.xml">
 <!ENTITY PASS_ALWAYS_WARN      SYSTEM "login.defs.d/PASS_ALWAYS_WARN.xml">
 <!ENTITY PASS_CHANGE_TRIES     SYSTEM "login.defs.d/PASS_CHANGE_TRIES.xml">
-<!ENTITY PASS_MAX_LEN          SYSTEM "login.defs.d/PASS_MAX_LEN.xml">
+<!ENTITY PASS_MIN_LEN          SYSTEM "login.defs.d/PASS_MIN_LEN.xml">
 <!ENTITY PASS_MAX_DAYS         SYSTEM "login.defs.d/PASS_MAX_DAYS.xml">
 <!ENTITY PASS_WARN_AGE         SYSTEM "login.defs.d/PASS_WARN_AGE.xml">
 <!ENTITY PORTTIME_CHECKS_ENAB  SYSTEM "login.defs.d/PORTTIME_CHECKS_ENAB.xml">
@@ -205,7 +205,7 @@
         time of account creation. Any changes to these settings won't affect
         existing accounts.
       </para>
-      &PASS_MAX_LEN; <!-- documents also PASS_MIN_LEN -->
+      &PASS_MIN_LEN;
       &PORTTIME_CHECKS_ENAB;
       &QUOTAS_ENAB;
       &SHA_CRYPT_MIN_ROUNDS; <!-- documents also SHA_CRYPT_MAX_ROUNDS -->
@@ -416,7 +416,7 @@
 	    <phrase condition="bcrypt">BCRYPT_MAX_ROUNDS
 	    BCRYPT_MIN_ROUNDS</phrase>
 	    ENCRYPT_METHOD OBSCURE_CHECKS_ENAB
-	    PASS_ALWAYS_WARN PASS_CHANGE_TRIES PASS_MAX_LEN PASS_MIN_LEN
+	    PASS_ALWAYS_WARN PASS_CHANGE_TRIES PASS_MIN_LEN
 	    SHA_CRYPT_MAX_ROUNDS SHA_CRYPT_MIN_ROUNDS
 	    <phrase condition="yescrypt">YESCRYPT_COST_FACTOR</phrase>
 	  </para>

--- a/tests/unit/test_chkhash.c
+++ b/tests/unit/test_chkhash.c
@@ -122,17 +122,6 @@ test_is_valid_hash_ok_md5(MAYBE_UNUSED void ** _1)
 
 
 static void
-test_is_valid_hash_ok_des(MAYBE_UNUSED void ** _1)
-{
-	// Basic DES hash: 13 characters
-	assert_true(is_valid_hash("abcDEF123./zZ"));
-
-	// DES with different character combinations
-	assert_true(is_valid_hash("ZZ./0123456xy"));
-}
-
-
-static void
 test_is_valid_hash_ok_special(MAYBE_UNUSED void ** _1)
 {
 	// Empty string - passwordless account
@@ -242,7 +231,6 @@ main(void)
         cmocka_unit_test(test_is_valid_hash_ok_sha512),
         cmocka_unit_test(test_is_valid_hash_ok_sha256),
         cmocka_unit_test(test_is_valid_hash_ok_md5),
-        cmocka_unit_test(test_is_valid_hash_ok_des),
         cmocka_unit_test(test_is_valid_hash_ok_special),
         cmocka_unit_test(test_is_valid_hash_edge_salt_chars),
         cmocka_unit_test(test_is_valid_hash_edge_account_locks),


### PR DESCRIPTION
We don't support it anymore.  These tests were now failing.

Fixes: 609bd9194174 (2026-07-17; "*/: Remove support for DES")
Closes: <https://github.com/shadow-maint/shadow/issues/1686>

---

Revisions:

<details>
<summary>v2</summary>

-  Fix more stuff that I forgot to do when removing support for DES.  I'm surprised that this didn't trigger failures!  I only noticed because the PR for removing MD5 failed because of this, which has me a bit puzzled.  Anyway, here's a fix.

```
$ git rd 
1:  8924a1d658f6 = 1:  8924a1d658f6 tests/unit/test_chkhash.c: Remove tests for DES
-:  ------------ > 2:  5dbeb20153a8 man/login.defs.5.xml: Remove references to PASS_MAX_LEN
```
</details>