### PR TITLE
subid: Add `<stdint.h>` for `uintmax_t`

### DIFF
--- a/lib/find_new_sub_gids.c
+++ b/lib/find_new_sub_gids.c
@@ -8,6 +8,7 @@
 
 #ifdef ENABLE_SUBIDS
 
+#include <stdint.h>
 #include <stdio.h>
 #include <errno.h>
 

--- a/lib/find_new_sub_uids.c
+++ b/lib/find_new_sub_uids.c
@@ -8,6 +8,7 @@
 
 #ifdef ENABLE_SUBIDS
 
+#include <stdint.h>
 #include <stdio.h>
 #include <errno.h>
 


### PR DESCRIPTION
With glibc-2.44 here:

```
find_new_sub_uids.c:80:27: error: 'uintmax_t' undeclared (first use in this function)
find_new_sub_gids.c:80:27: error: 'uintmax_t' undeclared (first use in this function)
```

Fixes: 4d800cf2eb9e0e01c40209abe96d22c34c9358a4