### PR TITLE
useradd: Only apply USRSKEL if the default SKEL is used

### DIFF
--- a/src/useradd.c
+++ b/src/useradd.c
@@ -2469,6 +2469,7 @@ int main (int argc, char **argv)
 	unsigned long subgid_count = 0;
 	struct option_flags  flags = {.chroot = false, .prefix = false};
 	bool process_selinux;
+	const char *default_skel;
 
 	log_set_progname(Prog);
 	log_set_logfd(stderr);
@@ -2500,6 +2501,8 @@ int main (int argc, char **argv)
 #endif
 
 	get_defaults (&flags);
+
+	default_skel = def_template;
 
 	process_flags (argc, argv, &flags);
 	process_selinux = !flags.chroot && !flags.prefix;
@@ -2660,8 +2663,10 @@ int main (int argc, char **argv)
 		if (home_added) {
 			copy_tree (def_template, prefix_user_home, false,
 			           (uid_t)-1, user_id, (gid_t)-1, user_gid);
-			copy_tree (def_usrtemplate, prefix_user_home, false,
-			           (uid_t)-1, user_id, (gid_t)-1, user_gid);
+			if (streq(def_template, default_skel)) {
+				copy_tree(def_usrtemplate, prefix_user_home, false,
+				           (uid_t)-1, user_id, (gid_t)-1, user_gid);
+			}
 		} else {
 			eprintf(_("%s: warning: the home directory %s already exists.\n"
 			          "%s: Not copying any file from skel directory into it.\n"),


### PR DESCRIPTION
Historically useradd(8) copied skeleton files from the directory specified by SKEL.
Since 74c17c7 (release 4.14.0) it also copies files from USRSKEL.

If an admin explicitly specifies an alternative skeleton directory using -k (for instance, to create an empty home directory with `-k /var/lib/empty`), the files from USRSKEL are still unconditionally merged in.

If the user has explicitly requested an alternative skeleton directory we shouldn't silently merge in files from USRSKEL behind their back.

However if they specify `-k /etc/skel` (explicitly requesting the default skeleton), they most likely still expect USRSKEL to be merged.

With this commit we only copy the USRSKEL files when the selected skeleton directory matches the default.

Resolves: https://bugzilla.suse.com/show_bug.cgi?id=1191490
Fixes: 74c17c7 (2022-11-09; "Add support for skeleton files from /usr/etc/skel")