### PR TITLE
lib/: Use the comma operator to perform lvalue conversion

### DIFF
--- a/lib/alloc/calloc.h
+++ b/lib/alloc/calloc.h
@@ -17,9 +17,10 @@
 // calloc_T - calloc type-safe
 #define calloc_T(n, T)   calloc_T_(n, typeas(T))
 #define calloc_T_(n, T)                                               \
-({                                                                    \
-	(T *){calloc(n, sizeof(T))};                                  \
-})
+(                                                                     \
+	(void)0,                                                      \
+	(T *){calloc(n, sizeof(T))}                                   \
+)
 
 
 // xcalloc_T - exit-on-error calloc type-safe

--- a/lib/alloc/malloc.h
+++ b/lib/alloc/malloc.h
@@ -18,9 +18,10 @@
 // malloc_T - malloc type-safe
 #define malloc_T(n, T)   malloc_T_(n, typeas(T))
 #define malloc_T_(n, T)                                               \
-({                                                                    \
-	(T *){mallocarray(n, sizeof(T))};                             \
-})
+(                                                                     \
+	(void)0,                                                      \
+	(T *){mallocarray(n, sizeof(T))}                              \
+)
 
 
 // xmalloc_T - exit-on-error malloc type-safe

--- a/lib/alloc/realloc.h
+++ b/lib/alloc/realloc.h
@@ -17,10 +17,10 @@
 // realloc_T - realloc type-safe
 #define realloc_T(p, n, T)   realloc_T_(p, n, typeas(T))
 #define realloc_T_(p, n, T)                                           \
-({                                                                    \
-	_Generic(p, T *: (void)0);                                    \
-	(T *){reallocarray_(p, n, sizeof(T))};                        \
-})
+(                                                                     \
+	_Generic(p, T *: (void)0),                                    \
+	(T *){reallocarray_(p, n, sizeof(T))}                         \
+)
 
 #define reallocarray_(p, n, size)  reallocarray(p, (n) ?: 1, (size) ?: 1)
 

--- a/lib/alloc/reallocf.h
+++ b/lib/alloc/reallocf.h
@@ -18,10 +18,10 @@
 // reallocf_T - realloc free-on-error type-safe
 #define reallocf_T(p, n, T)   reallocf_T_(p, n, typeas(T))
 #define reallocf_T_(p, n, T)                                          \
-({                                                                    \
-	_Generic(p, T *: (void)0);                                    \
-	(T *){reallocarrayf_(p, n, sizeof(T))};                       \
-})
+(                                                                     \
+	_Generic(p, T *: (void)0),                                    \
+	(T *){reallocarrayf_(p, n, sizeof(T))}                        \
+)
 
 #define reallocarrayf_(p, n, size)  reallocarrayf(p, (n) ?: 1, (size) ?: 1)
 

--- a/lib/search/l/lfind.h
+++ b/lib/search/l/lfind.h
@@ -18,11 +18,11 @@
 // lfind_T - linear find type-safe
 #define lfind_T(T, ...)            lfind_T_(typeas(T), __VA_ARGS__)
 #define lfind_T_(T, k, a, n, cmp)                                     \
-({                                                                    \
-	_Generic(k, T *: (void)0, const T *: (void)0);                \
-	_Generic(a, T *: (void)0, const T *: (void)0);                \
-	(T *){lfind_(k, a, n, sizeof(T), cmp)};                       \
-})
+(                                                                     \
+	_Generic(k, T *: (void)0, const T *: (void)0),                \
+	_Generic(a, T *: (void)0, const T *: (void)0),                \
+	(T *){lfind_(k, a, n, sizeof(T), cmp)}                        \
+)
 
 #define LFIND(T, ...)  lfind_T(T, __VA_ARGS__, CMP(T))
 

--- a/lib/sizeof.h
+++ b/lib/sizeof.h
@@ -17,7 +17,7 @@
 
 #define typeas(T)            typeof((T){0})
 
-#define ssizeof(x)           ({(ssize_t){sizeof(x)};})
+#define ssizeof(x)           ((void)0, (ssize_t){sizeof(x)})
 #define memberof(T, member)  ((T){}.member)
 #define WIDTHOF(x)           (sizeof(x) * CHAR_BIT)
 


### PR DESCRIPTION
Compound literals are lvalues, and thus somewhat dangerous.  Their address can be taken, and they can be assigned to.

We were using statement expressions to perform lvalue conversion on compound literals, transforming them to rvalues, and thus removing their dangers.  However, statement expressions are non-standard, and quite complex within the compiler, so it would be interesting to use simpler compiler features to achieve the same.

The comma operator also performs lvalue conversion, and we can use a dummy (void)0 expression to introduce it.  This is significantly simpler, and is more portable than the statement expression: it is valid all the way back to C99 (the comma operator and the (void)0 expression are portable to C89, but the compound literal is from C99).

By using a simpler feature, we have a smaller risk of running into a compiler bug.

Suggested-by: @uecker 
Cc: @chrisbazley
Cc: @kees
Cc: @flatcap

---

-  This is a subset of <https://github.com/shadow-maint/shadow/pull/1491> at v2g, to make it easier to review.

---

Revisions:

<details>
<summary>v1b</summary>

-  Rebase

```
$ git rd 
1:  a5953e443b47 = 1:  b24b07bf2a36 lib/: Use the comma operator to perform lvalue conversion
```
</details>