### PR TITLE
tests/system/etc/login.defs: set ENCRYPT_METHOD SHA512

### DIFF
--- a/tests/system/etc/login.defs
+++ b/tests/system/etc/login.defs
@@ -301,7 +301,7 @@ CHFN_RESTRICT		rwh
 # Note: If you use PAM, it is recommended to use a value consistent with
 # the PAM modules configuration.
 #
-#ENCRYPT_METHOD SHA512
+ENCRYPT_METHOD SHA512
 
 #
 # Only works if ENCRYPT_METHOD is set to SHA256 or SHA512.


### PR DESCRIPTION
Commit 609bd9194174d ("Remove support for DES") commented out ENCRYPT_METHOD, which caused tests to use the container's default password hashing. On OpenSUSE this defaults to DES, but since the shadow code no longer supports DES, tests fail.

Explicitly setting ENCRYPT_METHOD to SHA512 ensures tests use a supported modern hashing algorithm regardless of container defaults

Fixes: 609bd9194174 (2026-07-17; "*/: Remove support for DES")