### PR TITLE
man/login.defs.d/ENCRYPT_METHOD.xml: Document that other programs may still default to DES

### DIFF
--- a/man/login.defs.d/ENCRYPT_METHOD.xml
+++ b/man/login.defs.d/ENCRYPT_METHOD.xml
@@ -26,5 +26,12 @@
       PAM configuration. It is recommended to set this variable
       consistently with the PAM configuration.
     </para>
+    <para>
+      History:
+      This variable is used by other programs,
+      which may still default to unsafe algorithms such as DES.
+      To avoid using unsafe algorithms,
+      the variable should always be specified.
+    </para>
   </listitem>
 </varlistentry>


### PR DESCRIPTION


Link: <https://github.com/shadow-maint/shadow/pull/1691>
Cc: @thkukuk 
Cc: @Vogtinator
Cc: @ikerexxe 
Cc: @jubalh 