### PR TITLE
src/userdel, src/useradd.c: fix memory leak of n[s]grp

### DIFF
--- a/src/useradd.c
+++ b/src/useradd.c
@@ -1067,6 +1067,7 @@ static void grp_update (bool process_selinux)
 		              SHADOW_AUDIT_SUCCESS);
 #endif
 		SYSLOG(LOG_INFO, "add '%s' to group '%s'", user_name, ngrp->gr_name);
+		gr_free (ngrp);
 	}
 
 #ifdef	SHADOWGRP

--- a/src/useradd.c
+++ b/src/useradd.c
@@ -1131,6 +1131,7 @@ static void grp_update (bool process_selinux)
 #endif
 		SYSLOG(LOG_INFO, "add '%s' to shadow group '%s'",
 		       user_name, nsgrp->sg_namp);
+		sgr_free (nsgrp);
 	}
 #endif				/* SHADOWGRP */
 }

--- a/src/userdel.c
+++ b/src/userdel.c
@@ -282,6 +282,7 @@ static void update_groups (bool process_selinux)
 #endif				/* WITH_AUDIT */
 		SYSLOG(LOG_INFO, "delete '%s' from shadow group '%s'\n",
 		       user_name, nsgrp->sg_namp);
+		sgr_free (nsgrp);
 	}
 #endif				/* SHADOWGRP */
 }

--- a/src/userdel.c
+++ b/src/userdel.c
@@ -220,6 +220,7 @@ static void update_groups (bool process_selinux)
 #endif				/* WITH_AUDIT */
 		SYSLOG(LOG_INFO, "delete '%s' from group '%s'\n",
 			user_name, ngrp->gr_name);
+		gr_free (ngrp);
 	}
 
 	if (getdef_bool ("USERGROUPS_ENAB")) {


### PR DESCRIPTION
update_groups() duplicates each shadow group with __sgr_dup() to edit
its member list, but never releases the copy.  The 'nsgrp' struct sgrp,
along with its deep-copied name, passwd and member/admin arrays, leaks
once per iteration.

__sgr_dup() is not malloc()-like, so free() would not release the inner
allocations; use the matching sgr_free().

valgrind --leak-check=full --show-leak-kinds=all src/userdel -P <prefix> bob
(bob is a member of 10 groups), before this commit:

    551 (320 direct, 231 indirect) bytes in 10 blocks are definitely lost
       at 0x4848EB8: calloc
       by __sgr_dup (sgroupio.c:37)
       by update_groups (userdel.c:255)
    ...
    definitely lost: 1,120 bytes in 50 blocks

after this commit:

    definitely lost: 800 bytes in 40 blocks

