### PR TITLE
find_range: avoid count==0 bug

### DIFF
--- a/lib/subordinateio.c
+++ b/lib/subordinateio.c
@@ -222,6 +222,9 @@ static const struct subordinate_range *find_range(struct commonio_db *db,
 		unsigned long first = range->start;
 		unsigned long last = first + range->count - 1;
 
+		if (range->count == 0)
+			continue;
+
 		if (!streq(range->owner, owner))
 			continue;
 
@@ -248,6 +251,9 @@ static const struct subordinate_range *find_range(struct commonio_db *db,
 	while (NULL != (range = commonio_next(db))) {
 		unsigned long first = range->start;
 		unsigned long last = first + range->count - 1;
+
+		if (range->count == 0)
+			continue;
 
 		/* For performance reasons check range before using getpwnam() */
 		if ((val < first) || (val > last)) {


### PR DESCRIPTION
If someone has a subuid range with count==0, the variable last is calculated as first + count - 1, meaning last == first - 1.  Since the calculated range wraps around, this can invalidate later checks.

Check for this case explicitly.

Because of other checks, this can only lead to erroneous ranges being created if the first loweruid is 0.  This means that the subid range has to be user:0:0, which is doubly wrong, and should never be seen in the real world.

A note on formatting: the calculations of first and last are done in their declarations.  If range->count == 0, these go unused.  The alternatives would be to declare the variables later in the scope - which we do not do - or to assign them later, adding 3 more lines in each scope.

Since this case (again) should never happen, it's not worth avoiding the extra assignments in this error case.


Reported-by: Mohammad Hossein Abedini <mhmd.abedinii@gmail.com>