### PR TITLE
share/ansible/palybook.yml: remove unused reserved `name` variable

### DIFF
--- a/share/ansible/playbook.yml
+++ b/share/ansible/playbook.yml
@@ -12,7 +12,6 @@
     - role: build_container
       vars:
         privileged: "{{ privileged_mode | default(false) | bool }}"
-        name: "{{ container_name }}"
   post_tasks:
     - name: Register container as a host
       ansible.builtin.add_host:


### PR DESCRIPTION
It was generating a warning and since the variable isn't used it's better to remove it.
```
[WARNING]: Found variable using reserved name 'name'.
Origin: /home/ipedrosa/repos/shadow/share/ansible/playbook.yml:15:9

13       vars:
14         privileged: "{{ privileged_mode | default(false) | bool }}"
15         name: "{{ container_name }}"
           ^ column 9
```