### PR TITLE
lib/sizeof.h: typeas(): Add support for 'void' and function types

### DIFF
--- a/lib/sizeof.h
+++ b/lib/sizeof.h
@@ -12,10 +12,11 @@
 #if __has_include(<stdcountof.h>)
 # include <stdcountof.h>
 #endif
+#include <stddef.h>
 #include <sys/types.h>
 
 
-#define typeas(T)            typeof((T){0})
+#define typeas(T)  typeof(*(typeof(T) *){_Generic(0, T: NULL, default: NULL)})
 
 #define ssizeof(x)           ({(ssize_t){sizeof(x)};})
 #define memberof(T, member)  ((T){}.member)


### PR DESCRIPTION
typeas() should be a generic macro that accepts any types that typeof() accepts.

The current implementation, while simple, didn't allow 'void' and function types, since one can't create a compound literal of such a type.

The solution needs to create a pointer type, which accepts a compound literal even for void and function pointee types.  This requires using typeof() within the parenthesized type of the compound literal, and thus we need a different way to validate that the input is a type name (not an expression), which is done through _Generic().

Here's an expanded version of it, to help review it:

```c
	#define typeas(T)  typeof                                     \
	(                                                             \
		*(typeof(T) *){                                       \
			_Generic(0, T: NULL, default: NULL)           \
		}                                                     \
	)
```

For the source code, let's keep it as a one-liner.

BTW, a nice side effect of this implementation is that we use {NULL} instead of {0}, and thus we get rid of -Wzero-as-null-pointer-constant diagnostics when the type T is a pointer type.

This implementation is compatible to GNU C11 --and ISO C23, which standardized typeof()--.

Cc: @uecker, @kees , @chrisbazley

---

Revisions:

<details>
<summary>v2</summary>

-  Replace some remaining uses of typeof() by typeas().  After this, only two uses of typeof() remain, and they're both strictly necessary (they can't be replaced by typeas()).

```
$ git rd 
1:  1c42851aafc3 = 1:  1c42851aafc3 lib/sizeof.h: typeas(): Add support for 'void' and function types
-:  ------------ > 2:  c5a6a7adb832 lib/: Use typeas() instead of typeof() where possible
```
</details>

<details>
<summary>v2b</summary>

-  Rebase

```
$ git rd 
1:  1c42851aafc3 = 1:  8c1ed7af27a5 lib/sizeof.h: typeas(): Add support for 'void' and function types
2:  c5a6a7adb832 = 2:  24c7117e116e lib/: Use typeas() instead of typeof() where possible
```
</details>

<details>
<summary>v3</summary>

-  Drop second commit.  It didn't work with old compilers.

```
$ git rd 
1:  8c1ed7af27a5 = 1:  8c1ed7af27a5 lib/sizeof.h: typeas(): Add support for 'void' and function types
2:  24c7117e116e < -:  ------------ lib/: Use typeas() instead of typeof() where possible
```
</details>

<details>
<summary>v3b</summary>

-  Rebase

```
$ git rd 
1:  8c1ed7af27a5 = 1:  796f846acdaa lib/sizeof.h: typeas(): Add support for 'void' and function types
```
</details>