### PR TITLE
Tets: Fix indentation in test_groupadd.py

### DIFF
--- a/tests/system/tests/test_groupadd.py
+++ b/tests/system/tests/test_groupadd.py
@@ -141,12 +141,16 @@ def test_groupadd__force_group_creation(shadow: Shadow):
     :customerscenario: False
     """
     shadow.groupadd("tgroup")
+
     existing_group_entry = shadow.tools.getent.group("tgroup")
     assert existing_group_entry is not None, "Group should be found"
+
     shadow.groupadd("-f tgroup")
+
     group_entry = shadow.tools.getent.group("tgroup")
     assert group_entry is not None, "Group should be found"
     assert group_entry.name == "tgroup", "Incorrect groupname"
+
     if shadow.host.features["gshadow"]:
         gshadow_entry = shadow.tools.getent.gshadow("tgroup")
         assert gshadow_entry is not None, "Group should be found"


### PR DESCRIPTION
This patch fixes the indentation issue introduced by python tranformation of bash test `06_groupadd_-f_add_existing_group` to keep code aligned with other python tests in test_groupadd.py