### PR TITLE
lib/nscd.h: nscd_flush_cache(): Define as static inline function

### DIFF
--- a/lib/nscd.h
+++ b/lib/nscd.h
@@ -7,7 +7,11 @@
 #ifdef	USE_NSCD
 extern int nscd_flush_cache (const char *service);
 #else
-#define nscd_flush_cache(service) (0)
+static inline int
+nscd_flush_cache(MAYBE_UNUSED int _1)
+{
+	return 0;
+}
 #endif
 
 #endif


### PR DESCRIPTION
Being a macro, the unused return value triggers a diagnostic. This probably needs further investigation, but we have the issue #1221 linked below for that.

- Link: <https://github.com/shadow-maint/shadow/issues/1221>
- Closes: <https://github.com/shadow-maint/shadow/issues/1733>
- Reported-by: @AkihiroSuda