### PR TITLE
man: Document UAPI merging in login.defs

### DIFF
--- a/man/chfn.1.xml
+++ b/man/chfn.1.xml
@@ -187,7 +187,11 @@
     <title>FILES</title>
     <variablelist>
       <varlistentry>
-	<term><filename>/etc/login.defs</filename></term>
+	<term>
+	  <citerefentry>
+	    <refentrytitle>login.defs</refentrytitle><manvolnum>5</manvolnum>
+	  </citerefentry>
+	</term>
 	<listitem>
 	  <para>Shadow password suite configuration.</para>
 	</listitem>

--- a/man/chgpasswd.8.xml
+++ b/man/chgpasswd.8.xml
@@ -218,7 +218,11 @@
 	</listitem>
       </varlistentry>
       <varlistentry>
-	<term><filename>/etc/login.defs</filename></term>
+	<term>
+	  <citerefentry>
+	    <refentrytitle>login.defs</refentrytitle><manvolnum>5</manvolnum>
+	  </citerefentry>
+	</term>
 	<listitem>
 	  <para>Shadow password suite configuration.</para>
 	</listitem>

--- a/man/chpasswd.8.xml
+++ b/man/chpasswd.8.xml
@@ -272,7 +272,11 @@
 	</listitem>
       </varlistentry>
       <varlistentry>
-	<term><filename>/etc/login.defs</filename></term>
+	<term>
+	  <citerefentry>
+	    <refentrytitle>login.defs</refentrytitle><manvolnum>5</manvolnum>
+	  </citerefentry>
+	</term>
 	<listitem>
 	  <para>Shadow password suite configuration.</para>
 	</listitem>

--- a/man/chsh.1.xml
+++ b/man/chsh.1.xml
@@ -190,7 +190,11 @@
         </listitem>
       </varlistentry>
       <varlistentry>
-	<term><filename>/etc/login.defs</filename></term>
+	<term>
+	  <citerefentry>
+	    <refentrytitle>login.defs</refentrytitle><manvolnum>5</manvolnum>
+	  </citerefentry>
+	</term>
 	<listitem>
 	  <para>Shadow password suite configuration.</para>
 	</listitem>

--- a/man/groupadd.8.xml
+++ b/man/groupadd.8.xml
@@ -274,7 +274,11 @@
 	</listitem>
       </varlistentry>
       <varlistentry>
-	<term><filename>/etc/login.defs</filename></term>
+	<term>
+	  <citerefentry>
+	    <refentrytitle>login.defs</refentrytitle><manvolnum>5</manvolnum>
+	  </citerefentry>
+	</term>
 	<listitem>
 	  <para>Shadow password suite configuration.</para>
 	</listitem>

--- a/man/groupmod.8.xml
+++ b/man/groupmod.8.xml
@@ -237,7 +237,11 @@
 	</listitem>
       </varlistentry>
       <varlistentry>
-	<term><filename>/etc/login.defs</filename></term>
+	<term>
+	  <citerefentry>
+	    <refentrytitle>login.defs</refentrytitle><manvolnum>5</manvolnum>
+	  </citerefentry>
+	</term>
 	<listitem>
 	  <para>Shadow password suite configuration.</para>
 	</listitem>

--- a/man/login.1.xml
+++ b/man/login.1.xml
@@ -354,7 +354,11 @@
 	</listitem>
       </varlistentry>
       <varlistentry>
-	<term><filename>/etc/login.defs</filename></term>
+	<term>
+	  <citerefentry>
+	    <refentrytitle>login.defs</refentrytitle><manvolnum>5</manvolnum>
+	  </citerefentry>
+	</term>
 	<listitem>
 	  <para>Shadow password suite configuration.</para>
 	</listitem>

--- a/man/login.access.5.xml
+++ b/man/login.access.5.xml
@@ -97,7 +97,11 @@
     <title>FILES</title>
     <variablelist>
       <varlistentry>
-	<term><filename>/etc/login.defs</filename></term>
+	<term>
+	  <citerefentry>
+	    <refentrytitle>login.defs</refentrytitle><manvolnum>5</manvolnum>
+	  </citerefentry>
+	</term>
 	<listitem>
 	  <para>Shadow password suite configuration.</para>
 	</listitem>

--- a/man/login.defs.5.xml
+++ b/man/login.defs.5.xml
@@ -115,10 +115,23 @@
   <refsect1 id='description'>
     <title>DESCRIPTION</title>
     <para>
-      The <filename>/etc/login.defs</filename> file defines the
-      site-specific configuration for the shadow password suite. This file
-      is required. Absence of this file will not prevent system operation,
-      but will probably result in undesirable operation.
+      The configuration for the shadow password suite is defined by
+      <filename>login.defs</filename>.
+    </para>
+    <para>
+      Depending on compile-time configuration,
+      the settings are either read from a single file
+      (<filename>/etc/login.defs</filename>),
+      or merged hierarchically
+      (if compiled with <literal>libeconf</literal> support):
+      from <filename>/usr/etc/login.defs</filename>,
+      <filename>/usr/lib/login.defs</filename>,
+      <filename>/etc/login.defs</filename>,
+      and drop-ins under <filename>/etc/login.defs.d/</filename>.
+    </para>
+    <para>
+      The merging follows the UAPI configuration file specification:
+      https://uapi-group.org/specifications/specs/configuration_files_specification/
     </para>
 
     <para>

--- a/man/login.defs.5.xml
+++ b/man/login.defs.5.xml
@@ -115,10 +115,49 @@
   <refsect1 id='description'>
     <title>DESCRIPTION</title>
     <para>
-      The <filename>/etc/login.defs</filename> file defines the
-      site-specific configuration for the shadow password suite. This file
-      is required. Absence of this file will not prevent system operation,
-      but will probably result in undesirable operation.
+      The configuration for the shadow password suite is defined by
+      <filename>login.defs</filename>.
+    </para>
+    <para>
+      Depending on compile-time configuration, the settings are either read
+      from a single file (<filename>/etc/login.defs</filename>), or merged
+      hierarchically following the UAPI configuration file specification
+      (if compiled with <literal>libeconf</literal> support):
+      https://uapi-group.org/specifications/specs/configuration_files_specification/
+    </para>
+    <para>
+      When the stateless merging model is used, the configurations are parsed
+      and merged in the following order of precedence (later files override
+      earlier ones):
+    </para>
+    <itemizedlist>
+      <listitem>
+        <para>
+          <emphasis>Vendor defaults:</emphasis> typically located in
+          <filename>/usr/etc/login.defs</filename> or <filename>/usr/lib/login.defs</filename>.
+          These files are owned by the distribution packages and should not be
+          manually modified.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <emphasis>Local admin overrides:</emphasis> located in
+          <filename>/etc/login.defs</filename>. Administrators should use this file
+          to override vendor presets.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <emphasis>Admin drop-ins:</emphasis> located in
+          <filename>/etc/login.defs.d/</filename>. This directory allows for modular,
+          package-specific overrides without editing the main file.
+        </para>
+      </listitem>
+    </itemizedlist>
+    <para>
+      Neither <filename>/etc/login.defs</filename> nor the drop-in directories are
+      strictly required. If they are absent, the shadow utilities will seamlessly fall
+      back to the vendor-provided defaults.
     </para>
 
     <para>

--- a/man/newusers.8.xml
+++ b/man/newusers.8.xml
@@ -436,7 +436,11 @@
 	</listitem>
       </varlistentry>
       <varlistentry>
-	<term><filename>/etc/login.defs</filename></term>
+	<term>
+	  <citerefentry>
+	    <refentrytitle>login.defs</refentrytitle><manvolnum>5</manvolnum>
+	  </citerefentry>
+	</term>
 	<listitem>
 	  <para>Shadow password suite configuration.</para>
 	</listitem>

--- a/man/passwd.1.xml
+++ b/man/passwd.1.xml
@@ -411,7 +411,11 @@
 	</listitem>
       </varlistentry>
       <varlistentry condition="no_pam">
-	<term><filename>/etc/login.defs</filename></term>
+	<term>
+	  <citerefentry>
+	    <refentrytitle>login.defs</refentrytitle><manvolnum>5</manvolnum>
+	  </citerefentry>
+	</term>
 	<listitem>
 	  <para>Shadow password suite configuration.</para>
 	</listitem>

--- a/man/pwconv.8.xml
+++ b/man/pwconv.8.xml
@@ -225,7 +225,11 @@
     <title>FILES</title>
     <variablelist>
       <varlistentry>
-	<term><filename>/etc/login.defs</filename></term>
+	<term>
+	  <citerefentry>
+	    <refentrytitle>login.defs</refentrytitle><manvolnum>5</manvolnum>
+	  </citerefentry>
+	</term>
 	<listitem>
 	  <para>Shadow password suite configuration.</para>
 	</listitem>

--- a/man/su.1.xml
+++ b/man/su.1.xml
@@ -354,7 +354,11 @@
 	</listitem>
       </varlistentry>
       <varlistentry>
-	<term><filename>/etc/login.defs</filename></term>
+	<term>
+	  <citerefentry>
+	    <refentrytitle>login.defs</refentrytitle><manvolnum>5</manvolnum>
+	  </citerefentry>
+	</term>
 	<listitem>
 	  <para>Shadow password suite configuration.</para>
 	</listitem>

--- a/man/useradd.8.xml
+++ b/man/useradd.8.xml
@@ -893,7 +893,11 @@
 	</listitem>
       </varlistentry>
       <varlistentry>
-	<term><filename>/etc/login.defs</filename></term>
+	<term>
+	  <citerefentry>
+	    <refentrytitle>login.defs</refentrytitle><manvolnum>5</manvolnum>
+	  </citerefentry>
+	</term>
 	<listitem>
 	  <para>Shadow password suite configuration.</para>
 	</listitem>

--- a/man/userdel.8.xml
+++ b/man/userdel.8.xml
@@ -181,7 +181,11 @@
 	</listitem>
       </varlistentry>
       <varlistentry>
-	<term><filename>/etc/login.defs</filename></term>
+	<term>
+	  <citerefentry>
+	    <refentrytitle>login.defs</refentrytitle><manvolnum>5</manvolnum>
+	  </citerefentry>
+	</term>
 	<listitem>
 	  <para>Shadow password suite configuration.</para>
 	</listitem>

--- a/man/usermod.8.xml
+++ b/man/usermod.8.xml
@@ -601,7 +601,11 @@
 	</listitem>
       </varlistentry>
       <varlistentry>
-	<term><filename>/etc/login.defs</filename></term>
+	<term>
+	  <citerefentry>
+	    <refentrytitle>login.defs</refentrytitle><manvolnum>5</manvolnum>
+	  </citerefentry>
+	</term>
 	<listitem>
 	  <para>Shadow password suite configuration</para>
 	</listitem>


### PR DESCRIPTION
b52ce71c added support for UAPI/libeconf.
The first release to contain this change was 4.8.

Update our man pages to properly describe the various locations of login.defs if shadow is compiled with libeconf and without.

Ref: b52ce71c
Resolves: https://bugzilla.suse.com/show_bug.cgi?id=1264297
Fixes: https://github.com/shadow-maint/shadow/issues/1712