### PR TITLE
man/generate_translations.mak: depend on config.xml

### DIFF
--- a/man/generate_translations.mak
+++ b/man/generate_translations.mak
@@ -11,7 +11,7 @@ messages.mo: ../po/$(LANG).po
 login.defs.d:
 	ln -sf $(srcdir)/../login.defs.d login.defs.d
 
-%.xml: ../%.xml messages.mo login.defs.d
+%.xml: ../%.xml messages.mo login.defs.d config.xml
 	if grep -q SHADOW-CONFIG-HERE $< ; then \
 	    sed -e 's/^<!-- SHADOW-CONFIG-HERE -->/<!ENTITY % config SYSTEM "config.xml">%config;/' $< > $@; \
 	else \


### PR DESCRIPTION
The `%.xml` recipe seds an `<!ENTITY % config SYSTEM "config.xml">` reference
into its output before handing it to itstool, so under `-j` itstool can
beat the sibling config.xml rule and die on "Entity 'SHADOW_UTILS_VERSION' not defined".

Thanks!